### PR TITLE
FAD-5912 Make TableCollection sortable

### DIFF
--- a/src/components/collection/SortLabel.js
+++ b/src/components/collection/SortLabel.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { UnstyledLink, Icon } from '@sparkpost/matchbox';
+import cx from 'classnames';
+
+import styles from './SortLabel.module.scss';
+
+const SortLabel = ({ label, direction, ...rest }) => {
+
+  const classes = cx(
+    styles.SortLabel,
+    direction === 'asc' && styles.asc,
+    direction === 'desc' && styles.desc,
+  );
+
+  return (
+    <UnstyledLink className={classes} {...rest}>
+      <span>{label}</span>
+      <Icon name='CaretUp' className={styles.Up}/>
+      <Icon name='CaretDown' className={styles.Down}/>
+    </UnstyledLink>
+  );
+};
+
+export default SortLabel;

--- a/src/components/collection/SortLabel.module.scss
+++ b/src/components/collection/SortLabel.module.scss
@@ -1,0 +1,29 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.SortLabel {
+  display: inline-block;
+  position: relative;
+  color: color(gray, 2);
+  padding-right: spacing(large);
+
+  user-select: none; // Prevents highlight when clicking
+  transition: 0.15s;
+}
+
+.Up, .Down {
+  position: absolute;
+  right: 0;
+  opacity: 0.4;
+}
+
+.Up {
+  top: -4%;
+}
+
+.Down {
+  top: 24%;
+}
+
+.SortLabel.asc .Up, .SortLabel.desc .Down {
+  opacity: 1;
+}

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -44,7 +44,7 @@ class TableCollection extends Component {
         bodyWrapper={TableBody}
         rowComponent={TableRow}
         { ...this.props}
-        rows={getSortedCollection(rows, sortColumn, sortDirection)}
+        rows={sortColumn ? getSortedCollection(rows, sortColumn, sortDirection) : rows }
       />
     );
   }

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -1,28 +1,50 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Panel, Table } from '@sparkpost/matchbox';
 import Collection from './Collection';
 import TableHeader from './TableHeader';
+import { getSortedCollection } from 'src/helpers/sort';
 
 const TableWrapper = (props) => <Panel><Table>{props.children}</Table></Panel>;
 
 const TableBody = (props) => <tbody>{props.children}</tbody>;
 
-const TableCollection = (props) => {
-  const { rowComponent, headerComponent, columns, getRowData, onSort, sortColumn, sortDirection } = props;
-  const HeaderComponent = headerComponent ? headerComponent : () => <TableHeader columns={columns} onSort={onSort} sortColumn={sortColumn} sortDirection={sortDirection}/>;
-  const TableRow = rowComponent
-    ? rowComponent
-    : (props) => <Table.Row rowData={getRowData(props)} />;
+class TableCollection extends Component {
+  state = {
+    sortColumn: null,
+    sortDirection: 'asc'
+  }
 
-  return (
-    <Collection
-      outerWrapper={TableWrapper}
-      headerComponent={HeaderComponent}
-      bodyWrapper={TableBody}
-      rowComponent={TableRow}
-      {...props}
-    />
-  );
-};
+  componentDidMount() {
+    const { sortColumn, sortDirection } = this.props;
+    const { sortColumn: stateSortColumn, sortDirection: stateSortDirection } = this.state;
+    if (sortColumn || sortDirection) {
+      this.setState({ sortColumn: sortColumn || stateSortColumn, sortDirection: sortDirection || stateSortDirection });
+    }
+  }
+
+  handleSortChange = (column, direction) => {
+    this.setState({ sortColumn: column, sortDirection: direction });
+  }
+
+  render() {
+    const { rowComponent, headerComponent, columns, getRowData, rows } = this.props;
+    const { sortColumn, sortDirection } = this.state;
+
+    const HeaderComponent = headerComponent ? headerComponent : () => <TableHeader columns={columns} onSort={this.handleSortChange} sortColumn={sortColumn} sortDirection={sortDirection}/>;
+    const TableRow = rowComponent
+      ? rowComponent
+      : (props) => <Table.Row rowData={getRowData(props)} />;
+
+    return (
+      <Collection
+        outerWrapper={TableWrapper}
+        headerComponent={HeaderComponent}
+        bodyWrapper={TableBody}
+        rowComponent={TableRow}
+        {...{ ...this.props, rows: getSortedCollection(rows, sortColumn, sortDirection) }}
+      />
+    );
+  }
+}
 
 export default TableCollection;

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -11,15 +11,17 @@ const TableBody = (props) => <tbody>{props.children}</tbody>;
 class TableCollection extends Component {
   state = {
     sortColumn: null,
-    sortDirection: 'asc'
+    sortDirection: null
+  }
+
+  static defaultProps = {
+    defaultSortColumn: null,
+    defaultSortDirection: 'asc'
   }
 
   componentDidMount() {
-    const { sortColumn, sortDirection } = this.props;
-    const { sortColumn: stateSortColumn, sortDirection: stateSortDirection } = this.state;
-    if (sortColumn || sortDirection) {
-      this.setState({ sortColumn: sortColumn || stateSortColumn, sortDirection: sortDirection || stateSortDirection });
-    }
+    const { defaultSortColumn, defaultSortDirection } = this.props;
+    this.setState({ sortColumn: defaultSortColumn , sortDirection: defaultSortDirection });
   }
 
   handleSortChange = (column, direction) => {
@@ -41,7 +43,8 @@ class TableCollection extends Component {
         headerComponent={HeaderComponent}
         bodyWrapper={TableBody}
         rowComponent={TableRow}
-        {...{ ...this.props, rows: getSortedCollection(rows, sortColumn, sortDirection) }}
+        { ...this.props}
+        rows={getSortedCollection(rows, sortColumn, sortDirection)}
       />
     );
   }

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -5,7 +5,6 @@ import TableHeader from './TableHeader';
 
 const TableWrapper = (props) => <Panel><Table>{props.children}</Table></Panel>;
 
-
 const TableBody = (props) => <tbody>{props.children}</tbody>;
 
 const TableCollection = (props) => {

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -1,56 +1,10 @@
-import React, { Component } from 'react';
-import { Panel, Table, UnstyledLink, Icon } from '@sparkpost/matchbox';
+import React from 'react';
+import { Panel, Table } from '@sparkpost/matchbox';
 import Collection from './Collection';
+import TableHeader from './TableHeader';
 
 const TableWrapper = (props) => <Panel><Table>{props.children}</Table></Panel>;
 
-class TableHeader extends Component {
-  handleSorting = (column) => {
-    const { sortColumn, sortDirection } = this.props;
-    let direction;
-
-    if (column === sortColumn) { // change direction as same column is clicked again
-      direction = sortDirection === 'asc' ? 'desc' : 'asc';
-    } else {
-      direction = 'asc';
-    }
-
-    this.props.onSort(column, direction);
-  }
-
-  renderSortCell = (item) => {
-    const { label, sortKey } = item;
-    const { sortColumn, sortDirection = 'asc' } = this.props;
-
-    const icon = sortDirection === 'asc' ? <Icon name='CaretUp'/> : <Icon name='CaretDown'/>;
-    const formattedLabel = sortKey === sortColumn ? <span> { label }{ icon } </span> : label;
-
-    if (sortKey) {
-      return <UnstyledLink onClick={() => this.handleSorting(sortKey)}>{ formattedLabel }</UnstyledLink>;
-    } else {
-      return label;
-    }
-  }
-
-  render() {
-    const { columns } = this.props;
-
-    const cells = columns.map((item, i) => {
-      if (typeof item === 'string' || item === null) {
-        return <Table.HeaderCell key={`column ${i}: ${item}`}>{item}</Table.HeaderCell>;
-      }
-      const { label, sortKey, ...rest } = item;
-
-      return (<Table.HeaderCell key={label} {...rest}>{ this.renderSortCell(item) }</Table.HeaderCell>);
-    });
-
-    return (
-      <thead>
-        <Table.Row>{ cells }</Table.Row>
-      </thead>
-    );
-  }
-}
 
 const TableBody = (props) => <tbody>{props.children}</tbody>;
 

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -1,30 +1,62 @@
-import React from 'react';
-import { Panel, Table } from '@sparkpost/matchbox';
+import React, { Component } from 'react';
+import { Panel, Table, UnstyledLink, Icon } from '@sparkpost/matchbox';
 import Collection from './Collection';
 
 const TableWrapper = (props) => <Panel><Table>{props.children}</Table></Panel>;
 
-const TableHeader = ({ columns = []}) => {
-  const cells = columns.map((item, i) => {
-    if (typeof item === 'string' || item === null) {
-      return <Table.HeaderCell key={`column ${i}: ${item}`}>{item}</Table.HeaderCell>;
-    }
-    const { label, ...rest } = item;
-    return <Table.HeaderCell key={label} {...rest}>{label}</Table.HeaderCell>;
-  });
+class TableHeader extends Component {
+  handleSorting = (column) => {
+    const { sortColumn, sortDirection } = this.props;
+    let direction;
 
-  return (
-    <thead>
-      <Table.Row>{ cells }</Table.Row>
-    </thead>
-  );
-};
+    if (column === sortColumn) { // change direction as same column is clicked again
+      direction = sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      direction = 'asc';
+    }
+
+    this.props.onSort(column, direction);
+  }
+
+  renderSortCell = (item) => {
+    const { label, sortKey } = item;
+    const { sortColumn, sortDirection = 'asc' } = this.props;
+
+    const icon = sortDirection === 'asc' ? <Icon name='CaretUp'/> : <Icon name='CaretDown'/>;
+    const formattedLabel = sortKey === sortColumn ? <span> { label }{ icon } </span> : label;
+
+    if (sortKey) {
+      return <UnstyledLink onClick={() => this.handleSorting(sortKey)}>{ formattedLabel }</UnstyledLink>;
+    } else {
+      return label;
+    }
+  }
+
+  render() {
+    const { columns } = this.props;
+
+    const cells = columns.map((item, i) => {
+      if (typeof item === 'string' || item === null) {
+        return <Table.HeaderCell key={`column ${i}: ${item}`}>{item}</Table.HeaderCell>;
+      }
+      const { label, sortKey, ...rest } = item;
+
+      return (<Table.HeaderCell key={label} {...rest}>{ this.renderSortCell(item) }</Table.HeaderCell>);
+    });
+
+    return (
+      <thead>
+        <Table.Row>{ cells }</Table.Row>
+      </thead>
+    );
+  }
+}
 
 const TableBody = (props) => <tbody>{props.children}</tbody>;
 
 const TableCollection = (props) => {
-  const { rowComponent, headerComponent, columns, getRowData } = props;
-  const HeaderComponent = headerComponent ? headerComponent : () => <TableHeader columns={columns} />;
+  const { rowComponent, headerComponent, columns, getRowData, onSort, sortColumn, sortDirection } = props;
+  const HeaderComponent = headerComponent ? headerComponent : () => <TableHeader columns={columns} onSort={onSort} sortColumn={sortColumn} sortDirection={sortDirection}/>;
   const TableRow = rowComponent
     ? rowComponent
     : (props) => <Table.Row rowData={getRowData(props)} />;

--- a/src/components/collection/TableHeader.js
+++ b/src/components/collection/TableHeader.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react';
+import { Table, UnstyledLink, Icon } from '@sparkpost/matchbox';
+
+export default class TableHeader extends Component {
+  handleSorting = (column) => {
+    const { sortColumn, sortDirection } = this.props;
+    let direction;
+
+    if (column === sortColumn) { // change direction as same column is clicked again
+      direction = sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      direction = 'asc';
+    }
+
+    this.props.onSort(column, direction);
+  }
+
+  renderSortCell = (item) => {
+    const { label, sortKey } = item;
+    const { sortColumn, sortDirection = 'asc' } = this.props;
+
+    const icon = sortDirection === 'asc' ? <Icon name='CaretUp'/> : <Icon name='CaretDown'/>;
+    const formattedLabel = sortKey === sortColumn ? <span> { label }{ icon } </span> : label;
+
+    if (sortKey) {
+      return <UnstyledLink onClick={() => this.handleSorting(sortKey)}>{ formattedLabel }</UnstyledLink>;
+    } else {
+      return label;
+    }
+  }
+
+  render() {
+    const { columns } = this.props;
+
+    const cells = columns.map((item, i) => {
+      if (typeof item === 'string' || item === null) {
+        return <Table.HeaderCell key={`column ${i}: ${item}`}>{item}</Table.HeaderCell>;
+      }
+      const { label, sortKey, ...rest } = item;
+
+      return (<Table.HeaderCell key={label} {...rest}>{ this.renderSortCell(item) }</Table.HeaderCell>);
+    });
+
+    return (
+      <thead>
+        <Table.Row>{ cells }</Table.Row>
+      </thead>
+    );
+  }
+}

--- a/src/components/collection/TableHeader.js
+++ b/src/components/collection/TableHeader.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Table, UnstyledLink, Icon } from '@sparkpost/matchbox';
+import { Table } from '@sparkpost/matchbox';
+import SortLabel from './SortLabel';
 
 export default class TableHeader extends Component {
   handleSorting = (column) => {
@@ -17,16 +18,18 @@ export default class TableHeader extends Component {
 
   renderSortCell = (item) => {
     const { label, sortKey } = item;
-    const { sortColumn, sortDirection = 'asc' } = this.props;
-
-    const icon = sortDirection === 'asc' ? <Icon name='CaretUp'/> : <Icon name='CaretDown'/>;
-    const formattedLabel = sortKey === sortColumn ? <span> { label }{ icon } </span> : label;
+    const { sortColumn, sortDirection } = this.props;
 
     if (sortKey) {
-      return <UnstyledLink onClick={() => this.handleSorting(sortKey)}>{ formattedLabel }</UnstyledLink>;
-    } else {
-      return label;
+      return (
+        <SortLabel
+          onClick={() => this.handleSorting(sortKey)}
+          direction={sortKey === sortColumn && sortDirection}
+          label={label} />
+      );
     }
+
+    return label;
   }
 
   render() {

--- a/src/components/collection/TableHeader.js
+++ b/src/components/collection/TableHeader.js
@@ -41,7 +41,7 @@ export default class TableHeader extends Component {
       }
       const { label, sortKey, ...rest } = item;
 
-      return (<Table.HeaderCell key={label} {...rest}>{ this.renderSortCell(item) }</Table.HeaderCell>);
+      return <Table.HeaderCell key={label} {...rest}>{ this.renderSortCell(item) }</Table.HeaderCell>;
     });
 
     return (

--- a/src/components/collection/docs/Collection.md
+++ b/src/components/collection/docs/Collection.md
@@ -7,6 +7,8 @@ These are useful when you need to display any list of items. There is a generic 
   * [Collection with Pagination example](#collection-with-pagination)
 * [Using the TableCollection component](#using-tablecollection)
   * [Table Collection props](#tablecollection-props) 
+  * [Table Collection with Sorting example](#table-collection-with-sorting)
+
 * [Using the filterBox prop](#using-the-filterbox-prop)
   * [Filter box props](#filterbox-config)
   * [Filter box examples](#filter-box-examples)
@@ -168,6 +170,38 @@ A function that will be run against each item in the passed in `rows` list and s
 
 _Note: All [Collection props](#collection-props) (except `headerComponent` and `rowComponent`) will be passed through to the underlying `<Collection>` component. 
 
+**defaultSortColumn**
+
+Pass a key name to sort the collection by that key. Default: `null`. Collection won't be sorted unless this prop is passed.
+
+**defaultSortDirection**
+
+Pass sorting direction (`asc` or `desc`). Default: `asc`.
+
+
+### Table Collection with Sorting
+
+```jsx
+function MyTableCollectionComponent() {
+  return (
+    <TableCollection
+      rows={movies}
+      columns={[ 
+        { label: 'Title', sortKey: 'title' },
+        { label: 'Director', sortKey: 'director' }
+        { label: 'Released', sortKey: 'released' }
+        'Actions' //this column won't be sortable. 
+        ]}
+      getRowData={(item) => [item.title, item.director, item.year, '...']}
+      defaultPerPage={5}
+      perPageButtons={[3, 5, 10]}
+      pagination={true}
+      defaultSortColumn='released'
+      defaultSortDirection='desc'
+    />
+  )
+}
+```
 
 ## Using the `filterBox` prop
 

--- a/src/components/collection/index.js
+++ b/src/components/collection/index.js
@@ -1,3 +1,4 @@
 export { default as Collection } from './Collection';
 export { default as TableCollection } from './TableCollection';
 export { default as FilterBox } from './FilterBox';
+export { default as TableHeader } from './TableHeader';

--- a/src/components/collection/tests/SortLabel.test.js
+++ b/src/components/collection/tests/SortLabel.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import SortLabel from '../SortLabel';
+import { shallow } from 'enzyme';
+
+describe('Collection SortLabel Component', () => {
+  const props = {
+    direction: 'asc',
+    label: 'Table Header Label',
+    anotherprop: 'anotherProp'
+  };
+
+  // Can't test more than this
+  // Need to find out how to get css-modules rendered in enzyme
+  it('should render correctly', () => {
+    const wrapper = shallow(<SortLabel {...props}/>);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/collection/tests/TableCollection.test.js
+++ b/src/components/collection/tests/TableCollection.test.js
@@ -19,7 +19,8 @@ describe('TableCollection Component', () => {
     headerComponent: headerComponent,
     columns: columns,
     getRowData: () => {},
-    extraProp: 'plsPassDown'
+    extraProp: 'plsPassDown',
+    rows: []
   };
 
   it('should render with no props', () => {

--- a/src/components/collection/tests/TableCollection.test.js
+++ b/src/components/collection/tests/TableCollection.test.js
@@ -49,22 +49,22 @@ describe('TableCollection Component', () => {
       wrapper = shallow(<TableCollection {...props}/>);
     });
 
-    it('has uses default values for sortColumn and sortDirection if not passed', () => {
+    it('uses default if defaultSortColumn and defaultSortDirection are not passed', () => {
       wrapper = shallow(<TableCollection {...props}/>);
       expect(wrapper.state().sortColumn).toEqual(null);
       expect(wrapper.state().sortDirection).toEqual('asc');
     });
 
-    it('sets default state with sortColumn if passed', () => {
+    it('sets state with defaultSortColumn when passed', () => {
       expect(wrapper.state().sortColumn).toEqual(null);
-
-      props.sortColumn = 'col1';
+      props.defaultSortColumn = 'col1';
       wrapper = shallow(<TableCollection {...props}/>);
       expect(wrapper.state().sortColumn).toEqual('col1');
     });
 
-    it('sets default state with sortDirection if passed', () => {
-      props.sortDirection = 'desc';
+    it('sets default with sortDirection when passed', () => {
+      expect(wrapper.state().sortDirection).toEqual('asc');
+      props.defaultSortDirection = 'desc';
       wrapper = shallow(<TableCollection {...props}/>);
       expect(wrapper.state().sortDirection).toEqual('desc');
     });

--- a/src/components/collection/tests/TableCollection.test.js
+++ b/src/components/collection/tests/TableCollection.test.js
@@ -5,33 +5,82 @@ import { shallow } from 'enzyme';
 import TableCollection from '../TableCollection';
 
 describe('TableCollection Component', () => {
-  const columns = ['one', 'two'];
+  let columns;
+  let headerComponent;
+  let props;
 
-  const headerComponent = (
-    <thead>
-      <Table.Row>
-        {columns.map((title) => <Table.HeaderCell key={title}>{title}</Table.HeaderCell>)}
-      </Table.Row>
-    </thead>
-  );
+  beforeEach(() => {
+    columns = ['one', 'two'];
 
-  const props = {
-    headerComponent: headerComponent,
-    columns: columns,
-    getRowData: () => {},
-    extraProp: 'plsPassDown',
-    rows: []
-  };
+    headerComponent = (
+      <thead>
+        <Table.Row>
+          {columns.map((title) => <Table.HeaderCell key={title}>{title}</Table.HeaderCell>)}
+        </Table.Row>
+      </thead>
+    );
 
-  it('should render with no props', () => {
-    const wrapper = shallow(<TableCollection />);
-
-    expect(wrapper).toMatchSnapshot();
+    props = {
+      headerComponent: headerComponent,
+      columns: columns,
+      getRowData: () => {},
+      extraProp: 'plsPassDown',
+      rows: []
+    };
   });
 
-  it('should render with props', () => {
-    const wrapper = shallow(<TableCollection {...props}/>);
+  describe('render', () => {
+    it('renders with no props', () => {
+      const wrapper = shallow(<TableCollection />);
 
-    expect(wrapper).toMatchSnapshot();
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders with props', () => {
+      const wrapper = shallow(<TableCollection {...props}/>);
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe('componentDidMount', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = shallow(<TableCollection {...props}/>);
+    });
+
+    it('has uses default values for sortColumn and sortDirection if not passed', () => {
+      wrapper = shallow(<TableCollection {...props}/>);
+      expect(wrapper.state().sortColumn).toEqual(null);
+      expect(wrapper.state().sortDirection).toEqual('asc');
+    });
+
+    it('sets default state with sortColumn if passed', () => {
+      expect(wrapper.state().sortColumn).toEqual(null);
+
+      props.sortColumn = 'col1';
+      wrapper = shallow(<TableCollection {...props}/>);
+      expect(wrapper.state().sortColumn).toEqual('col1');
+    });
+
+    it('sets default state with sortDirection if passed', () => {
+      props.sortDirection = 'desc';
+      wrapper = shallow(<TableCollection {...props}/>);
+      expect(wrapper.state().sortDirection).toEqual('desc');
+    });
+  });
+
+  describe('handleSortChange', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = shallow(<TableCollection {...props}/>);
+    });
+
+    it('updates state correctly', () => {
+      expect(wrapper.state()).toEqual({ sortColumn: null, sortDirection: 'asc' });
+      wrapper.instance().handleSortChange('col1', 'desc');
+      expect(wrapper.state()).toEqual({ sortColumn: 'col1', sortDirection: 'desc' });
+    });
   });
 });

--- a/src/components/collection/tests/TableHeader.test.js
+++ b/src/components/collection/tests/TableHeader.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TableHeader from '../TableHeader';
+
+let props;
+let wrapper;
+
+describe('Component: TableHeader', () => {
+  const simpleColumns = ['one', 'two'];
+  const complexColumns = [
+    'Simple Column',
+    { label: 'Recipient', sortKey: 'recipient' },
+    { label: 'Type', sortKey: 'type', width: '18%' },
+    { label: 'Source', width: '20%' }
+  ];
+
+  props = {
+    columns: simpleColumns,
+    sortColumn: 'recipient',
+    sortDirection: 'asc',
+    onSort: jest.fn()
+  };
+
+  beforeEach(() => {
+    wrapper = shallow(<TableHeader {...props} />);
+  });
+
+  it('renders header correctly with string only column names', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders header correctly with complex column config', () => {
+    wrapper.setProps({ columns: complexColumns });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('handles sorting correctly', () => {
+    wrapper.setProps({ columns: complexColumns });
+
+    wrapper.find('UnstyledLink').first().simulate('click'); // click recipient column
+    expect(props.onSort).toHaveBeenCalledTimes(1);
+    expect(props.onSort).toHaveBeenCalledWith('recipient', 'desc');
+
+    wrapper.setProps({ sortDirection: 'desc' });
+    wrapper.find('UnstyledLink').first().simulate('click'); // clicks same (recipient) column again
+    expect(props.onSort).toHaveBeenCalledTimes(2);
+    expect(props.onSort).toHaveBeenCalledWith('recipient', 'asc');
+
+    wrapper.setProps({ sortDirection: 'desc' });
+    wrapper.find('UnstyledLink').last().simulate('click'); // click type column
+    expect(props.onSort).toHaveBeenCalledTimes(3);
+    expect(props.onSort).toHaveBeenCalledWith('type', 'asc');
+  });
+});

--- a/src/components/collection/tests/TableHeader.test.js
+++ b/src/components/collection/tests/TableHeader.test.js
@@ -40,17 +40,17 @@ describe('Component: TableHeader', () => {
   it('handles sorting correctly', () => {
     wrapper.setProps({ columns: complexColumns });
 
-    wrapper.find('UnstyledLink').first().simulate('click'); // click recipient column
+    wrapper.find('SortLabel').first().simulate('click'); // click recipient column
     expect(props.onSort).toHaveBeenCalledTimes(1);
     expect(props.onSort).toHaveBeenCalledWith('recipient', 'desc');
 
     wrapper.setProps({ sortDirection: 'desc' });
-    wrapper.find('UnstyledLink').first().simulate('click'); // clicks same (recipient) column again
+    wrapper.find('SortLabel').first().simulate('click'); // clicks same (recipient) column again
     expect(props.onSort).toHaveBeenCalledTimes(2);
     expect(props.onSort).toHaveBeenCalledWith('recipient', 'asc');
 
     wrapper.setProps({ sortDirection: 'desc' });
-    wrapper.find('UnstyledLink').last().simulate('click'); // click type column
+    wrapper.find('SortLabel').last().simulate('click'); // click type column
     expect(props.onSort).toHaveBeenCalledTimes(3);
     expect(props.onSort).toHaveBeenCalledWith('type', 'asc');
   });

--- a/src/components/collection/tests/TableHeader.test.js
+++ b/src/components/collection/tests/TableHeader.test.js
@@ -5,24 +5,26 @@ import TableHeader from '../TableHeader';
 
 let props;
 let wrapper;
+let complexColumns;
+let simpleColumns;
 
 describe('Component: TableHeader', () => {
-  const simpleColumns = ['one', 'two'];
-  const complexColumns = [
-    'Simple Column',
-    { label: 'Recipient', sortKey: 'recipient' },
-    { label: 'Type', sortKey: 'type', width: '18%' },
-    { label: 'Source', width: '20%' }
-  ];
-
-  props = {
-    columns: simpleColumns,
-    sortColumn: 'recipient',
-    sortDirection: 'asc',
-    onSort: jest.fn()
-  };
-
   beforeEach(() => {
+    simpleColumns = ['one', 'two'];
+    complexColumns = [
+      'Simple Column',
+      { label: 'Recipient', sortKey: 'recipient' },
+      { label: 'Type', sortKey: 'type', width: '18%' },
+      { label: 'Source', width: '20%' }
+    ];
+
+    props = {
+      columns: simpleColumns,
+      sortColumn: 'recipient',
+      sortDirection: 'asc',
+      onSort: jest.fn()
+    };
+
     wrapper = shallow(<TableHeader {...props} />);
   });
 

--- a/src/components/collection/tests/__snapshots__/SortLabel.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/SortLabel.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Collection SortLabel Component should render correctly 1`] = `
+<UnstyledLink
+  anotherprop="anotherProp"
+  className=""
+>
+  <span>
+    Table Header Label
+  </span>
+  <Icon
+    name="CaretUp"
+    size={18}
+  />
+  <Icon
+    name="CaretDown"
+    size={18}
+  />
+</UnstyledLink>
+`;

--- a/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
@@ -3,6 +3,8 @@
 exports[`TableCollection Component render renders with no props 1`] = `
 <withRouter(Collection)
   bodyWrapper={[Function]}
+  defaultSortColumn={null}
+  defaultSortDirection="asc"
   headerComponent={[Function]}
   outerWrapper={[Function]}
   rowComponent={[Function]}
@@ -19,6 +21,8 @@ exports[`TableCollection Component render renders with props 1`] = `
       "two",
     ]
   }
+  defaultSortColumn={null}
+  defaultSortDirection="asc"
   extraProp="plsPassDown"
   getRowData={[Function]}
   headerComponent={

--- a/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
@@ -8,7 +8,6 @@ exports[`TableCollection Component render renders with no props 1`] = `
   headerComponent={[Function]}
   outerWrapper={[Function]}
   rowComponent={[Function]}
-  rows={Array []}
 />
 `;
 

--- a/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableCollection Component should render with no props 1`] = `
+exports[`TableCollection Component render renders with no props 1`] = `
 <withRouter(Collection)
   bodyWrapper={[Function]}
   headerComponent={[Function]}
@@ -10,7 +10,7 @@ exports[`TableCollection Component should render with no props 1`] = `
 />
 `;
 
-exports[`TableCollection Component should render with props 1`] = `
+exports[`TableCollection Component render renders with props 1`] = `
 <withRouter(Collection)
   bodyWrapper={[Function]}
   columns={

--- a/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/TableCollection.test.js.snap
@@ -6,6 +6,7 @@ exports[`TableCollection Component should render with no props 1`] = `
   headerComponent={[Function]}
   outerWrapper={[Function]}
   rowComponent={[Function]}
+  rows={Array []}
 />
 `;
 
@@ -34,5 +35,6 @@ exports[`TableCollection Component should render with props 1`] = `
   }
   outerWrapper={[Function]}
   rowComponent={[Function]}
+  rows={Array []}
 />
 `;

--- a/src/components/collection/tests/__snapshots__/TableHeader.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/TableHeader.test.js.snap
@@ -11,29 +11,21 @@ exports[`Component: TableHeader renders header correctly with complex column con
     <Table.HeaderCell
       key="Recipient"
     >
-      <UnstyledLink
+      <SortLabel
+        direction="asc"
+        label="Recipient"
         onClick={[Function]}
-      >
-        <span>
-           
-          Recipient
-          <Icon
-            name="CaretUp"
-            size={18}
-          />
-           
-        </span>
-      </UnstyledLink>
+      />
     </Table.HeaderCell>
     <Table.HeaderCell
       key="Type"
       width="18%"
     >
-      <UnstyledLink
+      <SortLabel
+        direction={false}
+        label="Type"
         onClick={[Function]}
-      >
-        Type
-      </UnstyledLink>
+      />
     </Table.HeaderCell>
     <Table.HeaderCell
       key="Source"

--- a/src/components/collection/tests/__snapshots__/TableHeader.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/TableHeader.test.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: TableHeader renders header correctly with complex column config 1`] = `
+<thead>
+  <Table.Row>
+    <Table.HeaderCell
+      key="column 0: Simple Column"
+    >
+      Simple Column
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      key="Recipient"
+    >
+      <UnstyledLink
+        onClick={[Function]}
+      >
+        <span>
+           
+          Recipient
+          <Icon
+            name="CaretUp"
+            size={18}
+          />
+           
+        </span>
+      </UnstyledLink>
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      key="Type"
+      width="18%"
+    >
+      <UnstyledLink
+        onClick={[Function]}
+      >
+        Type
+      </UnstyledLink>
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      key="Source"
+      width="20%"
+    >
+      Source
+    </Table.HeaderCell>
+  </Table.Row>
+</thead>
+`;
+
+exports[`Component: TableHeader renders header correctly with string only column names 1`] = `
+<thead>
+  <Table.Row>
+    <Table.HeaderCell
+      key="column 0: one"
+    >
+      one
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      key="column 1: two"
+    >
+      two
+    </Table.HeaderCell>
+  </Table.Row>
+</thead>
+`;

--- a/src/helpers/sort.js
+++ b/src/helpers/sort.js
@@ -3,12 +3,3 @@ import _ from 'lodash';
 export function getSortedCollection(collection, sortColumn, sortDirection) {
   return _.orderBy(collection, sortColumn, sortDirection);
 }
-
-/**
- * Handles sorting. It sets states. So this function must be invoked with the context of the component (bind `this` to the component being used)
- * @param {*} column column name like recipient
- * @param {*} direction direction of sorting like asc/desc
- */
-export function handleSortChange(column, direction) {
-  this.setState({ sortColumn: column, sortDirection: direction }, this.forceUpdate);
-}

--- a/src/helpers/sort.js
+++ b/src/helpers/sort.js
@@ -1,0 +1,14 @@
+import _ from 'lodash';
+
+export function getSortedCollection(collection, sortColumn, sortDirection) {
+  return _.orderBy(collection, sortColumn, sortDirection);
+}
+
+/**
+ * Handles sorting. It sets states. So this function must be invoked with the context of the component (bind `this` to the component being used)
+ * @param {*} column column name like recipient
+ * @param {*} direction direction of sorting like asc/desc
+ */
+export function handleSortChange(column, direction) {
+  this.setState({ sortColumn: column, sortDirection: direction }, this.forceUpdate);
+}

--- a/src/helpers/tests/sort.test.js
+++ b/src/helpers/tests/sort.test.js
@@ -1,0 +1,18 @@
+
+import * as sortHelpers from '../sort';
+import _ from 'lodash';
+
+jest.mock('lodash');
+
+describe('Sort helpers', () => {
+  beforeEach(() => {
+    _.orderBy = jest.fn();
+  });
+
+  it('sorts correctly with lodash sorting', () => {
+    sortHelpers.getSortedCollection([], 'a', 'asc');
+    expect(_.orderBy).toHaveBeenCalledWith([], 'a', 'asc');
+  });
+});
+
+

--- a/src/pages/api-keys/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/api-keys/tests/__snapshots__/ListPage.test.js.snap
@@ -42,6 +42,8 @@ exports[`renders correctly 1`] = `
         },
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [
@@ -163,6 +165,8 @@ exports[`should show api key banner on successful create 1`] = `
         },
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [

--- a/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
@@ -39,6 +39,8 @@ exports[`IP Pools List Page should render the list page correctly 1`] = `
         "Number of IPs Assigned",
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [

--- a/src/pages/recipientLists/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/recipientLists/tests/__snapshots__/ListPage.test.js.snap
@@ -33,6 +33,8 @@ exports[`renders correctly 1`] = `
         "Recipients",
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [
@@ -113,6 +115,8 @@ exports[`renders empty state 1`] = `
         "Recipients",
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [
@@ -170,6 +174,8 @@ exports[`renders errors when present 1`] = `
         "Recipients",
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [

--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -32,7 +32,7 @@ export class BouncePage extends Component {
   state = {
     modal: false,
     query: {},
-    sortColumn: 'count',
+    sortColumn: 'count_bounce',
     sortDirection: 'desc'
   }
 

--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -113,8 +113,8 @@ export class BouncePage extends Component {
       columns={columns}
       rows={reasons}
       getRowData={this.getRowData}
-      sortColumn='count_bounce'
-      sortDirection='desc'
+      defaultSortColumn='count_bounce'
+      defaultSortDirection='desc'
       pagination={true}
     />;
   }

--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -3,6 +3,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
+import _ from 'lodash';
+
 import { refreshBounceChartMetrics, refreshBounceTableMetrics } from 'src/actions/bounceReport';
 import { addFilter, refreshTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
@@ -15,14 +17,23 @@ import ShareModal from '../components/ShareModal';
 import Filters from '../components/Filters';
 import ChartGroup from './components/ChartGroup';
 import MetricsSummary from '../components/MetricsSummary';
-import _ from 'lodash';
 
-const columns = [{ label: 'Reason', width: '45%' }, 'Domain', 'Category', 'Classification', 'Count (%)'];
+import { getSortedCollection, handleSortChange } from 'src/helpers/sort';
+
+const columns = [
+  { label: 'Reason', width: '45%', sortKey: 'reason' },
+  { label: 'Domain', sortKey: 'domain' },
+  { label: 'Category', sortKey: 'bounce_category_name' },
+  { label: 'Classification', sortKey: 'classification_id' },
+  { label: 'Count (%)', sortKey: 'count_bounce' }
+];
 
 export class BouncePage extends Component {
   state = {
     modal: false,
-    query: {}
+    query: {},
+    sortColumn: 'count',
+    sortDirection: 'desc'
   }
 
   componentDidMount() {
@@ -93,6 +104,7 @@ export class BouncePage extends Component {
 
   renderCollection() {
     const { tableLoading, reasons } = this.props;
+    const { sortColumn, sortDirection } = this.state;
 
     if (tableLoading) {
       return <PanelLoading />;
@@ -104,9 +116,12 @@ export class BouncePage extends Component {
 
     return <TableCollection
       columns={columns}
-      rows={reasons}
+      rows={getSortedCollection(reasons, sortColumn, sortDirection)}
       getRowData={this.getRowData}
       pagination={true}
+      sortColumn={sortColumn}
+      sortDirection={sortDirection}
+      onSort={handleSortChange.bind(this)}
     />;
   }
 
@@ -179,4 +194,5 @@ const mapDispatchToProps = {
   refreshTypeaheadCache,
   showAlert
 };
+
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(BouncePage));

--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -18,8 +18,6 @@ import Filters from '../components/Filters';
 import ChartGroup from './components/ChartGroup';
 import MetricsSummary from '../components/MetricsSummary';
 
-import { getSortedCollection, handleSortChange } from 'src/helpers/sort';
-
 const columns = [
   { label: 'Reason', width: '45%', sortKey: 'reason' },
   { label: 'Domain', sortKey: 'domain' },
@@ -31,9 +29,7 @@ const columns = [
 export class BouncePage extends Component {
   state = {
     modal: false,
-    query: {},
-    sortColumn: 'count_bounce',
-    sortDirection: 'desc'
+    query: {}
   }
 
   componentDidMount() {
@@ -104,7 +100,6 @@ export class BouncePage extends Component {
 
   renderCollection() {
     const { tableLoading, reasons } = this.props;
-    const { sortColumn, sortDirection } = this.state;
 
     if (tableLoading) {
       return <PanelLoading />;
@@ -116,12 +111,11 @@ export class BouncePage extends Component {
 
     return <TableCollection
       columns={columns}
-      rows={getSortedCollection(reasons, sortColumn, sortDirection)}
+      rows={reasons}
       getRowData={this.getRowData}
+      sortColumn='count_bounce'
+      sortDirection='desc'
       pagination={true}
-      sortColumn={sortColumn}
-      sortDirection={sortDirection}
-      onSort={handleSortChange.bind(this)}
     />;
   }
 

--- a/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
+++ b/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
@@ -23,15 +23,29 @@ exports[`BouncePage:  should display loading panel on top level metrics when agg
         Array [
           Object {
             "label": "Reason",
+            "sortKey": "reason",
             "width": "45%",
           },
-          "Domain",
-          "Category",
-          "Classification",
-          "Count (%)",
+          Object {
+            "label": "Domain",
+            "sortKey": "domain",
+          },
+          Object {
+            "label": "Category",
+            "sortKey": "bounce_category_name",
+          },
+          Object {
+            "label": "Classification",
+            "sortKey": "classification_id",
+          },
+          Object {
+            "label": "Count (%)",
+            "sortKey": "count_bounce",
+          },
         ]
       }
       getRowData={[Function]}
+      onSort={[Function]}
       pagination={true}
       rows={
         Array [
@@ -46,6 +60,8 @@ exports[`BouncePage:  should display loading panel on top level metrics when agg
           },
         ]
       }
+      sortColumn="count"
+      sortDirection="desc"
     />
   </Panel>
   <ShareModal
@@ -89,15 +105,29 @@ exports[`BouncePage:  should render 1`] = `
         Array [
           Object {
             "label": "Reason",
+            "sortKey": "reason",
             "width": "45%",
           },
-          "Domain",
-          "Category",
-          "Classification",
-          "Count (%)",
+          Object {
+            "label": "Domain",
+            "sortKey": "domain",
+          },
+          Object {
+            "label": "Category",
+            "sortKey": "bounce_category_name",
+          },
+          Object {
+            "label": "Classification",
+            "sortKey": "classification_id",
+          },
+          Object {
+            "label": "Count (%)",
+            "sortKey": "count_bounce",
+          },
         ]
       }
       getRowData={[Function]}
+      onSort={[Function]}
       pagination={true}
       rows={
         Array [
@@ -112,6 +142,8 @@ exports[`BouncePage:  should render 1`] = `
           },
         ]
       }
+      sortColumn="count"
+      sortDirection="desc"
     />
   </Panel>
   <ShareModal

--- a/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
+++ b/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
@@ -44,6 +44,8 @@ exports[`BouncePage:  should display loading panel on top level metrics when agg
           },
         ]
       }
+      defaultSortColumn="count_bounce"
+      defaultSortDirection="desc"
       getRowData={[Function]}
       pagination={true}
       rows={
@@ -59,8 +61,6 @@ exports[`BouncePage:  should display loading panel on top level metrics when agg
           },
         ]
       }
-      sortColumn="count_bounce"
-      sortDirection="desc"
     />
   </Panel>
   <ShareModal
@@ -125,6 +125,8 @@ exports[`BouncePage:  should render 1`] = `
           },
         ]
       }
+      defaultSortColumn="count_bounce"
+      defaultSortDirection="desc"
       getRowData={[Function]}
       pagination={true}
       rows={
@@ -140,8 +142,6 @@ exports[`BouncePage:  should render 1`] = `
           },
         ]
       }
-      sortColumn="count_bounce"
-      sortDirection="desc"
     />
   </Panel>
   <ShareModal
@@ -195,6 +195,8 @@ exports[`BouncePage:  should render correctly with no bounces 1`] = `
           },
         ]
       }
+      defaultSortColumn="count_bounce"
+      defaultSortDirection="desc"
       getRowData={[Function]}
       pagination={true}
       rows={
@@ -210,8 +212,6 @@ exports[`BouncePage:  should render correctly with no bounces 1`] = `
           },
         ]
       }
-      sortColumn="count_bounce"
-      sortDirection="desc"
     />
   </Panel>
   <ShareModal

--- a/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
+++ b/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
@@ -45,7 +45,6 @@ exports[`BouncePage:  should display loading panel on top level metrics when agg
         ]
       }
       getRowData={[Function]}
-      onSort={[Function]}
       pagination={true}
       rows={
         Array [
@@ -127,7 +126,6 @@ exports[`BouncePage:  should render 1`] = `
         ]
       }
       getRowData={[Function]}
-      onSort={[Function]}
       pagination={true}
       rows={
         Array [
@@ -176,12 +174,25 @@ exports[`BouncePage:  should render correctly with no bounces 1`] = `
         Array [
           Object {
             "label": "Reason",
+            "sortKey": "reason",
             "width": "45%",
           },
-          "Domain",
-          "Category",
-          "Classification",
-          "Count (%)",
+          Object {
+            "label": "Domain",
+            "sortKey": "domain",
+          },
+          Object {
+            "label": "Category",
+            "sortKey": "bounce_category_name",
+          },
+          Object {
+            "label": "Classification",
+            "sortKey": "classification_id",
+          },
+          Object {
+            "label": "Count (%)",
+            "sortKey": "count_bounce",
+          },
         ]
       }
       getRowData={[Function]}
@@ -199,6 +210,8 @@ exports[`BouncePage:  should render correctly with no bounces 1`] = `
           },
         ]
       }
+      sortColumn="count_bounce"
+      sortDirection="desc"
     />
   </Panel>
   <ShareModal

--- a/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
+++ b/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
@@ -60,7 +60,7 @@ exports[`BouncePage:  should display loading panel on top level metrics when agg
           },
         ]
       }
-      sortColumn="count"
+      sortColumn="count_bounce"
       sortDirection="desc"
     />
   </Panel>
@@ -142,7 +142,7 @@ exports[`BouncePage:  should render 1`] = `
           },
         ]
       }
-      sortColumn="count"
+      sortColumn="count_bounce"
       sortDirection="desc"
     />
   </Panel>

--- a/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
+++ b/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
@@ -40,6 +40,8 @@ exports[`DelayPage:  should render page 1`] = `
           "Delayed First Attempt (%)",
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       getRowData={[Function]}
       pagination={true}
       rows={
@@ -203,6 +205,8 @@ exports[`DelayPage:  should show loading panel when aggregates are still loading
           "Delayed First Attempt (%)",
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       getRowData={[Function]}
       pagination={true}
       rows={

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/HistoryTable.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/HistoryTable.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`HistoryTable Component should render with all props 1`] = `
 <TableCollection
+  defaultSortColumn={null}
+  defaultSortDirection="asc"
   headerComponent={[Function]}
   outerWrapper={[Function]}
   pagination={false}
@@ -37,6 +39,8 @@ exports[`HistoryTable Component should render with no props 1`] = `
     title="Message History"
   >
     <TableCollection
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       headerComponent={[Function]}
       outerWrapper={[Function]}
       pagination={false}

--- a/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
@@ -29,6 +29,8 @@ exports[`Page: Message Events tests renders correctly with too many (1000) recor
           null,
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       getRowData={[Function]}
       pagination={true}
       rows={
@@ -1101,6 +1103,8 @@ exports[`Page: Message Events tests should render page correctly 1`] = `
           null,
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       getRowData={[Function]}
       pagination={true}
       rows={

--- a/src/pages/reports/rejection/tests/__snapshots__/RejectionPage.test.js.snap
+++ b/src/pages/reports/rejection/tests/__snapshots__/RejectionPage.test.js.snap
@@ -62,6 +62,8 @@ exports[`RejectionPage:  renders correctly 1`] = `
           "Count",
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       getRowData={[Function]}
       pagination={true}
       rows={
@@ -197,6 +199,8 @@ exports[`RejectionPage:  renders loading pannel when aggregates are still loadin
           "Count",
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       getRowData={[Function]}
       pagination={true}
       rows={

--- a/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
@@ -145,6 +145,8 @@ exports[`Summary Table  should render with data 1`] = `
     ]
   }
   defaultPerPage={10}
+  defaultSortColumn={null}
+  defaultSortDirection="asc"
   filterBox={
     Object {
       "show": false,

--- a/src/pages/sendingDomains/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/sendingDomains/tests/__snapshots__/ListPage.test.js.snap
@@ -77,6 +77,8 @@ exports[`Sending Domains List Page renders correctly 1`] = `
         },
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [

--- a/src/pages/subaccounts/components/test/__snapshots__/ApiKeysTab.test.js.snap
+++ b/src/pages/subaccounts/components/test/__snapshots__/ApiKeysTab.test.js.snap
@@ -51,6 +51,8 @@ exports[`ApiKeysTab normal props 1`] = `
           },
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       filterBox={
         Object {
           "exampleModifiers": Array [

--- a/src/pages/subaccounts/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/subaccounts/tests/__snapshots__/ListPage.test.js.snap
@@ -43,6 +43,8 @@ exports[`renders correctly 1`] = `
         },
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [
@@ -129,6 +131,8 @@ exports[`renders empty state 1`] = `
         },
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [

--- a/src/pages/suppressions/components/Results.js
+++ b/src/pages/suppressions/components/Results.js
@@ -19,7 +19,9 @@ export class Results extends Component {
     del: { // delete confirmation modal
       open: false,
       data: null
-    }
+    },
+    sortColumn: 'recipient',
+    sortDirection: 'asc'
   }
 
   renderPlaceholder() {
@@ -83,13 +85,13 @@ export class Results extends Component {
     const { hasSubaccounts } = this.props;
 
     const columns = [
-      { label: 'Recipient' },
-      { label: 'Type', width: '18%' },
+      { label: 'Recipient', sortKey: 'recipient' },
+      { label: 'Type', sortKey: 'type', width: '18%' },
       { label: 'Source', width: '20%' }
     ];
 
     if (hasSubaccounts) {
-      columns.push({ label: 'Subaccount', width: '18%' });
+      columns.push({ label: 'Subaccount', width: '18%', sortKey: 'subaccount_id' });
     }
 
     columns.push({ label: '', width: '21%' });
@@ -137,6 +139,7 @@ export class Results extends Component {
       onCancel={this.toggleDeleteModal}
     />);
   }
+
 
   renderResults = () => {
     const { results } = this.props;

--- a/src/pages/suppressions/components/Results.js
+++ b/src/pages/suppressions/components/Results.js
@@ -4,7 +4,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Button } from '@sparkpost/matchbox';
-import { getSortedCollection, handleSortChange } from 'src/helpers/sort';
 import { PanelLoading, TableCollection, Empty, DeleteModal } from 'src/components';
 import { deleteSuppression } from 'src/actions/suppressions';
 import { formatSubaccountDisplay } from '../helpers';
@@ -21,9 +20,7 @@ export class Results extends Component {
     del: { // delete confirmation modal
       open: false,
       data: null
-    },
-    sortColumn: 'recipient',
-    sortDirection: 'asc'
+    }
   }
 
   renderPlaceholder() {
@@ -89,7 +86,7 @@ export class Results extends Component {
     const columns = [
       { label: 'Recipient', sortKey: 'recipient' },
       { label: 'Type', sortKey: 'type', width: '18%' },
-      { label: 'Source', width: '20%' }
+      { label: 'Source', width: '20%', sortKey: 'source' }
     ];
 
     if (hasSubaccounts) {
@@ -142,10 +139,8 @@ export class Results extends Component {
     />);
   }
 
-
   renderResults = () => {
     const { results } = this.props;
-    const { sortColumn, sortDirection } = this.state;
 
     return (
       <div>
@@ -154,11 +149,9 @@ export class Results extends Component {
 
         <TableCollection
           columns={this.getColumns()}
-          rows={getSortedCollection(results, sortColumn, sortDirection)}
+          rows={results}
           getRowData={this.getRowData}
-          sortColumn={sortColumn}
-          sortDirection={sortDirection}
-          onSort={handleSortChange.bind(this)}
+          sortColumn='recipient'
           pagination
         />
       </div>

--- a/src/pages/suppressions/components/Results.js
+++ b/src/pages/suppressions/components/Results.js
@@ -4,11 +4,13 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Button } from '@sparkpost/matchbox';
+import { getSortedCollection, handleSortChange } from 'src/helpers/sort';
 import { PanelLoading, TableCollection, Empty, DeleteModal } from 'src/components';
 import { deleteSuppression } from 'src/actions/suppressions';
 import { formatSubaccountDisplay } from '../helpers';
-import Detail from './Detail';
 import { showAlert } from 'src/actions/globalAlert';
+import Detail from './Detail';
+
 
 export class Results extends Component {
   state = {
@@ -143,6 +145,8 @@ export class Results extends Component {
 
   renderResults = () => {
     const { results } = this.props;
+    const { sortColumn, sortDirection } = this.state;
+
     return (
       <div>
         { this.renderDeleteModal() }
@@ -150,8 +154,11 @@ export class Results extends Component {
 
         <TableCollection
           columns={this.getColumns()}
-          rows={results}
+          rows={getSortedCollection(results, sortColumn, sortDirection)}
           getRowData={this.getRowData}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          onSort={handleSortChange.bind(this)}
           pagination
         />
       </div>

--- a/src/pages/suppressions/components/Results.js
+++ b/src/pages/suppressions/components/Results.js
@@ -151,7 +151,7 @@ export class Results extends Component {
           columns={this.getColumns()}
           rows={results}
           getRowData={this.getRowData}
-          sortColumn='recipient'
+          defaultSortColumn='recipient'
           pagination
         />
       </div>

--- a/src/pages/suppressions/components/tests/__snapshots__/Results.test.js.snap
+++ b/src/pages/suppressions/components/tests/__snapshots__/Results.test.js.snap
@@ -92,6 +92,8 @@ exports[`Results renders correctly (with suppressions) 1`] = `
         },
       ]
     }
+    defaultSortColumn="recipient"
+    defaultSortDirection="asc"
     getRowData={[Function]}
     pagination={true}
     rows={
@@ -109,7 +111,6 @@ exports[`Results renders correctly (with suppressions) 1`] = `
         },
       ]
     }
-    sortColumn="recipient"
   />
 </div>
 `;
@@ -144,6 +145,8 @@ exports[`Results renders correctly (with suppressions, with subaccount) 1`] = `
         },
       ]
     }
+    defaultSortColumn="recipient"
+    defaultSortDirection="asc"
     getRowData={[Function]}
     pagination={true}
     rows={
@@ -161,7 +164,6 @@ exports[`Results renders correctly (with suppressions, with subaccount) 1`] = `
         },
       ]
     }
-    sortColumn="recipient"
   />
 </div>
 `;
@@ -214,6 +216,8 @@ exports[`Results renders delete confirmation modal correctly 1`] = `
         },
       ]
     }
+    defaultSortColumn="recipient"
+    defaultSortDirection="asc"
     getRowData={[Function]}
     pagination={true}
     rows={
@@ -231,7 +235,6 @@ exports[`Results renders delete confirmation modal correctly 1`] = `
         },
       ]
     }
-    sortColumn="recipient"
   />
 </div>
 `;
@@ -272,6 +275,8 @@ exports[`Results renders detail modal correctly 1`] = `
         },
       ]
     }
+    defaultSortColumn="recipient"
+    defaultSortDirection="asc"
     getRowData={[Function]}
     pagination={true}
     rows={
@@ -289,7 +294,6 @@ exports[`Results renders detail modal correctly 1`] = `
         },
       ]
     }
-    sortColumn="recipient"
   />
 </div>
 `;

--- a/src/pages/suppressions/components/tests/__snapshots__/Results.test.js.snap
+++ b/src/pages/suppressions/components/tests/__snapshots__/Results.test.js.snap
@@ -74,13 +74,16 @@ exports[`Results renders correctly (with suppressions) 1`] = `
       Array [
         Object {
           "label": "Recipient",
+          "sortKey": "recipient",
         },
         Object {
           "label": "Type",
+          "sortKey": "type",
           "width": "18%",
         },
         Object {
           "label": "Source",
+          "sortKey": "source",
           "width": "20%",
         },
         Object {
@@ -106,6 +109,7 @@ exports[`Results renders correctly (with suppressions) 1`] = `
         },
       ]
     }
+    sortColumn="recipient"
   />
 </div>
 `;
@@ -117,17 +121,21 @@ exports[`Results renders correctly (with suppressions, with subaccount) 1`] = `
       Array [
         Object {
           "label": "Recipient",
+          "sortKey": "recipient",
         },
         Object {
           "label": "Type",
+          "sortKey": "type",
           "width": "18%",
         },
         Object {
           "label": "Source",
+          "sortKey": "source",
           "width": "20%",
         },
         Object {
           "label": "Subaccount",
+          "sortKey": "subaccount_id",
           "width": "18%",
         },
         Object {
@@ -153,6 +161,7 @@ exports[`Results renders correctly (with suppressions, with subaccount) 1`] = `
         },
       ]
     }
+    sortColumn="recipient"
   />
 </div>
 `;
@@ -187,13 +196,16 @@ exports[`Results renders delete confirmation modal correctly 1`] = `
       Array [
         Object {
           "label": "Recipient",
+          "sortKey": "recipient",
         },
         Object {
           "label": "Type",
+          "sortKey": "type",
           "width": "18%",
         },
         Object {
           "label": "Source",
+          "sortKey": "source",
           "width": "20%",
         },
         Object {
@@ -219,6 +231,7 @@ exports[`Results renders delete confirmation modal correctly 1`] = `
         },
       ]
     }
+    sortColumn="recipient"
   />
 </div>
 `;
@@ -236,17 +249,21 @@ exports[`Results renders detail modal correctly 1`] = `
       Array [
         Object {
           "label": "Recipient",
+          "sortKey": "recipient",
         },
         Object {
           "label": "Type",
+          "sortKey": "type",
           "width": "18%",
         },
         Object {
           "label": "Source",
+          "sortKey": "source",
           "width": "20%",
         },
         Object {
           "label": "Subaccount",
+          "sortKey": "subaccount_id",
           "width": "18%",
         },
         Object {
@@ -272,6 +289,7 @@ exports[`Results renders detail modal correctly 1`] = `
         },
       ]
     }
+    sortColumn="recipient"
   />
 </div>
 `;

--- a/src/pages/templates/test/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/test/__snapshots__/ListPage.test.js.snap
@@ -45,6 +45,8 @@ exports[`renders correctly 1`] = `
         },
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [
@@ -120,6 +122,8 @@ exports[`renders empty state 1`] = `
         },
       ]
     }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
     filterBox={
       Object {
         "exampleModifiers": Array [

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -61,6 +61,8 @@ exports[`Users list page renders table and hidden modal 1`] = `
           null,
         ]
       }
+      defaultSortColumn={null}
+      defaultSortDirection="asc"
       filterBox={
         Object {
           "exampleModifiers": Array [


### PR DESCRIPTION
This PR allows sorting in TableCollection. This PR includes example usage of sorting for suppression list and bounce reports. 

Doc:
 - Pass table configuration to table collection. For a column to be sortable, pass `sortKey` to it. The value should be a key of object. But it can be anything else for manual handling in sort callback. Example:
```
const columns = [
  { label: 'Reason', width: '45%', sortKey: 'reason' },
  { label: 'Domain', sortKey: 'domain' },
  'actions'
];
```
 Note: last column won't be sortable as it doesn't have `sortKey` 
- Add `sortColumn` and `sortDirection` to state in the component using TableCollection. Use the value for default sorting column and direction. `sortColumn` will be similar  as `sortKey` above.
- Pass a callback to TableCollection using `onSort` arg. You can re-use `handleSortChange` from `src/helpers/sort` but it must bound to current component (`handleSortChange.bind(this)`). 
- Pass `sortColumn` and `sortDirection` to TableCollection. 
- Re-use or implement do your own implementation of`getSortedCollection`  to sort collection before feeding it to TableCollection. 


Todo:
- [x]  Link's color for sortable columns
- [x]  Link's color for non-sortable columns
- [x]  Sorting direction icon
cc @jonambas 