### PR TITLE
Summary Chart Improvements

### DIFF
--- a/src/helpers/chart.js
+++ b/src/helpers/chart.js
@@ -19,7 +19,7 @@ function getDayLines(data, precision = 'day') {
 }
 
 const getTimeTickFormatter = _.memoize((precisionType) => {
-  const tickFormat = (precisionType === 'hours') ? 'ha' : 'MMM Do';
+  const tickFormat = (precisionType === 'hours') ? 'h:mma' : 'MMM Do';
   return (tick) => moment(tick).format(tickFormat);
 });
 

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -49,7 +49,7 @@ function getKeysFromMetrics(metrics) {
 function computeKeysForItem(metrics) {
   return (item) => metrics.reduce((acc, metric) => {
     if (metric.compute) {
-      acc[metric.key] = metric.compute(acc, metric.computeKeys);
+      acc[metric.key] = metric.compute(acc, metric.computeKeys) || 0;
     }
     return acc;
   }, item);

--- a/src/pages/reports/SummaryPage/SummaryPage.module.scss
+++ b/src/pages/reports/SummaryPage/SummaryPage.module.scss
@@ -9,7 +9,7 @@
 .ChartSection {
   position: relative;
   padding: spacing();
-  min-height: rem(480);
+  min-height: rem(200);
 
   opacity: 1;
   pointer-events: auto;

--- a/src/pages/reports/SummaryPage/components/ChartGroup.js
+++ b/src/pages/reports/SummaryPage/components/ChartGroup.js
@@ -50,9 +50,10 @@ export default class ChartGroup extends Component {
           }))}
           {...formatters}
           yTickFormatter={chart.yAxisFormatter}
+          yScale={yScale}
+          yLabel={chart.label}
           tooltipValueFormatter={chart.yAxisFormatter}
           referenceLines={referenceLines}
-          yScale={yScale}
           showXAxis={i === charts.length - 1}
         />)}
       </div>

