### PR TITLE
FAD-6041 sentry error logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13615,9 +13615,9 @@
       "integrity": "sha1-u6GYEtK765KGxx3PPbS1iVnW6Vc="
     },
     "raven-js": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.20.1.tgz",
-      "integrity": "sha512-Wr973Ipmd+dWUPQ6mSru/gyteavriEyP6G3iDZ2jpI3sBAWejtVtoXO5BHujEWB1z+/dqCLn+Zezgdc30xZcVA=="
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.23.0.tgz",
+      "integrity": "sha512-1izfa9aLGyfQoduiKxJdsaRJe9H0XmUzvFdku1x1ke0Publ9w2zKCU/6fxctoiGmYXN4NGLDWQh50O+xT5tJGg=="
     },
     "raw-body": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "print-js": "^1.0.31",
     "query-string": "^5.0.0",
     "raven-for-redux": "^1.1.1",
-    "raven-js": "^3.19.1",
+    "raven-js": "^3.23.0",
     "react": "^16.2.0",
     "react-chartjs-2": "^2.1.0",
     "react-day-picker": "^7.0.7",

--- a/src/actions/helpers/sparkpostApiError.js
+++ b/src/actions/helpers/sparkpostApiError.js
@@ -1,19 +1,21 @@
 import _ from 'lodash';
 
-export class SparkpostApiError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = 'SparkpostApiError';
+export default class SparkpostApiError extends Error {
+  name = 'SparkpostApiError';
+
+  constructor({ message, fileName, lineNumber, ...rest }) {
+    const error = _.get(rest, 'response.data.errors[0]', {});
+
+    super(
+      error.description || error.message || message,
+      fileName,
+      lineNumber
+    );
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, SparkpostApiError);
-    }
+    Error.captureStackTrace && Error.captureStackTrace(this, SparkpostApiError);
 
-    const description = _.get(message, 'response.data.errors[0].description');
-
-    if (description) {
-      this.message = description;
-    }
+    // Intentionally assigning additional properties
+    Object.assign(this, rest);
   }
 }

--- a/src/actions/helpers/sparkpostApiError.js
+++ b/src/actions/helpers/sparkpostApiError.js
@@ -1,0 +1,19 @@
+import _ from 'lodash';
+
+export class SparkpostApiError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'SparkpostApiError';
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SparkpostApiError);
+    }
+
+    const description = _.get(message, 'response.data.errors[0].description');
+
+    if (description) {
+      this.message = description;
+    }
+  }
+}

--- a/src/actions/helpers/sparkpostApiError.js
+++ b/src/actions/helpers/sparkpostApiError.js
@@ -1,21 +1,17 @@
 import _ from 'lodash';
 
