### PR TITLE
Fixes recursive mutation bug in nav render

### DIFF
--- a/src/components/auth/AccessControl.js
+++ b/src/components/auth/AccessControl.js
@@ -1,18 +1,23 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
+import { Loading } from 'src/components/loading/Loading';
 import accessConditionState from 'src/selectors/accessConditionState';
 
-export const AccessControl = function AccessControl({ children, redirect, show }) {
-  if (redirect && !show) {
+export const AccessControl = function AccessControl({ children, ready, redirect, show }) {
+  if (ready && redirect && !show) {
     return <Redirect to={redirect} />;
+  }
+  if (!ready && redirect) {
+    return <Loading />;
   }
   return show ? children : null;
 };
 
 const accept = () => true;
 const mapStateToProps = (state, { condition = accept, redirect }) => ({
-  redirect: state.accessControlReady && redirect,
+  ready: state.accessControlReady,
+  redirect,
   show: condition(accessConditionState(state))
 });
 

--- a/src/components/auth/tests/AccessControl.test.js
+++ b/src/components/auth/tests/AccessControl.test.js
@@ -4,18 +4,23 @@ import { AccessControl } from '../AccessControl';
 
 describe('Component: AccessControl', () => {
 
-  it('should render correctly when no access and redirecting', () => {
-    const component = <AccessControl redirect='/some/path' show={false}><h1>Some children</h1></AccessControl>;
+  it('should render correctly when no access but not ready to redirect', () => {
+    const component = <AccessControl redirect='/some/path' show={false} ready={false}><h1>Some children</h1></AccessControl>;
+    expect(shallow(component)).toMatchSnapshot();
+  });
+
+  it('should render correctly when no access and ready to redirect', () => {
+    const component = <AccessControl redirect='/some/path' show={false} ready={true}><h1>Some children</h1></AccessControl>;
     expect(shallow(component)).toMatchSnapshot();
   });
 
   it('should render correctly when no access and not redirecting', () => {
-    const component = <AccessControl show={false}><h1>Some children</h1></AccessControl>;
+    const component = <AccessControl show={false} ready={true}><h1>Some children</h1></AccessControl>;
     expect(shallow(component)).toMatchSnapshot();
   });
 
   it('should render correctly when access is granted', () => {
-    const component = <AccessControl show={true}><h1>Some children</h1></AccessControl>;
+    const component = <AccessControl show={true} ready={true}><h1>Some children</h1></AccessControl>;
     expect(shallow(component)).toMatchSnapshot();
   });
 

--- a/src/components/auth/tests/__snapshots__/AccessControl.test.js.snap
+++ b/src/components/auth/tests/__snapshots__/AccessControl.test.js.snap
@@ -8,9 +8,11 @@ exports[`Component: AccessControl should render correctly when access is granted
 
 exports[`Component: AccessControl should render correctly when no access and not redirecting 1`] = `""`;
 
-exports[`Component: AccessControl should render correctly when no access and redirecting 1`] = `
+exports[`Component: AccessControl should render correctly when no access and ready to redirect 1`] = `
 <Redirect
   push={false}
   to="/some/path"
 />
 `;
+
+exports[`Component: AccessControl should render correctly when no access but not ready to redirect 1`] = `<Component />`;

--- a/src/selectors/navItems.js
+++ b/src/selectors/navItems.js
@@ -6,18 +6,17 @@ import accessConditionState from './accessConditionState';
 
 const routesByPath = _.keyBy(routes, 'path');
 
-export function mapNavToRoutes(items) {
-  return items.map((item) => {
-    item.route = routesByPath[item.to];
-    if (item.children) {
-      item.children = mapNavToRoutes(item.children);
-    }
-    return item;
-  });
-}
+export const mapNavToRoutes = _.memoize((items) => items.map((item) => {
+  item.route = routesByPath[item.to];
+  if (item.children) {
+    item.children = mapNavToRoutes(item.children);
+  }
+  return item;
+}));
 
 export function filterNavByAccess(items, accessConditionState) {
-  return items.filter((item) => {
+  return items.filter((reference) => {
+    const item = { ...reference }; // prevent weird mutation bugs
     const condition = _.get(item, 'route.condition');
 
     // if condition function returns false, block access here


### PR DESCRIPTION
This is the bug where account mysteriously disappears from the nav after logout/login ... when the grants aren't found in the cookie (so first login or logout/login), it would compute access for nav items before it had grants and replace their children with empty arrays because none of the children had access yet. By the time we re-calculated it was too late and we had already mutated the children so they were gone forever, so we remove the parent too since none of the children were there.

Whole fix is just this:
```diff
 export function filterNavByAccess(items, accessConditionState) {
-  return items.filter((item) => {
+  return items.filter((reference) => {
+    const item = { ...reference }; // prevent weird mutation bugs
```

I also added a memoize around the mapping of the nav items so we don't have to re-map them over and over for no reason.