### PR TITLE
FAD-5593 Report: Engagement

### DIFF
--- a/src/__testHelpers__/time.js
+++ b/src/__testHelpers__/time.js
@@ -1,0 +1,11 @@
+export default function time({
+  year = 1970,
+  month = 1,
+  day = 1,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  millisecond = 0
+} = {}) {
+  return new Date(Date.UTC(year, --month, day, hour, minute, second, millisecond));
+}

--- a/src/actions/engagementReport.js
+++ b/src/actions/engagementReport.js
@@ -1,14 +1,17 @@
 import * as metrics from 'src/actions/metrics';
+import { getQueryFromOptions } from 'src/helpers/metrics';
 
 export function getChartData({ getMetrics = metrics.fetch } = {}) {
-  return getMetrics({
-    params: {
-      delimiter: ',',
-      from: '2018-01-10T15:00',
-      metrics: 'count_accepted,count_targeted,count_unique_clicked_approx,count_unique_confirmed_opened_approx',
-      to: '2018-01-11T15:40'
-    },
-    path: 'deliverability',
-    type: 'GET_ENGAGEMENT_CHART_DATA'
-  });
+  return (dispatch, getState) => {
+    const params = getQueryFromOptions(getState().reportFilters);
+
+    return dispatch(getMetrics({
+      params: {
+        ...params,
+        metrics: 'count_accepted,count_targeted,count_unique_clicked_approx,count_unique_confirmed_opened_approx'
+      },
+      path: 'deliverability',
+      type: 'GET_ENGAGEMENT_CHART_DATA'
+    }));
+  };
 }

--- a/src/actions/engagementReport.js
+++ b/src/actions/engagementReport.js
@@ -1,0 +1,14 @@
+import * as metrics from 'src/actions/metrics';
+
+export function getChartData({ getMetrics = metrics.fetch } = {}) {
+  return getMetrics({
+    params: {
+      delimiter: ',',
+      from: '2018-01-10T15:00',
+      metrics: 'count_accepted,count_targeted,count_unique_clicked_approx,count_unique_confirmed_opened_approx',
+      to: '2018-01-11T15:40'
+    },
+    path: 'deliverability',
+    type: 'GET_ENGAGEMENT_CHART_DATA'
+  });
+}

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -8,6 +8,7 @@ import {
 import { listTemplates } from './templates';
 import { list as listSubaccounts } from './subaccounts';
 import { list as listSendingDomains } from './sendingDomains';
+import { getRelativeDates } from 'src/helpers/date';
 import { getQueryFromOptions } from 'src/helpers/metrics';
 
 // array of all lists that need to be re-filtered when time changes
@@ -50,6 +51,13 @@ export function addFilter(payload) {
   };
 }
 
