### PR TITLE
Responsive Nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,15 @@
   "requires": true,
   "dependencies": {
     "@sparkpost/matchbox": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-0.1.22.tgz",
-      "integrity": "sha1-wDmWRs/lTIFNIRVQ/JrjnRUcsy4=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-0.5.0.tgz",
+      "integrity": "sha512-AHQ8z6Mf5G8raPmHQCcLiyPs1FAV21UKMYmhDDDH8H2AvtgUHMQpGKcnPUBnDkE3CVfS+cw0unwJLbkEVUGpgg==",
       "dev": true,
       "requires": {
         "react": "15.6.1",
+        "react-day-picker": "6.1.0",
         "react-dom": "15.6.1",
         "react-icon-base": "2.1.0"
-      },
-      "dependencies": {
-        "react-icon-base": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
-          "integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=",
-          "dev": true
-        }
       }
     },
     "@timer/detect-port": {
@@ -9108,6 +9101,16 @@
         "prop-types": "15.5.10"
       }
     },
+    "react-day-picker": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-6.1.0.tgz",
+      "integrity": "sha1-gRIsNL+07uwojsMXCeiqbUvBYcw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
+      }
+    },
     "react-dev-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-2.0.1.tgz",
@@ -9471,6 +9474,12 @@
           }
         }
       }
