### PR TITLE
Templates Editor FAD-5345

### DIFF
--- a/src/pages/Templates/EditPage.js
+++ b/src/pages/Templates/EditPage.js
@@ -130,8 +130,7 @@ class EditPage extends Component {
   render() {
     const {
       match,
-      loading,
-      draft
+      loading
     } = this.props;
 
     if (this.state.shouldRedirectToPublished) {
@@ -147,10 +146,10 @@ class EditPage extends Component {
         { this.renderPageHeader() }
         <Grid>
           <Grid.Column xs={12} lg={4}>
-            <Form name={FORM_NAME} initialValues={draft} />
+            <Form name={FORM_NAME} />
           </Grid.Column>
           <Grid.Column xs={12} lg={8}>
-            <Editor name={FORM_NAME} initialValues={draft} />
+            <Editor name={FORM_NAME} />
           </Grid.Column>
         </Grid>
         <DeleteModal

--- a/src/pages/Templates/EditPage.js
+++ b/src/pages/Templates/EditPage.js
@@ -18,7 +18,7 @@ import Layout from '../../components/Layout/Layout';
 import Form from './components/Form';
 import Editor from './components/Editor';
 import DeleteModal from './components/DeleteModal';
-import { Page, Panel, Grid } from '@sparkpost/matchbox';
+import { Page, Grid } from '@sparkpost/matchbox';
 
 const FORM_NAME = 'templateEdit';
 
@@ -142,18 +142,8 @@ class EditPage extends Component {
       return <Redirect to='/templates/' />;
     }
 
-    if (loading) {
-      return (
-        <Layout.App>
-          <Panel sectioned>
-            Loading template...
-          </Panel>
-        </Layout.App>
-      );
-    }
-
     return (
-      <Layout.App>
+      <Layout.App loading={loading}>
         { this.renderPageHeader() }
         <Grid>
           <Grid.Column xs={12} lg={4}>

--- a/src/pages/Templates/ListPage.js
+++ b/src/pages/Templates/ListPage.js
@@ -48,7 +48,7 @@ class ListPage extends Component {
         columns={columns}
         rows={templates}
         getRowData={getRowData}
-        pagination={true}
+        pagination
       />
     );
   }

--- a/src/pages/Templates/PublishedPage.js
+++ b/src/pages/Templates/PublishedPage.js
@@ -12,7 +12,7 @@ import {
 import Layout from '../../components/Layout/Layout';
 import Form from './components/Form';
 import Editor from './components/Editor';
-import { Page, Panel, Grid } from '@sparkpost/matchbox';
+import { Page, Grid } from '@sparkpost/matchbox';
 
 const FORM_NAME = 'templatePublished';
 
@@ -65,18 +65,8 @@ class PublishedPage extends Component {
   render() {
     const { loading, published } = this.props;
 
-    if (loading) {
-      return (
-        <Layout.App>
-          <Panel sectioned>
-            Loading template...
-          </Panel>
-        </Layout.App>
-      );
-    }
-
     return (
-      <Layout.App>
+      <Layout.App loading={loading}>
         { this.renderPageHeader() }
         <Grid>
           <Grid.Column xs={12} lg={4}>

--- a/src/pages/Templates/PublishedPage.js
+++ b/src/pages/Templates/PublishedPage.js
@@ -63,17 +63,17 @@ class PublishedPage extends Component {
   }
 
   render() {
-    const { loading, published } = this.props;
+    const { loading } = this.props;
 
     return (
       <Layout.App loading={loading}>
         { this.renderPageHeader() }
         <Grid>
           <Grid.Column xs={12} lg={4}>
-            <Form name={FORM_NAME} published initialValues={published} />
+            <Form name={FORM_NAME} published />
           </Grid.Column>
           <Grid.Column xs={12} lg={8}>
-            <Editor name={FORM_NAME} published initialValues={published} />
+            <Editor name={FORM_NAME} published />
           </Grid.Column>
         </Grid>
       </Layout.App>

--- a/src/pages/Templates/components/Editor.js
+++ b/src/pages/Templates/components/Editor.js
@@ -9,6 +9,7 @@ import 'brace/mode/html';
 import 'brace/theme/tomorrow';
 import { Panel, Button } from '@sparkpost/matchbox';
 
+import './Editor.scss';
 import styles from './FormEditor.module.scss';
 
 const AceWrapper = ({ input, ...rest }) => (
@@ -16,15 +17,18 @@ const AceWrapper = ({ input, ...rest }) => (
     mode='html'
     theme='tomorrow'
     name='emailContent'
+    className='TemplateEditor'
     height='900px'
     width='auto'
     style={{ marginBottom: '-18px' }}
     tabSize={2}
-    fontSize={11}
-    markers={[]}
+    fontSize={12}
     cursorStart={1}
     highlightActiveLine
     showPrintMargin={false}
+    setOptions={{
+      displayIndentGuides: false
+    }}
     {...rest}
     {...input}
   />
@@ -36,13 +40,12 @@ class Editor extends Component {
     return (
       <Panel className={styles.EditorPanel}>
         <Panel.Section>
-        <Button size='small'>Test Data</Button>
+          <Button size='small'>Test Data</Button>
         </Panel.Section>
         <Field
           name='content.html'
           component={AceWrapper}
-          readOnly={published}
-        />
+          readOnly={published} />
       </Panel>
     );
   }

--- a/src/pages/Templates/components/Editor.js
+++ b/src/pages/Templates/components/Editor.js
@@ -15,7 +15,7 @@ import styles from './FormEditor.module.scss';
 
 const AceWrapper = ({ input, ...rest }) => (
   <AceEditor
-    mode={input.name === 'testData' ? 'json' : 'html'}
+    mode={input.name === 'test' ? 'json' : 'html'}
     theme='tomorrow'
     name='emailContent'
     className='TemplateEditor'
@@ -54,7 +54,7 @@ class Editor extends Component {
     ];
 
     return (
-      <div>
+      <div className={styles.EditorSection}>
         <Tabs selected={this.state.selectedTab} tabs={tabs}/>
         <Panel className={styles.EditorPanel}>
           <Field

--- a/src/pages/Templates/components/Editor.js
+++ b/src/pages/Templates/components/Editor.js
@@ -6,21 +6,21 @@ import { Field, reduxForm } from 'redux-form';
 // Components
 import AceEditor from 'react-ace';
 import 'brace/mode/html';
+import 'brace/mode/json';
 import 'brace/theme/tomorrow';
-import { Panel, Button } from '@sparkpost/matchbox';
+import { Panel, Tabs } from '@sparkpost/matchbox';
 
 import './Editor.scss';
 import styles from './FormEditor.module.scss';
 
 const AceWrapper = ({ input, ...rest }) => (
   <AceEditor
-    mode='html'
+    mode={input.name === 'testData' ? 'json' : 'html'}
     theme='tomorrow'
     name='emailContent'
     className='TemplateEditor'
     height='900px'
     width='auto'
-    style={{ marginBottom: '-18px' }}
     tabSize={2}
     fontSize={12}
     cursorStart={1}
@@ -35,18 +35,34 @@ const AceWrapper = ({ input, ...rest }) => (
 );
 
 class Editor extends Component {
+  state = {
+    selectedTab: 0
+  }
+
+  fieldNames = ['content.html', 'text', 'test']
+
+  handleTab = (i) => {
+    this.setState({ selectedTab: i });
+  }
+
   render() {
     const { published } = this.props;
+    const tabs = [
+      { content: 'HTML', onClick: () => this.handleTab(0) },
+      { content: 'Text', onClick: () => this.handleTab(1) },
+      { content: 'Test Data', onClick: () => this.handleTab(2) }
+    ];
+
     return (
-      <Panel className={styles.EditorPanel}>
-        <Panel.Section>
-          <Button size='small'>Test Data</Button>
-        </Panel.Section>
-        <Field
-          name='content.html'
-          component={AceWrapper}
-          readOnly={published} />
-      </Panel>
+      <div>
+        <Tabs selected={this.state.selectedTab} tabs={tabs}/>
+        <Panel className={styles.EditorPanel}>
+          <Field
+            name={this.fieldNames[this.state.selectedTab]}
+            component={AceWrapper}
+            readOnly={published} />
+        </Panel>
+      </div>
     );
   }
 }

--- a/src/pages/Templates/components/Editor.scss
+++ b/src/pages/Templates/components/Editor.scss
@@ -2,11 +2,18 @@
 
 // These go into the global scope
 .TemplateEditor {
+  font-family: font-family(monospace);
+  border-bottom-right-radius: 2px;
+  border-bottom-left-radius: 2px;
+  overflow: hidden;
 
   // Error markers
-  .ace_gutter-cell.ace_error {
-    background-image: none;
+  .ace_gutter-cell {
+    &.ace_info, &.ace_error {
+      background-image: none;
+    }
   }
+
   .ace_tooltip {
     display: none !important;
   }
@@ -24,11 +31,6 @@
   .ace_gutter {
     background: color(gray, 10) !important;
     color: color(gray, 6) !important;
-  }
-
-  // Text wrapper
-  .ace_layer.ace_text-layer {
-    padding-left: rem(18) !important;
   }
 
   // Box shadow when left side overflowed

--- a/src/pages/Templates/components/Editor.scss
+++ b/src/pages/Templates/components/Editor.scss
@@ -1,0 +1,48 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+// These go into the global scope
+.TemplateEditor {
+
+  // Error markers
+  .ace_gutter-cell.ace_error {
+    background-image: none;
+  }
+  .ace_tooltip {
+    display: none !important;
+  }
+
+  .ace_gutter-cell {
+    padding-right: 19px;
+    padding-left: 6px;
+  }
+
+  .ace_fold-widget {
+    opacity: 0.5;
+  }
+
+  // Gutter wrapper
+  .ace_gutter {
+    background: color(gray, 10) !important;
+    color: color(gray, 6) !important;
+  }
+
+  // Text wrapper
+  .ace_layer.ace_text-layer {
+    padding-left: rem(18) !important;
+  }
+
+  // Box shadow when left side overflowed
+  .ace_scroller.ace_scroll-left {
+    box-shadow: 15px 0 25px rgba(color(gray, 2), 0.1) inset;
+  }
+
+  // Box shadow transition
+  .ace_scroller {
+    transition: 0.15s;
+  }
+
+  // Active line highlight
+  .ace_gutter-active-line, .ace_active-line {
+    background: color(gray, 9) !important;
+  }
+}

--- a/src/pages/Templates/components/Form.js
+++ b/src/pages/Templates/components/Form.js
@@ -4,15 +4,11 @@ import { connect } from 'react-redux';
 import { Field, reduxForm, change } from 'redux-form';
 
 // Components
-import { Panel, TextField } from '@sparkpost/matchbox';
+import { Panel } from '@sparkpost/matchbox';
 import ToggleBlock from './ToggleBlock';
+import { TextFieldWrapper } from 'components/reduxFormWrappers';
 
 import styles from './FormEditor.module.scss';
-
-// TODO use shared component instead of this
-const TextFieldWrapper = ({ input, meta: { error }, ...rest }) => (
-  <TextField {...rest} {...input} error={error} />
-);
 
 const ID_ALLOWED_CHARS = 'a-z0-9_-';
 
@@ -49,7 +45,7 @@ class Form extends Component {
       <Panel className={styles.Panel}>
         <Panel.Section>
           <Field
-            name='name' id='name'
+            name='name'
             component={TextFieldWrapper}
             label='Template Name'
             onChange={(e) => this.handleIdFill(e)}
@@ -57,7 +53,7 @@ class Form extends Component {
           />
 
           <Field
-            name='id' id='id'
+            name='id'
             component={TextFieldWrapper}
             label='Template ID'
             helpText={'A Unique ID for your template, we\'ll fill this in for you.'}
@@ -67,7 +63,7 @@ class Form extends Component {
 
         <Panel.Section>
           <Field
-            name='content.from.name' id='fromName'
+            name='content.from.name'
             component={TextFieldWrapper}
             label='From Name'
             helpText='A friendly from for your recipients.'
@@ -75,14 +71,14 @@ class Form extends Component {
           />
 
           <Field
-            name='content.from.email' id='fromEmail'
+            name='content.from.email'
             component={TextFieldWrapper}
             label='From Email'
             disabled={newTemplate || published}
           />
 
           <Field
-            name='reply_to' id='replyTo'
+            name='reply_to'
             component={TextFieldWrapper}
             label='Reply To'
             helpText='An email address recipients can reply to.'
@@ -90,14 +86,14 @@ class Form extends Component {
           />
 
           <Field
-            name='content.subject' id='subject'
+            name='content.subject'
             component={TextFieldWrapper}
             label='Subject'
             disabled={published}
           />
 
           <Field
-            name='description' id='description'
+            name='description'
             component={TextFieldWrapper}
             label='Description'
             helpText='Not visible to recipients.'
@@ -107,7 +103,7 @@ class Form extends Component {
 
         <Panel.Section>
           <Field
-            name='options.open_tracking' id='openTracking'
+            name='options.open_tracking'
             component={ToggleBlock}
             label='Track Opens'
             type='checkbox'
@@ -116,7 +112,7 @@ class Form extends Component {
           />
 
           <Field
-            name='options.click_tracking' id='clickTracking'
+            name='options.click_tracking'
             component={ToggleBlock}
             label='Track Clicks'
             type='checkbox'
@@ -127,7 +123,7 @@ class Form extends Component {
 
         <Panel.Section>
           <Field
-            name='options.transactional' id='transactional'
+            name='options.transactional'
             component={ToggleBlock}
             label='Transactional'
             type='checkbox'

--- a/src/pages/Templates/components/Form.js
+++ b/src/pages/Templates/components/Form.js
@@ -42,7 +42,7 @@ class Form extends Component {
     const { newTemplate, published } = this.props;
 
     return (
-      <Panel className={styles.Panel}>
+      <Panel className={styles.FormPanel}>
         <Panel.Section>
           <Field
             name='name'

--- a/src/pages/Templates/components/FormEditor.module.scss
+++ b/src/pages/Templates/components/FormEditor.module.scss
@@ -1,6 +1,6 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-.Panel, .EditorPanel {
+.FormPanel, .EditorPanel {
   height: 100%;
   position: relative;
 }
@@ -12,6 +12,12 @@
   @media screen and (min-width: breakpoint(medium)) {
     height: 100%;
     max-height: 100%;
+  }
+}
+
+.EditorSection {
+  margin-top: spacing();
+  @media screen and (min-width: breakpoint(medium)) {
     margin-top: 0;
   }
 }

--- a/src/pages/Templates/components/FormEditor.module.scss
+++ b/src/pages/Templates/components/FormEditor.module.scss
@@ -6,8 +6,7 @@
 }
 
 .EditorPanel {
-  height: 600px;
-  margin-top: spacing();
+  margin-bottom: 0;
   z-index: 1;
 
   @media screen and (min-width: breakpoint(medium)) {

--- a/src/pages/Templates/components/ToggleBlock.js
+++ b/src/pages/Templates/components/ToggleBlock.js
@@ -16,7 +16,7 @@ const ToggleBlock = ({ input, meta, label, helpText, ...rest }) => {
         </Grid.Column>
         <Grid.Column xs={4}>
           <div className={styles.ToggleWrapper}>
-            <Toggle {...input} {...rest} />
+            <Toggle id={input.name} {...input} {...rest} />
           </div>
         </Grid.Column>
       </Grid>


### PR DESCRIPTION
- Some global styles to override ace editor styles
- Cleanup, uses `loading` layout prop, shared redux textfield wrapper, etc
- Started some setup for the test data ticket