### PR TITLE
Hotfix/mb 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,9 +132,9 @@
       }
     },
     "@sparkpost/matchbox": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-2.0.1.tgz",
-      "integrity": "sha512-jo+7bs/pTfs17/uIRBOLIVw01UansC5/DDOQSfoGkGIIK5N5ys+fw7jY631pvUyQdTkQ5GZq/LPqlsRrCOl7ew==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-2.0.3.tgz",
+      "integrity": "sha512-d6su8VejKNZDZfPEOPtonjGfCUeYScW4PqDmLD9y9VrUOfic+fNtjALeYVfJU5xeCq9MHjIFlvyfzrHBHyWCig==",
       "requires": {
         "classnames": "2.2.5",
         "react": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,9 +132,9 @@
       }
     },
     "@sparkpost/matchbox": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-2.0.3.tgz",
-      "integrity": "sha512-d6su8VejKNZDZfPEOPtonjGfCUeYScW4PqDmLD9y9VrUOfic+fNtjALeYVfJU5xeCq9MHjIFlvyfzrHBHyWCig==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-2.0.4.tgz",
+      "integrity": "sha512-Cwi9zE3BvDsDAyRRb8QrojXtjkRKRIQkYZbzTmpH+AOt7YXJT6TWrdb5eDx1UyBVrVMgePFm59Jzr2ZwugItdA==",
       "requires": {
         "classnames": "2.2.5",
         "react": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/SparkPost/2web2ui/issues"
   },
   "dependencies": {
-    "@sparkpost/matchbox": "^2.0.1",
+    "@sparkpost/matchbox": "^2.0.3",
     "axios": "^0.17.1",
     "chart.js": "^2.6.0",
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/SparkPost/2web2ui/issues"
   },
   "dependencies": {
-    "@sparkpost/matchbox": "^2.0.3",
+    "@sparkpost/matchbox": "^2.0.4",
     "axios": "^0.17.1",
     "chart.js": "^2.6.0",
     "classnames": "^2.2.5",

--- a/src/components/collection/SortLabel.module.scss
+++ b/src/components/collection/SortLabel.module.scss
@@ -13,15 +13,17 @@
 .Up, .Down {
   position: absolute;
   right: 0;
+  top: 50%;
   opacity: 0.4;
+  transform: translate(0, -50%);
 }
 
 .Up {
-  top: -4%;
+  margin-top: -4px;
 }
 
 .Down {
-  top: 24%;
+  margin-top: 4px;
 }
 
 .SortLabel.asc .Up, .SortLabel.desc .Down {

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -3,8 +3,9 @@ import _ from 'lodash';
 import { Panel, Table } from '@sparkpost/matchbox';
 import Collection from './Collection';
 import TableHeader from './TableHeader';
+import styles from './TableCollection.module.scss';
 
-const TableWrapper = (props) => <Panel><Table>{props.children}</Table></Panel>;
+const TableWrapper = (props) => <Panel className={styles.TableWrapper}><Table>{props.children}</Table></Panel>;
 
 const TableBody = (props) => <tbody>{props.children}</tbody>;
 

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -5,7 +5,13 @@ import Collection from './Collection';
 import TableHeader from './TableHeader';
 import styles from './TableCollection.module.scss';
 
-const TableWrapper = (props) => <Panel className={styles.TableWrapper}><Table>{props.children}</Table></Panel>;
+const TableWrapper = (props) => (
+  <Panel>
+    <div className={styles.TableWrapper}>
+      <Table>{props.children}</Table>
+    </div>
+  </Panel>
+);
 
 const TableBody = (props) => <tbody>{props.children}</tbody>;
 

--- a/src/components/collection/TableCollection.module.scss
+++ b/src/components/collection/TableCollection.module.scss
@@ -1,0 +1,3 @@
+.TableWrapper {
+  overflow: auto;
+}

--- a/src/components/collection/TableCollection.module.scss
+++ b/src/components/collection/TableCollection.module.scss
@@ -1,3 +1,7 @@
 .TableWrapper {
-  overflow: auto;
+  overflow-x: auto;
+
+  & > * {
+    margin-bottom: 0;
+  }
 }

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -33,7 +33,8 @@
 
 .content {
   position: relative;
-  padding: spacing(larger);
+  padding: spacing();
+  overflow-x: hidden;
 
   .app & {
     flex: 1 0 0;
@@ -41,6 +42,7 @@
 
     @media screen and (min-width: breakpoint(medium)) {
       margin-top: rem(0);
+      padding: spacing(larger);
     }
   }
 

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -34,7 +34,7 @@
 .content {
   position: relative;
   padding: spacing();
-  overflow-x: hidden;
+  overflow: hidden;
 
   .app & {
     flex: 1 0 0;

--- a/src/components/navigation/Navigation.module.scss
+++ b/src/components/navigation/Navigation.module.scss
@@ -134,7 +134,6 @@
 }
 
 .nestedList {
-  // padding-bottom: spacing(smaller);
   margin-bottom: 0;
 }
 

--- a/src/components/navigation/Navigation.module.scss
+++ b/src/components/navigation/Navigation.module.scss
@@ -95,12 +95,21 @@
     }
   }
 
+  &:focus {
+    color: color(gray, 10);
+    outline: none;
+  }
+
   &.isActive {
     color: color(gray, 10);
     background: color(gray, 2);
 
     .icon {
       fill: color(gray, 9);
+    }
+
+    .chevron {
+      fill: color(gray, 10);
     }
   }
 
@@ -114,17 +123,19 @@
     background: color(gray, 1);
 
     .chevron {
-      transform: translate(0, -50%) rotate(-90deg);
+      transform: translate(0, -50%) rotate(0);
     }
 
     & + .nestedList {
       display: block;
+      background: darken(color(gray, 1), 2);
     }
   }
 }
 
 .nestedList {
-  margin-bottom: spacing(small);
+  // padding-bottom: spacing(smaller);
+  margin-bottom: 0;
 }
 
 .nestedList .link {
@@ -147,7 +158,7 @@
   right: rem(15);
   width: rem(24);
   height: rem(24);
-  transform: translate(0, -50%);
+  transform: translate(0, -50%) rotate(-90deg);
   fill: color(gray, 4);
   transition: 0.1s;
 }


### PR DESCRIPTION
MB
- Fixes EmptyState svg styling that broke in 2.0.0
- Removes pastel background colors from Banner
- Removes white Tooltip borders
- Removes text-decoration from `a` links globally
- Adds UnstyledLink proptypes and story
- Removes word break from table headers

App
- Removes blue `focus` text color on nav items
- Darkens nav nested children background
- Fixed sort icon spacing on summary chart table
- Prevent tables from overflowing on smaller screen sizes
  - They are now more responsive than before, but will need a better solution long term