+export function addFilters(payload) {
+  return {
+    type: 'ADD_FILTERS',
+    payload
+  };
+}
+
 export function removeFilter(payload) {
   return {
     type: 'REMOVE_FILTER',
@@ -62,5 +70,14 @@ export function refreshReportRange(options) {
   return {
     type: 'REFRESH_REPORT_RANGE',
     payload: options
+  };
+}
+
+export function refreshRelativeRange(options = {}) {
+  const range = { ...options, ...getRelativeDates(options.relativeRange) };
+
+  return {
+    type: 'REFRESH_REPORT_RANGE',
+    payload: range
   };
 }

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -44,13 +44,6 @@ export function maybeRefreshTypeaheadCache(dispatch, options, updates = {}) {
   }
 }
 
-export function addFilter(payload) {
-  return {
-    type: 'ADD_FILTER',
-    payload
-  };
-}
-
 export function addFilters(payload) {
   return {
     type: 'ADD_FILTERS',

--- a/src/actions/tests/__snapshots__/engagementReport.test.js.snap
+++ b/src/actions/tests/__snapshots__/engagementReport.test.js.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`get chart data 1`] = `
+exports[`params to get engagement chart data 1`] = `
 Object {
   "params": Object {
     "delimiter": ",",
-    "from": "2018-01-10T15:00",
+    "from": "1970-01-01T00:00",
     "metrics": "count_accepted,count_targeted,count_unique_clicked_approx,count_unique_confirmed_opened_approx",
-    "to": "2018-01-11T15:40",
+    "precision": "hour",
+    "to": "1970-01-02T00:00",
   },
   "path": "deliverability",
   "type": "GET_ENGAGEMENT_CHART_DATA",

--- a/src/actions/tests/__snapshots__/engagementReport.test.js.snap
+++ b/src/actions/tests/__snapshots__/engagementReport.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`get chart data 1`] = `
+Object {
+  "params": Object {
+    "delimiter": ",",
+    "from": "2018-01-10T15:00",
+    "metrics": "count_accepted,count_targeted,count_unique_clicked_approx,count_unique_confirmed_opened_approx",
+    "to": "2018-01-11T15:40",
+  },
+  "path": "deliverability",
+  "type": "GET_ENGAGEMENT_CHART_DATA",
+}
+`;

--- a/src/actions/tests/engagementReport.test.js
+++ b/src/actions/tests/engagementReport.test.js
@@ -1,6 +1,17 @@
 import * as actionCreators from '../engagementReport';
+import time from 'src/__testHelpers__/time';
 
-it('get chart data', () => {
-  const params = { getMetrics: jest.fn((a) => a) };
-  expect(actionCreators.getChartData(params)).toMatchSnapshot();
+
+it('params to get engagement chart data', () => {
+  const mockDispatch = jest.fn((a) => a);
+  const mockGetState = jest.fn(() => ({
+    reportFilters: {
+      from: time({ day: 1 }),
+      relativeRange: 'day',
+      to: time({ day: 2 })
+    }
+  }));
+  const thunk = actionCreators.getChartData({ getMetrics: jest.fn((a) => a) });
+
+  expect(thunk(mockDispatch, mockGetState)).toMatchSnapshot();
 });

--- a/src/actions/tests/engagementReport.test.js
+++ b/src/actions/tests/engagementReport.test.js
@@ -1,0 +1,6 @@
+import * as actionCreators from '../engagementReport';
+
+it('get chart data', () => {
+  const params = { getMetrics: jest.fn((a) => a) };
+  expect(actionCreators.getChartData(params)).toMatchSnapshot();
+});

--- a/src/actions/tests/reportFilters.test.js
+++ b/src/actions/tests/reportFilters.test.js
@@ -64,11 +64,6 @@ describe('Action Creator: Report Filters', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should create an action to add a filter', () => {
-    const filter = { type: 'Example Domain', value: 'example.com' };
-    expect(reportFilters.addFilter(filter)).toEqual({ payload: filter, type: 'ADD_FILTER' });
-  });
-
   it('should create an action to add multiple filters', () => {
     const filters = [
       { type: 'Example Domain', value: 'one.example.com' },

--- a/src/actions/tests/reportFilters.test.js
+++ b/src/actions/tests/reportFilters.test.js
@@ -3,7 +3,10 @@ import * as metrics from 'src/actions/metrics';
 import { listTemplates } from 'src/actions/templates';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 import { list as listSendingDomains } from 'src/actions/sendingDomains';
+import { getRelativeDates } from 'src/helpers/date';
+import time from 'src/__testHelpers__/time';
 
+jest.mock('src/helpers/date');
 jest.mock('src/helpers/metrics');
 jest.mock('src/actions/metrics');
 jest.mock('src/actions/templates');
@@ -61,4 +64,37 @@ describe('Action Creator: Report Filters', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('should create an action to add a filter', () => {
+    const filter = { type: 'Example Domain', value: 'example.com' };
+    expect(reportFilters.addFilter(filter)).toEqual({ payload: filter, type: 'ADD_FILTER' });
+  });
+
+  it('should create an action to add multiple filters', () => {
+    const filters = [
+      { type: 'Example Domain', value: 'one.example.com' },
+      { type: 'Example Domain', value: 'two.example.com' }
+    ];
+    expect(reportFilters.addFilters(filters)).toEqual({ payload: filters, type: 'ADD_FILTERS' });
+  });
+
+  it('should create an action with custom range to refresh report range', () => {
+    const range = { from: time(), relativeRange: 'custom', to: time({ hour: 2 }) };
+    getRelativeDates.mockImplementation(() => ({}));
+
+    expect(reportFilters.refreshRelativeRange(range)).toEqual({
+      payload: range,
+      type: 'REFRESH_REPORT_RANGE'
+    });
+  });
+
+  it('should create an action with relative range to refresh report range', () => {
+    const relativeRange = { relativeRange: 'day' };
+    const range = { from: time(), to: time({ day: 2 }) };
+    getRelativeDates.mockImplementation(() => range);
+
+    expect(reportFilters.refreshRelativeRange(relativeRange)).toEqual({
+      payload: { ...range, ...relativeRange },
+      type: 'REFRESH_REPORT_RANGE'
+    });
+  });
 });

--- a/src/components/asyncComponent/ChunkLoading.js
+++ b/src/components/asyncComponent/ChunkLoading.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Loading } from 'src/components/loading/Loading';
+import { Loading } from 'src/components';
 
-const ChunkLoading = ({ pastDelay }) => {
+const ChunkLoading = ({ LoadingComponent = Loading, pastDelay }) => {
   // if loading has taken more than 200 milliseconds
   if (pastDelay) {
-    return <Loading />;
-  } else {
-    return null;
+    return <LoadingComponent />;
   }
+
+  return null;
 };
 
 export default ChunkLoading;

--- a/src/components/asyncComponent/asyncComponent.js
+++ b/src/components/asyncComponent/asyncComponent.js
@@ -1,11 +1,11 @@
+import React from 'react';
 import loadable from 'react-loadable';
 import ChunkLoading from './ChunkLoading';
 
-
-export default function asyncComponent(importComponent) {
+export default function asyncComponent(importComponent, LoadingComponent) {
   const LoadableComponent = loadable({
     loader: importComponent,
-    loading: ChunkLoading
+    loading: (props) => <ChunkLoading LoadingComponent={LoadingComponent} {...props} />
   });
 
   return LoadableComponent;

--- a/src/components/asyncComponent/tests/ChunkLoading.test.js
+++ b/src/components/asyncComponent/tests/ChunkLoading.test.js
@@ -1,18 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import cases from 'jest-in-case';
 import ChunkLoading from '../ChunkLoading';
 
-describe('LoadableLoading Component', () => {
+const CustomLoading = () => '';
 
-  it('should return null if no props', () => {
-    const wrapper = shallow(<ChunkLoading />);
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should render loading if pastDelay is true', () => {
-    const wrapper = shallow(<ChunkLoading pastDelay={true}/>);
-
-    expect(wrapper).toMatchSnapshot();
-  });
+cases('ChunkLoading', (props) => {
+  const wrapper = shallow(<ChunkLoading {...props} />);
+  expect(wrapper).toMatchSnapshot();
+}, {
+  'should return null': {},
+  'should render loading': {
+    pastDelay: true
+  },
+  'should render custom loading': {
+    LoadingComponent: CustomLoading,
+    pastDelay: true
+  }
 });

--- a/src/components/asyncComponent/tests/__snapshots__/ChunkLoading.test.js.snap
+++ b/src/components/asyncComponent/tests/__snapshots__/ChunkLoading.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LoadableLoading Component should render loading if pastDelay is true 1`] = `<Loading />`;
+exports[`ChunkLoading should render custom loading 1`] = `<CustomLoading />`;
 
-exports[`LoadableLoading Component should return null if no props 1`] = `""`;
+exports[`ChunkLoading should render loading 1`] = `<Loading />`;
+
+exports[`ChunkLoading should return null 1`] = `""`;

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -124,7 +124,7 @@ const routes = [
   },
   {
     path: '/reports/engagement',
-    component: ComingSoonPage,
+    component: reports.EngagementPage,
     layout: App
   },
   {

--- a/src/helpers/tests/units.test.js
+++ b/src/helpers/tests/units.test.js
@@ -32,7 +32,7 @@ describe('Formatting helpers', () => {
     });
 
     it('should format floats', () => {
-      expect(formatting.formatFullNumber(23456.78)).toEqual('23,457');
+      expect(formatting.formatFullNumber(23456.78)).toEqual('23,456.78');
     });
 
     it('should format numbers', () => {

--- a/src/helpers/tests/units.test.js
+++ b/src/helpers/tests/units.test.js
@@ -25,6 +25,21 @@ describe('Formatting helpers', () => {
     });
   });
 
+  describe('formatFullNumber', () => {
+    it('should leave non-numbers alone', () => {
+      const iceCream = 'vanilla';
+      expect(formatting.formatFullNumber(iceCream)).toEqual(iceCream);
+    });
+
+    it('should format floats', () => {
+      expect(formatting.formatFullNumber(23456.78)).toEqual('23,457');
+    });
+
+    it('should format numbers', () => {
+      expect(formatting.formatFullNumber(23456)).toEqual('23,456');
+    });
+  });
+
   describe('formatMilliseconds', () => {
     it('should leave non-numbers alone', () => {
       const iceCream = 'vanilla';

--- a/src/helpers/units.js
+++ b/src/helpers/units.js
@@ -94,6 +94,15 @@ export const formatNumber = (value) => {
   return `${roundToPlaces(formatted, 2).toLocaleString()}${suffix}`;
 };
 
+// Formats number count to sting with commas
+export const formatFullNumber = (value) => {
+  if (!isNumber(value)) {
+    return value;
+  }
+
+  return value.toLocaleString();
+};
+
 export const formatPercent = (value) => {
   if (!isNumber(value)) {
     return value;

--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -6,7 +6,7 @@ import qs from 'query-string';
 import _ from 'lodash';
 
 import { refreshBounceChartMetrics, refreshBounceTableMetrics } from 'src/actions/bounceReport';
-import { addFilter, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
@@ -43,12 +43,8 @@ export class BouncePage extends Component {
    * and not in the helper
    */
   parseSearch() {
-    const { options, filters } = parseSearch(this.props.location.search);
-
-    if (filters) {
-      filters.forEach(this.props.addFilter);
-    }
-
+    const { filters = [], options } = parseSearch(this.props.location.search);
+    this.props.addFilters(filters);
     return options;
   }
 
@@ -74,7 +70,7 @@ export class BouncePage extends Component {
   }
 
   handleDomainClick = (domain) => {
-    this.props.addFilter({ type: 'Recipient Domain', value: domain });
+    this.props.addFilters([{ type: 'Recipient Domain', value: domain }]);
     this.handleRefresh();
   }
 
@@ -182,7 +178,7 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
-  addFilter,
+  addFilters,
   refreshBounceChartMetrics,
   refreshBounceTableMetrics,
   refreshTypeaheadCache,

--- a/src/pages/reports/bounce/tests/BouncePage.test.js
+++ b/src/pages/reports/bounce/tests/BouncePage.test.js
@@ -45,7 +45,7 @@ describe('BouncePage: ', () => {
   let spyParseSearch;
 
   beforeEach(() => {
-    props.addFilter = jest.fn();
+    props.addFilters = jest.fn();
     props.showAlert = jest.fn();
     reportHelpers.getFilterSearchOptions = jest.fn(() => []);
     spyParseSearch = reportHelpers.parseSearch = jest.fn(() => ({ options: {}}));
@@ -62,21 +62,20 @@ describe('BouncePage: ', () => {
     expect(props.refreshBounceTableMetrics).toHaveBeenCalled();
     expect(spyParseSearch).toHaveBeenCalled();
     expect(props.refreshTypeaheadCache).toHaveBeenCalled();
-    expect(props.addFilter).not.toHaveBeenCalled();
+    expect(props.addFilters).toHaveBeenCalledWith([]);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should call addfilter when there are filters', () => {
+  it('should call addfilters when there are filters', () => {
     reportHelpers.parseSearch = jest.fn(() => ({ options: {}, filters: ['1', '2', '3']}));
     wrapper.instance().parseSearch();
-    expect(props.addFilter).toHaveBeenCalledTimes(3);
+    expect(props.addFilters).toHaveBeenCalledWith(['1', '2', '3']);
   });
 
   it('should show alert when one of the refresh calls fails', async() => {
     wrapper.setProps({ refreshBounceChartMetrics: jest.fn(() => Promise.reject(new Error('failed to load'))) });
     await wrapper.instance().handleRefresh();
     expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: 'Unable to refresh bounce report.', details: 'failed to load' });
-
   });
 
   it('should render correctly with no bounces', () => {
@@ -125,7 +124,7 @@ describe('BouncePage: ', () => {
 
     const link = mount(rows[1]);
     link.find('UnstyledLink').simulate('click');
-    expect(props.addFilter).toHaveBeenCalledWith({ type: 'Recipient Domain', value: 'gmail' });
+    expect(props.addFilters).toHaveBeenCalledWith([{ type: 'Recipient Domain', value: 'gmail' }]);
   });
 
   it('should show modal toggle', () => {

--- a/src/pages/reports/components/Filters.js
+++ b/src/pages/reports/components/Filters.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { addFilter, removeFilter } from 'src/actions/reportFilters';
+import { addFilters, removeFilter } from 'src/actions/reportFilters';
 
 import { Grid, Button, Panel, Tag } from '@sparkpost/matchbox';
 import Typeahead from './Typeahead';
@@ -26,7 +26,7 @@ export class Filters extends Component {
   }
 
   handleTypeaheadSelect = (item) => {
-    this.props.addFilter(item);
+    this.props.addFilters([item]);
     this.props.refresh();
   }
 
@@ -65,4 +65,4 @@ const mapStateToProps = (state) => ({
   filters: state.reportFilters.activeList,
   typeaheadCache: typeaheadCacheSelector(state)
 });
-export default connect(mapStateToProps, { addFilter, removeFilter })(Filters);
+export default connect(mapStateToProps, { addFilters, removeFilter })(Filters);

--- a/src/pages/reports/components/tests/Filters.test.js
+++ b/src/pages/reports/components/tests/Filters.test.js
@@ -12,7 +12,7 @@ describe('Component: Report filters', () => {
   beforeEach(() => {
     testProps = {
       refresh: jest.fn(),
-      addFilter: jest.fn(),
+      addFilters: jest.fn(),
       removeFilter: jest.fn(),
       typeaheadCache: [],
       filters: [],
@@ -55,8 +55,7 @@ describe('Component: Report filters', () => {
     const typeahead = wrapper.find(Typeahead);
     const item = {};
     typeahead.simulate('select', item);
-    expect(testProps.addFilter).toHaveBeenCalledWith(item);
+    expect(testProps.addFilters).toHaveBeenCalledWith([item]);
     expect(testProps.refresh).toHaveBeenCalledTimes(1);
   });
-
 });

--- a/src/pages/reports/delays/DelayPage.js
+++ b/src/pages/reports/delays/DelayPage.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
-import { addFilter, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
 import { loadDelayReasonsByDomain, loadDelayMetrics } from 'src/actions/delayReport';
 import { parseSearch, getFilterSearchOptions } from 'src/helpers/reports';
 import { Percent } from 'src/components/formatters';
@@ -30,12 +30,8 @@ export class DelayPage extends Component {
   }
 
   parseSearch() {
-    const { options, filters } = parseSearch(this.props.location.search);
-
-    if (filters) {
-      filters.forEach(this.props.addFilter);
-    }
-
+    const { filters = [], options } = parseSearch(this.props.location.search);
+    this.props.addFilters(filters);
     return options;
   }
 
@@ -61,7 +57,7 @@ export class DelayPage extends Component {
   }
 
   handleDomainClick = (domain) => {
-    this.props.addFilter({ type: 'Recipient Domain', value: domain });
+    this.props.addFilters([{ type: 'Recipient Domain', value: domain }]);
     this.handleRefresh();
   }
 
@@ -156,8 +152,8 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
+  addFilters,
   refreshTypeaheadCache,
-  addFilter,
   loadDelayReasonsByDomain,
   loadDelayMetrics,
   showAlert

--- a/src/pages/reports/delays/tests/DelayPage.test.js
+++ b/src/pages/reports/delays/tests/DelayPage.test.js
@@ -11,7 +11,7 @@ Date.now = jest.fn(() => 1487076708000);
 describe('DelayPage: ', () => {
   const props = {
     filters: { relativeRange: 'hour' },
-    addFilter: jest.fn(),
+    addFilters: jest.fn(),
     tableLoading: false,
     reasons: [
       {
@@ -60,7 +60,7 @@ describe('DelayPage: ', () => {
     expect(props.loadDelayReasonsByDomain).toHaveBeenCalled();
     expect(parseSpy).toHaveBeenCalled();
     expect(props.refreshTypeaheadCache).toHaveBeenCalled();
-    expect(props.addFilter).not.toHaveBeenCalled();
+    expect(props.addFilters).toHaveBeenCalledWith([]);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -85,10 +85,10 @@ describe('DelayPage: ', () => {
     expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: 'Unable to refresh delay report.', details: 'no way jose' });
   });
 
-  it('should call addFilter when there are filters', () => {
+  it('should call addFilters when there are filters', () => {
     reportHelpers.parseSearch = jest.fn(() => ({ options: {}, filters: ['1', '2', '3']}));
     wrapper.instance().parseSearch();
-    expect(props.addFilter).toHaveBeenCalledTimes(3);
+    expect(props.addFilters).toHaveBeenCalledWith(['1', '2', '3']);
   });
 
   it('should render row data properly', () => {
@@ -100,7 +100,7 @@ describe('DelayPage: ', () => {
     const rows = wrapper.instance().getRowData({ reason: 'bad delay', count_delayed: 1, count_delayed_first: 10, domain: 'gmail.com' });
     const link = mount(rows[1]);
     link.find('UnstyledLink').simulate('click');
-    expect(props.addFilter).toHaveBeenCalledWith({ type: 'Recipient Domain', value: 'gmail.com' });
+    expect(props.addFilters).toHaveBeenCalledWith([{ type: 'Recipient Domain', value: 'gmail.com' }]);
   });
 
   it('should show modal toggle', () => {

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -1,36 +1,52 @@
-import React from 'react';
+import _ from 'lodash';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { Page } from '@sparkpost/matchbox';
 
 import { getChartData } from 'src/actions/engagementReport';
+import { showAlert } from 'src/actions/globalAlert';
 import EngagementChart from './components/EngagementChart';
 import EngagementFilters from './components/EngagementFilters';
 import EngagementSummary from './components/EngagementSummary';
 
-export function EngagementPage({ chart, getChartData }) {
-  return (
-    <Page title='Engagement Report'>
-      <EngagementFilters shareDisabled={chart.loading} onLoad={getChartData} />
-      <EngagementSummary
-        clicks={chart.data.count_unique_clicked_approx}
-        loading={chart.loading}
-        targeted={chart.data.count_targeted}
-      />
-      <EngagementChart
-        accepted={chart.data.count_accepted}
-        clicks={chart.data.count_unique_clicked_approx}
-        loading={chart.loading}
-        opens={chart.data.count_unique_confirmed_opened_approx}
-        targeted={chart.data.count_targeted}
-      />
-    </Page>
-  );
+export class EngagementPage extends Component {
+  onLoad = () => {
+    this.props.getChartData().catch((error) => {
+      this.props.showAlert({
+        details: _.get(error, 'response.data.errors[0].message'),
+        message: 'Unable to load engagement report data.',
+        type: 'error'
+      });
+    });
+  }
+
+  render() {
+    const { chart } = this.props;
+
+    return (
+      <Page title='Engagement Report'>
+        <EngagementFilters shareDisabled={chart.loading} onLoad={this.onLoad} />
+        <EngagementSummary
+          clicks={chart.data.count_unique_clicked_approx}
+          loading={chart.loading}
+          targeted={chart.data.count_targeted}
+        />
+        <EngagementChart
+          accepted={chart.data.count_accepted}
+          clicks={chart.data.count_unique_clicked_approx}
+          loading={chart.loading}
+          opens={chart.data.count_unique_confirmed_opened_approx}
+          targeted={chart.data.count_targeted}
+        />
+      </Page>
+    );
+  }
 }
 
 const mapStateToProps = (state, props) => ({
   chart: state.engagementReport.chart
 });
-const mapDispatchToProps = { getChartData };
+const mapDispatchToProps = { getChartData, showAlert };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EngagementPage));

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -15,7 +15,7 @@ export class EngagementPage extends Component {
     this.props.getChartData().catch((error) => {
       this.props.showAlert({
         details: _.get(error, 'response.data.errors[0].message'),
-        message: 'Unable to load engagement report data.',
+        message: 'Unable to load engagement data.',
         type: 'error'
       });
     });

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -8,20 +8,12 @@ import PanelLoading from 'src/components/panelLoading/PanelLoading';
 import EngagementChart from './components/EngagementChart';
 import EngagementFilters from './components/EngagementFilters';
 
-// Experimental alternative to inline JSX conditions
-// @see https://reactjs.org/docs/conditional-rendering.html#inline-if-with-logical--operator
-function If({ children, condition }) {
-  return condition ? children : null;
-}
-
 export function EngagementPage({ chart, getChartData }) {
   return (
     <Page title='Engagement Report'>
       <EngagementFilters disabled={chart.loading} onLoad={getChartData} />
-      <If condition={chart.loading}>
-        <PanelLoading />
-      </If>
-      <If condition={!chart.loading}>
+      {chart.loading && <PanelLoading />}
+      {!chart.loading && (
         <Panel sectioned>
           <EngagementChart
             accepted={chart.data.count_accepted}
@@ -30,7 +22,7 @@ export function EngagementPage({ chart, getChartData }) {
             targeted={chart.data.count_targeted}
           />
         </Panel>
-      </If>
+      )}
     </Page>
   );
 }

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -1,32 +1,38 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
 import { Page, Panel } from '@sparkpost/matchbox';
 import { getChartData } from 'src/actions/engagementReport';
+import PanelLoading from 'src/components/panelLoading/PanelLoading';
 import EngagementChart from './components/EngagementChart';
+import EngagementFilters from './components/EngagementFilters';
 
-export class EngagementPage extends Component {
-  componentDidMount() {
-    this.props.getChartData();
-  }
+// Experimental alternative to inline JSX conditions
+// @see https://reactjs.org/docs/conditional-rendering.html#inline-if-with-logical--operator
+function If({ children, condition }) {
+  return condition ? children : null;
+}
 
-  render() {
-    const { data } = this.props.chart;
-
-    return (
-      <Page title='Engagement Report'>
+export function EngagementPage({ chart, getChartData }) {
+  return (
+    <Page title='Engagement Report'>
+      <EngagementFilters disabled={chart.loading} onLoad={getChartData} />
+      <If condition={chart.loading}>
+        <PanelLoading />
+      </If>
+      <If condition={!chart.loading}>
         <Panel sectioned>
           <EngagementChart
-            accepted={data.count_accepted}
-            clicks={data.count_unique_clicked_approx}
-            opens={data.count_unique_confirmed_opened_approx}
-            targeted={data.count_targeted}
+            accepted={chart.data.count_accepted}
+            clicks={chart.data.count_unique_clicked_approx}
+            opens={chart.data.count_unique_confirmed_opened_approx}
+            targeted={chart.data.count_targeted}
           />
         </Panel>
-      </Page>
-    );
-  }
+      </If>
+    </Page>
+  );
 }
 
 const mapStateToProps = (state, props) => ({

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -3,29 +3,35 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
 import { Page, Panel } from '@sparkpost/matchbox';
+import { getChartData } from 'src/actions/engagementReport';
 import EngagementChart from './components/EngagementChart';
 
 export class EngagementPage extends Component {
+  componentDidMount() {
+    this.props.getChartData();
+  }
+
   render() {
-    // Sample data
-    const data = [
-      { name: 'Targeted', value: 1000 },
-      { name: 'Accepted', value: 500 },
-      { name: 'Unique Confirmed Opens', value: 100 },
-      { name: 'Unique Clicks', value: 1 }
-    ];
+    const { data } = this.props.chart;
 
     return (
       <Page title='Engagement Report'>
         <Panel sectioned>
-          <EngagementChart data={data} />
+          <EngagementChart
+            accepted={data.count_accepted}
+            clicks={data.count_unique_clicked_approx}
+            opens={data.count_unique_confirmed_opened_approx}
+            targeted={data.count_targeted}
+          />
         </Panel>
       </Page>
     );
   }
 }
 
-const mapStateToProps = (state, props) => ({});
-const mapDispatchToProps = {};
+const mapStateToProps = (state, props) => ({
+  chart: state.engagementReport.chart
+});
+const mapDispatchToProps = { getChartData };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EngagementPage));

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -11,7 +11,7 @@ import EngagementFilters from './components/EngagementFilters';
 export function EngagementPage({ chart, getChartData }) {
   return (
     <Page title='Engagement Report'>
-      <EngagementFilters disabled={chart.loading} onLoad={getChartData} />
+      <EngagementFilters shareDisabled={chart.loading} onLoad={getChartData} />
       {chart.loading && <PanelLoading />}
       {!chart.loading && (
         <Panel sectioned>

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+
+import { Page } from '@sparkpost/matchbox';
+
+export class EngagementPage extends Component {
+  render() {
+    return (
+      <Page title='Engagement Report' />
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => ({});
+const mapDispatchToProps = {};
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EngagementPage));

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -2,12 +2,25 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import { Page } from '@sparkpost/matchbox';
+import { Page, Panel } from '@sparkpost/matchbox';
+import EngagementChart from './components/EngagementChart';
 
 export class EngagementPage extends Component {
   render() {
+    // Sample data
+    const data = [
+      { name: 'Targeted', value: 1000 },
+      { name: 'Accepted', value: 500 },
+      { name: 'Unique Confirmed Opens', value: 100 },
+      { name: 'Unique Clicks', value: 1 }
+    ];
+
     return (
-      <Page title='Engagement Report' />
+      <Page title='Engagement Report'>
+        <Panel sectioned>
+          <EngagementChart data={data} />
+        </Panel>
+      </Page>
     );
   }
 }

--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -1,28 +1,29 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { Page } from '@sparkpost/matchbox';
 
-import { Page, Panel } from '@sparkpost/matchbox';
 import { getChartData } from 'src/actions/engagementReport';
-import PanelLoading from 'src/components/panelLoading/PanelLoading';
 import EngagementChart from './components/EngagementChart';
 import EngagementFilters from './components/EngagementFilters';
+import EngagementSummary from './components/EngagementSummary';
 
 export function EngagementPage({ chart, getChartData }) {
   return (
     <Page title='Engagement Report'>
       <EngagementFilters shareDisabled={chart.loading} onLoad={getChartData} />
-      {chart.loading && <PanelLoading />}
-      {!chart.loading && (
-        <Panel sectioned>
-          <EngagementChart
-            accepted={chart.data.count_accepted}
-            clicks={chart.data.count_unique_clicked_approx}
-            opens={chart.data.count_unique_confirmed_opened_approx}
-            targeted={chart.data.count_targeted}
-          />
-        </Panel>
-      )}
+      <EngagementSummary
+        clicks={chart.data.count_unique_clicked_approx}
+        loading={chart.loading}
+        targeted={chart.data.count_targeted}
+      />
+      <EngagementChart
+        accepted={chart.data.count_accepted}
+        clicks={chart.data.count_unique_clicked_approx}
+        loading={chart.loading}
+        opens={chart.data.count_unique_confirmed_opened_approx}
+        targeted={chart.data.count_targeted}
+      />
     </Page>
   );
 }

--- a/src/pages/reports/engagement/components/EngagementChart.js
+++ b/src/pages/reports/engagement/components/EngagementChart.js
@@ -1,0 +1,3 @@
+import asyncComponent from 'src/components/asyncComponent/asyncComponent';
+
+export default asyncComponent(() => import('./async/EngagementChart'));

--- a/src/pages/reports/engagement/components/EngagementChart.js
+++ b/src/pages/reports/engagement/components/EngagementChart.js
@@ -1,3 +1,4 @@
 import asyncComponent from 'src/components/asyncComponent/asyncComponent';
+import PanelLoading from 'src/components/panelLoading/PanelLoading';
 
-export default asyncComponent(() => import('./async/EngagementChart'));
+export default asyncComponent(() => import('./async/EngagementChart'), PanelLoading);

--- a/src/pages/reports/engagement/components/EngagementFilters.js
+++ b/src/pages/reports/engagement/components/EngagementFilters.js
@@ -9,7 +9,7 @@ import ShareModal from '../../components/ShareModal';
 
 export class EngagementFilters extends Component {
   static defaultProps = {
-    disabled: false
+    shareDisabled: false
   }
 
   state = {
@@ -47,7 +47,7 @@ export class EngagementFilters extends Component {
         <Filters
           refresh={this.onFilterChange}
           onShare={this.onToggleShareModal}
-          shareDisabled={this.props.disabled}
+          shareDisabled={this.props.shareDisabled}
         />
         <ShareModal
           open={this.state.open}

--- a/src/pages/reports/engagement/components/EngagementFilters.js
+++ b/src/pages/reports/engagement/components/EngagementFilters.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+
+import * as reportFilterActions from 'src/actions/reportFilters';
+import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
+import Filters from '../../components/Filters';
+import ShareModal from '../../components/ShareModal';
+
+export class EngagementFilters extends Component {
+  static defaultProps = {
+    disabled: false
+  }
+
+  state = {
+    open: false
+  }
+
+  componentDidMount() {
+    const { filters = [], options: range } = parseSearch(this.props.location.search);
+
+    // hydrate store with filters and range from query string before onLoad
+    this.props.addFilters(filters);
+    this.props.refreshRelativeRange(range);
+    this.props.onLoad();
+    this.props.refreshTypeaheadCache(); // this should wait until after onLoad
+  }
+
+  // This event handler is called on every date range and filter change, however only the next
+  // date range is provided.  The Filters component handles updating the store with the next
+  // filters.  Therefore, this handler only has to update the store with the next date range
+  // then call onLoad to update the chart/table data.
+  onFilterChange = (nextRange) => {
+    this.props.refreshRelativeRange(nextRange);
+    this.props.onLoad();
+  }
+
+  onToggleShareModal = () => {
+    this.setState({ open: !this.state.open });
+  }
+
+  render() {
+    const query = getFilterSearchOptions(this.props.filters);
+
+    return [
+      <Filters
+        refresh={this.onFilterChange}
+        onShare={this.onToggleShareModal}
+        shareDisabled={this.props.disabled}
+      />,
+      <ShareModal
+        open={this.state.open}
+        handleToggle={this.onToggleShareModal}
+        query={query}
+      />
+    ];
+  }
+}
+
+const mapStateToProps = (state, props) => ({
+  filters: state.reportFilters
+});
+const mapDispatchToProps = { ...reportFilterActions };
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EngagementFilters));

--- a/src/pages/reports/engagement/components/EngagementFilters.js
+++ b/src/pages/reports/engagement/components/EngagementFilters.js
@@ -42,18 +42,20 @@ export class EngagementFilters extends Component {
   render() {
     const query = getFilterSearchOptions(this.props.filters);
 
-    return [
-      <Filters
-        refresh={this.onFilterChange}
-        onShare={this.onToggleShareModal}
-        shareDisabled={this.props.disabled}
-      />,
-      <ShareModal
-        open={this.state.open}
-        handleToggle={this.onToggleShareModal}
-        query={query}
-      />
-    ];
+    return (
+      <div>
+        <Filters
+          refresh={this.onFilterChange}
+          onShare={this.onToggleShareModal}
+          shareDisabled={this.props.disabled}
+        />
+        <ShareModal
+          open={this.state.open}
+          handleToggle={this.onToggleShareModal}
+          query={query}
+        />
+      </div>
+    );
   }
 }
 

--- a/src/pages/reports/engagement/components/EngagementSummary.js
+++ b/src/pages/reports/engagement/components/EngagementSummary.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { PanelLoading } from 'src/components';
+import { formatFullNumber } from 'src/helpers/units';
+import MetricsSummary from '../../components/MetricsSummary';
+
+export function EngagementSummary({ clicks = 0, filters, loading = true, targeted = 0 }) {
+  if (loading) {
+    return <PanelLoading minHeight="115px" />;
+  }
+
+  // targeted should always be the largest number, so if it is zero all others should be zero
+  if (targeted === 0) {
+    return null;
+  }
+
+  return (
+    <MetricsSummary
+      {...filters}
+      rateTitle="Completion Rate"
+      rateValue={clicks / targeted * 100}
+    >
+      <strong>{formatFullNumber(clicks)}</strong> of your messages were clicked
+      of <strong>{formatFullNumber(targeted)}</strong> messages targeted
+    </MetricsSummary>
+  );
+}
+
+const mapStateToProps = ({ reportFilters: filters }) => ({ filters });
+export default connect(mapStateToProps)(EngagementSummary);

--- a/src/pages/reports/engagement/components/async/EngagementChart.js
+++ b/src/pages/reports/engagement/components/async/EngagementChart.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Bar, BarChart, CartesianGrid, LabelList, ResponsiveContainer, XAxis, YAxis } from 'recharts';
-import { formatNumber, formatPercent } from 'src/helpers/units';
+import { Panel } from '@sparkpost/matchbox';
 
+import { Empty, PanelLoading } from 'src/components';
+import { formatNumber } from 'src/helpers/units';
 import styles from './EngagementChart.module.scss';
 
 // Width must be less than 100% to get ResponsiveContainer to be responsive
@@ -13,31 +15,37 @@ const MARGINS = { bottom: 5, left: 5, right: 5, top: 25 };
 // Pad between tallest bar and top of the chart to provide room for the LabelList
 const TOP_PADDING = { top: 60 };
 
-export default function EngagementChart({ accepted = 0, clicks = 0, opens = 0, targeted = 0 }) {
+export default function EngagementChart({ accepted = 0, clicks = 0, loading = true, opens = 0, targeted = 0 }) {
   const data = [
     { label: 'Targeted', value: targeted },
     { label: 'Accepted', value: accepted },
     { label: 'Unique Confirmed Opens', value: opens },
     { label: 'Unique Clicks', value: clicks }
   ];
-  const completionPercentage = formatPercent(clicks / targeted * 100 || 0);
+
+  if (loading) {
+    return <PanelLoading />;
+  }
+
+  // targeted should always be the largest number, so if it is zero all others should be zero
+  if (targeted === 0) {
+    return <Empty message="No engagement to report" />;
+  }
 
   return (
-    <div className={styles.EngagementChart}>
-      <div className={styles.EngagementChartCompletionRate}>
-        <span>{completionPercentage}</span>
-        <label>Completion Rate</label>
+    <Panel sectioned>
+      <div className={styles.EngagementChart}>
+        <ResponsiveContainer {...DIMENSIONS}>
+          <BarChart barCategoryGap="35%" data={data} margin={MARGINS}>
+            <CartesianGrid strokeDasharray="4 1" vertical={false} />
+            <XAxis dataKey="label" tickLine={false} />
+            <YAxis padding={TOP_PADDING} tickLine={false} tickFormatter={formatNumber} />
+            <Bar dataKey="value" fill="#37aadc" isAnimationActive={false}>
+              <LabelList fill="#55555a" formatter={formatNumber} position="top" />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
       </div>
-      <ResponsiveContainer {...DIMENSIONS}>
-        <BarChart barCategoryGap="35%" data={data} margin={MARGINS}>
-          <CartesianGrid strokeDasharray="4 1" vertical={false} />
-          <XAxis dataKey="label" tickLine={false} />
-          <YAxis padding={TOP_PADDING} tickLine={false} tickFormatter={formatNumber} />
-          <Bar dataKey="value" fill="#37aadc" isAnimationActive={false}>
-            <LabelList fill="#55555a" formatter={formatNumber} position="top" />
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
-    </div>
+    </Panel>
   );
 }

--- a/src/pages/reports/engagement/components/async/EngagementChart.js
+++ b/src/pages/reports/engagement/components/async/EngagementChart.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Bar, BarChart, CartesianGrid, LabelList, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+
+import styles from './EngagementChart.module.scss';
+
+export default function EngagementChart({ data = []}) {
+  // Increased top margin to vertically center the chart
+  const margins = { bottom: 5, left: 5, right: 5, top: 25 };
+  // Pad between tallest bar and top of the chart to provide room for the LabelList
+  const topPadding = { top: 60 };
+
+  return (
+    <ResponsiveContainer className={styles.EngagementChart} height={350} width="100%">
+      <BarChart barCategoryGap="35%" data={data} margin={margins}>
+        <CartesianGrid strokeDasharray="4 1" vertical={false} />
+        <XAxis dataKey="name" tickLine={false} />
+        <YAxis padding={topPadding} tickLine={false} />
+        <Bar dataKey="value" fill="#37aadc" isAnimationAction={false}>
+          <LabelList fill="#55555a" position="top" />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/pages/reports/engagement/components/async/EngagementChart.js
+++ b/src/pages/reports/engagement/components/async/EngagementChart.js
@@ -1,24 +1,43 @@
 import React from 'react';
 import { Bar, BarChart, CartesianGrid, LabelList, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+import { formatNumber, formatPercent } from 'src/helpers/units';
 
 import styles from './EngagementChart.module.scss';
 
-export default function EngagementChart({ data = []}) {
-  // Increased top margin to vertically center the chart
-  const margins = { bottom: 5, left: 5, right: 5, top: 25 };
-  // Pad between tallest bar and top of the chart to provide room for the LabelList
-  const topPadding = { top: 60 };
+// Width must be less than 100% to get ResponsiveContainer to be responsive
+const DIMENSIONS = { height: 350, width: '99%' };
+
+// Increased top margin to vertically center the chart
+const MARGINS = { bottom: 5, left: 5, right: 5, top: 25 };
+
+// Pad between tallest bar and top of the chart to provide room for the LabelList
+const TOP_PADDING = { top: 60 };
+
+export default function EngagementChart({ accepted = 0, clicks = 0, opens = 0, targeted = 0 }) {
+  const data = [
+    { label: 'Targeted', value: targeted },
+    { label: 'Accepted', value: accepted },
+    { label: 'Unique Confirmed Opens', value: opens },
+    { label: 'Unique Clicks', value: clicks }
+  ];
+  const completionPercentage = formatPercent(clicks / targeted * 100 || 0);
 
   return (
-    <ResponsiveContainer className={styles.EngagementChart} height={350} width="100%">
-      <BarChart barCategoryGap="35%" data={data} margin={margins}>
-        <CartesianGrid strokeDasharray="4 1" vertical={false} />
-        <XAxis dataKey="name" tickLine={false} />
-        <YAxis padding={topPadding} tickLine={false} />
-        <Bar dataKey="value" fill="#37aadc" isAnimationAction={false}>
-          <LabelList fill="#55555a" position="top" />
-        </Bar>
-      </BarChart>
-    </ResponsiveContainer>
+    <div className={styles.EngagementChart}>
+      <div className={styles.EngagementChartCompletionRate}>
+        <span>{completionPercentage}</span>
+        <label>Completion Rate</label>
+      </div>
+      <ResponsiveContainer {...DIMENSIONS}>
+        <BarChart barCategoryGap="35%" data={data} margin={MARGINS}>
+          <CartesianGrid strokeDasharray="4 1" vertical={false} />
+          <XAxis dataKey="label" tickLine={false} />
+          <YAxis padding={TOP_PADDING} tickLine={false} tickFormatter={formatNumber} />
+          <Bar dataKey="value" fill="#37aadc" isAnimationActive={false}>
+            <LabelList fill="#55555a" formatter={formatNumber} position="top" />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
   );
 }

--- a/src/pages/reports/engagement/components/async/EngagementChart.module.scss
+++ b/src/pages/reports/engagement/components/async/EngagementChart.module.scss
@@ -1,9 +1,5 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-$font-weight: 500;
-$label-color: color(gray, 5);
-$label-font-size: 13;
-
 .EngagementChart {
   position: relative; // for the completion rate
 
@@ -14,31 +10,8 @@ $label-font-size: 13;
 
   // similar to match summary line  chart
   :global .recharts-text.recharts-cartesian-axis-tick-value {
-    fill: $label-color;
-    font-size: rem($label-font-size);
-    font-weight: $font-weight;
-  }
-}
-
-.EngagementChartCompletionRate {
-  display: flex;
-  align-items: flex-start; // vertically aligns items to top
-  position: absolute; // to sit on the chart
-  right: 15px;
-  top: 15px;
-
-  label {  // similar to ticks
-    color: $label-color;
-    font-size: rem($label-font-size);
-    font-weight: $font-weight;
-    line-height: rem($label-font-size + 5);  // added space between lines
-    margin-left: spacing(small);
-    width: rem(75);;  // forces to wrap after first word
-  }
-
-  span {
-    font-size: rem($label-font-size * 3);
-    font-weight: $font-weight;
-    line-height: rem($label-font-size * 3);
+    fill: color(gray, 5);
+    font-size: rem(13);
+    font-weight: 500;
   }
 }

--- a/src/pages/reports/engagement/components/async/EngagementChart.module.scss
+++ b/src/pages/reports/engagement/components/async/EngagementChart.module.scss
@@ -1,6 +1,44 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+$font-weight: 500;
+$label-color: color(gray, 5);
+$label-font-size: 13;
+
 .EngagementChart {
-  // Hide the top grid line
+  position: relative; // for the completion rate
+
+  // hide the top grid line
   :global .recharts-wrapper .recharts-cartesian-grid-horizontal line:last-child {
     stroke-opacity: 0;
+  }
+
+  // similar to match summary line  chart
+  :global .recharts-text.recharts-cartesian-axis-tick-value {
+    fill: $label-color;
+    font-size: rem($label-font-size);
+    font-weight: $font-weight;
+  }
+}
+
+.EngagementChartCompletionRate {
+  display: flex;
+  align-items: flex-start; // vertically aligns items to top
+  position: absolute; // to sit on the chart
+  right: 15px;
+  top: 15px;
+
+  label {  // similar to ticks
+    color: $label-color;
+    font-size: rem($label-font-size);
+    font-weight: $font-weight;
+    line-height: rem($label-font-size + 5);  // added space between lines
+    margin-left: spacing(small);
+    width: rem(75);;  // forces to wrap after first word
+  }
+
+  span {
+    font-size: rem($label-font-size * 3);
+    font-weight: $font-weight;
+    line-height: rem($label-font-size * 3);
   }
 }

--- a/src/pages/reports/engagement/components/async/EngagementChart.module.scss
+++ b/src/pages/reports/engagement/components/async/EngagementChart.module.scss
@@ -1,0 +1,6 @@
+.EngagementChart {
+  // Hide the top grid line
+  :global .recharts-wrapper .recharts-cartesian-grid-horizontal line:last-child {
+    stroke-opacity: 0;
+  }
+}

--- a/src/pages/reports/engagement/components/async/tests/EngagementChart.test.js
+++ b/src/pages/reports/engagement/components/async/tests/EngagementChart.test.js
@@ -2,7 +2,19 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import EngagementChart from '../EngagementChart';
 
-it('renders engagement chart', () => {
+it('renders engagement chart with defaults', () => {
   const wrapper = shallow(<EngagementChart />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('renders engagement chart with metrics', () => {
+  const props = {
+    accepted: 40000,
+    clicks: 2525,
+    opens: 5000,
+    targeted: 50000
+  };
+  const wrapper = shallow(<EngagementChart {...props} />);
+
   expect(wrapper).toMatchSnapshot();
 });

--- a/src/pages/reports/engagement/components/async/tests/EngagementChart.test.js
+++ b/src/pages/reports/engagement/components/async/tests/EngagementChart.test.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import cases from 'jest-in-case';
 import EngagementChart from '../EngagementChart';
 
-it('renders engagement chart with defaults', () => {
-  const wrapper = shallow(<EngagementChart />);
+cases('EngagementChart', (props) => {
+  const wrapper = shallow(<EngagementChart {...props} />);
   expect(wrapper).toMatchSnapshot();
-});
-
-it('renders engagement chart with metrics', () => {
-  const props = {
+}, {
+  'renders loading by default': {},
+  'renders empty panel': { loading: false },
+  'renders engagement chart': {
     accepted: 40000,
     clicks: 2525,
+    loading: false,
     opens: 5000,
     targeted: 50000
-  };
-  const wrapper = shallow(<EngagementChart {...props} />);
-
-  expect(wrapper).toMatchSnapshot();
+  }
 });

--- a/src/pages/reports/engagement/components/async/tests/EngagementChart.test.js
+++ b/src/pages/reports/engagement/components/async/tests/EngagementChart.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import EngagementChart from '../EngagementChart';
+
+it('renders engagement chart', () => {
+  const wrapper = shallow(<EngagementChart />);
+  expect(wrapper).toMatchSnapshot();
+});

--- a/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
+++ b/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
@@ -1,114 +1,287 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders engagement chart 1`] = `
-<ResponsiveContainer
-  debounce={0}
-  height={350}
-  width="100%"
->
-  <BarChart
-    barCategoryGap="35%"
-    barGap={4}
-    data={Array []}
-    layout="horizontal"
-    margin={
-      Object {
-        "bottom": 5,
-        "left": 5,
-        "right": 5,
-        "top": 25,
-      }
-    }
-    reverseStackOrder={false}
-    stackOffset="none"
+exports[`renders engagement chart with defaults 1`] = `
+<div>
+  <div>
+    <span>
+      0%
+    </span>
+    <label>
+      Completion Rate
+    </label>
+  </div>
+  <ResponsiveContainer
+    debounce={0}
+    height={350}
+    width="99%"
   >
-    <CartesianGrid
-      fill="none"
-      horizontal={true}
-      horizontalPoints={Array []}
-      stroke="#ccc"
-      strokeDasharray="4 1"
-      vertical={false}
-      verticalPoints={Array []}
-    />
-    <XAxis
-      allowDataOverflow={false}
-      allowDecimals={true}
-      dataKey="name"
-      domain={
+    <BarChart
+      barCategoryGap="35%"
+      barGap={4}
+      data={
         Array [
-          0,
-          "auto",
+          Object {
+            "label": "Targeted",
+            "value": 0,
+          },
+          Object {
+            "label": "Accepted",
+            "value": 0,
+          },
+          Object {
+            "label": "Unique Confirmed Opens",
+            "value": 0,
+          },
+          Object {
+            "label": "Unique Clicks",
+            "value": 0,
+          },
         ]
       }
-      height={30}
-      hide={false}
-      mirror={false}
-      orientation="bottom"
-      padding={
+      layout="horizontal"
+      margin={
         Object {
-          "left": 0,
-          "right": 0,
+          "bottom": 5,
+          "left": 5,
+          "right": 5,
+          "top": 25,
         }
       }
-      reversed={false}
-      scale="auto"
-      tickCount={5}
-      tickLine={false}
-      type="category"
-      width={0}
-      xAxisId={0}
-    />
-    <YAxis
-      allowDataOverflow={false}
-      allowDecimals={true}
-      domain={
-        Array [
-          0,
-          "auto",
-        ]
-      }
-      height={0}
-      hide={false}
-      mirror={false}
-      orientation="left"
-      padding={
-        Object {
-          "top": 60,
-        }
-      }
-      reversed={false}
-      scale="auto"
-      tickCount={5}
-      tickLine={false}
-      type="number"
-      width={60}
-      yAxisId={0}
-    />
-    <Bar
-      animationBegin={0}
-      animationDuration={400}
-      animationEasing="ease"
-      data={Array []}
-      dataKey="value"
-      fill="#37aadc"
-      hide={false}
-      isAnimationAction={false}
-      isAnimationActive={true}
-      layout="vertical"
-      legendType="rect"
-      minPointSize={0}
-      onAnimationEnd={[Function]}
-      onAnimationStart={[Function]}
-      xAxisId={0}
-      yAxisId={0}
+      reverseStackOrder={false}
+      stackOffset="none"
     >
-      <LabelList
-        fill="#55555a"
-        position="top"
-        valueAccessor={[Function]}
+      <CartesianGrid
+        fill="none"
+        horizontal={true}
+        horizontalPoints={Array []}
+        stroke="#ccc"
+        strokeDasharray="4 1"
+        vertical={false}
+        verticalPoints={Array []}
       />
-    </Bar>
-  </BarChart>
-</ResponsiveContainer>
+      <XAxis
+        allowDataOverflow={false}
+        allowDecimals={true}
+        dataKey="label"
+        domain={
+          Array [
+            0,
+            "auto",
+          ]
+        }
+        height={30}
+        hide={false}
+        mirror={false}
+        orientation="bottom"
+        padding={
+          Object {
+            "left": 0,
+            "right": 0,
+          }
+        }
+        reversed={false}
+        scale="auto"
+        tickCount={5}
+        tickLine={false}
+        type="category"
+        width={0}
+        xAxisId={0}
+      />
+      <YAxis
+        allowDataOverflow={false}
+        allowDecimals={true}
+        domain={
+          Array [
+            0,
+            "auto",
+          ]
+        }
+        height={0}
+        hide={false}
+        mirror={false}
+        orientation="left"
+        padding={
+          Object {
+            "top": 60,
+          }
+        }
+        reversed={false}
+        scale="auto"
+        tickCount={5}
+        tickFormatter={[Function]}
+        tickLine={false}
+        type="number"
+        width={60}
+        yAxisId={0}
+      />
+      <Bar
+        animationBegin={0}
+        animationDuration={400}
+        animationEasing="ease"
+        data={Array []}
+        dataKey="value"
+        fill="#37aadc"
+        hide={false}
+        isAnimationActive={false}
+        layout="vertical"
+        legendType="rect"
+        minPointSize={0}
+        onAnimationEnd={[Function]}
+        onAnimationStart={[Function]}
+        xAxisId={0}
+        yAxisId={0}
+      >
+        <LabelList
+          fill="#55555a"
+          formatter={[Function]}
+          position="top"
+          valueAccessor={[Function]}
+        />
+      </Bar>
+    </BarChart>
+  </ResponsiveContainer>
+</div>
+`;
+
+exports[`renders engagement chart with metrics 1`] = `
+<div>
+  <div>
+    <span>
+      5.05%
+    </span>
+    <label>
+      Completion Rate
+    </label>
+  </div>
+  <ResponsiveContainer
+    debounce={0}
+    height={350}
+    width="99%"
+  >
+    <BarChart
+      barCategoryGap="35%"
+      barGap={4}
+      data={
+        Array [
+          Object {
+            "label": "Targeted",
+            "value": 50000,
+          },
+          Object {
+            "label": "Accepted",
+            "value": 40000,
+          },
+          Object {
+            "label": "Unique Confirmed Opens",
+            "value": 5000,
+          },
+          Object {
+            "label": "Unique Clicks",
+            "value": 2525,
+          },
+        ]
+      }
+      layout="horizontal"
+      margin={
+        Object {
+          "bottom": 5,
+          "left": 5,
+          "right": 5,
+          "top": 25,
+        }
+      }
+      reverseStackOrder={false}
+      stackOffset="none"
+    >
+      <CartesianGrid
+        fill="none"
+        horizontal={true}
+        horizontalPoints={Array []}
+        stroke="#ccc"
+        strokeDasharray="4 1"
+        vertical={false}
+        verticalPoints={Array []}
+      />
+      <XAxis
+        allowDataOverflow={false}
+        allowDecimals={true}
+        dataKey="label"
+        domain={
+          Array [
+            0,
+            "auto",
+          ]
+        }
+        height={30}
+        hide={false}
+        mirror={false}
+        orientation="bottom"
+        padding={
+          Object {
+            "left": 0,
+            "right": 0,
+          }
+        }
+        reversed={false}
+        scale="auto"
+        tickCount={5}
+        tickLine={false}
+        type="category"
+        width={0}
+        xAxisId={0}
+      />
+      <YAxis
+        allowDataOverflow={false}
+        allowDecimals={true}
+        domain={
+          Array [
+            0,
+            "auto",
+          ]
+        }
+        height={0}
+        hide={false}
+        mirror={false}
+        orientation="left"
+        padding={
+          Object {
+            "top": 60,
+          }
+        }
+        reversed={false}
+        scale="auto"
+        tickCount={5}
+        tickFormatter={[Function]}
+        tickLine={false}
+        type="number"
+        width={60}
+        yAxisId={0}
+      />
+      <Bar
+        animationBegin={0}
+        animationDuration={400}
+        animationEasing="ease"
+        data={Array []}
+        dataKey="value"
+        fill="#37aadc"
+        hide={false}
+        isAnimationActive={false}
+        layout="vertical"
+        legendType="rect"
+        minPointSize={0}
+        onAnimationEnd={[Function]}
+        onAnimationStart={[Function]}
+        xAxisId={0}
+        yAxisId={0}
+      >
+        <LabelList
+          fill="#55555a"
+          formatter={[Function]}
+          position="top"
+          valueAccessor={[Function]}
+        />
+      </Bar>
+    </BarChart>
+  </ResponsiveContainer>
+</div>
 `;

--- a/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
+++ b/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders engagement chart 1`] = `
+<ResponsiveContainer
+  debounce={0}
+  height={350}
+  width="100%"
+>
+  <BarChart
+    barCategoryGap="35%"
+    barGap={4}
+    data={Array []}
+    layout="horizontal"
+    margin={
+      Object {
+        "bottom": 5,
+        "left": 5,
+        "right": 5,
+        "top": 25,
+      }
+    }
+    reverseStackOrder={false}
+    stackOffset="none"
+  >
+    <CartesianGrid
+      fill="none"
+      horizontal={true}
+      horizontalPoints={Array []}
+      stroke="#ccc"
+      strokeDasharray="4 1"
+      vertical={false}
+      verticalPoints={Array []}
+    />
+    <XAxis
+      allowDataOverflow={false}
+      allowDecimals={true}
+      dataKey="name"
+      domain={
+        Array [
+          0,
+          "auto",
+        ]
+      }
+      height={30}
+      hide={false}
+      mirror={false}
+      orientation="bottom"
+      padding={
+        Object {
+          "left": 0,
+          "right": 0,
+        }
+      }
+      reversed={false}
+      scale="auto"
+      tickCount={5}
+      tickLine={false}
+      type="category"
+      width={0}
+      xAxisId={0}
+    />
+    <YAxis
+      allowDataOverflow={false}
+      allowDecimals={true}
+      domain={
+        Array [
+          0,
+          "auto",
+        ]
+      }
+      height={0}
+      hide={false}
+      mirror={false}
+      orientation="left"
+      padding={
+        Object {
+          "top": 60,
+        }
+      }
+      reversed={false}
+      scale="auto"
+      tickCount={5}
+      tickLine={false}
+      type="number"
+      width={60}
+      yAxisId={0}
+    />
+    <Bar
+      animationBegin={0}
+      animationDuration={400}
+      animationEasing="ease"
+      data={Array []}
+      dataKey="value"
+      fill="#37aadc"
+      hide={false}
+      isAnimationAction={false}
+      isAnimationActive={true}
+      layout="vertical"
+      legendType="rect"
+      minPointSize={0}
+      onAnimationEnd={[Function]}
+      onAnimationStart={[Function]}
+      xAxisId={0}
+      yAxisId={0}
+    >
+      <LabelList
+        fill="#55555a"
+        position="top"
+        valueAccessor={[Function]}
+      />
+    </Bar>
+  </BarChart>
+</ResponsiveContainer>
+`;

--- a/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
+++ b/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
@@ -1,287 +1,152 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders engagement chart with defaults 1`] = `
-<div>
-  <div>
-    <span>
-      0%
-    </span>
-    <label>
-      Completion Rate
-    </label>
-  </div>
-  <ResponsiveContainer
-    debounce={0}
-    height={350}
-    width="99%"
-  >
-    <BarChart
-      barCategoryGap="35%"
-      barGap={4}
-      data={
-        Array [
-          Object {
-            "label": "Targeted",
-            "value": 0,
-          },
-          Object {
-            "label": "Accepted",
-            "value": 0,
-          },
-          Object {
-            "label": "Unique Confirmed Opens",
-            "value": 0,
-          },
-          Object {
-            "label": "Unique Clicks",
-            "value": 0,
-          },
-        ]
-      }
-      layout="horizontal"
-      margin={
-        Object {
-          "bottom": 5,
-          "left": 5,
-          "right": 5,
-          "top": 25,
-        }
-      }
-      reverseStackOrder={false}
-      stackOffset="none"
-    >
-      <CartesianGrid
-        fill="none"
-        horizontal={true}
-        horizontalPoints={Array []}
-        stroke="#ccc"
-        strokeDasharray="4 1"
-        vertical={false}
-        verticalPoints={Array []}
-      />
-      <XAxis
-        allowDataOverflow={false}
-        allowDecimals={true}
-        dataKey="label"
-        domain={
-          Array [
-            0,
-            "auto",
-          ]
-        }
-        height={30}
-        hide={false}
-        mirror={false}
-        orientation="bottom"
-        padding={
-          Object {
-            "left": 0,
-            "right": 0,
-          }
-        }
-        reversed={false}
-        scale="auto"
-        tickCount={5}
-        tickLine={false}
-        type="category"
-        width={0}
-        xAxisId={0}
-      />
-      <YAxis
-        allowDataOverflow={false}
-        allowDecimals={true}
-        domain={
-          Array [
-            0,
-            "auto",
-          ]
-        }
-        height={0}
-        hide={false}
-        mirror={false}
-        orientation="left"
-        padding={
-          Object {
-            "top": 60,
-          }
-        }
-        reversed={false}
-        scale="auto"
-        tickCount={5}
-        tickFormatter={[Function]}
-        tickLine={false}
-        type="number"
-        width={60}
-        yAxisId={0}
-      />
-      <Bar
-        animationBegin={0}
-        animationDuration={400}
-        animationEasing="ease"
-        data={Array []}
-        dataKey="value"
-        fill="#37aadc"
-        hide={false}
-        isAnimationActive={false}
-        layout="vertical"
-        legendType="rect"
-        minPointSize={0}
-        onAnimationEnd={[Function]}
-        onAnimationStart={[Function]}
-        xAxisId={0}
-        yAxisId={0}
-      >
-        <LabelList
-          fill="#55555a"
-          formatter={[Function]}
-          position="top"
-          valueAccessor={[Function]}
-        />
-      </Bar>
-    </BarChart>
-  </ResponsiveContainer>
-</div>
+exports[`EngagementChart renders empty panel 1`] = `
+<Empty
+  message="No engagement to report"
+/>
 `;
 
-exports[`renders engagement chart with metrics 1`] = `
-<div>
+exports[`EngagementChart renders engagement chart 1`] = `
+<Panel
+  sectioned={true}
+>
   <div>
-    <span>
-      5.05%
-    </span>
-    <label>
-      Completion Rate
-    </label>
-  </div>
-  <ResponsiveContainer
-    debounce={0}
-    height={350}
-    width="99%"
-  >
-    <BarChart
-      barCategoryGap="35%"
-      barGap={4}
-      data={
-        Array [
-          Object {
-            "label": "Targeted",
-            "value": 50000,
-          },
-          Object {
-            "label": "Accepted",
-            "value": 40000,
-          },
-          Object {
-            "label": "Unique Confirmed Opens",
-            "value": 5000,
-          },
-          Object {
-            "label": "Unique Clicks",
-            "value": 2525,
-          },
-        ]
-      }
-      layout="horizontal"
-      margin={
-        Object {
-          "bottom": 5,
-          "left": 5,
-          "right": 5,
-          "top": 25,
-        }
-      }
-      reverseStackOrder={false}
-      stackOffset="none"
+    <ResponsiveContainer
+      debounce={0}
+      height={350}
+      width="99%"
     >
-      <CartesianGrid
-        fill="none"
-        horizontal={true}
-        horizontalPoints={Array []}
-        stroke="#ccc"
-        strokeDasharray="4 1"
-        vertical={false}
-        verticalPoints={Array []}
-      />
-      <XAxis
-        allowDataOverflow={false}
-        allowDecimals={true}
-        dataKey="label"
-        domain={
+      <BarChart
+        barCategoryGap="35%"
+        barGap={4}
+        data={
           Array [
-            0,
-            "auto",
+            Object {
+              "label": "Targeted",
+              "value": 50000,
+            },
+            Object {
+              "label": "Accepted",
+              "value": 40000,
+            },
+            Object {
+              "label": "Unique Confirmed Opens",
+              "value": 5000,
+            },
+            Object {
+              "label": "Unique Clicks",
+              "value": 2525,
+            },
           ]
         }
-        height={30}
-        hide={false}
-        mirror={false}
-        orientation="bottom"
-        padding={
+        layout="horizontal"
+        margin={
           Object {
-            "left": 0,
-            "right": 0,
+            "bottom": 5,
+            "left": 5,
+            "right": 5,
+            "top": 25,
           }
         }
-        reversed={false}
-        scale="auto"
-        tickCount={5}
-        tickLine={false}
-        type="category"
-        width={0}
-        xAxisId={0}
-      />
-      <YAxis
-        allowDataOverflow={false}
-        allowDecimals={true}
-        domain={
-          Array [
-            0,
-            "auto",
-          ]
-        }
-        height={0}
-        hide={false}
-        mirror={false}
-        orientation="left"
-        padding={
-          Object {
-            "top": 60,
-          }
-        }
-        reversed={false}
-        scale="auto"
-        tickCount={5}
-        tickFormatter={[Function]}
-        tickLine={false}
-        type="number"
-        width={60}
-        yAxisId={0}
-      />
-      <Bar
-        animationBegin={0}
-        animationDuration={400}
-        animationEasing="ease"
-        data={Array []}
-        dataKey="value"
-        fill="#37aadc"
-        hide={false}
-        isAnimationActive={false}
-        layout="vertical"
-        legendType="rect"
-        minPointSize={0}
-        onAnimationEnd={[Function]}
-        onAnimationStart={[Function]}
-        xAxisId={0}
-        yAxisId={0}
+        reverseStackOrder={false}
+        stackOffset="none"
       >
-        <LabelList
-          fill="#55555a"
-          formatter={[Function]}
-          position="top"
-          valueAccessor={[Function]}
+        <CartesianGrid
+          fill="none"
+          horizontal={true}
+          horizontalPoints={Array []}
+          stroke="#ccc"
+          strokeDasharray="4 1"
+          vertical={false}
+          verticalPoints={Array []}
         />
-      </Bar>
-    </BarChart>
-  </ResponsiveContainer>
-</div>
+        <XAxis
+          allowDataOverflow={false}
+          allowDecimals={true}
+          dataKey="label"
+          domain={
+            Array [
+              0,
+              "auto",
+            ]
+          }
+          height={30}
+          hide={false}
+          mirror={false}
+          orientation="bottom"
+          padding={
+            Object {
+              "left": 0,
+              "right": 0,
+            }
+          }
+          reversed={false}
+          scale="auto"
+          tickCount={5}
+          tickLine={false}
+          type="category"
+          width={0}
+          xAxisId={0}
+        />
+        <YAxis
+          allowDataOverflow={false}
+          allowDecimals={true}
+          domain={
+            Array [
+              0,
+              "auto",
+            ]
+          }
+          height={0}
+          hide={false}
+          mirror={false}
+          orientation="left"
+          padding={
+            Object {
+              "top": 60,
+            }
+          }
+          reversed={false}
+          scale="auto"
+          tickCount={5}
+          tickFormatter={[Function]}
+          tickLine={false}
+          type="number"
+          width={60}
+          yAxisId={0}
+        />
+        <Bar
+          animationBegin={0}
+          animationDuration={400}
+          animationEasing="ease"
+          data={Array []}
+          dataKey="value"
+          fill="#37aadc"
+          hide={false}
+          isAnimationActive={false}
+          layout="vertical"
+          legendType="rect"
+          minPointSize={0}
+          onAnimationEnd={[Function]}
+          onAnimationStart={[Function]}
+          xAxisId={0}
+          yAxisId={0}
+        >
+          <LabelList
+            fill="#55555a"
+            formatter={[Function]}
+            position="top"
+            valueAccessor={[Function]}
+          />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  </div>
+</Panel>
+`;
+
+exports[`EngagementChart renders loading by default 1`] = `
+<PanelLoading
+  minHeight="400px"
+/>
 `;

--- a/src/pages/reports/engagement/components/tests/EngagementFilters.test.js
+++ b/src/pages/reports/engagement/components/tests/EngagementFilters.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { EngagementFilters } from '../EngagementFilters';
+import time from 'src/__testHelpers__/time';
+
+const defaultProps = {
+  addFilters: jest.fn(),
+  filters: {
+    activeList: [],
+    from: time({ day: 1 }),
+    relativeRange: 'day',
+    to: time({ day: 2 })
+  },
+  location: { search: '' },
+  onLoad: jest.fn(),
+  refreshRelativeRange: jest.fn(),
+  refreshTypeaheadCache: jest.fn()
+};
+
+afterEach(() => jest.clearAllMocks()); // for defaultProps
+
+it('renders filters, hydrates with filters from query string, and requests data', () => {
+  const props = {
+    ...defaultProps,
+    location: { search: '?range=custom&from=2018-01-15T00:00:00Z&to=2018-01-16T00:00:00Z' }
+  };
+  const wrapper = shallow(<EngagementFilters {...props} />);
+
+  expect(props.addFilters).toHaveBeenCalledWith([]);
+  expect(props.refreshRelativeRange).toHaveBeenCalledWith({
+    from: time({ year: 2018, month: 1, day: 15 }),
+    metrics: [],
+    relativeRange: 'custom',
+    to: time({ year: 2018, month: 1, day: 16 })
+  });
+  expect(props.onLoad).toHaveBeenCalled();
+  expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('updates range and requests new data when filters change', () => {
+  const props = { ...defaultProps };
+  const nextRange = {
+    from: time({ year: 2018, month: 1, day: 15 }),
+    relativeRange: 'custom',
+    to: time({ year: 2018, month: 1, day: 16 })
+  };
+  const wrapper = shallow(<EngagementFilters {...props} />);
+  wrapper.instance().onFilterChange(nextRange);
+
+  expect(props.refreshRelativeRange).toHaveBeenCalledWith(nextRange);
+  expect(props.onLoad).toHaveBeenCalledTimes(2); // on mount and event
+});
+
+it('displays share modal', () => {
+  const props = { ...defaultProps };
+  const wrapper = shallow(<EngagementFilters {...props} />);
+
+  wrapper.instance().onToggleShareModal();
+  wrapper.update();
+
+  expect(wrapper).toMatchSnapshot();
+});

--- a/src/pages/reports/engagement/components/tests/EngagementSummary.test.js
+++ b/src/pages/reports/engagement/components/tests/EngagementSummary.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import cases from 'jest-in-case';
+
+import { EngagementSummary } from '../EngagementSummary';
+
+cases('EngagementSummary', (props) => {
+  const wrapper = shallow(<EngagementSummary {...props} />);
+  expect(wrapper).toMatchSnapshot();
+}, {
+  'renders loading panel by default': {},
+  'returns null': { loading: false },
+  'redners metric summary': {
+    clicks: 123,
+    loading: false,
+    targeted: 123123
+  }
+});

--- a/src/pages/reports/engagement/components/tests/__snapshots__/EngagementFilters.test.js.snap
+++ b/src/pages/reports/engagement/components/tests/__snapshots__/EngagementFilters.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`displays share modal 1`] = `
+Array [
+  <Connect(Filters)
+    onShare={[Function]}
+    refresh={[Function]}
+    shareDisabled={false}
+  />,
+  <ShareModal
+    handleToggle={[Function]}
+    open={true}
+    query={
+      Object {
+        "filters": Array [],
+        "from": "1970-01-01T00:00:00Z",
+        "range": "day",
+        "to": "1970-01-02T00:00:00Z",
+      }
+    }
+  />,
+]
+`;
+
+exports[`renders filters, hydrates with filters from query string, and requests data 1`] = `
+Array [
+  <Connect(Filters)
+    onShare={[Function]}
+    refresh={[Function]}
+    shareDisabled={false}
+  />,
+  <ShareModal
+    handleToggle={[Function]}
+    open={false}
+    query={
+      Object {
+        "filters": Array [],
+        "from": "1970-01-01T00:00:00Z",
+        "range": "day",
+        "to": "1970-01-02T00:00:00Z",
+      }
+    }
+  />,
+]
+`;

--- a/src/pages/reports/engagement/components/tests/__snapshots__/EngagementFilters.test.js.snap
+++ b/src/pages/reports/engagement/components/tests/__snapshots__/EngagementFilters.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`displays share modal 1`] = `
-Array [
+<div>
   <Connect(Filters)
     onShare={[Function]}
     refresh={[Function]}
     shareDisabled={false}
-  />,
+  />
   <ShareModal
     handleToggle={[Function]}
     open={true}
@@ -18,17 +18,17 @@ Array [
         "to": "1970-01-02T00:00:00Z",
       }
     }
-  />,
-]
+  />
+</div>
 `;
 
 exports[`renders filters, hydrates with filters from query string, and requests data 1`] = `
-Array [
+<div>
   <Connect(Filters)
     onShare={[Function]}
     refresh={[Function]}
     shareDisabled={false}
-  />,
+  />
   <ShareModal
     handleToggle={[Function]}
     open={false}
@@ -40,6 +40,6 @@ Array [
         "to": "1970-01-02T00:00:00Z",
       }
     }
-  />,
-]
+  />
+</div>
 `;

--- a/src/pages/reports/engagement/components/tests/__snapshots__/EngagementSummary.test.js.snap
+++ b/src/pages/reports/engagement/components/tests/__snapshots__/EngagementSummary.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EngagementSummary redners metric summary 1`] = `
+<MetricsSummary
+  rateTitle="Completion Rate"
+  rateValue={0.0999000999000999}
+>
+  <strong>
+    123
+  </strong>
+   of your messages were clicked of 
+  <strong>
+    123,123
+  </strong>
+   messages targeted
+</MetricsSummary>
+`;
+
+exports[`EngagementSummary renders loading panel by default 1`] = `
+<PanelLoading
+  minHeight="115px"
+/>
+`;
+
+exports[`EngagementSummary returns null 1`] = `""`;

--- a/src/pages/reports/engagement/tests/EngagementPage.test.js
+++ b/src/pages/reports/engagement/tests/EngagementPage.test.js
@@ -19,3 +19,16 @@ it('renders engagement report page', () => {
 
   expect(wrapper).toMatchSnapshot();
 });
+
+it('displays global alert when request to fetch data fails', async() => {
+  const props = {
+    chart: { data: {}},
+    getChartData: jest.fn(() => Promise.reject()),
+    showAlert: jest.fn()
+  };
+
+  const wrapper = shallow(<EngagementPage {...props} />);
+  await wrapper.instance().onLoad();
+
+  expect(props.showAlert).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+});

--- a/src/pages/reports/engagement/tests/EngagementPage.test.js
+++ b/src/pages/reports/engagement/tests/EngagementPage.test.js
@@ -3,6 +3,31 @@ import { shallow } from 'enzyme';
 import { EngagementPage } from '../EngagementPage';
 
 it('renders engagement report page', () => {
-  const wrapper = shallow(<EngagementPage />);
+  const props = {
+    chart: {
+      data: {}
+    },
+    getChartData: jest.fn()
+  };
+  const wrapper = shallow(<EngagementPage {...props} />);
+
+  expect(props.getChartData).toHaveBeenCalled();
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('renders engagement report page with data', () => {
+  const props = {
+    chart: {
+      data: {
+        count_accepted: 1,
+        count_targeted: 2,
+        count_unique_clicked_approx: 3,
+        count_unique_confirmed_opened_approx: 4
+      }
+    },
+    getChartData: jest.fn()
+  };
+  const wrapper = shallow(<EngagementPage {...props} />);
+
   expect(wrapper).toMatchSnapshot();
 });

--- a/src/pages/reports/engagement/tests/EngagementPage.test.js
+++ b/src/pages/reports/engagement/tests/EngagementPage.test.js
@@ -1,33 +1,26 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import cases from 'jest-in-case';
 import { EngagementPage } from '../EngagementPage';
 
-it('renders engagement report page', () => {
-  const props = {
-    chart: {
-      data: {}
-    },
-    getChartData: jest.fn()
-  };
+cases('EngagementPage', (props) => {
   const wrapper = shallow(<EngagementPage {...props} />);
-
-  expect(props.getChartData).toHaveBeenCalled();
   expect(wrapper).toMatchSnapshot();
-});
-
-it('renders engagement report page with data', () => {
-  const props = {
+}, {
+  'renders loading panel': {
+    chart: { data: {}, loading: true },
+    getChartData: jest.fn()
+  },
+  'renders engagement report page with data': {
     chart: {
       data: {
         count_accepted: 1,
         count_targeted: 2,
         count_unique_clicked_approx: 3,
         count_unique_confirmed_opened_approx: 4
-      }
+      },
+      loading: false
     },
     getChartData: jest.fn()
-  };
-  const wrapper = shallow(<EngagementPage {...props} />);
-
-  expect(wrapper).toMatchSnapshot();
+  }
 });

--- a/src/pages/reports/engagement/tests/EngagementPage.test.js
+++ b/src/pages/reports/engagement/tests/EngagementPage.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { EngagementPage } from '../EngagementPage';
+
+it('renders engagement report page', () => {
+  const wrapper = shallow(<EngagementPage />);
+  expect(wrapper).toMatchSnapshot();
+});

--- a/src/pages/reports/engagement/tests/EngagementPage.test.js
+++ b/src/pages/reports/engagement/tests/EngagementPage.test.js
@@ -1,17 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import cases from 'jest-in-case';
 import { EngagementPage } from '../EngagementPage';
 
-cases('EngagementPage', (props) => {
-  const wrapper = shallow(<EngagementPage {...props} />);
-  expect(wrapper).toMatchSnapshot();
-}, {
-  'renders loading panel': {
-    chart: { data: {}, loading: true },
-    getChartData: jest.fn()
-  },
-  'renders engagement report page with data': {
+it('renders engagement report page', () => {
+  const props = {
     chart: {
       data: {
         count_accepted: 1,
@@ -22,5 +14,8 @@ cases('EngagementPage', (props) => {
       loading: false
     },
     getChartData: jest.fn()
-  }
+  };
+  const wrapper = shallow(<EngagementPage {...props} />);
+
+  expect(wrapper).toMatchSnapshot();
 });

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -6,8 +6,8 @@ exports[`EngagementPage renders engagement report page with data 1`] = `
   title="Engagement Report"
 >
   <withRouter(Connect(EngagementFilters))
-    disabled={false}
     onLoad={[Function]}
+    shareDisabled={false}
   />
   <Panel
     sectioned={true}
@@ -28,8 +28,8 @@ exports[`EngagementPage renders loading panel 1`] = `
   title="Engagement Report"
 >
   <withRouter(Connect(EngagementFilters))
-    disabled={true}
     onLoad={[Function]}
+    shareDisabled={true}
   />
   <PanelLoading
     minHeight="400px"

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -4,5 +4,32 @@ exports[`renders engagement report page 1`] = `
 <Page
   empty={Object {}}
   title="Engagement Report"
-/>
+>
+  <Panel
+    sectioned={true}
+  >
+    <LoadableComponent
+      data={
+        Array [
+          Object {
+            "name": "Targeted",
+            "value": 1000,
+          },
+          Object {
+            "name": "Accepted",
+            "value": 500,
+          },
+          Object {
+            "name": "Unique Confirmed Opens",
+            "value": 100,
+          },
+          Object {
+            "name": "Unique Clicks",
+            "value": 1,
+          },
+        ]
+      }
+    />
+  </Panel>
+</Page>
 `;

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -8,27 +8,24 @@ exports[`renders engagement report page 1`] = `
   <Panel
     sectioned={true}
   >
+    <LoadableComponent />
+  </Panel>
+</Page>
+`;
+
+exports[`renders engagement report page with data 1`] = `
+<Page
+  empty={Object {}}
+  title="Engagement Report"
+>
+  <Panel
+    sectioned={true}
+  >
     <LoadableComponent
-      data={
-        Array [
-          Object {
-            "name": "Targeted",
-            "value": 1000,
-          },
-          Object {
-            "name": "Accepted",
-            "value": 500,
-          },
-          Object {
-            "name": "Unique Confirmed Opens",
-            "value": 100,
-          },
-          Object {
-            "name": "Unique Clicks",
-            "value": 1,
-          },
-        ]
-      }
+      accepted={1}
+      clicks={3}
+      opens={4}
+      targeted={2}
     />
   </Panel>
 </Page>

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -31,6 +31,8 @@ exports[`EngagementPage renders loading panel 1`] = `
     disabled={true}
     onLoad={[Function]}
   />
-  <PanelLoading />
+  <PanelLoading
+    minHeight="400px"
+  />
 </Page>
 `;

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -1,32 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders engagement report page 1`] = `
+exports[`EngagementPage renders engagement report page with data 1`] = `
 <Page
   empty={Object {}}
   title="Engagement Report"
 >
-  <Panel
-    sectioned={true}
+  <withRouter(Connect(EngagementFilters))
+    disabled={false}
+    onLoad={[Function]}
+  />
+  <If
+    condition={false}
   >
-    <LoadableComponent />
-  </Panel>
+    <PanelLoading />
+  </If>
+  <If
+    condition={true}
+  >
+    <Panel
+      sectioned={true}
+    >
+      <LoadableComponent
+        accepted={1}
+        clicks={3}
+        opens={4}
+        targeted={2}
+      />
+    </Panel>
+  </If>
 </Page>
 `;
 
-exports[`renders engagement report page with data 1`] = `
+exports[`EngagementPage renders loading panel 1`] = `
 <Page
   empty={Object {}}
   title="Engagement Report"
 >
-  <Panel
-    sectioned={true}
+  <withRouter(Connect(EngagementFilters))
+    disabled={true}
+    onLoad={[Function]}
+  />
+  <If
+    condition={true}
   >
-    <LoadableComponent
-      accepted={1}
-      clicks={3}
-      opens={4}
-      targeted={2}
-    />
-  </Panel>
+    <PanelLoading />
+  </If>
+  <If
+    condition={false}
+  >
+    <Panel
+      sectioned={true}
+    >
+      <LoadableComponent />
+    </Panel>
+  </If>
 </Page>
 `;

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders engagement report page 1`] = `
+<Page
+  empty={Object {}}
+  title="Engagement Report"
+/>
+`;

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -9,25 +9,16 @@ exports[`EngagementPage renders engagement report page with data 1`] = `
     disabled={false}
     onLoad={[Function]}
   />
-  <If
-    condition={false}
+  <Panel
+    sectioned={true}
   >
-    <PanelLoading />
-  </If>
-  <If
-    condition={true}
-  >
-    <Panel
-      sectioned={true}
-    >
-      <LoadableComponent
-        accepted={1}
-        clicks={3}
-        opens={4}
-        targeted={2}
-      />
-    </Panel>
-  </If>
+    <LoadableComponent
+      accepted={1}
+      clicks={3}
+      opens={4}
+      targeted={2}
+    />
+  </Panel>
 </Page>
 `;
 
@@ -40,19 +31,6 @@ exports[`EngagementPage renders loading panel 1`] = `
     disabled={true}
     onLoad={[Function]}
   />
-  <If
-    condition={true}
-  >
-    <PanelLoading />
-  </If>
-  <If
-    condition={false}
-  >
-    <Panel
-      sectioned={true}
-    >
-      <LoadableComponent />
-    </Panel>
-  </If>
+  <PanelLoading />
 </Page>
 `;

--- a/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
+++ b/src/pages/reports/engagement/tests/__snapshots__/EngagementPage.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EngagementPage renders engagement report page with data 1`] = `
+exports[`renders engagement report page 1`] = `
 <Page
   empty={Object {}}
   title="Engagement Report"
@@ -9,30 +9,17 @@ exports[`EngagementPage renders engagement report page with data 1`] = `
     onLoad={[Function]}
     shareDisabled={false}
   />
-  <Panel
-    sectioned={true}
-  >
-    <LoadableComponent
-      accepted={1}
-      clicks={3}
-      opens={4}
-      targeted={2}
-    />
-  </Panel>
-</Page>
-`;
-
-exports[`EngagementPage renders loading panel 1`] = `
-<Page
-  empty={Object {}}
-  title="Engagement Report"
->
-  <withRouter(Connect(EngagementFilters))
-    onLoad={[Function]}
-    shareDisabled={true}
+  <Connect(EngagementSummary)
+    clicks={3}
+    loading={false}
+    targeted={2}
   />
-  <PanelLoading
-    minHeight="400px"
+  <LoadableComponent
+    accepted={1}
+    clicks={3}
+    loading={false}
+    opens={4}
+    targeted={2}
   />
 </Page>
 `;

--- a/src/pages/reports/index.js
+++ b/src/pages/reports/index.js
@@ -1,15 +1,17 @@
-import BouncePage from './bounce/BouncePage.js';
-import SummaryPage from './summary/SummaryPage.js';
-import MessageEventsPage from './messageEvents/MessageEventsPage.js';
-import EventPage from './messageEvents/EventPage.js';
+import BouncePage from './bounce/BouncePage';
 import DelayPage from './delays/DelayPage';
+import EngagementPage from './engagement/EngagementPage';
+import EventPage from './messageEvents/EventPage';
+import MessageEventsPage from './messageEvents/MessageEventsPage';
 import RejectionPage from './rejection/RejectionPage';
+import SummaryPage from './summary/SummaryPage';
 
 export default {
   BouncePage,
-  SummaryPage,
-  MessageEventsPage,
-  EventPage,
   DelayPage,
-  RejectionPage
+  EngagementPage,
+  EventPage,
+  MessageEventsPage,
+  RejectionPage,
+  SummaryPage
 };

--- a/src/pages/reports/rejection/RejectionPage.js
+++ b/src/pages/reports/rejection/RejectionPage.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
-import { addFilter, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
 import { loadRejectionMetrics, refreshRejectionTableMetrics } from 'src/actions/rejectionReport';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
 import PanelLoading from 'src/components/panelLoading/PanelLoading';
@@ -34,12 +34,8 @@ export class RejectionPage extends Component {
    * and not in the helper
    */
   parseSearch() {
-    const { options, filters } = parseSearch(this.props.location.search);
-
-    if (filters) {
-      filters.forEach(this.props.addFilter);
-    }
-
+    const { filters = [], options } = parseSearch(this.props.location.search);
+    this.props.addFilters(filters);
     return options;
   }
 
@@ -66,7 +62,7 @@ export class RejectionPage extends Component {
   }
 
   handleDomainClick = (domain) => {
-    this.props.addFilter({ type: 'Recipient Domain', value: domain });
+    this.props.addFilters([{ type: 'Recipient Domain', value: domain }]);
     this.handleRefresh();
   }
 
@@ -155,7 +151,7 @@ const mapStateToProps = ({ reportFilters, rejectionReport }) => ({
 });
 
 const mapDispatchToProps = {
-  addFilter,
+  addFilters,
   loadRejectionMetrics,
   refreshRejectionTableMetrics,
   refreshTypeaheadCache,

--- a/src/pages/reports/summary/SummaryPage.js
+++ b/src/pages/reports/summary/SummaryPage.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import qs from 'query-string';
 
 import { refresh as refreshSummaryChart } from 'src/actions/summaryChart';
-import { addFilter, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 
 import { Page, Panel } from '@sparkpost/matchbox';
@@ -36,12 +36,8 @@ export class SummaryReportPage extends Component {
    * and not in the helper
    */
   parseSearch() {
-    const { options, filters } = parseSearch(this.props.location.search);
-
-    if (filters) {
-      filters.forEach(this.props.addFilter);
-    }
-
+    const { filters = [], options } = parseSearch(this.props.location.search);
+    this.props.addFilters(filters);
     return options;
   }
 
@@ -135,9 +131,9 @@ const mapStateToProps = ({ reportFilters, summaryChart }) => ({
 });
 
 const mapDispatchToProps = {
+  addFilters,
   refreshSummaryChart,
-  refreshTypeaheadCache,
-  addFilter
+  refreshTypeaheadCache
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SummaryReportPage));

--- a/src/pages/reports/summary/components/Table.js
+++ b/src/pages/reports/summary/components/Table.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import cx from 'classnames';
 
 import { getTableData } from 'src/actions/summaryChart';
-import { addFilter } from 'src/actions/reportFilters';
+import { addFilters } from 'src/actions/reportFilters';
 import typeaheadCacheSelector from 'src/selectors/reportFilterTypeaheadCache';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 
@@ -21,7 +21,7 @@ export class Table extends Component {
   }
 
   handleRowClick = (item) => {
-    this.props.addFilter(item);
+    this.props.addFilters([item]);
     this.props.refresh();
   }
 
@@ -144,4 +144,4 @@ const mapStateToProps = (state) => ({
   hasSubaccounts: hasSubaccounts(state),
   ...state.summaryChart
 });
-export default connect(mapStateToProps, { getTableData, addFilter })(Table);
+export default connect(mapStateToProps, { getTableData, addFilters })(Table);

--- a/src/pages/reports/summary/components/tests/Table.test.js
+++ b/src/pages/reports/summary/components/tests/Table.test.js
@@ -8,7 +8,7 @@ describe('Summary Table ', () => {
   let wrapper;
 
   const props = {
-    addFilter: jest.fn(),
+    addFilters: jest.fn(),
     getTableData: jest.fn(),
     refresh: jest.fn(),
     metrics: [
@@ -66,7 +66,7 @@ describe('Summary Table ', () => {
     expect(snaps).toMatchSnapshot();
 
     snaps[0].find('UnstyledLink').simulate('click');
-    expect(props.addFilter).toHaveBeenCalledWith({ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' });
+    expect(props.addFilters).toHaveBeenCalledWith([{ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' }]);
     expect(props.refresh).toHaveBeenCalled();
   });
 

--- a/src/pages/reports/summary/tests/SummaryPage.test.js
+++ b/src/pages/reports/summary/tests/SummaryPage.test.js
@@ -29,7 +29,7 @@ describe('Page: SummaryPage', () => {
       },
       refreshSummaryChart: jest.fn(() => Promise.resolve()),
       refreshTypeaheadCache: jest.fn(),
-      addFilter: jest.fn()
+      addFilters: jest.fn()
     };
     wrapper = shallow(<SummaryReportPage {...testProps} />);
   });
@@ -50,7 +50,7 @@ describe('Page: SummaryPage', () => {
       filters: [1, 2, 3]
     }));
     wrapper = shallow(<SummaryReportPage {...testProps} />);
-    expect(testProps.addFilter).toHaveBeenCalledTimes(3);
+    expect(testProps.addFilters).toHaveBeenCalledWith([1, 2, 3]);
   });
 
   it('should toggle modals via filters', () => {

--- a/src/reducers/engagementReport.js
+++ b/src/reducers/engagementReport.js
@@ -13,7 +13,7 @@ export default (state = initialState, { type, payload }) => {
     case 'GET_ENGAGEMENT_CHART_DATA_PENDING':
       return { ...state, chart: { data: state.chart.data, error: null, loading: true }};
     case 'GET_ENGAGEMENT_CHART_DATA_SUCCESS':
-      return { ...state, chart: { data: payload[0], error: null, loading: true }};
+      return { ...state, chart: { data: payload[0], error: null, loading: false }};
     default:
       return state;
   }

--- a/src/reducers/engagementReport.js
+++ b/src/reducers/engagementReport.js
@@ -1,0 +1,20 @@
+const initialState = {
+  chart: {
+    data: {},
+    error: null,
+    loading: false
+  }
+};
+
+export default (state = initialState, { type, payload }) => {
+  switch (type) {
+    case 'GET_ENGAGEMENT_CHART_DATA_FAIL':
+      return { ...state, chart: { data: [], error: payload, loading: false }};
+    case 'GET_ENGAGEMENT_CHART_DATA_PENDING':
+      return { ...state, chart: { data: state.chart.data, error: null, loading: true }};
+    case 'GET_ENGAGEMENT_CHART_DATA_SUCCESS':
+      return { ...state, chart: { data: payload[0], error: null, loading: true }};
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import auth from './auth';
 import billing from './billing';
 import bounceReport from './bounceReport';
 import delayReport from './delayReport';
+import engagementReport from './engagementReport';
 import rejectionReport from './rejectionReport';
 import currentUser from './currentUser';
 import globalAlert from './globalAlert';
@@ -35,6 +36,7 @@ const appReducer = combineReducers({
   billing,
   bounceReport,
   delayReport,
+  engagementReport,
   rejectionReport,
   apiKeys,
   currentUser,

--- a/src/reducers/reportFilters.js
+++ b/src/reducers/reportFilters.js
@@ -23,6 +23,9 @@ export default (state = initialState, action) => {
     case 'ADD_FILTER':
       return { ...state, activeList: [ ...state.activeList, action.payload ]};
 
+    case 'ADD_FILTERS':
+      return { ...state, activeList: [ ...state.activeList, ...action.payload ]};
+
     case 'REMOVE_FILTER':
       return {
         ...state,

--- a/src/reducers/reportFilters.js
+++ b/src/reducers/reportFilters.js
@@ -20,9 +20,6 @@ export default (state = initialState, action) => {
       return { ...state, to, from, relativeRange };
     }
 
-    case 'ADD_FILTER':
-      return { ...state, activeList: [ ...state.activeList, action.payload ]};
-
     case 'ADD_FILTERS':
       return { ...state, activeList: [ ...state.activeList, ...action.payload ]};
 

--- a/src/reducers/tests/__snapshots__/engagementReport.test.js.snap
+++ b/src/reducers/tests/__snapshots__/engagementReport.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`get engagement chart data when failed 1`] = `
+Object {
+  "chart": Object {
+    "data": Array [],
+    "error": Object {
+      "message": "Oh no!",
+    },
+    "loading": false,
+  },
+}
+`;
+
+exports[`get engagement chart data when pending 1`] = `
+Object {
+  "chart": Object {
+    "data": Object {},
+    "error": null,
+    "loading": true,
+  },
+}
+`;
+
+exports[`get engagement chart data when succeeds 1`] = `
+Object {
+  "chart": Object {
+    "data": Object {
+      "count_accepted": 237433,
+      "count_targeted": 272234,
+    },
+    "error": null,
+    "loading": true,
+  },
+}
+`;

--- a/src/reducers/tests/__snapshots__/engagementReport.test.js.snap
+++ b/src/reducers/tests/__snapshots__/engagementReport.test.js.snap
@@ -30,7 +30,7 @@ Object {
       "count_targeted": 272234,
     },
     "error": null,
-    "loading": true,
+    "loading": false,
   },
 }
 `;

--- a/src/reducers/tests/__snapshots__/reportFilters.test.js.snap
+++ b/src/reducers/tests/__snapshots__/reportFilters.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Report Filters Reducer add a filter 1`] = `
+Object {
+  "activeList": Array [
+    Object {
+      "type": "Example Domain",
+      "value": "sparkpost.com",
+    },
+  ],
+  "from": 1970-01-01T00:00:00.000Z,
+  "relativeRange": "day",
+  "to": 1970-01-02T00:00:00.000Z,
+}
+`;
+
+exports[`Report Filters Reducer add multiple filters 1`] = `
+Object {
+  "activeList": Array [
+    Object {
+      "type": "Example Domain",
+      "value": "sparkpost.com",
+    },
+    Object {
+      "type": "Example Domain",
+      "value": "another.sparkpost.com",
+    },
+  ],
+  "from": 1970-01-01T00:00:00.000Z,
+  "relativeRange": "day",
+  "to": 1970-01-02T00:00:00.000Z,
+}
+`;
+
+exports[`Report Filters Reducer set report range 1`] = `
+Object {
+  "activeList": Array [],
+  "from": 2018-01-01T00:00:00.000Z,
+  "relativeRange": "day",
+  "to": 2018-01-02T00:00:00.000Z,
+}
+`;

--- a/src/reducers/tests/engagementReport.test.js
+++ b/src/reducers/tests/engagementReport.test.js
@@ -1,0 +1,20 @@
+import engagementReportReducer from '../engagementReport';
+import cases from 'jest-in-case';
+
+cases('get engagement chart data', (action) => {
+  expect(engagementReportReducer(undefined, action)).toMatchSnapshot();
+}, {
+  'when failed': {
+    type: 'GET_ENGAGEMENT_CHART_DATA_FAIL',
+    payload: {
+      message: 'Oh no!'
+    }
+  },
+  'when pending': {
+    type: 'GET_ENGAGEMENT_CHART_DATA_PENDING'
+  },
+  'when succeeds': {
+    type: 'GET_ENGAGEMENT_CHART_DATA_SUCCESS',
+    payload: [{ count_accepted: 237433, count_targeted: 272234 }]
+  }
+});

--- a/src/reducers/tests/reportFilters.test.js
+++ b/src/reducers/tests/reportFilters.test.js
@@ -1,0 +1,34 @@
+import reportFiltersReducer from '../reportFilters';
+import cases from 'jest-in-case';
+import time from 'src/__testHelpers__/time';
+
+cases('Report Filters Reducer', (action) => {
+  const state = {
+    activeList: [],
+    from: time(),
+    relativeRange: 'day',
+    to: time({ day: 2 })
+  };
+
+  expect(reportFiltersReducer(state, action)).toMatchSnapshot();
+}, {
+  'add a filter': {
+    payload: { type: 'Example Domain', value: 'sparkpost.com' },
+    type: 'ADD_FILTER'
+  },
+  'add multiple filters': {
+    payload: [
+      { type: 'Example Domain', value: 'sparkpost.com' },
+      { type: 'Example Domain', value: 'another.sparkpost.com' }
+    ],
+    type: 'ADD_FILTERS'
+  },
+  'set report range': {
+    payload: {
+      from: time({ year: 2018, month: 1, day: 1 }),
+      relativeRange: 'day',
+      to: time({ year: 2018, month: 1, day: 2 })
+    },
+    type: 'REFRESH_REPORT_RANGE'
+  }
+});

--- a/src/reducers/tests/reportFilters.test.js
+++ b/src/reducers/tests/reportFilters.test.js
@@ -13,8 +13,8 @@ cases('Report Filters Reducer', (action) => {
   expect(reportFiltersReducer(state, action)).toMatchSnapshot();
 }, {
   'add a filter': {
-    payload: { type: 'Example Domain', value: 'sparkpost.com' },
-    type: 'ADD_FILTER'
+    payload: [{ type: 'Example Domain', value: 'sparkpost.com' }],
+    type: 'ADD_FILTERS'
   },
   'add multiple filters': {
     payload: [


### PR DESCRIPTION
_Refer to [FAD-5593](https://jira.int.messagesystems.com/browse/FAD-5593) for AC_

**Before**

<img width="1385" alt="screen shot 2018-01-10 at 2 42 43 pm" src="https://user-images.githubusercontent.com/1335605/34791990-a2098dbe-f614-11e7-8869-70d19766a0c3.png">

**Design**

![engagement](https://user-images.githubusercontent.com/1335605/34844919-2c51a0fc-f6e1-11e7-9410-ec617e50aba7.png)

**After**

<img width="1383" alt="screen shot 2018-01-17 at 2 44 01 pm" src="https://user-images.githubusercontent.com/1335605/35063375-e968b434-fb94-11e7-917d-55e23c25f828.png">

**Test Scenarios**

1. With data (happy path, see above)
1. [With no data](https://github.com/SparkPost/2web2ui/pull/235#issuecomment-357344959)
1. With filters
1. With share link (i.e. http://localhost:3100/reports/engagement?range=day)

**Remaining Work**

- [x] Initial Page
- [x] Bar chart (targeted, accepted, unique confirmed opens, unique clicks)
- [x] Filters