### PR TITLE
FAD 6221: Tracking domains create throws after creation

### DIFF
--- a/src/actions/trackingDomains.js
+++ b/src/actions/trackingDomains.js
@@ -1,4 +1,5 @@
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
+import { apiResponseToAlert } from 'src/helpers/apiMessages';
 import setSubaccountHeader from './helpers/setSubaccountHeader';
 import { showAlert } from './globalAlert';
 
@@ -24,7 +25,7 @@ export function createTrackingDomain({ subaccount, ...data }) {
     }
   }))
     .then(() => dispatch(showAlert({ type: 'success', message: `Successfully added ${data.domain}` })))
-    .catch((err) => dispatch(showAlert({ type: 'error', message: `Unable to add ${data.domain}` })));
+    .catch((err) => dispatch(showAlert(apiResponseToAlert(err, `Unable to add ${data.domain}`))));
 }
 
 export function updateTrackingDomain({ domain, subaccount = null, ...data }) {

--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -6,21 +6,21 @@ import _ from 'lodash';
 
 export class ProtectedRoute extends Component {
 
-  renderComponent(propsFromRoute) {
+  renderComponent(reactRouterProps) {
     const { component: Component, condition } = this.props;
 
     return (
       <AccessControl condition={condition} redirect='/404'>
-        <Component {...propsFromRoute} />
+        <Component {...reactRouterProps} />
       </AccessControl>
     );
   }
 
-  renderRoute = () => {
+  renderRoute = (reactRouterProps) => {
     const { auth } = this.props;
 
     return auth.loggedIn
-      ? this.renderComponent(this.props)
+      ? this.renderComponent(reactRouterProps)
       : (
         <Redirect to={{
           pathname: '/auth',
@@ -31,8 +31,8 @@ export class ProtectedRoute extends Component {
 
   render() {
     // can't pass component prop to Route below or it confuses RR
-    const routeProps = _.omit(this.props, ['component', 'auth', 'condition']);
-    return (<Route {...routeProps} render={this.renderRoute} />);
+    const protectedRouteProps = _.omit(this.props, ['component', 'auth', 'condition']);
+    return (<Route {...protectedRouteProps} render={this.renderRoute} />);
   }
 }
 

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-import React from 'react';
 import {
   apiKeys,
   AuthPage,
@@ -77,11 +76,6 @@ const routes = [
     path: '/',
     public: true,
     redirect: '/auth'
-  },
-  {
-    path: '/routeprops',
-    public: true,
-    component: (props) => <pre><code>{JSON.stringify(props, null, 2)}</code></pre>
   },
   {
     path: '/auth',

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import React from 'react';
 import {
   apiKeys,
   AuthPage,
@@ -76,6 +77,11 @@ const routes = [
     path: '/',
     public: true,
     redirect: '/auth'
+  },
+  {
+    path: '/routeprops',
+    public: true,
+    component: (props) => <pre><code>{JSON.stringify(props, null, 2)}</code></pre>
   },
   {
     path: '/auth',


### PR DESCRIPTION
`trackingDomains/CreatePage.js` is missing`history.push`.

This ticket:
 - includes @jasonrhodes fix which passes react-router props down from `ProtectedRoute`
 - improves error messages on tracking domain create using `src/helpers/apiMessages.js`

### Testing
 - Create a new tracking domain - watch it succeed
 - Create a pre-existing tracking domain - watch it fail and give error details about the clash
