### PR TITLE
Date range management FAD-5334

### DIFF
--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -1,7 +1,14 @@
+/* eslint-disable */
+import { getRelativeDates } from 'helpers/metrics';
+
 export function setRelativeTime(payload) {
-  return {
-    type: 'SET_RELATIVE_TIME',
-    payload
+  const dates = { ...getRelativeDates(payload) }
+  return (dispatch) => {
+    dispatch({
+      type: 'SET_RELATIVE_TIME',
+      payload: { ...dates, range: payload }
+    });
+    return Promise.resolve();
   };
 }
 

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -1,23 +1,17 @@
 import { getRelativeDates } from 'helpers/metrics';
 
-export function setRelativeTime(payload) {
-  return (dispatch) => {
-    dispatch({
-      type: 'SET_RELATIVE_TIME',
-      payload: { ...getRelativeDates(payload), range: payload }
-    });
-    return Promise.resolve();
-  };
+export function setRelativeTime(range) {
+  return (dispatch) => Promise.resolve(dispatch({
+    type: 'SET_RELATIVE_TIME',
+    payload: { ...getRelativeDates(range), range }
+  }));
 }
 
-export function setExactTime(payload) {
-  return (dispatch) => {
-    dispatch({
-      type: 'SET_EXACT_TIME',
-      payload
-    });
-    return Promise.resolve();
-  };
+export function setExactTime(rangeDates) {
+  return (dispatch) => Promise.resolve(dispatch({
+    type: 'SET_EXACT_TIME',
+    payload: { ...rangeDates, range: 'custom' }
+  }));
 }
 
 export function addFilter(payload) {

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -1,12 +1,10 @@
-/* eslint-disable */
 import { getRelativeDates } from 'helpers/metrics';
 
 export function setRelativeTime(payload) {
-  const dates = { ...getRelativeDates(payload) }
   return (dispatch) => {
     dispatch({
       type: 'SET_RELATIVE_TIME',
-      payload: { ...dates, range: payload }
+      payload: { ...getRelativeDates(payload), range: payload }
     });
     return Promise.resolve();
   };

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -20,7 +20,9 @@ export {
   getLineChartFormatters,
   getPrecision,
   getDayLines,
-  getEndOfDay
+  getEndOfDay,
+  relativeDateOptions,
+  getRelativeDates
 };
 
 const getTickFormatter = _.memoize((precisionType) => {
@@ -109,4 +111,34 @@ function getEndOfDay(date) {
   end.setMilliseconds(0);
 
   return end;
+}
+
+const relativeDateOptions = [
+    { value: 'hour', label: 'Last Hour' },
+    { value: 'day', label: 'Last 24 Hours' },
+    { value: '7days', label: 'Last 7 Days' },
+    { value: '30days', label: 'Last 30 Days' },
+    { value: '90days', label: 'Last 90 Days' },
+    { value: 'custom', label: 'Custom' }
+];
+
+function getRelativeDates(range) {
+  const to = new Date();
+
+  switch (range) {
+    case 'hour':
+      return { to, from: moment(to).subtract(1, 'hour').toDate() };
+
+    case 'day':
+      return { to, from: moment(to).subtract(1, 'day').toDate() };
+
+    case '7days':
+      return { to, from: moment(to).subtract(7, 'day').toDate() };
+
+    case '30days':
+      return { to, from: moment(to).subtract(30, 'day').toDate() };
+
+    case '90days':
+      return { to, from: moment(to).subtract(90, 'day').toDate() };
+  }
 }

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -20,6 +20,7 @@ export {
   getLineChartFormatters,
   getPrecision,
   getDayLines,
+  getStartOfDay,
   getEndOfDay,
   relativeDateOptions,
   getRelativeDates
@@ -105,12 +106,22 @@ function getDayLines(data, { precision = 'day' }) {
 
 function getEndOfDay(date) {
   const end = new Date(date);
-  end.setHours(11);
+  end.setHours(23);
   end.setMinutes(59);
   end.setSeconds(59);
   end.setMilliseconds(0);
 
   return end;
+}
+
+function getStartOfDay(date) {
+  const start = new Date(date);
+  start.setHours(0);
+  start.setMinutes(0);
+  start.setSeconds(0);
+  start.setMilliseconds(0);
+
+  return start;
 }
 
 const relativeDateOptions = [

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -17,7 +17,7 @@ class DateFilter extends Component {
   }
 
   componentDidMount() {
-    this.syncStateToProps(this.props);
+    this.syncPropsToState(this.props);
     window.addEventListener('click', this.handleClickOutside);
     window.addEventListener('keydown', this.handleKeyDown);
   }
@@ -28,11 +28,11 @@ class DateFilter extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.syncStateToProps(nextProps);
+    this.syncPropsToState(nextProps);
   }
 
   // Sets local state from reportFilters redux state - need to separate to handle pre-apply state
-  syncStateToProps = ({ filter }) => {
+  syncPropsToState = ({ filter }) => {
     this.setState({ selected: { from: filter.from, to: filter.to }});
   }
 
@@ -65,7 +65,7 @@ class DateFilter extends Component {
   }
 
   cancelDatePicker = () => {
-    this.syncStateToProps(this.props);
+    this.syncPropsToState(this.props);
     this.setState({ showDatePicker: false });
   }
 
@@ -108,8 +108,8 @@ class DateFilter extends Component {
     }
   }
 
-  handleFormChange = ({ from, to }) => {
-    this.setState({ selected: { from, to }});
+  handleFormDates = ({ from, to }, callback) => {
+    this.setState({ selected: { from, to }}, () => callback());
   }
 
   handleSubmit = () => {
@@ -155,8 +155,8 @@ class DateFilter extends Component {
           selectedDays={this.state.selected}
         />
 
-        <DateForm onChange={this.handleFormChange} to={to} from={from} />
-        <Button primary onClick={this.handleSubmit}>Apply</Button>
+        <DateForm selectDates={this.handleFormDates} onEnter={this.handleKeyDown} to={to} from={from} />
+        <Button primary onClick={this.handleSubmit} className={styles.Apply}>Apply</Button>
         <Button onClick={this.cancelDatePicker}>Cancel</Button>
       </Popover>
     );

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -47,8 +47,13 @@ class DateFilter extends Component {
   // Closes popover on escape
   handleEsc = (e) => {
     if (this.state.showDatePicker && e.code === 'Escape') {
-      this.setState({ showDatePicker: false });
+      this.cancelDatePicker();
     }
+  }
+
+  cancelDatePicker = () => {
+    this.syncStateToProps(this.props);
+    this.setState({ showDatePicker: false });
   }
 
   showDatePicker = () => {
@@ -59,12 +64,10 @@ class DateFilter extends Component {
     const { selecting, selected } = this.state;
     const dates = selecting ? selected : { from: clicked, to: getEndOfDay(clicked) };
 
-    this.props.setRelativeTime('custom').then(() => {
-      this.setState({
-        selected: dates,
-        beforeSelected: dates,
-        selecting: !selecting
-      });
+    this.setState({
+      selected: dates,
+      beforeSelected: dates,
+      selecting: !selecting
     });
   }
 
@@ -86,7 +89,7 @@ class DateFilter extends Component {
 
     if (value === 'custom') {
       this.setState({ showDatePicker: true });
-      this.props.setRelativeTime(value);
+      // this.props.setRelativeTime(value);
     } else {
       this.setState({ showDatePicker: false });
       this.props.setRelativeTime(value).then(() => this.props.refresh());
@@ -103,12 +106,13 @@ class DateFilter extends Component {
   }
 
   render() {
-    const { selected: { from, to }} = this.state;
+    const { selected: { from, to }, showDatePicker } = this.state;
+    const selectedRange = showDatePicker ? 'custom' : this.props.filter.range;
 
     const rangeSelect = <Select
       options={relativeDateOptions}
       onChange={this.handleSelectRange}
-      value={this.props.filter.range} />;
+      value={selectedRange} />;
 
     const dateField = <TextField
       labelHidden={true}
@@ -134,10 +138,12 @@ class DateFilter extends Component {
           onDayClick={this.handleDayClick}
           onDayMouseEnter={this.handleDayHover}
           onDayFocus={this.handleDayHover}
-          selectedDays={this.state.selected} />
+          selectedDays={this.state.selected}
+        />
 
-          <DateForm onBlur={this.handleFormBlur} to={to} from={from} />
+        <DateForm onBlur={this.handleFormBlur} to={to} from={from} />
         <Button primary onClick={this.handleSubmit}>Apply</Button>
+        <Button onClick={this.cancelDatePicker}>Cancel</Button>
       </Popover>
     );
   }

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import ReactDOM from 'react-dom';
 import { subMonths, format } from 'date-fns';
-import { getEndOfDay, relativeDateOptions } from 'helpers/metrics';
+import { getStartOfDay, getEndOfDay, relativeDateOptions } from 'helpers/metrics';
 import { Button, Datepicker, TextField, Select, Popover } from '@sparkpost/matchbox';
 import { setExactTime, setRelativeTime } from 'actions/reportFilters';
 import DateForm from './DateForm';
@@ -75,7 +75,7 @@ class DateFilter extends Component {
 
   handleDayClick = (clicked) => {
     const { selecting, selected } = this.state;
-    const dates = selecting ? selected : { from: clicked, to: getEndOfDay(clicked) };
+    const dates = selecting ? selected : { from: getStartOfDay(clicked), to: getEndOfDay(clicked) };
 
     this.setState({
       selected: dates,
@@ -94,7 +94,7 @@ class DateFilter extends Component {
 
   getOrderedRange(newDate) {
     const { from, to } = this.state.beforeSelected;
-    return (from.getTime() <= newDate.getTime()) ? { from, to: newDate } : { from: newDate, to };
+    return (from.getTime() <= newDate.getTime()) ? { from, to: getEndOfDay(newDate) } : { from: getStartOfDay(newDate), to };
   }
 
   handleSelectRange = (e) => {
@@ -108,12 +108,12 @@ class DateFilter extends Component {
     }
   }
 
-  handleFormBlur = ({ from, to }) => {
+  handleFormChange = ({ from, to }) => {
     this.setState({ selected: { from, to }});
   }
 
   handleSubmit = () => {
-    this.setState({ showDatePicker: false });
+    this.setState({ showDatePicker: false, selecting: false });
     this.props.setExactTime(this.state.selected).then(() => this.props.refresh());
   }
 
@@ -155,7 +155,7 @@ class DateFilter extends Component {
           selectedDays={this.state.selected}
         />
 
-        <DateForm onBlur={this.handleFormBlur} to={to} from={from} />
+        <DateForm onChange={this.handleFormChange} to={to} from={from} />
         <Button primary onClick={this.handleSubmit}>Apply</Button>
         <Button onClick={this.cancelDatePicker}>Cancel</Button>
       </Popover>

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import ReactDOM from 'react-dom';
@@ -97,8 +96,8 @@ class DateFilter extends Component {
     }
   }
 
-  handleFormBlur = ({ from, to}) => {
-    this.setState({ selected: { from, to } })
+  handleFormBlur = ({ from, to }) => {
+    this.setState({ selected: { from, to }});
   }
 
   handleSubmit = () => {
@@ -107,12 +106,7 @@ class DateFilter extends Component {
   }
 
   render() {
-    const { selected: { from, to } } = this.state;
-
-    const formatted = {
-      from: format(from, this.format),
-      to: format(to, this.format)
-    };
+    const { selected: { from, to }} = this.state;
 
     const rangeSelect = <Select
       options={relativeDateOptions}
@@ -121,9 +115,9 @@ class DateFilter extends Component {
 
     const dateField = <TextField
       labelHidden={true}
-      onClick={() => this.showDatePicker()}
+      onClick={this.showDatePicker}
       connectLeft={rangeSelect}
-      value={`${formatted.from} - ${formatted.to}`}
+      value={`${format(from, this.format)} - ${format(to, this.format)}`}
       readOnly />;
 
     return (

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -61,10 +61,9 @@ class DateFilter extends Component {
 
     this.props.setRelativeTime('custom').then(() => {
       this.setState({
-        ...this.state,
         selected: dates,
-        selecting: !selecting,
-        beforeSelected: { ...dates }
+        beforeSelected: dates,
+        selecting: !selecting
       });
     });
   }
@@ -73,9 +72,7 @@ class DateFilter extends Component {
     const { selecting } = this.state;
 
     if (selecting) {
-      this.setState({
-        selected: { ...this.state.selected, ...this.getOrderedRange(hovered) }
-      });
+      this.setState({ selected: { ...this.getOrderedRange(hovered) }});
     }
   }
 

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -19,7 +19,7 @@ class DateFilter extends Component {
   componentDidMount() {
     this.syncStateToProps(this.props);
     window.addEventListener('click', this.handleClickOutside);
-    window.addEventListener('keydown', this.handleEsc);
+    window.addEventListener('keydown', this.handleKeyDown);
   }
 
   componentWillUnmount() {
@@ -44,11 +44,24 @@ class DateFilter extends Component {
     }
   }
 
-  // Closes popover on escape
-  handleEsc = (e) => {
-    if (this.state.showDatePicker && e.code === 'Escape') {
+  // Closes popover on escape, submits on enter
+  handleKeyDown = (e) => {
+    if (!this.state.showDatePicker) {
+      return;
+    }
+
+    if (e.key === 'Escape') {
       this.cancelDatePicker();
     }
+
+    if (!this.state.selecting && e.key === 'Enter') {
+      this.handleSubmit();
+    }
+  }
+
+  handleDayKeyDown = (day, modifiers, e) => {
+    this.handleKeyDown(e);
+    e.stopPropagation();
   }
 
   cancelDatePicker = () => {
@@ -89,7 +102,6 @@ class DateFilter extends Component {
 
     if (value === 'custom') {
       this.setState({ showDatePicker: true });
-      // this.props.setRelativeTime(value);
     } else {
       this.setState({ showDatePicker: false });
       this.props.setRelativeTime(value).then(() => this.props.refresh());
@@ -138,6 +150,8 @@ class DateFilter extends Component {
           onDayClick={this.handleDayClick}
           onDayMouseEnter={this.handleDayHover}
           onDayFocus={this.handleDayHover}
+          onKeyDown={this.handleKeyDown}
+          onDayKeyDown={this.handleDayKeyDown}
           selectedDays={this.state.selected}
         />
 

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -4,19 +4,17 @@ import { connect } from 'react-redux';
 import ReactDOM from 'react-dom';
 import { subMonths, format } from 'date-fns';
 import { getEndOfDay, relativeDateOptions } from 'helpers/metrics';
-import { Grid, Button, Datepicker, TextField, Select, Popover, Icon } from '@sparkpost/matchbox';
+import { Button, Datepicker, TextField, Select, Popover } from '@sparkpost/matchbox';
 import { setExactTime, setRelativeTime } from 'actions/reportFilters';
-
+import DateForm from './DateForm';
 import styles from './DateFilter.module.scss';
 
 class DateFilter extends Component {
+  format = 'MMM DD, YY h:mma';
   state = {
     showDatePicker: false,
     selecting: false,
-    selected: {
-      from: null,
-      to: null
-    }
+    selected: { }
   }
 
   componentDidMount() {
@@ -77,7 +75,6 @@ class DateFilter extends Component {
 
     if (selecting) {
       this.setState({
-        ...this.state,
         selected: { ...this.state.selected, ...this.getOrderedRange(hovered) }
       });
     }
@@ -95,12 +92,13 @@ class DateFilter extends Component {
       this.setState({ showDatePicker: true });
       this.props.setRelativeTime(value);
     } else {
+      this.setState({ showDatePicker: false });
       this.props.setRelativeTime(value).then(() => this.props.refresh());
     }
   }
 
-  handleFieldChange = () => {
-
+  handleFormBlur = ({ from, to}) => {
+    this.setState({ selected: { from, to } })
   }
 
   handleSubmit = () => {
@@ -110,21 +108,10 @@ class DateFilter extends Component {
 
   render() {
     const { selected: { from, to } } = this.state;
-    const fullFormat = 'MMM DD, YY h:mma';
-    const dayFormat = 'MM/DD/YY';
-    const timeFormat = 'h:mma';
 
     const formatted = {
-      from: {
-        full: format(from, fullFormat),
-        day: format(from, dayFormat),
-        time: format(from, timeFormat)
-      },
-      to: {
-        full: format(to, fullFormat),
-        day: format(to, dayFormat),
-        time: format(to, timeFormat)
-      }
+      from: format(from, this.format),
+      to: format(to, this.format)
     };
 
     const rangeSelect = <Select
@@ -136,7 +123,7 @@ class DateFilter extends Component {
       labelHidden={true}
       onClick={() => this.showDatePicker()}
       connectLeft={rangeSelect}
-      value={`${formatted.from.full} - ${formatted.to.full}`}
+      value={`${formatted.from} - ${formatted.to}`}
       readOnly />;
 
     return (
@@ -158,41 +145,7 @@ class DateFilter extends Component {
           onDayFocus={this.handleDayHover}
           selectedDays={this.state.selected} />
 
-        <div className={styles.DateFields}>
-          <Grid middle='xs'>
-            <Grid.Column >
-              <TextField
-                label='From'
-                labelHidden
-                onChange={this.handleFieldChange}
-                value={formatted.from.day} />
-            </Grid.Column>
-            <Grid.Column >
-              <TextField
-                labelHidden
-                onChange={this.handleFieldChange}
-                value={formatted.from.time} />
-            </Grid.Column>
-            <Grid.Column xs={1}>
-              <div className={styles.ArrowWrapper}>
-                <Icon name='ArrowRight'/>
-              </div>
-            </Grid.Column>
-            <Grid.Column >
-              <TextField
-                label='To'
-                labelHidden
-                onChange={this.handleFieldChange}
-                value={formatted.to.day} />
-            </Grid.Column>
-            <Grid.Column >
-              <TextField
-                labelHidden
-                onChange={this.handleFieldChange}
-                value={formatted.to.time} />
-            </Grid.Column>
-          </Grid>
-        </div>
+          <DateForm onBlur={this.handleFormBlur} to={to} from={from} />
         <Button primary onClick={this.handleSubmit}>Apply</Button>
       </Popover>
     );

--- a/src/pages/reports/components/DateFilter.module.scss
+++ b/src/pages/reports/components/DateFilter.module.scss
@@ -1,18 +1,6 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-.RangeButtonWrapper {
-  margin-bottom: spacing(small);
-}
-
 .Popover {
   width: rem(640);
   padding: spacing();
-}
-
-.DateFields {
-  margin: spacing() 0;
-}
-
-.ArrowWrapper {
-  text-align: center;
 }

--- a/src/pages/reports/components/DateFilter.module.scss
+++ b/src/pages/reports/components/DateFilter.module.scss
@@ -4,3 +4,7 @@
   width: rem(640);
   padding: spacing();
 }
+
+.Apply {
+  margin-right: spacing();
+}

--- a/src/pages/reports/components/DateForm.js
+++ b/src/pages/reports/components/DateForm.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import moment from 'moment';
 import { format } from 'date-fns';
+import _ from 'lodash';
 
 import { Grid, TextField, Icon } from '@sparkpost/matchbox';
 import styles from './DateForm.module.scss';
@@ -31,21 +32,22 @@ class DateForm extends Component {
 
   handleFieldChange = (e, key) => {
     this.setState({ [key]: e.target.value });
+    this.debounceChanges();
   }
 
-  handleBlur = (e) => {
+  debounceChanges = _.debounce(() => {
     const format = `${this.dayFormat} ${this.timeFormat}`;
     const to = moment(`${this.state.toDate} ${this.state.toTime}`, format, true);
     const from = moment(`${this.state.fromDate} ${this.state.fromTime}`, format, true);
     const now = moment();
 
     if (to.isValid() && from.isValid() && from.isBefore(to) && to.isBefore(now)) {
-      this.props.onBlur({ to: to.toDate(), from: from.toDate() });
+      this.props.onChange({ to: to.toDate(), from: from.toDate() });
     } else {
       // Resets fields if dates are not valid
       this.syncStateToProps(this.props);
     }
-  }
+  }, 500);
 
   render() {
     const { toDate, toTime, fromDate, fromTime } = this.state;
@@ -57,14 +59,12 @@ class DateForm extends Component {
             <TextField
               label='From Date' labelHidden
               onChange={(e) => this.handleFieldChange(e, 'fromDate')}
-              onBlur={this.handleBlur}
               value={fromDate} />
           </Grid.Column>
           <Grid.Column >
             <TextField
               label='From Time' labelHidden
               onChange={(e) => this.handleFieldChange(e, 'fromTime')}
-              onBlur={this.handleBlur}
               value={fromTime} />
           </Grid.Column>
           <Grid.Column xs={1}>
@@ -76,14 +76,12 @@ class DateForm extends Component {
             <TextField
               label='To Date' labelHidden
               onChange={(e) => this.handleFieldChange(e, 'toDate')}
-              onBlur={this.handleBlur}
               value={toDate} />
           </Grid.Column>
           <Grid.Column >
             <TextField
               label='To Time' labelHidden
               onChange={(e) => this.handleFieldChange(e, 'toTime')}
-              onBlur={this.handleBlur}
               value={toTime} />
           </Grid.Column>
         </Grid>

--- a/src/pages/reports/components/DateForm.js
+++ b/src/pages/reports/components/DateForm.js
@@ -7,8 +7,9 @@ import { Grid, TextField, Icon } from '@sparkpost/matchbox';
 import styles from './DateForm.module.scss';
 
 class DateForm extends Component {
-  dayFormat = 'MM/DD/YY';
+  dayFormat = 'YYYY-M-D';
   timeFormat = 'h:mma';
+  debounce = 500;
 
   state = {
     toDate: '',
@@ -18,10 +19,10 @@ class DateForm extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.syncStateToProps(nextProps);
+    this.syncPropsToState(nextProps);
   }
 
-  syncStateToProps({ to, from }) {
+  syncPropsToState({ to, from }) {
     this.setState({
       toDate: format(to, this.dayFormat),
       toTime: format(to, this.timeFormat),
@@ -36,35 +37,54 @@ class DateForm extends Component {
   }
 
   debounceChanges = _.debounce(() => {
+    this.validate();
+  }, this.DEBOUNCE);
+
+  handleEnter = (e) => {
+    if (e.key === 'Enter') {
+      this.validate(e, true);
+    }
+  };
+
+  handleBlur = (e) => {
+    this.validate(e, true);
+  }
+
+  validate = (e, shouldReset) => {
     const format = `${this.dayFormat} ${this.timeFormat}`;
     const to = moment(`${this.state.toDate} ${this.state.toTime}`, format, true);
     const from = moment(`${this.state.fromDate} ${this.state.fromTime}`, format, true);
     const now = moment();
 
     if (to.isValid() && from.isValid() && from.isBefore(to) && to.isBefore(now)) {
-      this.props.onChange({ to: to.toDate(), from: from.toDate() });
-    } else {
-      // Resets fields if dates are not valid
-      this.syncStateToProps(this.props);
+      return this.props.selectDates({ to: to.toDate(), from: from.toDate() }, () => {
+        if (e && e.key === 'Enter') {
+          this.props.onEnter(e);
+        }
+      });
+    } else if (shouldReset) {
+      this.syncPropsToState(this.props); // Resets fields if dates are not valid
     }
-  }, 500);
+  }
 
   render() {
     const { toDate, toTime, fromDate, fromTime } = this.state;
 
     return (
-      <div className={styles.DateFields}>
+      <form onKeyDown={this.handleEnter} className={styles.DateFields}>
         <Grid middle='xs'>
           <Grid.Column >
             <TextField
-              label='From Date' labelHidden
+              label='From Date' labelHidden placeholder='YYYY-MM-DD'
               onChange={(e) => this.handleFieldChange(e, 'fromDate')}
+              onBlur={(e) => this.handleBlur(e)}
               value={fromDate} />
           </Grid.Column>
           <Grid.Column >
             <TextField
-              label='From Time' labelHidden
+              label='From Time' labelHidden placeholder='12:00am'
               onChange={(e) => this.handleFieldChange(e, 'fromTime')}
+              onBlur={(e) => this.handleBlur(e)}
               value={fromTime} />
           </Grid.Column>
           <Grid.Column xs={1}>
@@ -74,18 +94,20 @@ class DateForm extends Component {
           </Grid.Column>
           <Grid.Column >
             <TextField
-              label='To Date' labelHidden
+              label='To Date' labelHidden placeholder='YYYY-MM-DD'
               onChange={(e) => this.handleFieldChange(e, 'toDate')}
+              onBlur={(e) => this.handleBlur(e)}
               value={toDate} />
           </Grid.Column>
           <Grid.Column >
             <TextField
-              label='To Time' labelHidden
+              label='To Time' labelHidden placeholder='12:00am'
               onChange={(e) => this.handleFieldChange(e, 'toTime')}
+              onBlur={(e) => this.handleBlur(e)}
               value={toTime} />
           </Grid.Column>
         </Grid>
-      </div>
+      </form>
     );
   }
 }

--- a/src/pages/reports/components/DateForm.js
+++ b/src/pages/reports/components/DateForm.js
@@ -1,0 +1,95 @@
+import React, { Component } from 'react';
+import moment from 'moment';
+import { format } from 'date-fns';
+
+import { Grid, TextField, Icon } from '@sparkpost/matchbox';
+import styles from './DateForm.module.scss';
+
+class DateForm extends Component {
+  dayFormat = 'MM/DD/YY';
+  timeFormat = 'h:mma';
+
+  state = {
+    toDate: '',
+    toTime: '',
+    fromDate: '',
+    fromTime: ''
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.syncStateToProps(nextProps);
+  }
+
+  syncStateToProps({ to, from }) {
+    this.setState({
+      toDate: format(to, this.dayFormat),
+      toTime: format(to, this.timeFormat),
+      fromDate: format(from, this.dayFormat),
+      fromTime: format(from, this.timeFormat)
+    });
+  }
+
+  handleFieldChange = (e, key) => {
+    this.setState({ [key]: e.target.value });
+  }
+
+  handleBlur = (e) => {
+    const format = `${this.dayFormat} ${this.timeFormat}`;
+    const to = moment(`${this.state.toDate} ${this.state.toTime}`, format, true);
+    const from = moment(`${this.state.fromDate} ${this.state.fromTime}`, format, true);
+    const now = moment();
+
+    if (to.isValid() && from.isValid() && from.isBefore(to) && to.isBefore(now)) {
+      this.props.onBlur({ to: to.toDate(), from: from.toDate() });
+    } else {
+      // Resets fields if dates are not valid
+      this.syncStateToProps(this.props);
+    }
+  }
+
+  render() {
+    const { toDate, toTime, fromDate, fromTime } = this.state;
+
+    return (
+      <div className={styles.DateFields}>
+        <Grid middle='xs'>
+          <Grid.Column >
+            <TextField
+              label='From Date' labelHidden
+              onChange={(e) => this.handleFieldChange(e, 'fromDate')}
+              onBlur={this.handleBlur}
+              value={fromDate} />
+          </Grid.Column>
+          <Grid.Column >
+            <TextField
+              label='From Time' labelHidden
+              onChange={(e) => this.handleFieldChange(e, 'fromTime')}
+              onBlur={this.handleBlur}
+              value={fromTime} />
+          </Grid.Column>
+          <Grid.Column xs={1}>
+            <div className={styles.ArrowWrapper}>
+              <Icon name='ArrowRight'/>
+            </div>
+          </Grid.Column>
+          <Grid.Column >
+            <TextField
+              label='To Date' labelHidden
+              onChange={(e) => this.handleFieldChange(e, 'toDate')}
+              onBlur={this.handleBlur}
+              value={toDate} />
+          </Grid.Column>
+          <Grid.Column >
+            <TextField
+              label='To Time' labelHidden
+              onChange={(e) => this.handleFieldChange(e, 'toTime')}
+              onBlur={this.handleBlur}
+              value={toTime} />
+          </Grid.Column>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+export default DateForm;

--- a/src/pages/reports/components/DateForm.module.scss
+++ b/src/pages/reports/components/DateForm.module.scss
@@ -1,0 +1,9 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.DateFields {
+  margin: spacing() 0;
+}
+
+.ArrowWrapper {
+  text-align: center;
+}

--- a/src/reducers/reportFilters.js
+++ b/src/reducers/reportFilters.js
@@ -1,11 +1,9 @@
-import moment from 'moment';
+import { getRelativeDates } from 'helpers/metrics';
 
-const to = new Date();
-const from = moment(to).subtract(1, 'day').toDate();
-
+const DEFAULT_RANGE = 'day';
 const initialState = {
-  to,
-  from,
+  ...getRelativeDates(DEFAULT_RANGE),
+  range: DEFAULT_RANGE,
   activeList: [],
   searchList: []
 };
@@ -16,7 +14,7 @@ export default (state = initialState, action) => {
       return { ...state, ...action.payload };
 
     case 'SET_RELATIVE_TIME':
-      return { ...state };
+      return { ...state, ...action.payload };
 
     case 'ADD_FILTER':
       return { ...state, activeList: [ ...state.activeList, action.payload ]};


### PR DESCRIPTION
- Selecting "Custom" opens Datepicker
- Datepicker & Date fields stay in sync
  - Date Fields are validated on blur
  - Dates must be valid dates
  - From must be before To
  - To must be before now
  - Must match `MM/DD/YY` and `h:mma`
- Reverts to previous dates if invalid

![kapture 2017-08-22 at 16 09 16](https://user-images.githubusercontent.com/3903325/29585421-0c3bc712-8755-11e7-853a-4dc26249bccb.gif)
