### PR TITLE
FAD-6194 (b) only initialize typeahead cache once

### DIFF
--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -19,8 +19,14 @@ const metricLists = [
   fetchMetricsIpPools
 ];
 
-// TODO: rename initTypeaheadCache
-export function refreshTypeaheadCache(params) {
+/**
+ * Returns a thunk that gets the metrics filter lists to populate cache,
+ * plus templates, subaccounts, and sending domains
+ *
+ * The thunk is a no-op if the cache has already been initialized, i.e.
+ * metrics.domains is an array and not undefined
+ */
+export function initTypeaheadCache(params) {
   return (dispatch, getState) => {
     const { metrics } = getState();
     if (Array.isArray(metrics.domains)) {
@@ -33,7 +39,7 @@ export function refreshTypeaheadCache(params) {
 }
 
 // TODO: rename refreshTypeaheadCache
-export function refreshListsByTime(params) {
+export function refreshTypeaheadCache(params) {
   return (dispatch) => {
     const requests = metricLists.map((list) => dispatch(list(params)));
     return Promise.all(requests);
@@ -46,7 +52,7 @@ export function maybeRefreshTypeaheadCache(dispatch, options, updates = {}) {
 
   if (relativeRange || from || to) {
     const params = getQueryFromOptions({ from: options.from, to: options.to });
-    dispatch(refreshListsByTime(params));
+    dispatch(refreshTypeaheadCache(params));
   }
 }
 

--- a/src/actions/reportFilters.js
+++ b/src/actions/reportFilters.js
@@ -19,14 +19,20 @@ const metricLists = [
   fetchMetricsIpPools
 ];
 
+// TODO: rename initTypeaheadCache
 export function refreshTypeaheadCache(params) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const { metrics } = getState();
+    if (Array.isArray(metrics.domains)) {
+      return;
+    }
     const requests = metricLists.map((list) => dispatch(list(params)));
     requests.push(dispatch(listTemplates()), dispatch(listSubaccounts()), dispatch(listSendingDomains()));
     return Promise.all(requests);
   };
 }
 
+// TODO: rename refreshTypeaheadCache
 export function refreshListsByTime(params) {
   return (dispatch) => {
     const requests = metricLists.map((list) => dispatch(list(params)));

--- a/src/actions/summaryChart.js
+++ b/src/actions/summaryChart.js
@@ -1,5 +1,5 @@
 import { fetch as fetchMetrics } from 'src/actions/metrics';
-import { refreshTypeaheadCache, refreshReportRange } from 'src/actions/reportFilters';
+import { initTypeaheadCache, refreshReportRange } from 'src/actions/reportFilters';
 import { getQueryFromOptions, getMetricsFromKeys } from 'src/helpers/metrics';
 import { getRelativeDates } from 'src/helpers/date';
 
@@ -22,7 +22,7 @@ export function refresh(updates = {}) {
 
     if (from || to) {
       const params = getQueryFromOptions({ from, to });
-      dispatch(refreshTypeaheadCache(params));
+      dispatch(initTypeaheadCache(params));
     }
 
     // merge in existing state

--- a/src/actions/tests/reportFilters.test.js
+++ b/src/actions/tests/reportFilters.test.js
@@ -16,14 +16,20 @@ jest.mock('src/actions/sendingDomains');
 
 describe('Action Creator: Report Filters', () => {
   let dispatchMock;
+  let mockState;
+  let getStateMock;
 
   beforeEach(() => {
+    mockState = {
+      metrics: {}
+    };
     dispatchMock = jest.fn((a) => Promise.resolve(a));
+    getStateMock = jest.fn(() => mockState);
   });
 
   it('should call all requests on refresh', async() => {
-    const thunk = reportFilters.refreshTypeaheadCache({ foo: 'bar' });
-    await thunk(dispatchMock);
+    const thunk = reportFilters.initTypeaheadCache({ foo: 'bar' });
+    await thunk(dispatchMock, getStateMock);
     expect(metrics.fetchMetricsDomains).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsCampaigns).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsSendingIps).toHaveBeenCalledTimes(1);
@@ -31,11 +37,23 @@ describe('Action Creator: Report Filters', () => {
     expect(listTemplates).toHaveBeenCalledTimes(1);
     expect(listSubaccounts).toHaveBeenCalledTimes(1);
     expect(listSendingDomains).toHaveBeenCalledTimes(1);
-
   });
 
-  it('should call the metrics lists on refresh lists by time', async() => {
-    const thunk = reportFilters.refreshListsByTime({ foo: 'bar' });
+  it('should make no calls if the cache is already initialized', async() => {
+    const thunk = reportFilters.initTypeaheadCache({ foo: 'bar' });
+    mockState.metrics.domains = [];
+    await thunk(dispatchMock, getStateMock);
+    expect(metrics.fetchMetricsDomains).not.toHaveBeenCalled();
+    expect(metrics.fetchMetricsCampaigns).not.toHaveBeenCalled();
+    expect(metrics.fetchMetricsSendingIps).not.toHaveBeenCalled();
+    expect(metrics.fetchMetricsIpPools).not.toHaveBeenCalled();
+    expect(listTemplates).not.toHaveBeenCalled();
+    expect(listSubaccounts).not.toHaveBeenCalled();
+    expect(listSendingDomains).not.toHaveBeenCalled();
+  });
+
+  it('should refresh the metrics lists', async() => {
+    const thunk = reportFilters.refreshTypeaheadCache({ foo: 'bar' });
     await thunk(dispatchMock);
     expect(metrics.fetchMetricsDomains).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsCampaigns).toHaveBeenCalledTimes(1);

--- a/src/pages/reports/accepted/AcceptedPage.js
+++ b/src/pages/reports/accepted/AcceptedPage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import { refreshAcceptedMetrics } from 'src/actions/acceptedReport';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
 import { Empty, PanelLoading } from 'src/components';
@@ -21,7 +21,7 @@ export class AcceptedPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   parseSearch() {
@@ -108,7 +108,7 @@ const mapStateToProps = ({ reportFilters, acceptedReport }) => ({
 
 const mapDispatchToProps = {
   refreshAcceptedMetrics,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   addFilters,
   showAlert
 };

--- a/src/pages/reports/accepted/tests/AcceptedPage.test.js
+++ b/src/pages/reports/accepted/tests/AcceptedPage.test.js
@@ -14,7 +14,7 @@ describe('AcceptedPage: ', () => {
     loading: false,
     aggregates: { count_accepted: 1 },
     refreshAcceptedMetrics: jest.fn(() => Promise.resolve()),
-    refreshTypeaheadCache: jest.fn(() => Promise.resolve()),
+    initTypeaheadCache: jest.fn(() => Promise.resolve()),
     addFilters: jest.fn(),
     showAlert: jest.fn(),
     location: {
@@ -48,7 +48,7 @@ describe('AcceptedPage: ', () => {
     wrapper.instance().componentDidMount();
     expect(props.refreshAcceptedMetrics).toHaveBeenCalled();
     expect(parseSpy).toHaveBeenCalled();
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -6,7 +6,7 @@ import qs from 'query-string';
 import _ from 'lodash';
 
 import { refreshBounceChartMetrics, refreshBounceTableMetrics } from 'src/actions/bounceReport';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
@@ -34,7 +34,7 @@ export class BouncePage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   /**
@@ -182,7 +182,7 @@ const mapDispatchToProps = {
   addFilters,
   refreshBounceChartMetrics,
   refreshBounceTableMetrics,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   showAlert
 };
 

--- a/src/pages/reports/bounce/tests/BouncePage.test.js
+++ b/src/pages/reports/bounce/tests/BouncePage.test.js
@@ -31,7 +31,7 @@ describe('BouncePage: ', () => {
     } ],
     refreshBounceChartMetrics: jest.fn((a) => Promise.resolve()),
     refreshBounceTableMetrics: jest.fn((a) => Promise.resolve()),
-    refreshTypeaheadCache: jest.fn((a) => Promise.resolve()),
+    initTypeaheadCache: jest.fn((a) => Promise.resolve()),
     location: {
       search: {}
     },
@@ -56,7 +56,7 @@ describe('BouncePage: ', () => {
     expect(props.refreshBounceChartMetrics).toHaveBeenCalled();
     expect(props.refreshBounceTableMetrics).toHaveBeenCalled();
     expect(spyParseSearch).toHaveBeenCalled();
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(props.addFilters).toHaveBeenCalledWith([]);
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/reports/delays/DelayPage.js
+++ b/src/pages/reports/delays/DelayPage.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import _ from 'lodash';
 
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { loadDelayReasonsByDomain, loadDelayMetrics } from 'src/actions/delayReport';
 import { parseSearch, getFilterSearchOptions } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
@@ -23,7 +23,7 @@ export class DelayPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   parseSearch() {
@@ -129,7 +129,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   addFilters,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   loadDelayReasonsByDomain,
   loadDelayMetrics,
   showAlert

--- a/src/pages/reports/delays/tests/DelayPage.test.js
+++ b/src/pages/reports/delays/tests/DelayPage.test.js
@@ -26,7 +26,7 @@ describe('DelayPage: ', () => {
     },
     totalAccepted: 1000,
     loadDelayReasonsByDomain: jest.fn(() => Promise.resolve()),
-    refreshTypeaheadCache: jest.fn(() => Promise.resolve()),
+    initTypeaheadCache: jest.fn(() => Promise.resolve()),
     location: { search: {}},
     loadDelayMetrics: jest.fn(() => Promise.resolve()),
     showAlert: jest.fn(),
@@ -58,7 +58,7 @@ describe('DelayPage: ', () => {
     expect(props.loadDelayMetrics).toHaveBeenCalled();
     expect(props.loadDelayReasonsByDomain).toHaveBeenCalled();
     expect(parseSpy).toHaveBeenCalled();
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(props.addFilters).toHaveBeenCalledWith([]);
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/reports/engagement/components/EngagementFilters.js
+++ b/src/pages/reports/engagement/components/EngagementFilters.js
@@ -23,7 +23,7 @@ export class EngagementFilters extends Component {
     this.props.addFilters(filters);
     this.props.refreshRelativeRange(range);
     this.props.onLoad();
-    this.props.refreshTypeaheadCache(); // this should wait until after onLoad
+    this.props.initTypeaheadCache(); // this should wait until after onLoad
   }
 
   // This event handler is called on every date range and filter change, however only the next

--- a/src/pages/reports/engagement/components/tests/EngagementFilters.test.js
+++ b/src/pages/reports/engagement/components/tests/EngagementFilters.test.js
@@ -14,7 +14,7 @@ const defaultProps = {
   location: { search: '' },
   onLoad: jest.fn(),
   refreshRelativeRange: jest.fn(),
-  refreshTypeaheadCache: jest.fn()
+  initTypeaheadCache: jest.fn()
 };
 
 it('renders filters, hydrates with filters from query string, and requests data', () => {
@@ -32,7 +32,7 @@ it('renders filters, hydrates with filters from query string, and requests data'
     to: time({ year: 2018, month: 1, day: 16 })
   });
   expect(props.onLoad).toHaveBeenCalled();
-  expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+  expect(props.initTypeaheadCache).toHaveBeenCalled();
   expect(wrapper).toMatchSnapshot();
 });
 

--- a/src/pages/reports/rejection/RejectionPage.js
+++ b/src/pages/reports/rejection/RejectionPage.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 import { showAlert } from 'src/actions/globalAlert';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { loadRejectionMetrics, refreshRejectionTableMetrics } from 'src/actions/rejectionReport';
 import PanelLoading from 'src/components/panelLoading/PanelLoading';
 import { Page, Panel } from '@sparkpost/matchbox';
@@ -23,7 +23,7 @@ export class RejectionPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   /**
@@ -132,7 +132,7 @@ const mapDispatchToProps = {
   addFilters,
   loadRejectionMetrics,
   refreshRejectionTableMetrics,
-  refreshTypeaheadCache,
+  initTypeaheadCache,
   showAlert
 };
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(RejectionPage));

--- a/src/pages/reports/rejection/tests/RejectionPage.test.js
+++ b/src/pages/reports/rejection/tests/RejectionPage.test.js
@@ -39,7 +39,7 @@ describe('RejectionPage: ', () => {
       },
       loadRejectionMetrics: jest.fn(() => Promise.resolve()),
       refreshRejectionTableMetrics: jest.fn(() => Promise.resolve()),
-      refreshTypeaheadCache: jest.fn(),
+      initTypeaheadCache: jest.fn(),
       addFilters: jest.fn(),
       location: {
         search: {}
@@ -56,7 +56,7 @@ describe('RejectionPage: ', () => {
 
   it('renders correctly', () => {
     expect(spyParseSearch).toHaveBeenCalledTimes(1);
-    expect(props.refreshTypeaheadCache).toHaveBeenCalled();
+    expect(props.initTypeaheadCache).toHaveBeenCalled();
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/reports/summary/SummaryPage.js
+++ b/src/pages/reports/summary/SummaryPage.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import qs from 'query-string';
 
 import { refresh as refreshSummaryChart } from 'src/actions/summaryChart';
-import { addFilters, refreshTypeaheadCache } from 'src/actions/reportFilters';
+import { addFilters, initTypeaheadCache } from 'src/actions/reportFilters';
 import { getFilterSearchOptions, parseSearch } from 'src/helpers/reports';
 
 import { Page, Panel } from '@sparkpost/matchbox';
@@ -27,7 +27,7 @@ export class SummaryReportPage extends Component {
 
   componentDidMount() {
     this.handleRefresh(this.parseSearch());
-    this.props.refreshTypeaheadCache();
+    this.props.initTypeaheadCache();
   }
 
   /**
@@ -133,7 +133,7 @@ const mapStateToProps = ({ reportFilters, summaryChart }) => ({
 const mapDispatchToProps = {
   addFilters,
   refreshSummaryChart,
-  refreshTypeaheadCache
+  initTypeaheadCache
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SummaryReportPage));

--- a/src/pages/reports/summary/tests/SummaryPage.test.js
+++ b/src/pages/reports/summary/tests/SummaryPage.test.js
@@ -28,7 +28,7 @@ describe('Page: SummaryPage', () => {
         replace: jest.fn()
       },
       refreshSummaryChart: jest.fn(() => Promise.resolve()),
-      refreshTypeaheadCache: jest.fn(),
+      initTypeaheadCache: jest.fn(),
       addFilters: jest.fn()
     };
     wrapper = shallow(<SummaryReportPage {...testProps} />);


### PR DESCRIPTION
This is half of the work needed to fix the issue in FAD-6194, so we are cutting it loose and pushing it out. The rest of the work will be done in #276 and pushed ASAP