### PR TITLE
Enforce lodash/chaining never linting rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-jsx-a11y": "5.0.3",
+    "eslint-plugin-lodash": "^2.5.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^7.0.1",
@@ -185,7 +186,8 @@
             ":": "before"
           }
         }
-      ]
+      ],
+      "lodash/chaining": ["error", "never"]
     },
     "extends": [
       "react-app",
@@ -193,6 +195,7 @@
       "plugin:jest/recommended"
     ],
     "plugins": [
+      "lodash",
       "jest"
     ]
   },


### PR DESCRIPTION
This is to enforce our "Don't use lodash _.chain" rule.