### PR TITLE
FAD-6109 Support necessary Sift Science events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4973,6 +4973,11 @@
         "strip-eof": "1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -10428,7 +10433,7 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -13780,6 +13785,17 @@
       "integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw==",
       "dev": true
     },
+    "react-helmet": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
+      "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
+      "requires": {
+        "deep-equal": "1.0.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "react-side-effect": "1.1.5"
+      }
+    },
     "react-icon-base": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.2.tgz",
@@ -13858,6 +13874,15 @@
         "prop-types": "15.6.0",
         "react-router": "4.2.0",
         "warning": "3.0.0"
+      }
+    },
+    "react-side-effect": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
+      "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
+      "requires": {
+        "exenv": "1.2.2",
+        "shallowequal": "1.0.2"
       }
     },
     "react-smooth": {
@@ -14363,7 +14388,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "request-promise-core": {
@@ -14933,6 +14958,11 @@
         }
       }
     },
+    "shallowequal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
+      "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -15146,7 +15176,7 @@
       "dev": true,
       "requires": {
         "faye-websocket": "0.10.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "faye-websocket": {
@@ -16766,10 +16796,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-day-picker": "^7.0.7",
     "react-dom": "^16.2.0",
     "react-dropzone": "^4.2.3",
+    "react-helmet": "^5.2.0",
     "react-load-script": "0.0.6",
     "react-loadable": "^5.3.1",
     "react-qr-svg": "^2.1.0",
@@ -78,7 +79,8 @@
     "redux-form": "^7.2.3",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1",
-    "source-map-explorer": "^1.5.0"
+    "source-map-explorer": "^1.5.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "autoprefixer": "^7.2.5",

--- a/public/static/tenant-config/production.js
+++ b/public/static/tenant-config/production.js
@@ -7,6 +7,9 @@ window.SP.productionConfig = {
     has_signup: true
   },
   gaTag: 'UA-111136819-2',
+  siftScience: {
+    id: '88affa8e11'
+  },
   splashPage: '/dashboard',
   smtpAuth: {
     host: 'smtp.sparkmail.com',

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { PublicRoute, ProtectedRoute, AuthenticationGate } from 'src/components/auth';
 import { Support, GlobalAlertWrapper, RouteWatch } from 'src/components';
+import SiftScience from 'src/components/siftScience/SiftScience';
 import Layout from 'src/components/layout/Layout';
 import routes from 'src/config/routes';
+import config from 'src/config';
 
 import {
   BrowserRouter as Router,
@@ -13,6 +15,7 @@ import {
 const App = () => (
   <Router>
     <div>
+      {config.siftScience && <SiftScience config={config.siftScience} />}
       <RouteWatch />
       <AuthenticationGate />
       <Layout>

--- a/src/components/siftScience/SiftScience.js
+++ b/src/components/siftScience/SiftScience.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import Cookies from 'js-cookie';
+import uuidV4 from 'uuid/v4';
+
+import { COOKIE_DOMAIN } from 'src/constants';
+
+const COOKIE_EXPIRATION = 1; // days
+
+// Shared with corporate website
+// SEE: https://github.com/SparkPost/sparkpost.com/blob/fcc6758b78abf3dc4b1c6ee4f99799d999c75a7f/wordpress/wp-content/themes/jolteon/js/siftscience.js
+const COOKIE_NAME = '_sp_session_id';
+const SNIPPET_URL = 'https://cdn.siftscience.com/s.js';
+
+// When you don't have or know the user's id, set the value to the empty string.
+// SEE: https://support.siftscience.com/hc/en-us/articles/208370598
+const UNDEFINED_CUSTOMER = '';
+
+// SEE: https://siftscience.com/developers/docs/javascript/javascript-api
+export class SiftScience extends Component {
+  componentDidMount() {
+    this.pushEvent('_setAccount', this.props.config.id);
+    this.pushEvent('_setSessionId', this.findOrCreateSessionId());
+    this.pushEvent('_setUserId', this.getPrefixedCustomer());
+    this.pushEvent('_trackPageview');
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.customer !== prevProps.customer) {
+      this.pushEvent('_setUserId', this.getPrefixedCustomer());
+    }
+
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      this.pushEvent('_trackPageview');
+    }
+  }
+
+  getPrefixedCustomer() {
+    const prefix = this.props.config.accountPrefix || '';
+
+    if (!this.props.customer) {
+      return UNDEFINED_CUSTOMER;
+    }
+
+    return `${prefix}${this.props.customer}`;
+  }
+
+  findOrCreateSessionId() {
+    const sessionId = Cookies.get(COOKIE_NAME);
+
+    if (sessionId) {
+      return sessionId;
+    }
+
+    const newSessionId = uuidV4();
+
+    Cookies.set(COOKIE_NAME, newSessionId, {
+      domain: COOKIE_DOMAIN,
+      expires: COOKIE_EXPIRATION
+    });
+
+    return newSessionId;
+  }
+
+  pushEvent(...event) {
+    if (!window._sift) {
+      window._sift = [];
+    }
+
+    window._sift.push(event);
+  }
+
+  render() {
+    return (
+      <Helmet>
+        <script src={SNIPPET_URL} type="text/javascript" />
+      </Helmet>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  customer: state.currentUser.customer
+});
+
+export default withRouter(connect(mapStateToProps)(SiftScience));

--- a/src/components/siftScience/tests/SiftScience.test.js
+++ b/src/components/siftScience/tests/SiftScience.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Cookies from 'js-cookie';
+import { SiftScience } from '../SiftScience';
+
+jest.mock('js-cookie');
+jest.mock('uuid/v4', () => jest.fn(() => 'new-test-session-id'));
+
+describe('SiftScience', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    delete window._sift;
+    Cookies.get = jest.fn();
+    wrapper = shallow(
+      <SiftScience
+        config={{ id: 'test-id' }}
+        location={{ pathname: '/auth' }}
+      />
+    );
+  });
+
+  it('renders the snippet', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('sends setup events', () => {
+    expect(window._sift).toMatchSnapshot();
+  });
+
+  it('sends update event when customer changes', () => {
+    wrapper.setProps({ customer: '123456' });
+    expect(window._sift).toMatchSnapshot();
+  });
+
+  it('sends update event when page changes', () => {
+    wrapper.setProps({ location: { pathname: '/dashboard' }});
+    expect(window._sift).toMatchSnapshot();
+  });
+
+  describe('getPrefixedCustomer', () => {
+    it('returns empty string', () => {
+      const customer = wrapper.instance().getPrefixedCustomer();
+      expect(customer).toEqual('');
+    });
+
+    it('returns customer id', () => {
+      wrapper.setProps({ customer: 123 });
+      const customer = wrapper.instance().getPrefixedCustomer();
+      expect(customer).toEqual('123');
+    });
+
+    it('returns prefixed customer id', () => {
+      wrapper.setProps({
+        config: { accountPrefix: 'test-' },
+        customer: 123
+      });
+      const customer = wrapper.instance().getPrefixedCustomer();
+      expect(customer).toEqual('test-123');
+    });
+  });
+
+  describe('findOrCreateSessionId', () => {
+    it('returns current session id', () => {
+      Cookies.get = jest.fn(() => 'test-session-id');
+      const sessionId = wrapper.instance().findOrCreateSessionId();
+      expect(sessionId).toEqual('test-session-id');
+    });
+
+    it('returns new session id and sets cookie', () => {
+      const sessionId = wrapper.instance().findOrCreateSessionId();
+
+      expect(Cookies.set).toHaveBeenCalledWith('_sp_session_id', 'new-test-session-id', {
+        domain: '.sparkpost.com',
+        expires: 1
+      });
+      expect(sessionId).toEqual('new-test-session-id');
+    });
+  });
+});

--- a/src/components/siftScience/tests/__snapshots__/SiftScience.test.js.snap
+++ b/src/components/siftScience/tests/__snapshots__/SiftScience.test.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SiftScience renders the snippet 1`] = `
+<HelmetWrapper
+  defer={true}
+  encodeSpecialCharacters={true}
+>
+  <script
+    src="https://cdn.siftscience.com/s.js"
+    type="text/javascript"
+  />
+</HelmetWrapper>
+`;
+
+exports[`SiftScience sends setup events 1`] = `
+Array [
+  Array [
+    "_setAccount",
+    "test-id",
+  ],
+  Array [
+    "_setSessionId",
+    "new-test-session-id",
+  ],
+  Array [
+    "_setUserId",
+    "",
+  ],
+  Array [
+    "_trackPageview",
+  ],
+]
+`;
+
+exports[`SiftScience sends update event when customer changes 1`] = `
+Array [
+  Array [
+    "_setAccount",
+    "test-id",
+  ],
+  Array [
+    "_setSessionId",
+    "new-test-session-id",
+  ],
+  Array [
+    "_setUserId",
+    "",
+  ],
+  Array [
+    "_trackPageview",
+  ],
+  Array [
+    "_setUserId",
+    "123456",
+  ],
+]
+`;
+
+exports[`SiftScience sends update event when page changes 1`] = `
+Array [
+  Array [
+    "_setAccount",
+    "test-id",
+  ],
+  Array [
+    "_setSessionId",
+    "new-test-session-id",
+  ],
+  Array [
+    "_setUserId",
+    "",
+  ],
+  Array [
+    "_trackPageview",
+  ],
+  Array [
+    "_trackPageview",
+  ],
+]
+`;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,6 +1,8 @@
 export const DEFAULT_REDIRECT_ROUTE = '/landing';
 export const AFTER_JOIN_REDIRECT_ROUTE = '/onboarding/plan';
 
+export const COOKIE_DOMAIN = '.sparkpost.com';
+
 export const DATE_FORMATS = {
   READABLE_DATE_TIME: 'MMM D YYYY h:mma',
   INPUT_DATE: 'YYYY-MM-DD',


### PR DESCRIPTION
_Refer to [FAD-6109](https://jira.int.messagesystems.com/browse/FAD-6109) for AC_

The intention of this PR is to integrate with Sift Science (SS) similar to the webui setup.

**About SS JavaScript Snippet**

Here are the [installation instructions](https://siftscience.com/developers/docs/javascript/javascript-api).  Communication is done by pushing one of the following events on a global variable, `window._sift`, and letting the snippet process them as needed.

* _setAccount - set with [Javascript Snippet Key](https://console.siftscience.com/developer/api-keys)
* _setUserId - set with user's customer ID (account prefixed if available)
* _setSessionId - set with a UUID that is shared our other sites (e.g. [sparkpost.com](https://github.com/SparkPost/sparkpost.com/blob/8bf34fd430e4ed55843040c07a0078288e321dd6/wordpress/wp-content/themes/jolteon/js/siftscience.js))
* _trackPageview - this event is magical, it doesn't accept any arguments/values, it grabs all it needs from window

NOTE: We currently do not set _setCookieDomain.  It is my understanding that this could be an alternative for _setSessionId to identify unique visitors without needing to create a UUID and store it in a cookie to share with our other sites.  Instead, we would set the cookie domain to 'sparkpost.com' and let SS do the rest.

**Overview of Webui Setup**

1. [index.html](https://github.com/SparkPost/webui/blob/master/src/index.html#L40) loads the inline-scripts.js script
1. [common/inline-scripts.js](https://github.com/SparkPost/webui/blob/master/src/common/inline-scripts.js#L20-L35) loads the SS snippet [onload](https://developer.mozilla.org/en-US/docs/Web/Events/load) after all other resources have finished loading and defines `window._sift`
1. The Angular app during configuration [calls Analytics.setup()](https://github.com/SparkPost/webui/blob/master/src/app/app.js#L153)
1. [setup()](https://github.com/SparkPost/webui/blob/master/src/common/services/analytics.js#L58-L76) registers a function to call Sift Science events.
1. On `$stateChangeSuccess` (a page change), [Analytics.setCustomData(userData)](https://github.com/SparkPost/webui/blob/master/src/app/app.js#L227) and [Analytics.trackPageView($location.url(), $rootScope.stateData.title)](https://github.com/SparkPost/webui/blob/master/src/app/app.js#L230) are called.
1. `setCustomData` calls [getCustomDataArgs](https://github.com/SparkPost/webui/blob/master/src/common/services/analytics.js#L86-L88) which executes the [case 'user_data'](https://github.com/SparkPost/webui/blob/master/src/common/services/analytics.js#L70-L72) to set _setUserId.
1. `trackPageView` calls [getPageViewArgs](https://github.com/SparkPost/webui/blob/master/src/common/services/analytics.js#L77-L85) which executes the [case 'page_view'](https://github.com/SparkPost/webui/blob/master/src/common/services/analytics.js#L67-L69) to call _trackPageview.

NOTE: There are no additional events captured ([`getEventArgs`](https://github.com/SparkPost/webui/blob/master/src/common/services/analytics.js#L89-L91) is a noop).  The API events come from accusers-api.

**How to Test**

For local development, testing, and staging, we **_MUST_** use the SS sandbox account.  For production, create a throwaway SP account with the [fake credit card](https://confluence.int.messagesystems.com/pages/viewpage.action?pageId=43157618).

- [ ] Happy path - all is setup and pushing events to SS
- [ ] Without SS snippet key - shouldn't load SS snippet or push any events to `window._sift`
- [ ] Without customer ID (unauthorized user) - should [set _setUserId to empty string](https://support.siftscience.com/hc/en-us/articles/208370598), leave _setSessionId set to current value and call _trackPageview to continue tracking page views
- [ ] With account prefix (specifically, in EU) - should set _setUserId with a prefix (e.g. 'eu-')
- [ ] With a chocolate chip cookie - should expire after a minute, should persist like a normal cookie for our application (e.g. a cross tabs, etc.), and should be accessible by sparkpost.com

**Todo**
- [x] ~Add configuration variables to production.js.js2 template~ [APP-3162](https://fisheye.int.messagesystems.com/cru/APP-3162)
- [x] Setup [JavaScript snippet](https://siftscience.com/developers/docs/javascript/javascript-api)
- [x] Why does `getPageViewArgs` have the [`resp.meta = { auth: false };`](https://github.com/SparkPost/webui/blob/master/src/common/services/analytics.js#L80-L82) condition.
- [ ] File ticket to see if _setCookieDomain is a better solution than _setSessionId