### PR TITLE
Refactored chart refresh logic to use redux

### DIFF
--- a/src/actions/metrics.js
+++ b/src/actions/metrics.js
@@ -6,13 +6,14 @@ const defaultParams = () => ({
   metrics: 'count_targeted'
 });
 
-export function fetch(url, params = {}) {
+export function fetch({ path, params = {}, meta = {}}) {
   return {
     type: 'SPARKPOST_API_REQUEST',
     meta: {
+      ...meta,
       type: 'FETCH_METRICS',
       method: 'GET',
-      url: `/metrics/${url}`,
+      url: `/metrics/${path}`,
       params: {
         ...defaultParams(),
         ...params
@@ -21,10 +22,12 @@ export function fetch(url, params = {}) {
   };
 }
 
-export function fetchDeliverability(params = {}) {
-  return fetch('deliverability', params);
+export function fetchDeliverability(params = {}, meta = {}) {
+  const path = 'deliverability';
+  return fetch({ path, params, meta });
 }
 
-export function getTimeSeries(params = {}) {
-  return fetch('time-series', params);
+export function getTimeSeries(params = {}, meta = {}) {
+  const path = 'deliverability/time-series';
+  return fetch({ path , params, meta });
 }

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -1,18 +1,18 @@
-import { getRelativeDates } from 'helpers/metrics';
+// import { getRelativeDates } from 'helpers/metrics';
 
-export function setRelativeTime(range) {
-  return (dispatch) => Promise.resolve(dispatch({
-    type: 'SET_RELATIVE_TIME',
-    payload: { ...getRelativeDates(range), range }
-  }));
-}
+// export function setRelativeTime(range) {
+//   return (dispatch) => Promise.resolve(dispatch({
+//     type: 'SET_RELATIVE_TIME',
+//     payload: { ...getRelativeDates(range), range }
+//   }));
+// }
 
-export function setExactTime(rangeDates) {
-  return (dispatch) => Promise.resolve(dispatch({
-    type: 'SET_EXACT_TIME',
-    payload: { ...rangeDates, range: 'custom' }
-  }));
-}
+// export function setExactTime(rangeDates) {
+//   return (dispatch) => Promise.resolve(dispatch({
+//     type: 'SET_EXACT_TIME',
+//     payload: { ...rangeDates, range: 'custom' }
+//   }));
+// }
 
 export function addFilter(payload) {
   return {

--- a/src/actions/summaryChart.js
+++ b/src/actions/summaryChart.js
@@ -1,0 +1,32 @@
+import { fetch as fetchMetrics } from 'actions/metrics';
+import { getQueryFromOptions, getMetricsFromList, getRelativeDates } from 'helpers/metrics';
+
+export function refresh(options = {}, { clear } = {}) {
+  return (dispatch, getState) => {
+    const state = getState();
+
+    // if new metrics are includedd, convert them to their full representation from config
+    if (options.metrics) {
+      options.metrics = getMetricsFromList(options.metrics);
+    }
+
+    // if relativeRange is included, merge in the calculated from/to values
+    Object.assign(options, getRelativeDates(options.relativeRange) || {});
+
+    // if clear is true, just use options, otherwise merge in existing state
+    const meta = clear ? options : {
+      ...state.summaryChart,
+      ...state.reportFilters,
+      ...options
+    };
+
+    // convert new meta data into query param format
+    const params = getQueryFromOptions(meta);
+
+    // attach precision and range to passed through meta
+    meta.precision = params.precision;
+    meta.range = options.relativeRange;
+
+    dispatch(fetchMetrics({ path: 'deliverability/time-series', params, meta }));
+  };
+}

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -1,6 +1,8 @@
 import moment from 'moment';
 import _ from 'lodash';
+import { list as METRICS_LIST } from 'config/metrics';
 
+const COLORS = ['#20578E', '#F38415', '#45A6FF', '#FFD300', '#41B5AB', '#6BEAA8'];
 const apiDateFormat = 'YYYY-MM-DDTHH:mm';
 const precisionMap = [
   { time: 60, value: '1min', format: 'ha' },
@@ -32,7 +34,8 @@ export {
   getStartOfDay,
   getEndOfDay,
   relativeDateOptions,
-  getRelativeDates
+  getRelativeDates,
+  getMetricsFromList
 };
 
 const getTickFormatter = _.memoize((precisionType) => {
@@ -48,7 +51,7 @@ const getTooltipLabelFormatter = _.memoize((precisionType) => {
   return (label) => moment(label).format(labelFormat);
 });
 
-function getLineChartFormatters({ precision }) {
+function getLineChartFormatters(precision) {
   const formatters = {};
   const precisionType = getPrecisionType(precision);
 
@@ -75,6 +78,10 @@ function getQueryFromOptions({ from, to, metrics }) {
   from = moment(from).utc();
   to = moment(to).utc();
 
+  if (_.isObject(metrics[0])) {
+    metrics = metrics.map((m) => m.key);
+  }
+
   return {
     metrics: metrics.join(','),
     precision: getPrecision(from, to),
@@ -97,7 +104,7 @@ function getPrecisionType(precision) {
   return (indexedPrecisions[precision].time <= (60 * 24 * 2)) ? 'hours' : 'days';
 }
 
-function getDayLines(data, { precision = 'day' }) {
+function getDayLines(data, precision = 'day') {
   if (getPrecisionType(precision) !== 'hours') {
     return [];
   }
@@ -152,4 +159,11 @@ function getRelativeDates(range) {
     case '90days':
       return { to, from: moment(to).subtract(90, 'day').toDate() };
   }
+}
+
+function getMetricsFromList(list) {
+  return list.map((metric, i) => {
+    const found = METRICS_LIST.find((M) => M.key === metric);
+    return { ...found, name: found.key, stroke: COLORS[i] };
+  });
 }

--- a/src/middleware/sparkpostApiMiddleware.js
+++ b/src/middleware/sparkpostApiMiddleware.js
@@ -30,7 +30,8 @@ export default function sparkpostApiRequest({ dispatch, getState }) {
     const FAIL_TYPE = `${type}_FAIL`;
 
     dispatch({
-      type: PENDING_TYPE
+      type: PENDING_TYPE,
+      meta
     });
 
     const httpOptions = {
@@ -57,7 +58,8 @@ export default function sparkpostApiRequest({ dispatch, getState }) {
       // we only get here if the request returned a 2xx status code
       dispatch({
         type: SUCCESS_TYPE,
-        payload: results
+        payload: results,
+        meta
       });
 
       // if we need to chain together another action, do it here
@@ -111,7 +113,8 @@ export default function sparkpostApiRequest({ dispatch, getState }) {
       // any other API error should automatically fail, to be handled in the reducers/components
       dispatch({
         type: FAIL_TYPE,
-        payload: { message, response }
+        payload: { message, response },
+        meta
       });
 
       if (response.status >= 500) {

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom';
 import { subMonths, format } from 'date-fns';
 import { getStartOfDay, getEndOfDay, relativeDateOptions } from 'helpers/metrics';
 import { Button, Datepicker, TextField, Select, Popover } from '@sparkpost/matchbox';
-import { setExactTime, setRelativeTime } from 'actions/reportFilters';
 import DateForm from './DateForm';
 import styles from './DateFilter.module.scss';
 
@@ -104,7 +103,7 @@ class DateFilter extends Component {
       this.setState({ showDatePicker: true });
     } else {
       this.setState({ showDatePicker: false });
-      this.props.setRelativeTime(value).then(() => this.props.refresh());
+      this.props.refresh({ relativeRange: value });
     }
   }
 
@@ -114,7 +113,7 @@ class DateFilter extends Component {
 
   handleSubmit = () => {
     this.setState({ showDatePicker: false, selecting: false });
-    this.props.setExactTime(this.state.selected).then(() => this.props.refresh());
+    this.props.refresh({ ...this.state.selected, relativeRange: 'custom' });
   }
 
   render() {
@@ -164,4 +163,4 @@ class DateFilter extends Component {
 }
 
 const mapStateToProps = ({ reportFilters }) => ({ filter: reportFilters });
-export default connect(mapStateToProps, { setExactTime, setRelativeTime })(DateFilter);
+export default connect(mapStateToProps)(DateFilter);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import templates from './templates';
 import webhooks from './webhooks';
 import apiFailure from './apiFailure';
 import reportFilters from './reportFilters';
+import summaryChart from './summaryChart';
 
 export default combineReducers({
   auth,
@@ -18,5 +19,6 @@ export default combineReducers({
   webhooks,
   apiFailure,
   reportFilters,
+  summaryChart,
   form: reduxFormReducer
 });

--- a/src/reducers/reportFilters.js
+++ b/src/reducers/reportFilters.js
@@ -16,6 +16,11 @@ export default (state = initialState, action) => {
     case 'SET_RELATIVE_TIME':
       return { ...state, ...action.payload };
 
+    case 'FETCH_METRICS_SUCCESS': {
+      const { to, from, range } = action.meta;
+      return { ...state, to, from, range };
+    }
+
     case 'ADD_FILTER':
       return { ...state, activeList: [ ...state.activeList, action.payload ]};
 

--- a/src/reducers/summaryChart.js
+++ b/src/reducers/summaryChart.js
@@ -1,0 +1,18 @@
+import { getMetricsFromList } from 'helpers/metrics';
+
+const initialState = {
+  metrics: getMetricsFromList(['count_targeted', 'count_rendered', 'count_accepted', 'count_bounce']),
+  precision: ''
+};
+
+export default (state = initialState, { type, payload, meta }) => {
+  switch (type) {
+    case 'FETCH_METRICS_SUCCESS': {
+      const { metrics, precision } = meta;
+      return { metrics, precision };
+    }
+
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
Basic goal of this was to move "chart options" into redux, which made it easier to simplify the chart refresh flow. So instead of doing this in a component:

1. get new query data (date, typeahead filters, new list of metrics)
1. calculate query into format
1. store local state
1. refresh metrics call

We can just do:

1. refresh chart with new query data `this.props.refreshSummaryChart({ from, to })`

That action will calculate the query and do the metrics call attaching some additional info to that call's `meta` key, and the chartSummary and reportFilters reducers are listening for `FETCH_METRICS_SUCCESS` and populating their state accordingly.

I thought about combining those 2 reducers into 1, but chartSummary is stuff specific to the summary chart while reportFilters will be shared across all reports, so I think this works ok for now.

It still feels a little complicated tbh, but I think it's heading in a good redux direction. Thoughts? We can go over in person. 