### PR TITLE
FAD-6234 Hide view details button when message_id does property does not exist

### DIFF
--- a/src/pages/reports/messageEvents/EventPage.js
+++ b/src/pages/reports/messageEvents/EventPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { withRouter, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { getMessageHistory, getDocumentation } from 'src/actions/messageEvents';
 import { selectMessageHistory, selectInitialEventId } from 'src/selectors/messageEvents';
@@ -85,4 +85,4 @@ const mapStateToProps = (state, props) => ({
   selectedEventId: selectInitialEventId(state, props)
 });
 
-export default withRouter(connect(mapStateToProps, { getMessageHistory, getDocumentation })(EventPage));
+export default connect(mapStateToProps, { getMessageHistory, getDocumentation })(EventPage);

--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -50,9 +50,11 @@ export class MessageEventsPage extends Component {
       snakeToFriendly(type),
       rcpt_to,
       friendly_from,
-      <div style={{ textAlign: 'right' }}>
-        <Button onClick={() => this.handleDetailClick({ message_id, event_id })} size='small'>View Details</Button>
-      </div>
+      message_id
+        ? <div style={{ textAlign: 'right' }}>
+          <Button onClick={() => this.handleDetailClick({ message_id, event_id })} size='small'>View Details</Button>
+        </div>
+        : null
     ];
   }
 

--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -2,10 +2,12 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { snakeToFriendly } from 'src/helpers/string';
-import { Page, Banner, Button, Panel } from '@sparkpost/matchbox';
+import { Page, Banner, Panel } from '@sparkpost/matchbox';
 import { PanelLoading, TableCollection, ApiErrorBanner, Empty } from 'src/components';
 import DisplayDate from './components/DisplayDate';
 import BasicFilter from './components/BasicFilter';
+import ViewDetailsButton from './components/ViewDetailsButton';
+
 import { getMessageEvents } from 'src/actions/messageEvents';
 import { selectMessageEvents } from 'src/selectors/messageEvents';
 
@@ -34,26 +36,14 @@ export class MessageEventsPage extends Component {
     this.refresh({ reportFilters });
   }
 
-  handleDetailClick = ({ message_id, event_id }) => {
-    const { history } = this.props;
-    history.push({
-      pathname: `/reports/message-events/details/${message_id}`,
-      state: { selectedEventId: event_id }
-    });
-  }
-
   getRowData = (rowData) => {
-    const { timestamp, formattedDate, type, friendly_from, rcpt_to, message_id, event_id } = rowData;
+    const { timestamp, formattedDate, type, friendly_from, rcpt_to } = rowData;
     return [
       <DisplayDate timestamp={timestamp} formattedDate={formattedDate} />,
       snakeToFriendly(type),
       rcpt_to,
       friendly_from,
-      message_id
-        ? <div style={{ textAlign: 'right' }}>
-          <Button onClick={() => this.handleDetailClick({ message_id, event_id })} size='small'>View Details</Button>
-        </div>
-        : null
+      <ViewDetailsButton {...rowData} />
     ];
   }
 
@@ -108,7 +98,6 @@ export class MessageEventsPage extends Component {
         { error ? this.renderError() : this.renderCollection() }
       </Page>
     );
-
   }
 
 }

--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 
 import { snakeToFriendly } from 'src/helpers/string';
 import { Page, Banner, Button, Panel } from '@sparkpost/matchbox';
@@ -126,4 +125,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default withRouter(connect(mapStateToProps, { getMessageEvents })(MessageEventsPage));
+export default connect(mapStateToProps, { getMessageEvents })(MessageEventsPage);

--- a/src/pages/reports/messageEvents/components/ViewDetailsButton.js
+++ b/src/pages/reports/messageEvents/components/ViewDetailsButton.js
@@ -20,7 +20,7 @@ export class ViewDetailsButton extends Component {
       return null;
     }
 
-    return (<div className={styles.Center}>
+    return (<div className={styles.AlignRight}>
       <Button onClick={this.handleDetailClick} size='small'>View Details</Button>
     </div>);
   }

--- a/src/pages/reports/messageEvents/components/ViewDetailsButton.js
+++ b/src/pages/reports/messageEvents/components/ViewDetailsButton.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
 import { Button } from '@sparkpost/matchbox';
-
+import styles from './ViewDetailsButton.module.scss';
 
 export class ViewDetailsButton extends Component {
-  handleDetailClick = ({ message_id, event_id }) => {
-    const { history } = this.props;
+  handleDetailClick = () => {
+    const { history, message_id, event_id } = this.props;
     history.push({
       pathname: `/reports/message-events/details/${message_id}`,
       state: { selectedEventId: event_id }
@@ -15,16 +14,16 @@ export class ViewDetailsButton extends Component {
   };
 
   render() {
-    const { message_id, event_id } = this.props;
+    const { message_id } = this.props;
 
     if (!message_id) {
       return null;
     }
 
-    return (<div style={{ textAlign: 'right' }}>
-      <Button onClick={() => this.handleDetailClick({ message_id, event_id })} size='small'>View Details</Button>
+    return (<div className={styles.Center}>
+      <Button onClick={this.handleDetailClick} size='small'>View Details</Button>
     </div>);
   }
 }
 
-export default withRouter(connect()(ViewDetailsButton));
+export default withRouter(ViewDetailsButton);

--- a/src/pages/reports/messageEvents/components/ViewDetailsButton.js
+++ b/src/pages/reports/messageEvents/components/ViewDetailsButton.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+
+import { Button } from '@sparkpost/matchbox';
+
+
+export class ViewDetailsButton extends Component {
+  handleDetailClick = ({ message_id, event_id }) => {
+    const { history } = this.props;
+    history.push({
+      pathname: `/reports/message-events/details/${message_id}`,
+      state: { selectedEventId: event_id }
+    });
+  };
+
+  render() {
+    const { message_id, event_id } = this.props;
+
+    if (!message_id) {
+      return null;
+    }
+
+    return (<div style={{ textAlign: 'right' }}>
+      <Button onClick={() => this.handleDetailClick({ message_id, event_id })} size='small'>View Details</Button>
+    </div>);
+  }
+}
+
+export default withRouter(connect()(ViewDetailsButton));

--- a/src/pages/reports/messageEvents/components/ViewDetailsButton.module.scss
+++ b/src/pages/reports/messageEvents/components/ViewDetailsButton.module.scss
@@ -1,0 +1,5 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.Center {
+    text-align: center;
+}

--- a/src/pages/reports/messageEvents/components/ViewDetailsButton.module.scss
+++ b/src/pages/reports/messageEvents/components/ViewDetailsButton.module.scss
@@ -1,5 +1,5 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-.Center {
-    text-align: center;
+.AlignRight {
+    text-align: right;
 }

--- a/src/pages/reports/messageEvents/components/tests/ViewDetailsButton.test.js
+++ b/src/pages/reports/messageEvents/components/tests/ViewDetailsButton.test.js
@@ -1,0 +1,41 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { ViewDetailsButton } from '../ViewDetailsButton';
+
+let props;
+
+describe('Component ViewDetailsButton', () => {
+  beforeEach(() => {
+    props = {
+      formattedDate: 'formatted',
+      type: 'injection',
+      friendly_from: 'mean@friendly',
+      rcpt_to: 'tom.haverford@pawnee.state.in.us',
+      message_id: '123abc',
+      event_id: '456xyz',
+      history: {
+        push: jest.fn()
+      }
+    };
+  });
+
+  it('renders correctly', () => {
+    expect(shallow(<ViewDetailsButton {...props} />)).toMatchSnapshot();
+  });
+
+  it('renders nothing if message_id is abset', () => {
+    delete props.message_id;
+    expect(shallow(<ViewDetailsButton {...props} />)).toMatchSnapshot();
+  });
+
+  it('should handle view details click', () => {
+    const wrapper = shallow(<ViewDetailsButton {...props} />);
+    wrapper.instance().handleDetailClick({ message_id: 'message', event_id: 'event' });
+    expect(props.history.push).toHaveBeenCalledWith({
+      pathname: '/reports/message-events/details/message',
+      state: { selectedEventId: 'event' }
+    });
+  });
+
+});

--- a/src/pages/reports/messageEvents/components/tests/ViewDetailsButton.test.js
+++ b/src/pages/reports/messageEvents/components/tests/ViewDetailsButton.test.js
@@ -24,28 +24,27 @@ describe('Component ViewDetailsButton', () => {
     expect(shallow(<ViewDetailsButton {...props} />)).toMatchSnapshot();
   });
 
-  it('renders nothing if message_id is abset', () => {
+  it('renders nothing if message_id is absent', () => {
     delete props.message_id;
     expect(shallow(<ViewDetailsButton {...props} />)).toMatchSnapshot();
   });
 
-  it('should handle view details click', () => {
-    const wrapper = shallow(<ViewDetailsButton {...props} />);
-    wrapper.instance().handleDetailClick({ message_id: 'message', event_id: 'event' });
-    expect(props.history.push).toHaveBeenCalledWith({
-      pathname: '/reports/message-events/details/message',
-      state: { selectedEventId: 'event' }
+  describe('handleDetailClick', () => {
+    it('pushes state to history', () => {
+      const wrapper = shallow(<ViewDetailsButton {...props} />);
+      wrapper.instance().handleDetailClick();
+      expect(props.history.push).toHaveBeenCalledWith({
+        pathname: '/reports/message-events/details/123abc',
+        state: { selectedEventId: '456xyz' }
+      });
     });
   });
 
   describe('button', () => {
     it('calls handleDetailClick upon click', () => {
       const wrapper = shallow(<ViewDetailsButton {...props} />);
-      const instance = wrapper.instance();
-      instance.handleDetailClick = jest.fn();
-
       wrapper.find('Button').simulate('click');
-      expect(instance.handleDetailClick).toHaveBeenLastCalledWith({ message_id: '123abc', event_id: '456xyz' });
+      expect(props.history.push).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/pages/reports/messageEvents/components/tests/ViewDetailsButton.test.js
+++ b/src/pages/reports/messageEvents/components/tests/ViewDetailsButton.test.js
@@ -38,4 +38,15 @@ describe('Component ViewDetailsButton', () => {
     });
   });
 
+  describe('button', () => {
+    it('calls handleDetailClick upon click', () => {
+      const wrapper = shallow(<ViewDetailsButton {...props} />);
+      const instance = wrapper.instance();
+      instance.handleDetailClick = jest.fn();
+
+      wrapper.find('Button').simulate('click');
+      expect(instance.handleDetailClick).toHaveBeenLastCalledWith({ message_id: '123abc', event_id: '456xyz' });
+    });
+  });
+
 });

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/ViewDetailsButton.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/ViewDetailsButton.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component ViewDetailsButton renders correctly 1`] = `
+<div
+  style={
+    Object {
+      "textAlign": "right",
+    }
+  }
+>
+  <Button
+    onClick={[Function]}
+    size="small"
+  >
+    View Details
+  </Button>
+</div>
+`;
+
+exports[`Component ViewDetailsButton renders nothing if message_id is abset 1`] = `""`;

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/ViewDetailsButton.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/ViewDetailsButton.test.js.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component ViewDetailsButton renders correctly 1`] = `
-<div
-  style={
-    Object {
-      "textAlign": "right",
-    }
-  }
->
+<div>
   <Button
     onClick={[Function]}
     size="small"
@@ -17,4 +11,4 @@ exports[`Component ViewDetailsButton renders correctly 1`] = `
 </div>
 `;
 
-exports[`Component ViewDetailsButton renders nothing if message_id is abset 1`] = `""`;
+exports[`Component ViewDetailsButton renders nothing if message_id is absent 1`] = `""`;

--- a/src/pages/reports/messageEvents/tests/MessageEventsPage.test.js
+++ b/src/pages/reports/messageEvents/tests/MessageEventsPage.test.js
@@ -2,6 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { MessageEventsPage } from '../MessageEventsPage';
 
+let wrapper;
+let instance;
+
 describe('Page: Message Events tests', () => {
   const props = {
     empty: false,
@@ -27,10 +30,9 @@ describe('Page: Message Events tests', () => {
     }
   };
 
-  let wrapper;
-
   beforeEach(() => {
     wrapper = shallow(<MessageEventsPage {...props} />);
+    instance = wrapper.instance();
   });
 
   it('should render page correctly', () => {
@@ -63,5 +65,30 @@ describe('Page: Message Events tests', () => {
   it('renders correctly with too many (1000) records', () => {
     wrapper.setProps({ events: new Array(1000) });
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('getRowData', () => {
+    let event;
+    beforeEach(() => {
+      event = {
+        formattedDate: 'formatted',
+        type: 'injection',
+        friendly_from: 'mean@friendly',
+        rcpt_to: 'tom.haverford@pawnee.state.in.us',
+        message_id: '123abc',
+        event_id: '456xyz'
+      };
+    });
+
+    it('renders correctly', () => {
+      expect(instance.getRowData(event)).toMatchSnapshot();
+    });
+
+    it('hides view details button if message_id property does not exist', () => {
+      delete event.message_id;
+
+      expect(instance.getRowData(event)).toMatchSnapshot();
+    });
+
   });
 });

--- a/src/pages/reports/messageEvents/tests/MessageEventsPage.test.js
+++ b/src/pages/reports/messageEvents/tests/MessageEventsPage.test.js
@@ -54,14 +54,6 @@ describe('Page: Message Events tests', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should handle view details click', () => {
-    wrapper.instance().handleDetailClick({ message_id: 'message', event_id: 'event' });
-    expect(props.history.push).toHaveBeenCalledWith({
-      pathname: '/reports/message-events/details/message',
-      state: { selectedEventId: 'event' }
-    });
-  });
-
   it('renders correctly with too many (1000) records', () => {
     wrapper.setProps({ events: new Array(1000) });
     expect(wrapper).toMatchSnapshot();
@@ -81,12 +73,6 @@ describe('Page: Message Events tests', () => {
     });
 
     it('renders correctly', () => {
-      expect(instance.getRowData(event)).toMatchSnapshot();
-    });
-
-    it('hides view details button if message_id property does not exist', () => {
-      delete event.message_id;
-
       expect(instance.getRowData(event)).toMatchSnapshot();
     });
 

--- a/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
@@ -9,7 +9,7 @@ Array [
   "Injection",
   "tom.haverford@pawnee.state.in.us",
   "mean@friendly",
-  <withRouter(Connect(ViewDetailsButton))
+  <withRouter(ViewDetailsButton)
     event_id="456xyz"
     formattedDate="formatted"
     friendly_from="mean@friendly"

--- a/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Page: Message Events tests getRowData hides view details button if message_id property does not exist 1`] = `
+Array [
+  <DisplayDate
+    formattedDate="formatted"
+    timestamp={undefined}
+  />,
+  "Injection",
+  "tom.haverford@pawnee.state.in.us",
+  "mean@friendly",
+  null,
+]
+`;
+
+exports[`Page: Message Events tests getRowData renders correctly 1`] = `
+Array [
+  <DisplayDate
+    formattedDate="formatted"
+    timestamp={undefined}
+  />,
+  "Injection",
+  "tom.haverford@pawnee.state.in.us",
+  "mean@friendly",
+  <div
+    style={
+      Object {
+        "textAlign": "right",
+      }
+    }
+  >
+    <Button
+      onClick={[Function]}
+      size="small"
+    >
+      View Details
+    </Button>
+  </div>,
+]
+`;
+
 exports[`Page: Message Events tests renders correctly with too many (1000) records 1`] = `
 <Page
   empty={Object {}}

--- a/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
@@ -1,18 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Page: Message Events tests getRowData hides view details button if message_id property does not exist 1`] = `
-Array [
-  <DisplayDate
-    formattedDate="formatted"
-    timestamp={undefined}
-  />,
-  "Injection",
-  "tom.haverford@pawnee.state.in.us",
-  "mean@friendly",
-  null,
-]
-`;
-
 exports[`Page: Message Events tests getRowData renders correctly 1`] = `
 Array [
   <DisplayDate
@@ -22,20 +9,14 @@ Array [
   "Injection",
   "tom.haverford@pawnee.state.in.us",
   "mean@friendly",
-  <div
-    style={
-      Object {
-        "textAlign": "right",
-      }
-    }
-  >
-    <Button
-      onClick={[Function]}
-      size="small"
-    >
-      View Details
-    </Button>
-  </div>,
+  <withRouter(Connect(ViewDetailsButton))
+    event_id="456xyz"
+    formattedDate="formatted"
+    friendly_from="mean@friendly"
+    message_id="123abc"
+    rcpt_to="tom.haverford@pawnee.state.in.us"
+    type="injection"
+  />,
 ]
 `;
 


### PR DESCRIPTION
See ticket for the detail context

Didn't find a easy way to manually test it. It would be good if I could modify redux store to modify the data but didn't find a way even though feel like there is a way. 

However, this is pretty trivial and easy enough to verify from snapshot. 


*Update*
Testing:
You can test it using redux dev tool. Click 'Dispatcher'. 

put something like:

```
{
type: 'GET_MESSAGE_EVENTS_SUCCESS',
payload: [{
        formattedDate: 'formatted',
        type: 'injection',
        friendly_from: 'mean@friendly',
        rcpt_to: 'tom.haverford@pawnee.state.in.us',
        message_id: '123abc',
        event_id: '456xyz'
      }, {
        formattedDate: 'formatted',
        type: 'policy_rejection',
        friendly_from: 'mean@friendly',
        rcpt_to: 'tom.haverford@pawnee.state.in.us',
        event_id: '456xyz'
      }]
}
```
And then click tiny little almost microscopic `Dispatch` button on the right. UI should be updated. 