### PR TITLE
FAD-5884: coming soon pages

### DIFF
--- a/src/components/navigation/Footer.js
+++ b/src/components/navigation/Footer.js
@@ -8,7 +8,7 @@ export class Footer extends Component {
   render() {
     return (
       <ul className={styles.footer}>
-        <li><a className={styles.link}>Help &amp; API</a></li>
+        <li><a className={styles.link} href='https://www.sparkpost.com/docs/' target='_blank' rel='noopener noreferrer'>Help &amp; API</a></li>
         <li><a className={styles.link} onClick={() => this.props.logout()}>Log Out</a></li>
       </ul>
     );

--- a/src/config/navItems.js
+++ b/src/config/navItems.js
@@ -86,7 +86,7 @@ export default [
         to: '/account/security'
       },
       {
-        label: 'Sending domains',
+        label: 'Sending Domains',
         to: '/account/sending-domains'
       },
       {

--- a/src/config/navItems.js
+++ b/src/config/navItems.js
@@ -18,6 +18,22 @@ export default [
         to: '/reports/bounce'
       },
       {
+        label: 'Rejections',
+        to: '/reports/rejections'
+      },
+      {
+        label: 'Accepted',
+        to: '/reports/accepted'
+      },
+      {
+        label: 'Delayed',
+        to: '/reports/delayed'
+      },
+      {
+        label: 'Engagement',
+        to: '/reports/engagement'
+      },
+      {
         label: 'Message Events',
         to: '/reports/message-events'
       }
@@ -39,7 +55,7 @@ export default [
       },
       {
         label: 'Suppressions',
-        to: '/lits/suppression-list'
+        to: '/lists/suppressions'
       }
     ]
   },
@@ -64,6 +80,18 @@ export default [
       {
         label: 'Profile',
         to: '/account/profile'
+      },
+      {
+        label: 'Security',
+        to: '/account/security'
+      },
+      {
+        label: 'Sending domains',
+        to: '/account/sending-domains'
+      },
+      {
+        label: 'SMTP Relay',
+        to: '/account/smtp'
       },
       {
         label: 'Subaccounts',

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -186,6 +186,12 @@ export default [
     layout: App
   },
   {
+    path: '/templates/preview/:id',
+    component: ComingSoonPage,
+    condition: hasGrants('templates/modify'),
+    layout: App
+  },
+  {
     path: '/lists/recipient-lists',
     component: recipientLists.ListPage,
     condition: hasGrants('recipient_lists/manage'),

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -198,6 +198,12 @@ export default [
     layout: App
   },
   {
+    path: '/lists/recipient-lists/edit/:id',
+    component: ComingSoonPage,
+    condition: hasGrants('recipient_lists/manage'),
+    layout: App
+  },
+  {
     path: '/lists/suppressions',
     component: ComingSoonPage,
     condition: hasGrants('suppression_lists/manage'),

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -13,7 +13,8 @@ import {
   trackingDomains,
   users,
   webhooks,
-  ipPools
+  ipPools,
+  ComingSoonPage
 } from 'src/pages';
 
 import {
@@ -100,6 +101,26 @@ export default [
     layout: App
   },
   {
+    path: '/reports/rejections',
+    component: ComingSoonPage,
+    layout: App
+  },
+  {
+    path: '/reports/accepted',
+    component: ComingSoonPage,
+    layout: App
+  },
+  {
+    path: '/reports/delayed',
+    component: ComingSoonPage,
+    layout: App
+  },
+  {
+    path: '/reports/engagement',
+    component: ComingSoonPage,
+    layout: App
+  },
+  {
     path: '/reports/message-events',
     component: reports.MessageEventsPage,
     layout: App
@@ -171,6 +192,18 @@ export default [
     layout: App
   },
   {
+    path: '/lists/recipient-lists/create',
+    component: ComingSoonPage,
+    condition: hasGrants('recipient_lists/manage'),
+    layout: App
+  },
+  {
+    path: '/lists/suppressions',
+    component: ComingSoonPage,
+    condition: hasGrants('suppression_lists/manage'),
+    layout: App
+  },
+  {
     path: '/webhooks',
     component: webhooks.ListPage,
     condition: hasGrants('webhooks/view'),
@@ -223,6 +256,24 @@ export default [
     path: '/account/profile',
     component: ProfilePage,
     condition: hasGrants('users/self-manage'),
+    layout: App
+  },
+  {
+    path: '/account/security',
+    component: ComingSoonPage,
+    condition: hasGrants('users/self-manage'),
+    layout: App
+  },
+  {
+    path: '/account/sending-domains',
+    component: ComingSoonPage,
+    condition: hasGrants('sending_domains/manage'),
+    layout: App
+  },
+  {
+    path: '/account/smtp',
+    component: ComingSoonPage,
+    condition: hasGrants('api_keys/manage'),
     layout: App
   },
   {

--- a/src/pages/comingSoon/ComingSoonPage.js
+++ b/src/pages/comingSoon/ComingSoonPage.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { EmptyState } from '@sparkpost/matchbox';
+
+export default function ComingSoonPage() {
+  return <EmptyState
+        title='We are not quite finished in here.'
+        image='Generic'>
+        <p>We won't bother putting up blinking construction stripes but you get the idea. <span role='img' aria-label='smile'>&#x1F603;</span></p>
+    </EmptyState>;
+}
+

--- a/src/pages/comingSoon/tests/ComingSoonPage.snapshot.test.js
+++ b/src/pages/comingSoon/tests/ComingSoonPage.snapshot.test.js
@@ -1,0 +1,14 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import ComingSoonPage from '../ComingSoonPage';
+
+let wrapper;
+
+beforeEach(() => {
+  wrapper = shallow(<ComingSoonPage />);
+});
+
+it('renders correctly', () => {
+  expect(wrapper).toMatchSnapshot();
+});

--- a/src/pages/comingSoon/tests/__snapshots__/ComingSoonPage.snapshot.test.js.snap
+++ b/src/pages/comingSoon/tests/__snapshots__/ComingSoonPage.snapshot.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<EmptyState
+  image="Generic"
+  title="We are not quite finished in here."
+>
+  <p>
+    We won't bother putting up blinking construction stripes but you get the idea. 
+    <span
+      aria-label="smile"
+      role="img"
+    >
+      😃
+    </span>
+  </p>
+</EmptyState>
+`;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,3 +12,4 @@ export { default as trackingDomains } from './trackingDomains';
 export { default as webhooks } from './webhooks';
 export { default as ipPools } from './ipPools';
 export { default as SSOPage } from './sso/SSOPage';
+export { default as ComingSoonPage } from './comingSoon/ComingSoonPage';

--- a/src/pages/recipientLists/ListPage.js
+++ b/src/pages/recipientLists/ListPage.js
@@ -16,7 +16,7 @@ const primaryAction = {
 };
 
 const getRowData = ({ name, id, total_accepted_recipients }) => [
-  <Link to={`/lists/recipient-lists/${id}`}>{name}</Link>,
+  <Link to={`/lists/recipient-lists/edit/${id}`}>{name}</Link>,
   id,
   total_accepted_recipients
 ];

--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -105,7 +105,7 @@ export class EditPage extends Component {
       },
       { content: 'Delete', onClick: this.handleDeleteModalToggle },
       { content: 'Duplicate', Component: Link, to: `/templates/create/${match.params.id}` },
-      { content: 'Preview & Send', disabled: true }
+      { content: 'Preview & Send', Component: Link, to: `/templates/preview/${match.params.id}` }
     ];
 
     const breadcrumbAction = {

--- a/src/pages/trackingDomains/components/TrackingDomainRow.js
+++ b/src/pages/trackingDomains/components/TrackingDomainRow.js
@@ -91,7 +91,7 @@ export class TrackingDomainRow extends Component {
     }
   }
 
-  handleChangeDefault(){
+  handleChangeDefault() {
     //TODO implement this
   }
 


### PR DESCRIPTION
## Changes
 - Added a ComingSoonPage with only an EmptyState in it.
 - Added the following coming soon pages:
     - reports
         - rejections
         - accepted
         - delayed
         - engagement
      - lists
         - recipient lists -> create
         - suppression lists
      - account
         - security
         - sending domains
         - smtp relay
 - Fixed a lint issue in tracking domains

## Questions
 - Did *not* add account -> usage since its a dup of the dashboard. TBD?
 - ComingSoonPage view and copy could use a sense of humour.
 - A modal might be nicer for recipient lists -> create

## Issues
 - ~My test snapshots are made in GMT so any with dates will fail outside the UK (!).~ Sidestepped with `TZ=` env variable. Better fix in progress on `feature/FAD-5876`.
 - The bounce report snapshot contains an ID attribute not in the snapshot. Just an out of date snapshot?

```
 FAIL  src/pages/reports/bounce/components/tests/BounceChart.test.js
  ● BounceChart:  › should render

    expect(value).toMatchSnapshot()

    Received value does not match stored snapshot 1.

    - Snapshot
    + Received

    @@ -45,11 +45,10 @@
              }
              dataKey="count"
              endAngle={450}
              fill="#808080"
              hide={false}
    -         id="recharts-pie-1"
              innerRadius={100}
              isAnimationActive={true}
              labelLine={true}
              legendType="rect"
              minAngle={2}
    @@ -79,11 +78,10 @@
              }
              dataKey="count"
              endAngle={450}
              fill="#808080"
              hide={false}
    -         id="recharts-pie-1"
              innerRadius={75}
              isAnimationActive={true}
              labelLine={true}
              legendType="rect"
              minAngle={2}

      at Object.it (src/pages/reports/bounce/components/tests/BounceChart.test.js:23:21)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```