+    },
+    "react-icon-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
+      "integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=",
+      "dev": true
     },
     "react-redux": {
       "version": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
-    "@sparkpost/matchbox": "^0.1.22",
+    "@sparkpost/matchbox": "^0.5.0",
     "autoprefixer": "7.1.0",
     "babel-core": "6.24.1",
     "babel-eslint": "7.2.3",

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -4,6 +4,7 @@
   position: relative;
   display: flex;
   min-height: 100vh;
+  background: color(gray, 9);
 }
 
 .accent:before {
@@ -20,19 +21,27 @@
 
 .aside {
   position: relative;
-  flex: 1 0 0;
-  max-width: rem(220);
-  min-width: rem(220);
+  flex: 0 0 0;
+
+  @media screen and (min-width: breakpoint(medium)) {
+    flex: 1 0 0;
+    max-width: rem(220);
+    min-width: rem(220);
+  }
 }
 
 .content, .formContent {
   position: relative;
-  background: color(gray, 9);
   padding: spacing(larger);
 }
 
 .content {
   flex: 1 0 0;
+  margin-top: rem(70);
+
+  @media screen and (min-width: breakpoint(medium)) {
+    margin-top: rem(0);
+  }
 }
 
 .container {

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -1,24 +1,63 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import classnames from 'classnames';
 
 import Item from './Item';
 import Footer from './Footer';
 import navItems from './navItems';
+import { Icon } from '@sparkpost/matchbox';
 import styles from './Navigation.module.scss';
 
 class Navigation extends Component {
+  state = {
+    open: false
+  }
+
   renderItems () {
     return navItems.map((item, key) => <Item {...item} location={this.props.location} key={key} />);
   }
 
+  handleClick () {
+    this.setState({ open: !this.state.open });
+  }
+
   render () {
+    const navClasses = classnames(
+      styles.navigation,
+      this.state.open && styles.showNav
+    );
+
+    const overlayClasses = classnames(
+      styles.overlay,
+      this.state.open && styles.showOverlay
+    );
+
     return (
-      <nav className={styles.navigation}>
-        <ul className={styles.list}>
-          { this.renderItems() }
-        </ul>
-        <Footer />
-      </nav>
+      <div>
+        <div
+          className={overlayClasses}
+          onClick={() => this.handleClick()} />
+
+        <nav className={navClasses}>
+          <div className={styles.wrapper}>
+            <ul className={styles.list}>
+              { this.renderItems() }
+            </ul>
+            <Footer />
+          </div>
+          <Icon
+            name='Close'
+            className={styles.close}
+            size={33}
+            onClick={() => this.handleClick()} />
+        </nav>
+
+        <nav className={styles.bar}>
+          <a className={styles.open} onClick={() => this.handleClick()}>
+            <span className={styles.hamburger} />
+          </a>
+        </nav>
+      </div>
     );
   }
 }

--- a/src/components/Navigation/Navigation.module.scss
+++ b/src/components/Navigation/Navigation.module.scss
@@ -2,12 +2,49 @@
 
 .navigation {
   position: fixed;
-  width: rem(220);
-  background: color(gray, 1);
-  height: 100vh;
-  overflow-y: auto;
+  width: rem(250);
+  z-index: 100;
+
+  transform: translate(-100%, 0);
+  transition: 0.2s;
+
+  @media screen and (min-width: breakpoint(medium)) {
+    width: rem(220);
+    transform: translate(0);
+  }
+
+  &.showNav {
+    transform: translate(0);
+    box-shadow: 10px 0px 30px rgba(#414146, 0.16)
+  }
 }
 
+.overlay {
+  display: block;
+  content: "";
+  position: fixed;
+  z-index: 99;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(color(gray, 3), 0.8);
+
+  opacity: 0;
+  pointer-events: none;
+  transition: 0.3s;
+
+  &.showOverlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.wrapper {
+  overflow-y: auto;
+  height: 100vh;
+  background: color(gray, 1);
+}
 
 .list, .nestedList, .footer {
   list-style: none;
@@ -108,6 +145,76 @@
   transition: 0.1s;
 }
 
-.footer {
-  padding-bottom: spacing();
+// Open Trigger
+.bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  z-index: 98;
+  display: block;
+  padding: rem(15) rem(18) rem(9);
+  background: color(gray, 2);
+
+  @media screen and (min-width: breakpoint(medium)) {
+    display: none;
+  }
+}
+
+.open {
+  position: relative;
+  display: inline-block;
+  padding: rem(18);
+  border-radius: border-radius();
+
+  &:hover {
+    cursor: pointer;
+
+    .hamburger, .hamburger:before, .hamburger:after {
+      background: color(gray, 10);
+    }
+  }
+}
+
+.close {
+  position: absolute;
+  left: 105%;
+  top: rem(14);
+  fill: color(gray, 10);
+
+  opacity: 0;
+  pointer-events: none;
+  transition: 0.2s;
+
+  .showNav & {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+%hamburgerbar {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  height: 2px;
+  width: rem(30);
+  background: color(gray, 7);
+  border-radius: border-radius();
+  transition: 0.15s;
+}
+
+.hamburger {
+  @extend %hamburgerbar;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:before, &:after {
+    display: block;
+    content: "";
+    @extend %hamburgerbar;
+  }
+
+  &:before { top: -7px; }
+  &:after { top: 7px; }
 }

--- a/src/components/Navigation/navItems.js
+++ b/src/components/Navigation/navItems.js
@@ -6,7 +6,7 @@ export default [
   },
   {
     label: 'Reports',
-    to: '/reports', // This does nothing right now
+    to: '/reports',
     icon: 'InsertChart',
     children: [
       {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,1 +1,11 @@
 @import '~@sparkpost/matchbox/styles.scss'; // Global Compiled
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+// All components use REMs for sizing
+// Adjusting the root font size here will scale the UI proportionally
+
+html {
+  font-size: rem(16);
+  @media screen and (min-width: breakpoint(medium)) { font-size: rem(18); }
+  @media screen and (min-width: breakpoint(larger)) { font-size: rem(20); }
+}


### PR DESCRIPTION
- Makes side navigation responsive
- We now have an empty top bar on smaller screens. Have room to put in the SP logo or other actions.
- Also scales root font-size at breakpoints. All the MB components use REMs for sizing so we can scale the UI proportionally whenever we want.

![kapture 2017-07-20 at 14 40 39](https://user-images.githubusercontent.com/3903325/28433412-75c7860a-6d59-11e7-9bd9-1562552fd63c.gif)

![kapture 2017-07-20 at 14 43 42](https://user-images.githubusercontent.com/3903325/28433516-f7acca36-6d59-11e7-97eb-8f4ec0b2675c.gif)