-export default class SparkpostApiError extends Error {
-  name = 'SparkpostApiError';
+// TODO: Return an Error object as if we were to create it with class and extends Error
+function SparkpostApiError(error) {
+  const apiError = _.get(error, 'response.data.errors[0]', {});
 
-  constructor({ message, fileName, lineNumber, ...rest }) {
-    const error = _.get(rest, 'response.data.errors[0]', {});
+  this.name = 'SparkpostApiError';
+  this.message = apiError.description || apiError.message || error.message;
+  this.stack = error.stack; // must manually assign prototype value
 
-    super(
-      error.description || error.message || message,
-      fileName,
-      lineNumber
-    );
-
-    // Maintains proper stack trace for where our error was thrown (only available on V8)
-    Error.captureStackTrace && Error.captureStackTrace(this, SparkpostApiError);
-
-    // Intentionally assigning additional properties
-    Object.assign(this, rest);
-  }
+  // Intentionally assigning additional properties
+  Object.assign(this, error);
 }
+
+SparkpostApiError.prototype = Object.create(Error.prototype);
+
+export default SparkpostApiError;

--- a/src/actions/helpers/sparkpostApiRequest.js
+++ b/src/actions/helpers/sparkpostApiRequest.js
@@ -5,7 +5,7 @@ import { useRefreshToken } from 'src/helpers/http';
 import { resolveOnCondition } from 'src/helpers/promise';
 import _ from 'lodash';
 import { sparkpost as sparkpostAxios } from 'src/helpers/axiosInstances';
-import { SparkpostApiError } from './sparkpostApiError';
+import SparkpostApiError from './sparkpostApiError';
 
 const maxRefreshRetries = 3;
 export const refreshTokensUsed = new Set();
@@ -81,7 +81,7 @@ const sparkpostRequest = requestHelperFactory({
     // If we have a 403 or a 401 and we're not refreshing, log the user out silently
     if (response.status === 401 || response.status === 403) {
       dispatch(logout());
-      throw err;
+      throw apiError;
     }
 
     // any other API error should automatically fail, to be handled in the reducers/components

--- a/src/actions/helpers/tests/sparkpostApiError.test.js
+++ b/src/actions/helpers/tests/sparkpostApiError.test.js
@@ -1,4 +1,4 @@
-import SparkpostApiError from '../SparkpostApiError';
+import SparkpostApiError from '../sparkpostApiError';
 
 function createTestError(sugar = {}) {
   const error = new Error('Oh no!');

--- a/src/actions/helpers/tests/sparkpostApiError.test.js
+++ b/src/actions/helpers/tests/sparkpostApiError.test.js
@@ -1,0 +1,67 @@
+import SparkpostApiError from '../SparkpostApiError';
+
+function createTestError(sugar = {}) {
+  const error = new Error('Oh no!');
+  return new SparkpostApiError(Object.assign(error, sugar));
+}
+
+describe('SparkpostApiError', () => {
+  it('instance of SparkpostApiError', () => {
+    const error = createTestError();
+    expect(error).toBeInstanceOf(SparkpostApiError);
+  });
+
+  it('instance of Error', () => {
+    const error = createTestError();
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('returns error name', () => {
+    const error = createTestError();
+    expect(error).toHaveProperty('name', 'SparkpostApiError');
+  });
+
+  it('returns error message', () => {
+    const error = createTestError();
+    expect(error).toHaveProperty('message', 'Oh no!');
+  });
+
+  it('returns api error message', () => {
+    const error = createTestError({
+      response: {
+        data: {
+          errors: [
+            {
+              message: 'Something specific!'
+            }
+          ]
+        }
+      }
+    });
+
+    expect(error).toHaveProperty('message', 'Something specific!');
+  });
+
+  it('returns api error description', () => {
+    const error = createTestError({
+      response: {
+        data: {
+          errors: [
+            {
+              description: 'Something really specific!'
+            }
+          ]
+        }
+      }
+    });
+
+    expect(error).toHaveProperty('message', 'Something really specific!');
+  });
+
+  it('returns extra properties', () => {
+    const error = createTestError({
+      extra: 'shh'
+    });
+    expect(error).toHaveProperty('extra');
+  });
+});

--- a/src/actions/helpers/tests/sparkpostApiRequest.test.js
+++ b/src/actions/helpers/tests/sparkpostApiRequest.test.js
@@ -1,5 +1,6 @@
 /* eslint max-lines: ["error", 202] */
 import sparkpostApiRequest, { refreshTokensUsed } from '../sparkpostApiRequest';
+import SparkpostApiError from '../SparkpostApiError';
 import { createMockStore } from 'src/__testHelpers__/mockStore';
 import * as axiosMocks from 'src/helpers/axiosInstances';
 import * as authMock from 'src/actions/auth';
@@ -52,7 +53,7 @@ describe('Helper: SparkPost API Request', () => {
     let apiErr;
 
     beforeEach(() => {
-      apiErr = new Error('API call failed');
+      apiErr = new SparkpostApiError(new Error('API call failed'));
       apiErr.response = { status: 400, data: { results }};
       axiosMocks.sparkpost.mockImplementation(() => Promise.reject(apiErr));
       refreshTokensUsed.clear();

--- a/src/actions/helpers/tests/sparkpostApiRequest.test.js
+++ b/src/actions/helpers/tests/sparkpostApiRequest.test.js
@@ -1,6 +1,6 @@
 /* eslint max-lines: ["error", 202] */
 import sparkpostApiRequest, { refreshTokensUsed } from '../sparkpostApiRequest';
-import SparkpostApiError from '../SparkpostApiError';
+import SparkpostApiError from '../sparkpostApiError';
 import { createMockStore } from 'src/__testHelpers__/mockStore';
 import * as axiosMocks from 'src/helpers/axiosInstances';
 import * as authMock from 'src/actions/auth';

--- a/src/actions/helpers/tests/sparkpostApiRequest.test.js
+++ b/src/actions/helpers/tests/sparkpostApiRequest.test.js
@@ -53,8 +53,10 @@ describe('Helper: SparkPost API Request', () => {
     let apiErr;
 
     beforeEach(() => {
-      apiErr = new SparkpostApiError(new Error('API call failed'));
-      apiErr.response = { status: 400, data: { results }};
+      const error = new Error('API call failed');
+      error.response = { status: 400, data: { results }};
+      apiErr = new SparkpostApiError(error);
+
       axiosMocks.sparkpost.mockImplementation(() => Promise.reject(apiErr));
       refreshTokensUsed.clear();
     });
@@ -63,7 +65,7 @@ describe('Helper: SparkPost API Request', () => {
       try {
         await mockStore.dispatch(sparkpostApiRequest(action));
       } catch (err) {
-        expect(err).toBe(apiErr);
+        expect(err).toEqual(apiErr);
         expect(mockStore.getActions()).toMatchSnapshot();
       }
     });

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,7 +1,7 @@
 const config = {
   apiBase: 'no-default-set',
   apiDateFormat: 'YYYY-MM-DDTHH:mm',
-  apiRequestTimeout: 15000,
+  apiRequestTimeout: 30000,
   apiRequestHeaders: {
     'X-Sparky': '1d24c3473dd52a2f4a53fb6808cf9a73'
   },

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -15,7 +15,10 @@ const BLACKLIST = new Set([
   '@@redux-form/REGISTER_FIELD',
   '@@redux-form/TOUCH',
   '@@redux-form/UNREGISTER_FIELD',
-  '@@redux-form/UPDATE_SYNC_ERRORS'
+  '@@redux-form/UPDATE_SYNC_ERRORS',
+  '@@redux-form/INITIALIZE',
+  '@@redux-form/STOP_SUBMIT',
+  '@@redux-form/SET_SUBMIT_FAILED'
 ]);
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -44,13 +44,3 @@ gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${config.gaTag}`;
 gaScript.async = true;
 document.head.appendChild(gaScript);
 /*  Google Analytics End */
-
-/**
- * Track unhandled promise rejects
- *
- * @param {PromiseRejectionEvent} event
- * @param {Error} event.reason
- */
-window.onunhandledrejection = ({ reason }) => {
-  ErrorTracker.report('onunhandledrejection', reason);
-};

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,8 @@ const composeEnhancers = process.env.NODE_ENV !== 'production' && window.__REDUX
 const store = createStore(
   rootReducer,
   composeEnhancers(
-    applyMiddleware(thunk),
-    applyMiddleware(ErrorTracker.middleware)
+    applyMiddleware(ErrorTracker.middleware),
+    applyMiddleware(thunk)
   )
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,8 @@ const composeEnhancers = process.env.NODE_ENV !== 'production' && window.__REDUX
 const store = createStore(
   rootReducer,
   composeEnhancers(
-    applyMiddleware(ErrorTracker.middleware),
-    applyMiddleware(thunk)
+    applyMiddleware(thunk),
+    applyMiddleware(ErrorTracker.middleware)
   )
 );
 


### PR DESCRIPTION
- Based on idea of @bkemper we're assigning api error message in the error object but seems sentry still grouping based on [stack track](https://docs.sentry.io/learn/rollups/#grouping-priorities) (not message)
- Updated api timeout to 30s. 
- based on guide of [this doc](https://blog.sentry.io/2016/08/24/redux-middleware-error-logging), i put raven at first of redux middleware. i didn't notice any difference though. 