### PR TITLE
FAD-6222: getTestData action creator now supports old style template test data

### DIFF
--- a/src/actions/templates.js
+++ b/src/actions/templates.js
@@ -169,9 +169,18 @@ export function getTestData({ id, mode }) {
       if (results) {
         testData = JSON.parse(results);
 
-        // Reshapes test data if it does not conform with default JSON structure
-        if (!['substitution_data', 'metadata', 'options'].every((key) => key in testData)) {
+        if (!('substitution_data' in testData)) {
+          // Reshape test data if it does not conform with the current format.
+          // There was an earlier format which included only substitution_data values.
           testData = { ...config.templates.testData, substitution_data: testData };
+        } else {
+          // Note: this technique leaves any toplevel keys from local storage intact.
+          testData = {
+            // Set defaults for each key
+            ...config.templates.testData,
+            // Bring in existing fields from local storage
+            ...testData
+          };
         }
       }
 

--- a/src/actions/tests/__snapshots__/templates.test.js.snap
+++ b/src/actions/tests/__snapshots__/templates.test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Action Creator: Templates getTestData should handle old test data 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "metadata": Object {},
+      "options": Object {},
+      "substitution_data": Object {
+        "test": "test",
+      },
+    },
+    "type": "GET_TEMPLATE_TEST_DATA",
+  },
+]
+`;
+
+exports[`Action Creator: Templates getTestData should handle partial test data 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "metadata": Object {},
+      "options": Object {},
+      "substitution_data": Object {
+        "test": "test",
+      },
+    },
+    "type": "GET_TEMPLATE_TEST_DATA",
+  },
+]
+`;
+
 exports[`Action Creator: Templates should dispatch a create action 1`] = `
 Array [
   Object {

--- a/src/actions/tests/__snapshots__/templates.test.js.snap
+++ b/src/actions/tests/__snapshots__/templates.test.js.snap
@@ -15,7 +15,54 @@ Array [
 ]
 `;
 
-exports[`Action Creator: Templates getTestData should handle partial test data 1`] = `
+exports[`Action Creator: Templates getTestData should handle partial test data combo 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "metadata": Object {},
+      "options": Object {
+        "sandbox": true,
+      },
+      "substitution_data": Object {
+        "test": "test",
+      },
+    },
+    "type": "GET_TEMPLATE_TEST_DATA",
+  },
+]
+`;
+
+exports[`Action Creator: Templates getTestData should handle partial test data metadata only 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "metadata": Object {
+        "flavour": "vanilla",
+      },
+      "options": Object {},
+      "substitution_data": Object {},
+    },
+    "type": "GET_TEMPLATE_TEST_DATA",
+  },
+]
+`;
+
+exports[`Action Creator: Templates getTestData should handle partial test data options only 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "metadata": Object {},
+      "options": Object {
+        "sandbox": true,
+      },
+      "substitution_data": Object {},
+    },
+    "type": "GET_TEMPLATE_TEST_DATA",
+  },
+]
+`;
+
+exports[`Action Creator: Templates getTestData should handle partial test data substitution_data only 1`] = `
 Array [
   Object {
     "payload": Object {
@@ -202,13 +249,7 @@ Array [
     "type": "GET_DRAFT_TEMPLATE",
   },
   Object {
-    "payload": Object {
-      "metadata": Object {},
-      "options": Object {},
-      "substitution_data": Object {
-        "test": "test",
-      },
-    },
+    "payload": undefined,
     "type": "GET_TEMPLATE_TEST_DATA",
   },
   Object {
@@ -219,9 +260,7 @@ Array [
       },
       "data": Object {
         "content": undefined,
-        "substitution_data": Object {
-          "test": "test",
-        },
+        "substitution_data": Object {},
       },
       "headers": Object {},
       "method": "POST",
@@ -246,13 +285,7 @@ Array [
     "type": "GET_PUBLISHED_TEMPLATE",
   },
   Object {
-    "payload": Object {
-      "metadata": Object {},
-      "options": Object {},
-      "substitution_data": Object {
-        "test": "test",
-      },
-    },
+    "payload": undefined,
     "type": "GET_TEMPLATE_TEST_DATA",
   },
   Object {
@@ -263,9 +296,7 @@ Array [
       },
       "data": Object {
         "content": undefined,
-        "substitution_data": Object {
-          "test": "test",
-        },
+        "substitution_data": Object {},
       },
       "headers": Object {},
       "method": "POST",
@@ -279,13 +310,7 @@ Array [
 exports[`Action Creator: Templates should dispatch getTestData and sendPreview actions 1`] = `
 Array [
   Object {
-    "payload": Object {
-      "metadata": Object {},
-      "options": Object {},
-      "substitution_data": Object {
-        "test": "test",
-      },
-    },
+    "payload": undefined,
     "type": "GET_TEMPLATE_TEST_DATA",
   },
   Object {
@@ -295,7 +320,6 @@ Array [
           "template_id": "test-template",
           "use_draft_template": true,
         },
-        "metadata": Object {},
         "options": Object {
           "sandbox": true,
         },
@@ -306,9 +330,6 @@ Array [
             },
           },
         ],
-        "substitution_data": Object {
-          "test": "test",
-        },
       },
       "headers": Object {},
       "method": "POST",

--- a/src/actions/tests/templates.test.js
+++ b/src/actions/tests/templates.test.js
@@ -3,6 +3,8 @@ import localforage from 'localforage';
 import * as templates from '../templates';
 import * as templatesHelpers from '../helpers/templates';
 
+import cases from 'jest-in-case';
+
 import _ from 'lodash';
 
 jest.mock('../helpers/sparkpostApiRequest', () => jest.fn((a) => a));
@@ -17,8 +19,9 @@ describe('Action Creator: Templates', () => {
     }
   };
 
-  beforeEach(() => {
+  beforeEach(async() => {
     localforage.setItem = jest.fn((a) => Promise.resolve(a));
+    localforage.getItem = jest.fn(() => Promise.resolve(null));
     templatesHelpers.getTestDataKey = jest.fn(() => 'key');
     dispatchMock = jest.fn((a) => Promise.resolve(a));
     mockStore = createMockStore(user);
@@ -100,13 +103,18 @@ describe('Action Creator: Templates', () => {
       await mockStore.dispatch(templates.getTestData(template));
       expect(mockStore.getActions()).toMatchSnapshot();
     });
-    it('should handle partial test data' , async() => {
 
-      localforage.getItem = jest.fn((a) => Promise.resolve('{"substitution_data": {"test": "test"}}'));
+    cases('should handle partial test data', async(testRecord) => {
+      localforage.getItem = jest.fn((a) => Promise.resolve(JSON.stringify(testRecord.payload)));
       const template = { id: 'id', mode: 'draft' };
       await mockStore.dispatch(templates.getTestData(template));
       expect(mockStore.getActions()).toMatchSnapshot();
-    });
+    }, [
+      { name: 'substitution_data only', payload: { substitution_data: { test: 'test' }}},
+      { name: 'metadata only', payload: { metadata: { flavour: 'vanilla' }}},
+      { name: 'options only', payload: { options: { sandbox: true }}},
+      { name: 'combo', payload: { substitution_data: { test: 'test' }, options: { sandbox: true }}}
+    ]);
   });
 
   it('should dispatch getDraft, getTestData, and getPreview actions', async() => {

--- a/src/actions/tests/templates.test.js
+++ b/src/actions/tests/templates.test.js
@@ -93,6 +93,22 @@ describe('Action Creator: Templates', () => {
     expect(mockStore.getActions()).toMatchSnapshot();
   });
 
+  describe('getTestData', () => {
+    it('should handle old test data', async() => {
+      localforage.getItem = jest.fn((a) => Promise.resolve('{"test": "test"}'));
+      const template = { id: 'id', mode: 'draft' };
+      await mockStore.dispatch(templates.getTestData(template));
+      expect(mockStore.getActions()).toMatchSnapshot();
+    });
+    it('should handle partial test data' , async() => {
+
+      localforage.getItem = jest.fn((a) => Promise.resolve('{"substitution_data": {"test": "test"}}'));
+      const template = { id: 'id', mode: 'draft' };
+      await mockStore.dispatch(templates.getTestData(template));
+      expect(mockStore.getActions()).toMatchSnapshot();
+    });
+  });
+
   it('should dispatch getDraft, getTestData, and getPreview actions', async() => {
     const action = templates.getDraftAndPreview('test-template');
     await mockStore.dispatch(action);


### PR DESCRIPTION
### Testing
 - `{"name": "blarg"}`
 - `{"substitution_data": { "name": "blarg"} }`
 - `{"substitution_data": { "name": "blarg"}, "metadata": { "k" } }`
 - `{"substitution_data": { "name": "blarg"}, "metadata": { "k" }, "options": { "w": "asdf" } }`