### PR TITLE
FAD-6296: Subaccount typeahead only loads subaccounts once

### DIFF
--- a/src/components/subaccountTypeahead/SubaccountTypeahead.js
+++ b/src/components/subaccountTypeahead/SubaccountTypeahead.js
@@ -72,8 +72,8 @@ export class SubaccountTypeahead extends Component {
   };
 
   componentDidMount() {
-    const { hasSubaccounts, subaccounts } = this.props;
-    if (hasSubaccounts && subaccounts.length === 0) {
+    const { hasSubaccounts } = this.props;
+    if (hasSubaccounts) {
       this.props.getSubaccountsList();
     }
   }


### PR DESCRIPTION
Symptom: subaccount typeahead does not show newly created subaccounts until the app is hard refreshed.

Fix: Subaccount typeahead now always (re)loads subaccounts if the account has them.

### Testing
1. Create a subaccount
1. Create a sending domain and assign it to the new subaccount
1. Win 🎉 