### PR TITLE
FAD-6194 refactor report refresh cycle

### DIFF
--- a/src/actions/rejectionReport.js
+++ b/src/actions/rejectionReport.js
@@ -1,64 +1,35 @@
-import _ from 'lodash';
-
 import { fetchRejectionReasonsByDomain, fetchDeliverability } from 'src/actions/metrics';
-import { refreshReportRange, maybeRefreshTypeaheadCache } from 'src/actions/reportFilters';
+import { refreshReportRange } from 'src/actions/reportFilters';
 import { getQueryFromOptions, buildCommonOptions, getMetricsFromKeys } from 'src/helpers/metrics';
 
-function refreshRejectionsTable(reasons) {
-  return {
-    type: 'REFRESH_REJECTION_BY_DOMAIN_TABLE',
-    payload: { reasons }
-  };
-}
+const rejectionMetrics = getMetricsFromKeys([
+  'count_rejected',
+  'count_targeted'
+]);
 
-export function refreshRejectionTableMetrics(updates = {}) {
+export function refreshRejections(updates = {}) {
   return (dispatch, getState) => {
     const { reportFilters } = getState();
-    const unsupportedParams = ['precision', 'metrics'];
 
+    updates.metrics = rejectionMetrics;
     const options = buildCommonOptions(reportFilters, updates);
     const query = getQueryFromOptions(options);
-    const params = _.omit(query, unsupportedParams);
 
-    maybeRefreshTypeaheadCache(dispatch, options, updates);
     dispatch(refreshReportRange(options));
 
-    return dispatch(fetchRejectionReasonsByDomain(params))
-      .then((reasons) => {
-        dispatch(refreshRejectionsTable(reasons));
-      });
-
-  };
-}
-
-function refreshRejectionMetrics(aggregates) {
-  return {
-    type: 'REFRESH_REJECTION_AGGREGATES',
-    payload: {
-      aggregates: aggregates[0]
-    }
-  };
-}
-
-export function loadRejectionMetrics(updates = {}) {
-  return (dispatch, getState) => {
-    const { reportFilters } = getState();
-
-    const rejectionMetrics = [
-      'count_rejected',
-      'count_targeted'
-    ];
-
-    updates.metrics = getMetricsFromKeys(rejectionMetrics);
-    const options = buildCommonOptions(reportFilters, updates);
-    const params = _.omit(getQueryFromOptions(options), 'precision');
-
-    maybeRefreshTypeaheadCache(dispatch, options, updates);
-    dispatch(refreshReportRange(options));
-
-    return dispatch(fetchDeliverability(params))
-      .then((aggregates) => {
-        dispatch(refreshRejectionMetrics(aggregates));
+    return Promise.all([
+      dispatch(fetchRejectionReasonsByDomain(query)),
+      dispatch(fetchDeliverability(query))
+    ])
+      .then(([reasons, [aggregates]]) => {
+        dispatch({
+          type: 'REFRESH_REJECTION_BY_DOMAIN_TABLE',
+          payload: { reasons }
+        });
+        dispatch({
+          type: 'REFRESH_REJECTION_AGGREGATES',
+          payload: { aggregates }
+        });
       });
   };
 }

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -19,8 +19,14 @@ const metricLists = [
   fetchMetricsIpPools
 ];
 
-// TODO: rename initTypeaheadCache
-export function refreshTypeaheadCache(params) {
+/**
+ * Returns a thunk that gets the metrics filter lists to populate cache,
+ * plus templates, subaccounts, and sending domains
+ *
+ * The thunk is a no-op if the cache has already been initialized, i.e.
+ * metrics.domains is an array and not undefined
+ */
+export function initTypeaheadCache(params) {
   return (dispatch, getState) => {
     const { metrics } = getState();
     if (Array.isArray(metrics.domains)) {
@@ -33,7 +39,7 @@ export function refreshTypeaheadCache(params) {
 }
 
 // TODO: rename refreshTypeaheadCache
-export function refreshListsByTime(params) {
+export function refreshTypeaheadCache(params) {
   return (dispatch) => {
     const requests = metricLists.map((list) => dispatch(list(params)));
     return Promise.all(requests);
@@ -46,7 +52,7 @@ export function maybeRefreshTypeaheadCache(dispatch, options, updates = {}) {
 
   if (relativeRange || from || to) {
     const params = getQueryFromOptions({ from: options.from, to: options.to });
-    dispatch(refreshListsByTime(params));
+    dispatch(refreshTypeaheadCache(params));
   }
 }
 

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -19,14 +19,20 @@ const metricLists = [
   fetchMetricsIpPools
 ];
 
+// TODO: rename initTypeaheadCache
 export function refreshTypeaheadCache(params) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const { metrics } = getState();
+    if (Array.isArray(metrics.domains)) {
+      return;
+    }
     const requests = metricLists.map((list) => dispatch(list(params)));
     requests.push(dispatch(listTemplates()), dispatch(listSubaccounts()), dispatch(listSendingDomains()));
     return Promise.all(requests);
   };
 }
 
+// TODO: rename refreshTypeaheadCache
 export function refreshListsByTime(params) {
   return (dispatch) => {
     const requests = metricLists.map((list) => dispatch(list(params)));

--- a/src/actions/summaryChart.js
+++ b/src/actions/summaryChart.js
@@ -1,5 +1,5 @@
 import { fetch as fetchMetrics } from 'src/actions/metrics';
-import { initTypeaheadCache, refreshReportRange } from 'src/actions/reportFilters';
+import { refreshReportRange } from 'src/actions/reportFilters';
 import { getQueryFromOptions, getMetricsFromKeys } from 'src/helpers/metrics';
 import { getRelativeDates } from 'src/helpers/date';
 
@@ -15,14 +15,6 @@ export function refresh(updates = {}) {
     // if relativeRange is included, merge in the calculated from/to values
     if (updates.relativeRange) {
       Object.assign(updates, getRelativeDates(updates.relativeRange) || {});
-    }
-
-    // refresh the typeahead cache if the date range has been updated
-    const { from, to } = updates;
-
-    if (from || to) {
-      const params = getQueryFromOptions({ from, to });
-      dispatch(initTypeaheadCache(params));
     }
 
     // merge in existing state

--- a/src/actions/summaryChart.js
+++ b/src/actions/summaryChart.js
@@ -1,5 +1,5 @@
 import { fetch as fetchMetrics } from 'src/actions/metrics';
-import { refreshTypeaheadCache, refreshReportRange } from 'src/actions/reportFilters';
+import { initTypeaheadCache, refreshReportRange } from 'src/actions/reportFilters';
 import { getQueryFromOptions, getMetricsFromKeys } from 'src/helpers/metrics';
 import { getRelativeDates } from 'src/helpers/date';
 
@@ -22,7 +22,7 @@ export function refresh(updates = {}) {
 
     if (from || to) {
       const params = getQueryFromOptions({ from, to });
-      dispatch(refreshTypeaheadCache(params));
+      dispatch(initTypeaheadCache(params));
     }
 
     // merge in existing state

--- a/src/actions/tests/reportFilters.test.js
+++ b/src/actions/tests/reportFilters.test.js
@@ -16,14 +16,20 @@ jest.mock('src/actions/sendingDomains');
 
 describe('Action Creator: Report Filters', () => {
   let dispatchMock;
+  let mockState;
+  let getStateMock;
 
   beforeEach(() => {
+    mockState = {
+      metrics: {}
+    };
     dispatchMock = jest.fn((a) => Promise.resolve(a));
+    getStateMock = jest.fn(() => mockState);
   });
 
   it('should call all requests on refresh', async() => {
-    const thunk = reportFilters.refreshTypeaheadCache({ foo: 'bar' });
-    await thunk(dispatchMock);
+    const thunk = reportFilters.initTypeaheadCache({ foo: 'bar' });
+    await thunk(dispatchMock, getStateMock);
     expect(metrics.fetchMetricsDomains).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsCampaigns).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsSendingIps).toHaveBeenCalledTimes(1);
@@ -31,11 +37,23 @@ describe('Action Creator: Report Filters', () => {
     expect(listTemplates).toHaveBeenCalledTimes(1);
     expect(listSubaccounts).toHaveBeenCalledTimes(1);
     expect(listSendingDomains).toHaveBeenCalledTimes(1);
-
   });
 
-  it('should call the metrics lists on refresh lists by time', async() => {
-    const thunk = reportFilters.refreshListsByTime({ foo: 'bar' });
+  it('should make no calls if the cache is already initialized', async() => {
+    const thunk = reportFilters.initTypeaheadCache({ foo: 'bar' });
+    mockState.metrics.domains = [];
+    await thunk(dispatchMock, getStateMock);
+    expect(metrics.fetchMetricsDomains).not.toHaveBeenCalled();
+    expect(metrics.fetchMetricsCampaigns).not.toHaveBeenCalled();
+    expect(metrics.fetchMetricsSendingIps).not.toHaveBeenCalled();
+    expect(metrics.fetchMetricsIpPools).not.toHaveBeenCalled();
+    expect(listTemplates).not.toHaveBeenCalled();
+    expect(listSubaccounts).not.toHaveBeenCalled();
+    expect(listSendingDomains).not.toHaveBeenCalled();
+  });
+
+  it('should refresh the metrics lists', async() => {
+    const thunk = reportFilters.refreshTypeaheadCache({ foo: 'bar' });
     await thunk(dispatchMock);
     expect(metrics.fetchMetricsDomains).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsCampaigns).toHaveBeenCalledTimes(1);

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,19 @@ import './critical.scss';
 import './index.scss';
 import App from './App';
 
+const debug = () => (next) => (action) => {
+  console.log(`=== ACTION: ${action.type} ===`); // eslint-disable-line no-console
+  console.log(action); // eslint-disable-line no-console
+  next(action);
+};
+
 // necessary for redux devtools in development mode only
 const composeEnhancers = process.env.NODE_ENV !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // eslint-disable-line no-mixed-operators
 const store = createStore(
   rootReducer,
   composeEnhancers(
     applyMiddleware(thunk),
+    applyMiddleware(debug),
     applyMiddleware(ErrorTracker.middleware)
   )
 );

--- a/src/pages/reports/accepted/AcceptedPage.js
+++ b/src/pages/reports/accepted/AcceptedPage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import { refreshAcceptedMetrics } from 'src/actions/acceptedReport';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
 import { Empty, PanelLoading } from 'src/components';
@@ -21,7 +21,7 @@ export class AcceptedPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   parseSearch() {
@@ -108,7 +108,7 @@ const mapStateToProps = ({ reportFilters, acceptedReport }) => ({
 
 const mapDispatchToProps = {
   refreshAcceptedMetrics,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   addFilters,
   showAlert
 };

--- a/src/pages/reports/accepted/tests/AcceptedPage.test.js
+++ b/src/pages/reports/accepted/tests/AcceptedPage.test.js
@@ -14,7 +14,7 @@ describe('AcceptedPage: ', () => {
     loading: false,
     aggregates: { count_accepted: 1 },
     refreshAcceptedMetrics: jest.fn(() => Promise.resolve()),
-    refreshTypeaheadCache: jest.fn(() => Promise.resolve()),
+    initTypeaheadCache: jest.fn(() => Promise.resolve()),
     addFilters: jest.fn(),
     showAlert: jest.fn(),
     location: {
@@ -48,7 +48,7 @@ describe('AcceptedPage: ', () => {
     wrapper.instance().componentDidMount();
     expect(props.refreshAcceptedMetrics).toHaveBeenCalled();
     expect(parseSpy).toHaveBeenCalled();
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -6,7 +6,7 @@ import qs from 'query-string';
 import _ from 'lodash';
 
 import { refreshBounceChartMetrics, refreshBounceTableMetrics } from 'src/actions/bounceReport';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
@@ -34,7 +34,7 @@ export class BouncePage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   /**
@@ -182,7 +182,7 @@ const mapDispatchToProps = {
   addFilters,
   refreshBounceChartMetrics,
   refreshBounceTableMetrics,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   showAlert
 };
 

--- a/src/pages/reports/bounce/tests/BouncePage.test.js
+++ b/src/pages/reports/bounce/tests/BouncePage.test.js
@@ -31,7 +31,7 @@ describe('BouncePage: ', () => {
     } ],
     refreshBounceChartMetrics: jest.fn((a) => Promise.resolve()),
     refreshBounceTableMetrics: jest.fn((a) => Promise.resolve()),
-    refreshTypeaheadCache: jest.fn((a) => Promise.resolve()),
+    initTypeaheadCache: jest.fn((a) => Promise.resolve()),
     location: {
       search: {}
     },
@@ -56,7 +56,7 @@ describe('BouncePage: ', () => {
     expect(props.refreshBounceChartMetrics).toHaveBeenCalled();
     expect(props.refreshBounceTableMetrics).toHaveBeenCalled();
     expect(spyParseSearch).toHaveBeenCalled();
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(props.addFilters).toHaveBeenCalledWith([]);
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/reports/delays/DelayPage.js
+++ b/src/pages/reports/delays/DelayPage.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import _ from 'lodash';
 
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { loadDelayReasonsByDomain, loadDelayMetrics } from 'src/actions/delayReport';
 import { parseSearch, getFilterSearchOptions } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
@@ -23,7 +23,7 @@ export class DelayPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   parseSearch() {
@@ -129,7 +129,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   addFilters,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   loadDelayReasonsByDomain,
   loadDelayMetrics,
   showAlert

--- a/src/pages/reports/delays/tests/DelayPage.test.js
+++ b/src/pages/reports/delays/tests/DelayPage.test.js
@@ -26,7 +26,7 @@ describe('DelayPage: ', () => {
     },
     totalAccepted: 1000,
     loadDelayReasonsByDomain: jest.fn(() => Promise.resolve()),
-    refreshTypeaheadCache: jest.fn(() => Promise.resolve()),
+    initTypeaheadCache: jest.fn(() => Promise.resolve()),
     location: { search: {}},
     loadDelayMetrics: jest.fn(() => Promise.resolve()),
     showAlert: jest.fn(),
@@ -58,7 +58,7 @@ describe('DelayPage: ', () => {
     expect(props.loadDelayMetrics).toHaveBeenCalled();
     expect(props.loadDelayReasonsByDomain).toHaveBeenCalled();
     expect(parseSpy).toHaveBeenCalled();
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(props.addFilters).toHaveBeenCalledWith([]);
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/reports/engagement/components/EngagementFilters.js
+++ b/src/pages/reports/engagement/components/EngagementFilters.js
@@ -23,7 +23,7 @@ export class EngagementFilters extends Component {
     this.props.addFilters(filters);
     this.props.refreshRelativeRange(range);
     this.props.onLoad();
-    this.props.refreshTypeaheadCache(); // this should wait until after onLoad
+    this.props.initTypeaheadCache(); // this should wait until after onLoad
   }
 
   // This event handler is called on every date range and filter change, however only the next

--- a/src/pages/reports/engagement/components/tests/EngagementFilters.test.js
+++ b/src/pages/reports/engagement/components/tests/EngagementFilters.test.js
@@ -14,7 +14,7 @@ const defaultProps = {
   location: { search: '' },
   onLoad: jest.fn(),
   refreshRelativeRange: jest.fn(),
-  refreshTypeaheadCache: jest.fn()
+  initTypeaheadCache: jest.fn()
 };
 
 it('renders filters, hydrates with filters from query string, and requests data', () => {
@@ -32,7 +32,7 @@ it('renders filters, hydrates with filters from query string, and requests data'
     to: time({ year: 2018, month: 1, day: 16 })
   });
   expect(props.onLoad).toHaveBeenCalled();
-  expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+  expect(props.initTypeaheadCache).toHaveBeenCalled();
   expect(wrapper).toMatchSnapshot();
 });
 

--- a/src/pages/reports/rejection/RejectionPage.js
+++ b/src/pages/reports/rejection/RejectionPage.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { loadRejectionMetrics, refreshRejectionTableMetrics } from 'src/actions/rejectionReport';
 import PanelLoading from 'src/components/panelLoading/PanelLoading';
 import { Page, Panel } from '@sparkpost/matchbox';
@@ -23,7 +23,7 @@ export class RejectionPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   /**
@@ -132,7 +132,7 @@ const mapDispatchToProps = {
   addFilters,
   loadRejectionMetrics,
   refreshRejectionTableMetrics,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   showAlert
 };
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(RejectionPage));

--- a/src/pages/reports/rejection/RejectionPage.js
+++ b/src/pages/reports/rejection/RejectionPage.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
 import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
-import { loadRejectionMetrics, refreshRejectionTableMetrics } from 'src/actions/rejectionReport';
+import { refreshRejections } from 'src/actions/rejectionReport';
 import PanelLoading from 'src/components/panelLoading/PanelLoading';
 import { Page, Panel } from '@sparkpost/matchbox';
 import ShareModal from '../components/ShareModal';
@@ -38,11 +38,8 @@ export class RejectionPage extends Component {
   }
 
   handleRefresh = (options) => {
-    const { showAlert, refreshRejectionTableMetrics, loadRejectionMetrics } = this.props;
-    return Promise.all([
-      loadRejectionMetrics(options),
-      refreshRejectionTableMetrics(options)
-    ])
+    const { showAlert } = this.props;
+    return this.props.refreshRejections(options)
       .then(() => this.updateLink())
       .catch((err) => showAlert({ type: 'error', message: 'Unable to refresh rejection reports.', details: err.message }));
   }
@@ -130,8 +127,7 @@ const mapStateToProps = ({ reportFilters, rejectionReport }) => ({
 
 const mapDispatchToProps = {
   addFilters,
-  loadRejectionMetrics,
-  refreshRejectionTableMetrics,
+  refreshRejections,
   initTypeaheadCache,
   showAlert
 };

--- a/src/pages/reports/rejection/tests/RejectionPage.test.js
+++ b/src/pages/reports/rejection/tests/RejectionPage.test.js
@@ -39,7 +39,7 @@ describe('RejectionPage: ', () => {
       },
       loadRejectionMetrics: jest.fn(() => Promise.resolve()),
       refreshRejectionTableMetrics: jest.fn(() => Promise.resolve()),
-      refreshTypeaheadCache: jest.fn(),
+      initTypeaheadCache: jest.fn(),
       addFilters: jest.fn(),
       location: {
         search: {}
@@ -56,7 +56,7 @@ describe('RejectionPage: ', () => {
 
   it('renders correctly', () => {
     expect(spyParseSearch).toHaveBeenCalledTimes(1);
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/reports/summary/SummaryPage.js
+++ b/src/pages/reports/summary/SummaryPage.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import qs from 'query-string';
 
 import { refresh as refreshSummaryChart } from 'src/actions/summaryChart';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 
 import { Page, Panel } from '@sparkpost/matchbox';
@@ -27,7 +27,7 @@ export class SummaryReportPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   /**
@@ -133,7 +133,7 @@ const mapStateToProps = ({ reportFilters, summaryChart }) => ({
 const mapDispatchToProps = {
   addFilters,
   refreshSummaryChart,
-  refreshTypeaheadCache
+  initTypeaheadCache
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SummaryReportPage));

--- a/src/pages/reports/summary/tests/SummaryPage.test.js
+++ b/src/pages/reports/summary/tests/SummaryPage.test.js
@@ -28,7 +28,7 @@ describe('Page: SummaryPage', () => {
         replace: jest.fn()
       },
       refreshSummaryChart: jest.fn(() => Promise.resolve()),
-      refreshTypeaheadCache: jest.fn(),
+      initTypeaheadCache: jest.fn(),
       addFilters: jest.fn()
     };
     wrapper = shallow(<SummaryReportPage {...testProps} />);

--- a/src/reducers/reportFilters.js
+++ b/src/reducers/reportFilters.js
@@ -1,9 +1,4 @@
-import { getRelativeDates } from 'src/helpers/date';
-
-const DEFAULT_RANGE = 'day';
 const initialState = {
-  ...getRelativeDates(DEFAULT_RANGE),
-  relativeRange: DEFAULT_RANGE,
   activeList: []
 };
 


### PR DESCRIPTION
Re: some performance concerns with how we retrieve the Typeahead cache, this change stops us from refreshing on each report page change and only initializes the cache once.

This PR doesn't change "refreshing on date range change" behavior, but I think this is far less strain on our DB than the existing UI. I did a simple search for 3-4 filters in the existing UI and generated 116 requests, 20 of which were just for the `metrics/domains` endpoint. The new UI will only make one set of metrics requests for each new date range, then use that cache for every filter search.

<img width="1142" alt="screen shot 2018-02-08 at 10 30 29 pm" src="https://user-images.githubusercontent.com/159370/36010491-b86afbf2-0d1f-11e8-922b-4cab5d4f39c1.png">
