### PR TITLE
FAD-6311 removed check for subaccount list loading to prevent infinite remounts

### DIFF
--- a/src/selectors/api-keys.js
+++ b/src/selectors/api-keys.js
@@ -8,10 +8,8 @@ const getApiKeys = (state) => state.apiKeys.keys;
 const getGrantsArray = (state) => state.apiKeys.grants;
 const getSubaccountGrantsArray = (state) => state.apiKeys.subaccountGrants;
 export const selectApiKeyId = (props) => props.match.params.id;
-
 const getGrantsLoading = (state) => state.apiKeys.grantsLoading;
 const getSubaccountGrantsLoading = (state) => state.apiKeys.subaccountGrantsLoading;
-const getSubaccountsLoading = (state) => state.subaccounts.listLoading;
 
 // Convert grants array to an object keyed by `grant.key`
 export const getGrants = createSelector(getGrantsArray, (grants) =>
@@ -23,9 +21,9 @@ export const getSubaccountGrants = createSelector(getSubaccountGrantsArray, (gra
 );
 
 export const getFormLoading = createSelector(
-  [getGrantsLoading, getSubaccountGrantsLoading, getSubaccountsLoading],
-  (grantsLoading, subaccountGrantsLoading, subaccountsLoading) =>
-    grantsLoading || subaccountGrantsLoading || subaccountsLoading
+  [getGrantsLoading, getSubaccountGrantsLoading],
+  (grantsLoading, subaccountGrantsLoading) =>
+    grantsLoading || subaccountGrantsLoading
 );
 
 /*

--- a/src/selectors/tests/api-keys.test.js
+++ b/src/selectors/tests/api-keys.test.js
@@ -15,11 +15,10 @@ describe('ApiKey Selectors', () => {
         { key: 'sub grant one' },
         { key: 'sub grant two' }
       ],
-      grantsLoading: false,
+      grantsLoading: true,
       subaccountGrantsLoading: false
     },
     subaccounts: {
-      listLoading: true,
       list: [
         { id: 'subId' }
       ]


### PR DESCRIPTION
Peeked in to test a theory and it was right, so here we are with a fix! Summary:

* In FAD-6296 we made the SubaccountTypeahead re-fetch subaccounts on every mount. 

* In the Create and Details pages for the API Keys section, if `props.loading` is true, we render the `<Loading>` component, otherwise we render the page.

* The `loading` prop for both of these pages is from a selector that was checking if the subaccounts list was loading

* When the page stops loading, it mounts the `<ApiKeyForm>` which loads the typeahead, which mounts and re-fetches the subaccounts list, which makes subaccounts loading true, which puts the Create/Details page back into "loading" state, which then causes a remount  ............

**Easiest fix was to remove the check on subaccounts list loading for that selector.**