### PR TITLE
FAD-6086: Add Marketing email opt-in to signup form

### DIFF
--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -51,8 +51,14 @@ export class JoinPage extends Component {
     this.setState({ formData: values });
     const { register, authenticate } = this.props;
     const attributionData = this.getAndSetAttributionData();
+    const salesforceData = { ...attributionData, email_opt_out: !values.email_opt_in };
+    const accountFields = _.omit(values, 'email_opt_in');
 
-    const signupData = { ...values, salesforce_data: attributionData, sfdcid: attributionData.sfdcid };
+    const signupData = {
+      ...accountFields,
+      salesforce_data: salesforceData,
+      sfdcid: attributionData.sfdcid
+    };
 
     return register(signupData)
       .then((accountData) => {
@@ -71,7 +77,12 @@ export class JoinPage extends Component {
         <CenteredLogo />
 
         <Panel accent title="Sign Up">
-          { createError && <Panel.Section><Error error={<JoinError errors={createError} data={formData} />} /></Panel.Section> }
+          {
+            createError &&
+              <Panel.Section>
+                <Error error={<JoinError errors={createError} data={formData} />} />
+              </Panel.Section>
+          }
           <Panel.Section>
             <JoinForm onSubmit={this.registerSubmit} />
           </Panel.Section>

--- a/src/pages/join/components/JoinForm.js
+++ b/src/pages/join/components/JoinForm.js
@@ -109,6 +109,15 @@ export class JoinForm extends Component {
         />
 
         <Field
+          name='email_opt_in'
+          id='email_opt_in'
+          component={CheckboxWrapper}
+          disabled={!reCaptchaReady || loading}
+          type='checkbox'
+          label={<span>I'm happy to receive marketing email from SparkPost</span>}
+        />
+
+        <Field
           name="tou_accepted"
           id='tou_accepted'
           component={CheckboxWrapper}
@@ -116,15 +125,6 @@ export class JoinForm extends Component {
           disabled={!reCaptchaReady || loading}
           validate={required}
           label={<span>I agree to SparkPost's <UnstyledLink to={LINKS.TOU} external>Terms of Use</UnstyledLink></span>}
-        />
-
-        <Field
-          name='email_opt_in'
-          id='email_opt_in'
-          component={CheckboxWrapper}
-          disabled={!reCaptchaReady || loading}
-          type='checkbox'
-          label={<span>I'm happy to receive marketing email from SparkPost</span>}
         />
 
         <Button primary

--- a/src/pages/join/components/JoinForm.js
+++ b/src/pages/join/components/JoinForm.js
@@ -28,6 +28,7 @@ const { recaptcha } = config;
  * verifyCallback: this is triggered upon user completes recaptcha challenge successfuly. we pass the data we've received
  */
 
+
 export class JoinForm extends Component {
   state = {
     reCaptchaReady: false,
@@ -117,6 +118,15 @@ export class JoinForm extends Component {
           label={<span>I agree to SparkPost's <UnstyledLink to={LINKS.TOU} external>Terms of Use</UnstyledLink></span>}
         />
 
+        <Field
+          name='email_opt_in'
+          id='email_opt_in'
+          component={CheckboxWrapper}
+          disabled={!reCaptchaReady || loading}
+          type='checkbox'
+          label={<span>I'm happy to receive marketing email from SparkPost</span>}
+        />
+
         <Button primary
           disabled={loading || pristine || invalid || !reCaptchaReady }
           onClick={this.executeRecaptcha}
@@ -140,7 +150,8 @@ export class JoinForm extends Component {
 const formName = 'registerAccountForm';
 const mapStateToProps = (state, props) => ({
   initialValues: {
-    tou_accepted: false
+    tou_accepted: false,
+    email_opt_in: false
   },
   loading: state.account.createLoading || state.auth.loginPending,
   formValues: getFormValues(formName)(state)

--- a/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
+++ b/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
@@ -65,6 +65,18 @@ exports[`JoinForm render disables form when loading 1`] = `
   <Field
     component={[Function]}
     disabled={true}
+    id="email_opt_in"
+    label={
+      <span>
+        I'm happy to receive marketing email from SparkPost
+      </span>
+    }
+    name="email_opt_in"
+    type="checkbox"
+  />
+  <Field
+    component={[Function]}
+    disabled={true}
     id="tou_accepted"
     label={
       <span>
@@ -80,18 +92,6 @@ exports[`JoinForm render disables form when loading 1`] = `
     name="tou_accepted"
     type="checkbox"
     validate={[Function]}
-  />
-  <Field
-    component={[Function]}
-    disabled={true}
-    id="email_opt_in"
-    label={
-      <span>
-        I'm happy to receive marketing email from SparkPost
-      </span>
-    }
-    name="email_opt_in"
-    type="checkbox"
   />
   <Button
     disabled={true}
@@ -185,6 +185,18 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
   <Field
     component={[Function]}
     disabled={true}
+    id="email_opt_in"
+    label={
+      <span>
+        I'm happy to receive marketing email from SparkPost
+      </span>
+    }
+    name="email_opt_in"
+    type="checkbox"
+  />
+  <Field
+    component={[Function]}
+    disabled={true}
     id="tou_accepted"
     label={
       <span>
@@ -200,18 +212,6 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
     name="tou_accepted"
     type="checkbox"
     validate={[Function]}
-  />
-  <Field
-    component={[Function]}
-    disabled={true}
-    id="email_opt_in"
-    label={
-      <span>
-        I'm happy to receive marketing email from SparkPost
-      </span>
-    }
-    name="email_opt_in"
-    type="checkbox"
   />
   <Button
     disabled={true}
@@ -305,6 +305,18 @@ exports[`JoinForm render enables form correctly 1`] = `
   <Field
     component={[Function]}
     disabled={false}
+    id="email_opt_in"
+    label={
+      <span>
+        I'm happy to receive marketing email from SparkPost
+      </span>
+    }
+    name="email_opt_in"
+    type="checkbox"
+  />
+  <Field
+    component={[Function]}
+    disabled={false}
     id="tou_accepted"
     label={
       <span>
@@ -320,18 +332,6 @@ exports[`JoinForm render enables form correctly 1`] = `
     name="tou_accepted"
     type="checkbox"
     validate={[Function]}
-  />
-  <Field
-    component={[Function]}
-    disabled={false}
-    id="email_opt_in"
-    label={
-      <span>
-        I'm happy to receive marketing email from SparkPost
-      </span>
-    }
-    name="email_opt_in"
-    type="checkbox"
   />
   <Button
     disabled={false}

--- a/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
+++ b/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
@@ -81,6 +81,18 @@ exports[`JoinForm render disables form when loading 1`] = `
     type="checkbox"
     validate={[Function]}
   />
+  <Field
+    component={[Function]}
+    disabled={true}
+    id="email_opt_in"
+    label={
+      <span>
+        I'm happy to receive marketing email from SparkPost
+      </span>
+    }
+    name="email_opt_in"
+    type="checkbox"
+  />
   <Button
     disabled={true}
     onClick={[Function]}
@@ -189,6 +201,18 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
     type="checkbox"
     validate={[Function]}
   />
+  <Field
+    component={[Function]}
+    disabled={true}
+    id="email_opt_in"
+    label={
+      <span>
+        I'm happy to receive marketing email from SparkPost
+      </span>
+    }
+    name="email_opt_in"
+    type="checkbox"
+  />
   <Button
     disabled={true}
     onClick={[Function]}
@@ -296,6 +320,18 @@ exports[`JoinForm render enables form correctly 1`] = `
     name="tou_accepted"
     type="checkbox"
     validate={[Function]}
+  />
+  <Field
+    component={[Function]}
+    disabled={false}
+    id="email_opt_in"
+    label={
+      <span>
+        I'm happy to receive marketing email from SparkPost
+      </span>
+    }
+    name="email_opt_in"
+    type="checkbox"
   />
   <Button
     disabled={false}


### PR DESCRIPTION
### Accusers Dependency
This new field is accepted by `/account` as a salesforce_data field. It is not stored in the app, just passed through directly to SalesForce as `HasOptedOutOfEmail`. That work was deployed under FAD-6150 on 2018-02-22.

Note: The form has an `email_opt_in` field but `POST /account` expects `salesforce_data.email_opt_out`. I added an explicit test for that negation.

### Testing
 - Create accounts through `/join` with the new field checked and unchecked.
 - Verify the resulting call to `POST /account` in the browser.
 - The contact for the main user on each account you create will appear in test.salesforce.com (creds in LastPass)
 - That contact will include the `HasOptedOutOfEmail` field with the value you set at signup.