### PR TITLE
FAD-6314: Handler rcpt list CSV errors properly

### DIFF
--- a/src/pages/recipientLists/CreatePage.js
+++ b/src/pages/recipientLists/CreatePage.js
@@ -44,13 +44,9 @@ export class CreatePage extends Component {
   }
 }
 
-const mapStateToProps = ({ recipientLists }) => ({
-  error: recipientLists.error
-});
-
 const mapDispatchToProps = {
   createRecipientList,
   showAlert
 };
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CreatePage));
+export default withRouter(connect(undefined, mapDispatchToProps)(CreatePage));

--- a/src/pages/recipientLists/CreatePage.js
+++ b/src/pages/recipientLists/CreatePage.js
@@ -24,7 +24,7 @@ export class CreatePage extends Component {
     }).catch((err) => {
       showAlert({
         type: 'error',
-        message: 'Failed to recipient list. Please try again.'
+        message: 'Failed to create recipient list. Please try again.'
       });
     });
   };

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -19,14 +19,9 @@ import exampleRecipientListPath from './example-recipient-list.csv';
 const formName = 'recipientListForm';
 
 export class RecipientListForm extends Component {
-  state = {
-    csvErrors: null
-  };
-
   parseCsv = (csv) => parseRecipientListCsv(csv)
     .catch((csvErrors) => {
-      this.setState({ csvErrors });
-      throw new SubmissionError();
+      throw new SubmissionError({ _error: csvErrors });
     });
 
   // `csv` is an internal field. The outer conponent can access the parsed records in `recipients`.
@@ -51,14 +46,14 @@ export class RecipientListForm extends Component {
   };
 
   renderCsvErrors() {
+    const { error } = this.props;
     return <Banner status='danger' title='CSV Format Errors'>
-      {this.state.csvErrors.map((err, idx) => <Error key={idx} error={err}/>)}
+      {error.map((err, idx) => <Error key={idx} error={err}/>)}
     </Banner>;
   }
 
   render() {
-    const { editMode, pristine, valid, submitting, handleSubmit } = this.props;
-    const { csvErrors } = this.state;
+    const { editMode, pristine, valid, error, submitting, handleSubmit } = this.props;
 
     const submitDisabled = pristine || !valid || submitting;
 
@@ -73,7 +68,7 @@ export class RecipientListForm extends Component {
     }
 
     return <div>
-      { csvErrors && this.renderCsvErrors() }
+      { error && this.renderCsvErrors() }
       <form onSubmit={handleSubmit(this.preSubmit)}>
         <Panel>
           <Panel.Section>

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -79,6 +79,7 @@ export class RecipientListForm extends Component {
               validate={[required, maxLength(64)]}
               disabled={submitting}
               component={TextFieldWrapper}
+              required
             />
             { ! editMode && <Field
               name='id'
@@ -87,6 +88,7 @@ export class RecipientListForm extends Component {
               validate={[required, maxLength(64)]}
               disabled={submitting}
               component={TextFieldWrapper}
+              required
             /> }
             <Field
               name='description'
@@ -110,6 +112,7 @@ export class RecipientListForm extends Component {
               label={uploadHint}
               name="csv"
               validate={uploadValidators}
+              required
             />
           </Panel.Section>
           <Panel.Section>

--- a/src/pages/recipientLists/components/tests/RecipientListForm.test.js
+++ b/src/pages/recipientLists/components/tests/RecipientListForm.test.js
@@ -43,7 +43,7 @@ describe('RecipientListForm', () => {
       'Line 73: Too many notes',
       'Line 247: Vanilla is unacceptable'
     ];
-    wrapper.setState({ csvErrors });
+    wrapper.setProps({ error: csvErrors });
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
@@ -10,6 +10,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
           label="Label"
           name="name"
           placeholder="My favorite recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -22,6 +23,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
           label="Identifier"
           name="id"
           placeholder="my-favorite-recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -56,6 +58,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
+          required={true}
           validate={
             Array [
               [Function],
@@ -103,6 +106,7 @@ exports[`RecipientListForm renders CSV errors 1`] = `
           label="Label"
           name="name"
           placeholder="My favorite recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -115,6 +119,7 @@ exports[`RecipientListForm renders CSV errors 1`] = `
           label="Identifier"
           name="id"
           placeholder="my-favorite-recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -149,6 +154,7 @@ exports[`RecipientListForm renders CSV errors 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
+          required={true}
           validate={
             Array [
               [Function],
@@ -183,6 +189,7 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
           label="Label"
           name="name"
           placeholder="My favorite recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -195,6 +202,7 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
           label="Identifier"
           name="id"
           placeholder="my-favorite-recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -229,6 +237,7 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
+          required={true}
           validate={
             Array [
               [Function],
@@ -263,6 +272,7 @@ exports[`RecipientListForm renders correctly in edit mode 1`] = `
           label="Label"
           name="name"
           placeholder="My favorite recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -297,6 +307,7 @@ exports[`RecipientListForm renders correctly in edit mode 1`] = `
           }
           label="Optional: Upload a CSV file of recipients to replace the existing recipients in this list"
           name="csv"
+          required={true}
           validate={
             Array [
               [Function],
@@ -331,6 +342,7 @@ exports[`RecipientListForm should disable form elements on submit 1`] = `
           label="Label"
           name="name"
           placeholder="My favorite recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -344,6 +356,7 @@ exports[`RecipientListForm should disable form elements on submit 1`] = `
           label="Identifier"
           name="id"
           placeholder="my-favorite-recipients"
+          required={true}
           validate={
             Array [
               [Function],
@@ -380,6 +393,7 @@ exports[`RecipientListForm should disable form elements on submit 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
+          required={true}
           validate={
             Array [
               [Function],


### PR DESCRIPTION
Issue: We were using `throw SubmissionError()` along with component state to artifically handle CSV parsing errors. Also, constructing SubmissionError without an argument does not set the redux-form error state.
Fix: Use redux-form submission errors properly: `throw SubmissionError({ _error: '...'})` to stop form submission and set the form-connected components `error` prop on CSV parsing errors.

(Also fixed some broken language in `recipientLists/CreatePage.js`)

### Testing
Create or update a recipient list with the following CSV file:
```
ewan,dennis
sue,storm
colin,powell
hidalgo,mundungus
bobby,brown
afifth,error
asixth,error
aseventh,error
```