--- a/src/pages/reports/SummaryPage/components/ChartGroup.js
+++ b/src/pages/reports/SummaryPage/components/ChartGroup.js
@@ -42,6 +42,7 @@ export default class ChartGroup extends Component {
           key={`chart=${i}`}
           syncId='summaryChart'
           data={data}
+          precision={precision}
           lines={chart.metrics.map(({ name, label, stroke }) => ({
             key: name,
             dataKey: name,

--- a/src/pages/reports/SummaryPage/components/LineChart.js
+++ b/src/pages/reports/SummaryPage/components/LineChart.js
@@ -63,8 +63,10 @@ export default class SpLineChart extends React.Component {
     const { data, precision } = this.props;
 
     if (precision === '1min') {
+      // Show ticks every 15 minutes
       return { ticks: data.map((tick) => tick.ts).filter((time) => moment(time).minutes() % 15 === 0) };
     } else if (precision === '15min') {
+      // Show ticks every 30 minutes
       return { ticks: data.map((tick) => tick.ts).filter((time) => moment(time).minutes() % 30 === 0) };
     }
 

--- a/src/pages/reports/SummaryPage/components/LineChart.js
+++ b/src/pages/reports/SummaryPage/components/LineChart.js
@@ -1,7 +1,7 @@
-/* eslint-disable */
 import React from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
 import _ from 'lodash';
+import moment from 'moment';
 import './LineChart.scss';
 
 function orderDesc(a, b) {
@@ -47,15 +47,30 @@ export default class SpLineChart extends React.Component {
     return _.max(lineData);
   }
 
+  // Manually generates Y axis ticks
   getYTicks() {
     const { yLabel, yScale } = this.props;
     if (yLabel === 'Percent' && yScale === 'linear') {
       return { ticks: [0, 25, 50, 75, 100]};
     }
 
-    // The ticks prop does not have a default value
-    // Need to spread an empty object automatically set them
+    // The ticks prop does not have a default value, need to spread an empty object automatically set them
     return {};
+  }
+
+  // Manually generates X axis ticks
+  getXTicks() {
+    const { data, precision } = this.props;
+    const times = data.map((tick) => tick.ts);
+    let ticks = {};
+
+    if (precision === '1min') {
+      ticks = { ticks: times.filter((time) => moment(time).minutes() % 15 === 0) };
+    } else if (precision === '15min') {
+      ticks = { ticks: times.filter((time) => moment(time).minutes() % 30 === 0) };
+    }
+
+    return ticks;
   }
 
   render() {
@@ -74,7 +89,8 @@ export default class SpLineChart extends React.Component {
 
     const yDomain = this.getYDomain();
     const yTicks = this.getYTicks();
-    console.log(data);
+    const xTicks = this.getXTicks();
+
     return (
       <div className='sp-linechart-wrapper'>
         <ResponsiveContainer width='99%' height={150 + (40 * lines.length)}>
@@ -82,6 +98,7 @@ export default class SpLineChart extends React.Component {
             <CartesianGrid vertical={false} strokeDasharray="4 1"/>
             <XAxis
               tickFormatter={xTickFormatter}
+              {...xTicks}
               scale='utcTime'
               dataKey='ts'
               interval='preserveEnd'

--- a/src/pages/reports/SummaryPage/components/LineChart.js
+++ b/src/pages/reports/SummaryPage/components/LineChart.js
@@ -27,47 +27,61 @@ export default class SpLineChart extends React.Component {
     return referenceLines.map((props) => <ReferenceLine {...props} />);
   }
 
+  getDomain() {
+    const { yLabel, yScale } = this.props;
+    let domain = yScale === 'log' ? domain = [0.001, 'auto'] : [0, 'auto'];
+
+    if (yLabel === 'Percent') {
+      domain = [0, 100];
+    }
+
+    return domain;
+  }
+
   render() {
     const {
       data,
       lines = [],
       syncId,
       xTickFormatter = _.identity,
+      yTickFormatter = _.identity,
       yScale = 'linear', // eslint-disable-line
       tooltipLabelFormatter = _.identity,
       tooltipValueFormatter = _.identity,
-      showXAxis
+      showXAxis,
+      yLabel
     } = this.props;
 
-    const domain = yScale === 'log' ? [0.001, 'auto'] : [0, 'auto'];
+    const domain = this.getDomain();
 
     return (
-      <ResponsiveContainer width='99%' height={120 * lines.length}>
-        <LineChart data={data} syncId={syncId}>
-          <CartesianGrid vertical={false} strokeDasharray="4 1"/>
-          <XAxis
-            tickFormatter={xTickFormatter}
-            dataKey='ts'
-            interval='preserveEnd'
-            height={30}
-            hide={!showXAxis}
-          />
-          <YAxis
-            tickLine={false}
-            width={50}
-            scale={yScale}
-            domain={domain}
-            allowDataOverflow={yScale === 'log'}
-          />
-          <Tooltip
-            labelFormatter={tooltipLabelFormatter}
-            formatter={tooltipValueFormatter}
-            itemSorter={orderDesc}
-          />
-          {this.renderReferenceLines()}
-          {this.renderLines()}
-        </LineChart>
-      </ResponsiveContainer>
+      <div className='sp-linechart-wrapper'>
+        <ResponsiveContainer width='99%' height={120 * lines.length}>
+          <LineChart data={data} syncId={syncId}>
+            <CartesianGrid vertical={false} strokeDasharray="4 1"/>
+            <XAxis
+              tickFormatter={xTickFormatter}
+              dataKey='ts'
+              interval='preserveEnd'
+              height={30}
+              hide={!showXAxis} />
+            <YAxis
+              tickFormatter={yTickFormatter}
+              tickLine={false}
+              width={60}
+              scale={yScale}
+              domain={domain}
+              allowDataOverflow={yScale === 'log'} />
+            <Tooltip
+              labelFormatter={tooltipLabelFormatter}
+              formatter={tooltipValueFormatter}
+              itemSorter={orderDesc} />
+            {this.renderReferenceLines()}
+            {this.renderLines()}
+          </LineChart>
+        </ResponsiveContainer>
+        <span className='sp-linechart-yLabel'>{yLabel}</span>
+      </div>
     );
   }
 }

--- a/src/pages/reports/SummaryPage/components/LineChart.js
+++ b/src/pages/reports/SummaryPage/components/LineChart.js
@@ -30,14 +30,15 @@ export default class SpLineChart extends React.Component {
 
   getYDomain() {
     const { yLabel, yScale } = this.props;
-    const max = this.getMax();
-    let domainMax = 100; // Defaults to 100 max domain so y axis always renders at least 0 - 100
+    const minDomain = yScale === 'log' ? 0.001 : 0;
+    let maxDomain = 100; // Defaults to 100 max domain so y axis always renders at least 0 - 100
 
-    if (yLabel !== 'Percent' && max) {
-      domainMax = `dataMax + ${max * 0.08}`; // Adds 8% top 'padding'
+    if (yLabel !== 'Percent') {
+      const max = this.getMax();
+      maxDomain = max ? `dataMax + ${max * 0.08}` : maxDomain; // Adds 8% top 'padding'
     }
 
-    return yScale === 'log' ? [0.001, domainMax] : [0, domainMax];
+    return [minDomain, maxDomain];
   }
 
   // Gets max value for this LineChart
@@ -54,23 +55,20 @@ export default class SpLineChart extends React.Component {
       return { ticks: [0, 25, 50, 75, 100]};
     }
 
-    // The ticks prop does not have a default value, need to spread an empty object automatically set them
     return {};
   }
 
   // Manually generates X axis ticks
   getXTicks() {
     const { data, precision } = this.props;
-    const times = data.map((tick) => tick.ts);
-    let ticks = {};
 
     if (precision === '1min') {
-      ticks = { ticks: times.filter((time) => moment(time).minutes() % 15 === 0) };
+      return { ticks: data.map((tick) => tick.ts).filter((time) => moment(time).minutes() % 15 === 0) };
     } else if (precision === '15min') {
-      ticks = { ticks: times.filter((time) => moment(time).minutes() % 30 === 0) };
+      return { ticks: data.map((tick) => tick.ts).filter((time) => moment(time).minutes() % 30 === 0) };
     }
 
-    return ticks;
+    return {};
   }
 
   render() {

--- a/src/pages/reports/SummaryPage/components/LineChart.js
+++ b/src/pages/reports/SummaryPage/components/LineChart.js
@@ -48,7 +48,7 @@ export default class SpLineChart extends React.Component {
           <XAxis
             tickFormatter={xTickFormatter}
             dataKey='ts'
-            interval={1}
+            interval='preserveEnd'
             height={30}
             hide={!showXAxis}
           />

--- a/src/pages/reports/SummaryPage/components/LineChart.scss
+++ b/src/pages/reports/SummaryPage/components/LineChart.scss
@@ -13,7 +13,7 @@
   }
   .recharts-cartesian-axis-tick {
     &:first-child, &:last-child {
-      display: none;
+      // display: none;
     }
   }
 }

--- a/src/pages/reports/SummaryPage/components/LineChart.scss
+++ b/src/pages/reports/SummaryPage/components/LineChart.scss
@@ -27,22 +27,23 @@
 .sp-linechart-wrapper {
   position: relative;
   margin-bottom: rem(30);
+  backface-visibility: hidden;
   &:last-child {
     margin-bottom: 0;
   }
 }
 
-.sp-linechart-yLabel, .recharts-label {
-  fill: color(gray, 4);
+.sp-linechart-yLabel {
+  color: color(gray, 4);
   font-size: 13px
 }
 
 .sp-linechart-yLabel {
   position: absolute;
-  top: 43%;
-  left: -10px;
-  transform: translate(0, -50%) rotate(-90deg);
-  backface-visibility: hidden;
+  top: 50%;
+  left: 9px;
+  transform: rotate(-90deg);
+  transform-origin: 0;
 }
 
 .recharts-line > path {}

--- a/src/pages/reports/SummaryPage/components/LineChart.scss
+++ b/src/pages/reports/SummaryPage/components/LineChart.scss
@@ -24,9 +24,21 @@
   }
 }
 
-.recharts-label {
+.sp-linechart-wrapper {
+  position: relative;
+}
+
+.sp-linechart-yLabel, .recharts-label {
   fill: color(gray, 4);
-  font-size: 12px
+  font-size: 13px
+}
+
+.sp-linechart-yLabel {
+  position: absolute;
+  top: 43%;
+  left: -10px;
+  transform: translate(0, -50%) rotate(-90deg);
+  backface-visibility: hidden;
 }
 
 .recharts-line > path {}
@@ -108,6 +120,7 @@
 }
 
 .recharts-responsive-container {
+  position: relative;
   margin-bottom: rem(30);
   &:last-child {
     margin-bottom: 0;

--- a/src/pages/reports/SummaryPage/components/LineChart.scss
+++ b/src/pages/reports/SummaryPage/components/LineChart.scss
@@ -26,6 +26,10 @@
 
 .sp-linechart-wrapper {
   position: relative;
+  margin-bottom: rem(30);
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .sp-linechart-yLabel, .recharts-label {
@@ -121,8 +125,4 @@
 
 .recharts-responsive-container {
   position: relative;
-  margin-bottom: rem(30);
-  &:last-child {
-    margin-bottom: 0;
-  }
 }

--- a/src/pages/reports/SummaryPage/components/LineChart.scss
+++ b/src/pages/reports/SummaryPage/components/LineChart.scss
@@ -11,11 +11,6 @@
   .recharts-text.recharts-cartesian-axis-tick-value {
     transform: translate(0, 6px);
   }
-  .recharts-cartesian-axis-tick {
-    &:first-child, &:last-child {
-      // display: none;
-    }
-  }
 }
 
 .yAxis {
@@ -27,15 +22,9 @@
 .sp-linechart-wrapper {
   position: relative;
   margin-bottom: rem(30);
-  backface-visibility: hidden;
   &:last-child {
     margin-bottom: 0;
   }
-}
-
-.sp-linechart-yLabel {
-  color: color(gray, 4);
-  font-size: 13px
 }
 
 .sp-linechart-yLabel {
@@ -44,6 +33,10 @@
   left: 9px;
   transform: rotate(-90deg);
   transform-origin: 0;
+  backface-visibility: hidden;
+
+  color: color(gray, 4);
+  font-size: 13px
 }
 
 .recharts-line > path {}

--- a/src/pages/reports/components/DateFilter.js
+++ b/src/pages/reports/components/DateFilter.js
@@ -118,7 +118,7 @@ class DateFilter extends Component {
 
   render() {
     const { selected: { from, to }, showDatePicker } = this.state;
-    const selectedRange = showDatePicker ? 'custom' : this.props.filter.range;
+    const selectedRange = showDatePicker ? 'custom' : this.props.filter.relativeRange;
 
     const rangeSelect = <Select
       options={relativeDateOptions}

--- a/src/reducers/reportFilters.js
+++ b/src/reducers/reportFilters.js
@@ -3,7 +3,7 @@ import { getRelativeDates } from 'helpers/date';
 const DEFAULT_RANGE = 'day';
 const initialState = {
   ...getRelativeDates(DEFAULT_RANGE),
-  range: DEFAULT_RANGE,
+  relativeRange: DEFAULT_RANGE,
   activeList: [],
   searchList: []
 };
@@ -17,8 +17,8 @@ export default (state = initialState, action) => {
       return { ...state, ...action.payload };
 
     case 'REFRESH_REPORT_FILTERS': {
-      const { to, from, range } = action.payload;
-      return { ...state, to, from, range };
+      const { to, from, relativeRange } = action.payload;
+      return { ...state, to, from, relativeRange };
     }
 
     case 'ADD_FILTER':


### PR DESCRIPTION
- Closes #49
  - When `precision` = `1min`, shows ticks every 15 minutes
  - When `precision` = `15min`, shows ticks every 30 minutes
- Relative range dropdown works again.
- Adds y axis labels
- Closes #63
  - fixes for percent graphs - forces 0 - 100 domain
  - 0 - 100 also used if no data exists
- Adds extra padding above the highest line inside a graph
- Added `getYTicks` to format y axis ticks
  - for linear percent graphs: `[0, 25, 50, 75, 100]`
