### PR TITLE
Critical CSS & Production build fixes

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -305,9 +305,9 @@ module.exports = {
     }),
 
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
-    appCSS,
-    globalCSS,
     criticalCSS,
+    globalCSS,
+    appCSS,
 
     // This is for inlining critical CSS
     new StyleExtHtmlWebpackPlugin('critical.css'),

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
     "css-loader": "0.28.1",
+    "cssnano": "^3.10.0",
     "dotenv": "4.0.0",
     "enzyme": "^2.8.2",
     "enzyme-to-json": "^1.5.1",
@@ -69,6 +70,7 @@
     "react-error-overlay": "^1.0.6",
     "react-test-renderer": "^15.5.4",
     "sass-loader": "^6.0.5",
+    "style-ext-html-webpack-plugin": "^3.4.1",
     "style-loader": "0.17.0",
     "sw-precache-webpack-plugin": "0.9.1",
     "url-loader": "0.5.8",
@@ -110,7 +112,9 @@
     "snapshotSerializers": [
       "<rootDir>/node_modules/enzyme-to-json/serializer"
     ],
-    "modulePaths": ["src"]
+    "modulePaths": [
+      "src"
+    ]
   },
   "babel": {
     "presets": [

--- a/public/index.html
+++ b/public/index.html
@@ -42,5 +42,10 @@
       To begin the development, run `npm start`.
       To create a production bundle, use `npm run build`.
     -->
+    <div id="critical">
+      <svg class='critical__icon' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.5 260">
+        <path class='critical__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
+      </svg>
+    </div>
   </body>
 </html>

--- a/src/critical.scss
+++ b/src/critical.scss
@@ -1,0 +1,3 @@
+body {
+  background: green;
+}

--- a/src/critical.scss
+++ b/src/critical.scss
@@ -1,3 +1,42 @@
-body {
-  background: green;
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+#root {
+  opacity: 0;
+}
+
+#critical {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: color(gray, 9);
+  z-index: 99999;
+
+  opacity: 1;
+  transition: 0.4s 0.6s;
+
+  .critical__icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    display: inline-block;
+    height: 120px;
+    animation: pulse 1.5s linear infinite;
+  }
+
+  .critical__flame {
+    fill: color(gray, 6);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
 }

--- a/src/critical.scss
+++ b/src/critical.scss
@@ -1,9 +1,5 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-#root {
-  opacity: 0;
-}
-
 #critical {
   position: fixed;
   top: 0;

--- a/src/index.js
+++ b/src/index.js
@@ -25,3 +25,6 @@ render(
   document.getElementById('root')
 );
 registerServiceWorker();
+
+// Kill loading screen
+document.getElementById('critical').className += ' ready';

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import spApiMiddleware from './middleware/sparkpostApiMiddleware';
 import registerServiceWorker from './helpers/registerServiceWorker';
 import rootReducer from './reducers';
 
+import './critical.scss';
 import './index.scss';
 import App from './App';
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,11 +11,7 @@ html {
 }
 
 // Overrides Critical CSS. Prevents FOUT.
-#root {
-  opacity: 1 !important;
-}
-
-#critical {
+#critical.ready {
   opacity: 0 !important;
   pointer-events: none !important;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,3 +9,13 @@ html {
   @media screen and (min-width: breakpoint(medium)) { font-size: rem(18); }
   @media screen and (min-width: breakpoint(larger)) { font-size: rem(20); }
 }
+
+// Overrides Critical CSS. Prevents FOUT.
+#root {
+  opacity: 1 !important;
+}
+
+#critical {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}


### PR DESCRIPTION
- Both global and module css now extract to `.css` files.
- All css is now minified
- CSS in `critical.scss` inlines inside `<head>`
- Adds a loading screen with the SP logo

![kapture 2017-08-30 at 22 42 00](https://user-images.githubusercontent.com/3903325/29904000-b6f86202-8dd4-11e7-8442-516f5c71356d.gif)


