### PR TITLE
Removed environment configuration variable

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -27,7 +27,6 @@ const config = {
     supportEmail: 'support@sparkpost.com',
     billingEmail: 'billing@sparkpost.com'
   },
-  environment: 'development',
   metricsPrecisionMap: [
     { time: 60, value: '1min', format: 'ha' },
     { time: 60 * 2, value: '5min', format: 'ha' },

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -55,7 +55,7 @@ class ErrorTracker {
    * @param {object}
    */
   install(config, store) {
-    const { environment, release, sentry, tenant } = config;
+    const { release, sentry, tenant } = config;
 
     // Silently ignore installation if Sentry configuration is not provided
     if (!sentry) { return; }
@@ -64,7 +64,6 @@ class ErrorTracker {
     const options = {
       breadcrumbCallback,
       dataCallback: getEnricherOrDieTryin(store),
-      environment,
       release,
       extra: { tenant }
     };


### PR DESCRIPTION
This is to address [Ewan's code review comment](https://fisheye.int.messagesystems.com/cru/APP-2975#CFR-120512).  The `environment` variable is not needed.  Each Sentry project is setup per environment.