### PR TITLE
FAD-6305 send dates to metrics API with local timezone

### DIFF
--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -48,6 +48,28 @@ export function isSameDate(a, b) {
   return (a instanceof Date) && (b instanceof Date) && (a.getTime() === b.getTime());
 }
 
+/**
+ * Use native JS methods to get user's local
+ * timezone, if those methods are present
+ *
+ * Defaults to UTC otherwise
+ */
+export function getLocalTimezone() {
+  // eslint-disable-next-line new-cap
+  if (typeof Intl.DateTimeFormat !== 'function') {
+    return 'UTC';
+  }
+
+  // eslint-disable-next-line new-cap
+  const format = Intl.DateTimeFormat();
+
+  if (typeof format.resolvedOptions !== 'function') {
+    return 'UTC';
+  }
+
+  return format.resolvedOptions().timeZone;
+}
+
 export function getRelativeDates(range) {
   const now = moment.utc();
   const to = now.toDate();

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import _ from 'lodash';
 import { list as METRICS_LIST } from 'src/config/metrics';
 import config from 'src/config';
-import { getRelativeDates } from 'src/helpers/date';
+import { getRelativeDates, getLocalTimezone } from 'src/helpers/date';
 import { safeDivide, safeRate } from './math';
 
 const { metricsPrecisionMap: precisionMap, apiDateFormat, chartColors = []} = config;
@@ -33,8 +33,7 @@ export function getQueryFromOptions({ from, to, metrics, filters = []}) {
     to: to.format(apiDateFormat),
     delimiter,
     ...getFilterSets(filters, delimiter),
-    // eslint-disable-next-line new-cap
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+    timezone: getLocalTimezone()
   };
 }
 

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -20,8 +20,8 @@ const FILTER_KEY_MAP = {
 const DELIMITERS = ',;:+~`!@#$%^*()-={}[]"\'<>?./|\\'.split('');
 
 export function getQueryFromOptions({ from, to, metrics, filters = []}) {
-  from = moment(from).utc();
-  to = moment(to).utc();
+  from = moment(from);
+  to = moment(to);
 
   const apiMetricsKeys = getKeysFromMetrics(metrics);
   const delimiter = getDelimiter(filters);
@@ -32,7 +32,9 @@ export function getQueryFromOptions({ from, to, metrics, filters = []}) {
     from: from.format(apiDateFormat),
     to: to.format(apiDateFormat),
     delimiter,
-    ...getFilterSets(filters, delimiter)
+    ...getFilterSets(filters, delimiter),
+    // eslint-disable-next-line new-cap
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
   };
 }
 

--- a/src/helpers/tests/__snapshots__/metrics.test.js.snap
+++ b/src/helpers/tests/__snapshots__/metrics.test.js.snap
@@ -14,11 +14,12 @@ exports[`metrics helpers should build return correct options from updates 1`] = 
 Object {
   "delimiter": ",",
   "domains": "gmail.com",
-  "from": "2017-12-18T00:00",
+  "from": "2017-12-17T19:00",
   "metrics": "count_bounce,test + last",
   "precision": "hour",
   "subaccounts": "100",
-  "to": "2017-12-18T11:00",
+  "timezone": "Mock/Timezone",
+  "to": "2017-12-18T06:00",
 }
 `;
 

--- a/src/helpers/tests/date.test.js
+++ b/src/helpers/tests/date.test.js
@@ -5,7 +5,8 @@ import {
   formatDate,
   formatTime,
   formatDateTime,
-  isSameDate
+  isSameDate,
+  getLocalTimezone
 } from '../date';
 import cases from 'jest-in-case';
 import moment from 'moment';
@@ -96,6 +97,37 @@ describe('Date helpers', () => {
 
     it('should format a date-time consistently', () => {
       expect(formatDateTime(testDate)).toEqual('Oct 15 2017, 8:55am');
+    });
+  });
+
+  describe('getLocalTimezone', () => {
+
+    it('should return UTC if DateFormat is not a function', () => {
+      global.Intl = {};
+      expect(getLocalTimezone()).toEqual('UTC');
+    });
+
+    it('should return UTC if resolvedOptions is not a function', () => {
+      const dtfMock = jest.fn(() => ({}));
+      global.Intl = {
+        DateTimeFormat: dtfMock
+      };
+
+      expect(getLocalTimezone()).toEqual('UTC');
+      expect(dtfMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return the timezone', () => {
+      const optionsMock = jest.fn(() => ({ timeZone: 'Cool/Story' }));
+      const dtfMock = jest.fn(() => ({
+        resolvedOptions: optionsMock
+      }));
+      global.Intl = {
+        DateTimeFormat: dtfMock
+      };
+      expect(getLocalTimezone()).toEqual('Cool/Story');
+      expect(dtfMock).toHaveBeenCalledTimes(1);
+      expect(optionsMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/helpers/tests/metrics.test.js
+++ b/src/helpers/tests/metrics.test.js
@@ -2,7 +2,14 @@ import * as metricsHelpers from '../metrics';
 import moment from 'moment';
 import * as dateHelpers from 'src/helpers/date';
 
+jest.mock('src/helpers/date');
+
 describe('metrics helpers', () => {
+
+  beforeEach(() => {
+    dateHelpers.getLocalTimezone = jest.fn(() => 'Mock/Timezone');
+  });
+
   it('should build return correct options from updates', () => {
     const actual = metricsHelpers.getQueryFromOptions({
       from: '2017-12-18T00:00Z',
@@ -112,4 +119,5 @@ describe('metrics helpers', () => {
     const keys = ['count_accepted', 'count_targeted'];
     expect(metricsHelpers.rate(item, keys)).toEqual(90);
   });
+
 });


### PR DESCRIPTION
Added timezone using native JS method, support seems good (no IE, missing some Android webview)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions