### PR TITLE
FAD-6241: Missing billing summary and dedicated IPs purchase forms

### DIFF
--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -25,6 +25,7 @@ export class SummaryPage extends Component {
   }
 
   componentDidMount() {
+    this.props.fetchAccount({ include: 'billing' });
     this.props.getPlans();
     this.props.getSendingIps();
   }

--- a/src/pages/billing/tests/SummaryPage.test.js
+++ b/src/pages/billing/tests/SummaryPage.test.js
@@ -11,6 +11,7 @@ describe('Page: SummaryPage', () => {
     },
     billing: {},
     dedicatedIpPrice: jest.fn(() => ''),
+    fetchAccount: jest.fn(),
     getPlans: jest.fn(),
     getBillingCountries: jest.fn(),
     getSendingIps: jest.fn(),
@@ -25,6 +26,13 @@ describe('Page: SummaryPage', () => {
 
   beforeEach(() => {
     wrapper = shallow(<SummaryPage {...props} />);
+  });
+
+  it('gets account billing details on mount', () => {
+    wrapper.instance().componentDidMount();
+    expect(props.fetchAccount).toBeCalledWith(expect.objectContaining({
+      include: expect.stringContaining('billing')
+    }));
   });
 
   it('gets plans on mount', () => {


### PR DESCRIPTION
For non-free, self-billed accounts, `/account/billing` is meant to show a billing address and CC summary and a form for buying dedicated IPs.

Neither currently show because they use a condition variable based on `/account?include=billing`. Auth stopped loading billing details some time ago and so both parts of the billing page stayed hidden.

The fix below is to have the billing page preload account billing details on mount.

## Testing
 - Create a self-billed non-free account
    [This page](https://confluence.int.messagesystems.com/pages/viewpage.action?pageId=43157618) may be useful in creating that account ;)
 - Visit /account/billing
 - Verify that billing address and CC details are visible
 - Verify that you can buy dedicated IPs
