### PR TITLE
FAD-6286: GDPR cookie consent banner

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,39 @@
+# Phoenix UI Configuration
+
+## Using Config In Code
+
+```js
+import config from 'src/config'
+```
+
+The configuration module under `src/config/` merges variables from these locations in order:
+
+ - `src/config/default.js`
+ - `SP.productionConfig` from the current tenant's config file (see below)
+ - `src/config/test-config.js` if NODE_ENV==='test'
+
+## Default Configuration
+
+Any variables you'd like to use across all environments and tenants go in `src/config/default.js`.
+
+## Per-Environment Overrides
+
+### Test Environment
+Test config is active during `npm run test`
+
+Put test-time values in `src/config/test-config.js`.
+
+# Per-Tenant Overrides
+Ansible generates `public/static/tenant-config/<tenant-hostname>.js` for each tenant. The format of this file is a little different than the others since it's loaded at runtime.
+
+Tenant config is stored under `window.SP.productionConfig` and then merged with defaults in the config module. 
+
+The app then loads a fixed tenant config URL which Nginx on the UI tier routes to the current tenant's config file. See `A-D/roles/ui_tier/templates/web_proxy.conf.j2` for details.
+
+### Development Environment
+Start your dev environment by running `npm start` :)
+
+Put dev values in `public/static/tenant-config/production.js`.
+
+Note: we tend to use `.sparkpost.test` domains during development.
+

--- a/public/static/tenant-config/production.js
+++ b/public/static/tenant-config/production.js
@@ -1,6 +1,13 @@
 window.SP = window.SP || {};
 window.SP.productionConfig = {
   apiBase: 'http://api.sparkpost.test/api/v1',
+  cookieConsent: {
+    cookie: {
+      options: {
+        domain: 'sparkpost.test'
+      }
+    }
+  },
   featureFlags: {
     allow_mailbox_verification: true,
     allow_anyone_at_verification: true,

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PublicRoute, ProtectedRoute, AuthenticationGate } from 'src/components/auth';
-import { Support, GlobalAlertWrapper, BoomerangBanner, SiftScience } from 'src/components';
+import { CookieConsent, Support, GlobalAlertWrapper, BoomerangBanner, SiftScience } from 'src/components';
 import GoogleTagManager from 'src/components/googleTagManager/GoogleTagManager';
 import Layout from 'src/components/layout/Layout';
 import routes from 'src/config/routes';
@@ -19,6 +19,7 @@ const App = () => (
       <BoomerangBanner />
       {config.gtmId && <GoogleTagManager id={config.gtmId} />}
       <AuthenticationGate />
+      <CookieConsent />
       <Layout>
         <Switch>
           {

--- a/src/actions/cookieConsent.js
+++ b/src/actions/cookieConsent.js
@@ -1,0 +1,7 @@
+import helpers from 'src/helpers/cookieConsent';
+
+export const setConsentCookie = () => {
+  helpers.setCookie();
+  return { type: 'GIVE_COOKIE_CONSENT' };
+};
+

--- a/src/actions/currentUser.js
+++ b/src/actions/currentUser.js
@@ -56,3 +56,18 @@ export function verifyEmail(data = {}, { showErrorAlert = true, type = 'VERIFY_E
 export function verifyEmailToken(data) {
   return verifyEmail(data, { showErrorAlert: false, type: 'VERIFY_EMAIL_TOKEN' });
 }
+
+export function userGivesCookieConsent(username) {
+  return (dispatch, getState) => {
+    const { username } = getState().currentUser;
+    const action = {
+      type: 'USER_GIVES_COOKIE_CONSENT',
+      meta: {
+        method: 'PUT',
+        url: `/users/${username}`,
+        data: { cookie_consent: true }
+      }
+    };
+    return dispatch(sparkpostApiRequest(action)).then(() => dispatch(get()));
+  };
+}

--- a/src/actions/tests/__snapshots__/cookieConsent.test.js.snap
+++ b/src/actions/tests/__snapshots__/cookieConsent.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Action Creator: cookie consent  setConsentCookie should set the cookie 1`] = `
+Object {
+  "type": "GIVE_COOKIE_CONSENT",
+}
+`;

--- a/src/actions/tests/cookieConsent.test.js
+++ b/src/actions/tests/cookieConsent.test.js
@@ -1,0 +1,16 @@
+import { setConsentCookie } from '../cookieConsent';
+
+import helpers from 'src/helpers/cookieConsent';
+
+jest.mock('src/helpers/cookieConsent');
+
+describe('Action Creator: cookie consent ', () => {
+  describe('setConsentCookie', () => {
+    it('should set the cookie', () => {
+      helpers.setCookie.mockReturnValue(true);
+      expect(setConsentCookie()).toMatchSnapshot();
+      expect(helpers.setCookie).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+

--- a/src/components/cookieConsent/CookieConsent.js
+++ b/src/components/cookieConsent/CookieConsent.js
@@ -12,7 +12,8 @@ import styles from './CookieConsent.module.scss';
 
 export const ConsentBar = ({ onDismiss }) => <div className={styles.CookieConsent}>
   <div className={styles.ConsentBar}>
-    <Snackbar maxWidth={700} onDismiss={onDismiss}>We use cookies to offer you a better browsing experience, analyze site traffic, and personalize content and advertisements.  Read more about how we use cookies and how you can control them by visiting our <UnstyledLink external to={'https://www.sparkpost.com/policies/privacy/'}>Cookie Policy</UnstyledLink>.  Note that parts of our site will not function properly if you disable them.  If you continue to use this site without disabling cookies, you consent to our use of them.</Snackbar>
+    <Snackbar maxWidth={700} onDismiss={onDismiss}>
+      We use cookies to optimize your experience, analyze traffic, and personalize content.  To learn more, please visit our <UnstyledLink external to={'https://www.sparkpost.com/policies/privacy/'}>Cookie Policy</UnstyledLink>.  By using our site without disabling cookies, you consent to our use of them.</Snackbar>
   </div>
 </div>;
 

--- a/src/components/cookieConsent/CookieConsent.js
+++ b/src/components/cookieConsent/CookieConsent.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { UnstyledLink, Snackbar } from '@sparkpost/matchbox';
+
+import { setConsentCookie } from 'src/actions/cookieConsent';
+import { userGivesCookieConsent } from 'src/actions/currentUser';
+
+import { consentCookieSetSelector, cookieConsentGivenSelector } from 'src/selectors/cookieConsent';
+import { userCookieConsentFlagSelector } from 'src/selectors/currentUser';
+
+import styles from './CookieConsent.module.scss';
+
+export const ConsentBar = ({ onDismiss }) => <div className={styles.CookieConsent}>
+  <div className={styles.ConsentBar}>
+    <Snackbar maxWidth={700} onDismiss={onDismiss}>We use cookies to offer you a better browsing experience, analyze site traffic, and personalize content and advertisements.  Read more about how we use cookies and how you can control them by visiting our <UnstyledLink external to={'https://www.sparkpost.com/policies/privacy/'}>Cookie Policy</UnstyledLink>.  Note that parts of our site will not function properly if you disable them.  If you continue to use this site without disabling cookies, you consent to our use of them.</Snackbar>
+  </div>
+</div>;
+
+export class CookieConsent extends React.Component {
+  storeConsent = () => {
+    this.props.setConsentCookie();
+    this.setConsentFlag();
+  };
+
+  setConsentFlag = () => {
+    const { accessControlReady, loggedIn, userGivesCookieConsent } = this.props;
+    if (accessControlReady && loggedIn) {
+      return userGivesCookieConsent();
+    }
+  };
+
+  componentDidUpdate() {
+    // If cookie is set but user consent flag is not, set the flag to
+    // indicate the user has consented but either they consented through another
+    // .sparkpost.com property or they were not logged in when they consented.
+    const { cookieSet, userFlagSet } = this.props;
+    if (cookieSet && !userFlagSet) {
+      this.setConsentFlag();
+    }
+  }
+
+  render() {
+    const { consentGiven } = this.props;
+
+    if (consentGiven) {
+      return null;
+    }
+
+    return <ConsentBar onDismiss={this.storeConsent}/>;
+  }
+}
+
+const mapStateToProps = (state) => ({
+  consentGiven: cookieConsentGivenSelector(state),
+  cookieSet: consentCookieSetSelector(state),
+  userFlagSet: userCookieConsentFlagSelector(state),
+  accessControlReady: state.accessControlReady,
+  loggedIn: state.auth.loggedIn
+});
+
+const mapDispatchToProps = { setConsentCookie, userGivesCookieConsent };
+
+// connect consent state, set consent action
+export default connect(mapStateToProps, mapDispatchToProps)(CookieConsent);
+

--- a/src/components/cookieConsent/CookieConsent.js
+++ b/src/components/cookieConsent/CookieConsent.js
@@ -31,17 +31,28 @@ export class CookieConsent extends React.Component {
   };
 
   componentDidUpdate() {
+    const { cookieSet, userFlagSet, setConsentCookie } = this.props;
+
     // If cookie is set but user consent flag is not, set the flag to
     // indicate the user has consented but either they consented through another
     // .sparkpost.com property or they were not logged in when they consented.
-    const { cookieSet, userFlagSet } = this.props;
     if (cookieSet && !userFlagSet) {
       this.setConsentFlag();
+    }
+
+    // If the user flag is set, the user has previously consented but has 'lost'
+    // the cookie, so set it again.
+    if (!cookieSet && userFlagSet) {
+      setConsentCookie();
     }
   }
 
   render() {
-    const { consentGiven } = this.props;
+    const { accessControlReady, consentGiven } = this.props;
+
+    if (!accessControlReady) {
+      return null;
+    }
 
     if (consentGiven) {
       return null;

--- a/src/components/cookieConsent/CookieConsent.js
+++ b/src/components/cookieConsent/CookieConsent.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { UnstyledLink, Snackbar } from '@sparkpost/matchbox';
 
 import { setConsentCookie } from 'src/actions/cookieConsent';
 import { userGivesCookieConsent } from 'src/actions/currentUser';
@@ -8,14 +7,7 @@ import { userGivesCookieConsent } from 'src/actions/currentUser';
 import { consentCookieSetSelector, cookieConsentGivenSelector } from 'src/selectors/cookieConsent';
 import { userCookieConsentFlagSelector } from 'src/selectors/currentUser';
 
-import styles from './CookieConsent.module.scss';
-
-export const ConsentBar = ({ onDismiss }) => <div className={styles.CookieConsent}>
-  <div className={styles.ConsentBar}>
-    <Snackbar maxWidth={700} onDismiss={onDismiss}>
-      We use cookies to optimize your experience, analyze traffic, and personalize content.  To learn more, please visit our <UnstyledLink external to={'https://www.sparkpost.com/policies/privacy/'}>Cookie Policy</UnstyledLink>.  By using our site without disabling cookies, you consent to our use of them.</Snackbar>
-  </div>
-</div>;
+import { ConsentBar } from './components/ConsentBar';
 
 export class CookieConsent extends React.Component {
   storeConsent = () => {
@@ -24,8 +16,8 @@ export class CookieConsent extends React.Component {
   };
 
   setConsentFlag = () => {
-    const { accessControlReady, loggedIn, userGivesCookieConsent } = this.props;
-    if (accessControlReady && loggedIn) {
+    const { accessControlReady, loggedIn, savingFlag, userGivesCookieConsent } = this.props;
+    if (accessControlReady && loggedIn && !savingFlag) {
       return userGivesCookieConsent();
     }
   };
@@ -66,6 +58,7 @@ const mapStateToProps = (state) => ({
   consentGiven: cookieConsentGivenSelector(state),
   cookieSet: consentCookieSetSelector(state),
   userFlagSet: userCookieConsentFlagSelector(state),
+  savingFlag: state.currentUser.storingCookieConsent,
   accessControlReady: state.accessControlReady,
   loggedIn: state.auth.loggedIn
 });

--- a/src/components/cookieConsent/CookieConsent.module.scss
+++ b/src/components/cookieConsent/CookieConsent.module.scss
@@ -1,0 +1,16 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.CookieConsent {
+  position: fixed;
+  bottom: spacing(large);
+  z-index: z-index(overlay);
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.ConsentBar {
+  pointer-events: auto;
+}
+

--- a/src/components/cookieConsent/components/ConsentBar.js
+++ b/src/components/cookieConsent/components/ConsentBar.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { UnstyledLink, Snackbar } from '@sparkpost/matchbox';
+import styles from '../CookieConsent.module.scss';
+
+export const ConsentBar = ({ onDismiss }) => <div className={styles.CookieConsent}>
+  <div className={styles.ConsentBar}>
+    <Snackbar maxWidth={700} onDismiss={onDismiss}>
+      We use cookies to optimize your experience, analyze traffic, and personalize content. To learn more, please visit our <UnstyledLink external to={'https://www.sparkpost.com/policies/privacy/'}>Cookie Policy</UnstyledLink>. By using our site without disabling cookies, you consent to our use of them.</Snackbar>
+  </div>
+</div>;
+

--- a/src/components/cookieConsent/components/tests/ConsentBar.test.js
+++ b/src/components/cookieConsent/components/tests/ConsentBar.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { ConsentBar } from '../ConsentBar';
+
+describe('ConsentBar', () => {
+  let props;
+
+  beforeEach(() => {
+    props = { onDismiss: jest.fn() };
+  });
+
+  it('should render correctly', () => {
+    expect(shallow(<ConsentBar {...props} />)).toMatchSnapshot();
+  });
+
+  it('should wire up onDismiss', () => {
+    const wrapper = mount(<ConsentBar {...props} />);
+    wrapper.find('a').at(1).simulate('click');
+    expect(props.onDismiss).toHaveBeenCalled();
+  });
+});
+

--- a/src/components/cookieConsent/components/tests/__snapshots__/ConsentBar.test.js.snap
+++ b/src/components/cookieConsent/components/tests/__snapshots__/ConsentBar.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConsentBar should render correctly 1`] = `
+<div>
+  <div>
+    <Snackbar
+      maxWidth={700}
+      onDismiss={[MockFunction]}
+      status="default"
+    >
+      We use cookies to optimize your experience, analyze traffic, and personalize content. To learn more, please visit our 
+      <UnstyledLink
+        external={true}
+        to="https://www.sparkpost.com/policies/privacy/"
+      >
+        Cookie Policy
+      </UnstyledLink>
+      . By using our site without disabling cookies, you consent to our use of them.
+    </Snackbar>
+  </div>
+</div>
+`;

--- a/src/components/cookieConsent/tests/CookieConsent.test.js
+++ b/src/components/cookieConsent/tests/CookieConsent.test.js
@@ -46,4 +46,14 @@ describe('Component: CookieConsent', () => {
     wrapper.setProps({ cookieSet: true });
     expect(props.userGivesCookieConsent).toHaveBeenCalled();
   });
+
+  it('should set the cookie if only the flag is set', () => {
+    wrapper.setProps({ userFlagSet: true });
+    expect(props.setConsentCookie).toHaveBeenCalled();
+  });
+
+  it('should not set the flag if already set', () => {
+    wrapper.setProps({ userFlagset: true });
+    expect(props.userGivesCookieConsent).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/cookieConsent/tests/CookieConsent.test.js
+++ b/src/components/cookieConsent/tests/CookieConsent.test.js
@@ -57,7 +57,7 @@ describe('Component: CookieConsent', () => {
   });
 
   it('should not set the flag unless access control is ready', () => {
-    wrapper.setProps({ cookieSet: true, loggedIn: false });
+    wrapper.setProps({ cookieSet: true, accessControlReady: false });
     expect(props.userGivesCookieConsent).not.toHaveBeenCalled();
   });
 

--- a/src/components/cookieConsent/tests/CookieConsent.test.js
+++ b/src/components/cookieConsent/tests/CookieConsent.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { CookieConsent, ConsentBar } from '../CookieConsent';
+
+describe('Component: CookieConsent', () => {
+  let props;
+  let wrapper;
+
+  beforeEach(() => {
+    props = {
+      consentGiven: false,
+      cookieSet: false,
+      userFlagSet: false,
+      accessControlReady: true,
+      loggedIn: true,
+      setConsentCookie: jest.fn(),
+      userGivesCookieConsent: jest.fn()
+    };
+
+    wrapper = shallow(<CookieConsent {...props} />);
+  });
+
+  describe('ConsentBar', () => {
+    it('should render correctly', () => {
+      const props = { onDismiss: jest.fn() };
+      expect(shallow(<ConsentBar {...props} />)).toMatchSnapshot();
+    });
+  });
+
+  it('should render the banner without consent', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not render the banner with consent', () => {
+    wrapper.setProps({ consentGiven: true });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should give consent on dismissal', () => {
+    wrapper.instance().storeConsent();
+    expect(props.setConsentCookie).toHaveBeenCalledTimes(1);
+    expect(props.userGivesCookieConsent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should set the flag if only the cookie is set', () => {
+    wrapper.setProps({ cookieSet: true });
+    expect(props.userGivesCookieConsent).toHaveBeenCalled();
+  });
+});

--- a/src/components/cookieConsent/tests/CookieConsent.test.js
+++ b/src/components/cookieConsent/tests/CookieConsent.test.js
@@ -13,11 +13,17 @@ describe('Component: CookieConsent', () => {
       userFlagSet: false,
       accessControlReady: true,
       loggedIn: true,
+      savingFlag: false,
       setConsentCookie: jest.fn(),
       userGivesCookieConsent: jest.fn()
     };
 
     wrapper = shallow(<CookieConsent {...props} />);
+  });
+
+  it('should not render until access control is ready', () => {
+    wrapper.setProps({ accessControlReady: false });
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should render the banner without consent', () => {
@@ -45,8 +51,23 @@ describe('Component: CookieConsent', () => {
     expect(props.setConsentCookie).toHaveBeenCalled();
   });
 
+  it('should not set the flag unless logged in', () => {
+    wrapper.setProps({ cookieSet: true, loggedIn: false });
+    expect(props.userGivesCookieConsent).not.toHaveBeenCalled();
+  });
+
+  it('should not set the flag unless access control is ready', () => {
+    wrapper.setProps({ cookieSet: true, loggedIn: false });
+    expect(props.userGivesCookieConsent).not.toHaveBeenCalled();
+  });
+
   it('should not set the flag if already set', () => {
-    wrapper.setProps({ userFlagset: true });
+    wrapper.setProps({ userFlagSet: true });
+    expect(props.userGivesCookieConsent).not.toHaveBeenCalled();
+  });
+
+  it('should not set the flag if a call to set it is in flight', () => {
+    wrapper.setProps({ savingFlag: true });
     expect(props.userGivesCookieConsent).not.toHaveBeenCalled();
   });
 });

--- a/src/components/cookieConsent/tests/CookieConsent.test.js
+++ b/src/components/cookieConsent/tests/CookieConsent.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { CookieConsent, ConsentBar } from '../CookieConsent';
+import { CookieConsent } from '../CookieConsent';
 
 describe('Component: CookieConsent', () => {
   let props;
@@ -18,13 +18,6 @@ describe('Component: CookieConsent', () => {
     };
 
     wrapper = shallow(<CookieConsent {...props} />);
-  });
-
-  describe('ConsentBar', () => {
-    it('should render correctly', () => {
-      const props = { onDismiss: jest.fn() };
-      expect(shallow(<ConsentBar {...props} />)).toMatchSnapshot();
-    });
   });
 
   it('should render the banner without consent', () => {

--- a/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
+++ b/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
@@ -8,14 +8,14 @@ exports[`Component: CookieConsent ConsentBar should render correctly 1`] = `
       onDismiss={[MockFunction]}
       status="default"
     >
-      We use cookies to offer you a better browsing experience, analyze site traffic, and personalize content and advertisements.  Read more about how we use cookies and how you can control them by visiting our 
+      We use cookies to optimize your experience, analyze traffic, and personalize content.  To learn more, please visit our 
       <UnstyledLink
         external={true}
         to="https://www.sparkpost.com/policies/privacy/"
       >
         Cookie Policy
       </UnstyledLink>
-      .  Note that parts of our site will not function properly if you disable them.  If you continue to use this site without disabling cookies, you consent to our use of them.
+      .  By using our site without disabling cookies, you consent to our use of them.
     </Snackbar>
   </div>
 </div>

--- a/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
+++ b/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
@@ -1,26 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: CookieConsent ConsentBar should render correctly 1`] = `
-<div>
-  <div>
-    <Snackbar
-      maxWidth={700}
-      onDismiss={[MockFunction]}
-      status="default"
-    >
-      We use cookies to optimize your experience, analyze traffic, and personalize content.  To learn more, please visit our 
-      <UnstyledLink
-        external={true}
-        to="https://www.sparkpost.com/policies/privacy/"
-      >
-        Cookie Policy
-      </UnstyledLink>
-      .  By using our site without disabling cookies, you consent to our use of them.
-    </Snackbar>
-  </div>
-</div>
-`;
-
 exports[`Component: CookieConsent should not render the banner with consent 1`] = `""`;
 
 exports[`Component: CookieConsent should render the banner without consent 1`] = `

--- a/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
+++ b/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`Component: CookieConsent should not render the banner with consent 1`] = `""`;
 
+exports[`Component: CookieConsent should not render until access control is ready 1`] = `""`;
+
 exports[`Component: CookieConsent should render the banner without consent 1`] = `
 <Component
   onDismiss={[Function]}

--- a/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
+++ b/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: CookieConsent ConsentBar should render correctly 1`] = `
+<div>
+  <div>
+    <Snackbar
+      maxWidth={700}
+      onDismiss={[MockFunction]}
+      status="default"
+    >
+      We use cookies to offer you a better browsing experience, analyze site traffic, and personalize content and advertisements.  Read more about how we use cookies and how you can control them by visiting our 
+      <UnstyledLink
+        external={true}
+        to="https://www.sparkpost.com/policies/privacy/"
+      >
+        Cookie Policy
+      </UnstyledLink>
+      .  Note that parts of our site will not function properly if you disable them.  If you continue to use this site without disabling cookies, you consent to our use of them.
+    </Snackbar>
+  </div>
+</div>
+`;
+
+exports[`Component: CookieConsent should not render the banner with consent 1`] = `""`;
+
+exports[`Component: CookieConsent should render the banner without consent 1`] = `
+<Component
+  onDismiss={[Function]}
+/>
+`;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -24,6 +24,7 @@ export { default as ReadyFor } from './domainStatus/ReadyFor';
 export { default as SiftScience } from './siftScience/SiftScience';
 export { default as StatusTooltipHeader } from './domainStatus/StatusTooltipHeader';
 export { default as DomainStatusCell } from './domainStatus/DomainStatusCell';
+export { default as CookieConsent } from './cookieConsent/CookieConsent';
 
 
 export * from './collection';

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -30,6 +30,16 @@ const config = {
     supportEmail: 'support@sparkpost.com',
     billingEmail: 'billing@sparkpost.com'
   },
+  cookieConsent: {
+    cookie: {
+      name: 'cookieConsent',
+      ageDays: 365,
+      options: {
+        domain: 'sparkpost.com',
+        path: '/'
+      }
+    }
+  },
   featureFlags: {
     allow_mailbox_verification: true,
     allow_anyone_at_verification: false,

--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -19,6 +19,16 @@ const testConfig = {
         path: '/'
       }
     }
+  },
+  cookieConsent: {
+    cookie: {
+      name: 'cookieConsent',
+      ageDays: 365,
+      options: {
+        domain: 'test',
+        path: '/'
+      }
+    }
   }
 };
 

--- a/src/helpers/cookieConsent.js
+++ b/src/helpers/cookieConsent.js
@@ -1,0 +1,12 @@
+import moment from 'moment';
+import * as jsCookie from 'js-cookie';
+import config from 'src/config';
+
+const { name, ageDays, options } = config.cookieConsent.cookie;
+
+const isCookieSet = () => jsCookie.get(name) !== undefined;
+
+const setCookie = () =>
+  jsCookie.set(name, moment().format(), { ...options, expires: ageDays });
+
+export default { isCookieSet, setCookie };

--- a/src/helpers/tests/cookieConsent.test.js
+++ b/src/helpers/tests/cookieConsent.test.js
@@ -1,0 +1,43 @@
+import cookieMock from 'js-cookie';
+import { fn as mockMoment } from 'moment';
+import cookieConsent from '../cookieConsent';
+import config from 'src/config';
+
+jest.mock('js-cookie');
+
+describe('Helper: cookie consent helper', () => {
+  const { name, ageDays, options } = config.cookieConsent.cookie;
+  const mockNow = '2018-02-01T10:10';
+
+  beforeEach(() => {
+    mockMoment.format = jest.fn().mockReturnValue(mockNow);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    mockMoment.format.mockReset();
+  });
+
+  it('should set cookie using config', () => {
+    cookieConsent.setCookie();
+    expect(cookieMock.set).toHaveBeenCalledWith(name, mockNow, expect.objectContaining({
+      domain: options.domain,
+      expires: ageDays
+    }));
+  });
+
+  it('should detect cookie existance', () => {
+    cookieMock.get.mockReturnValueOnce('');
+    expect(cookieConsent.isCookieSet()).toEqual(true);
+    expect(cookieMock.get).toHaveBeenCalledWith(name);
+  });
+
+  it('should detect a missing cookie', () => {
+    cookieMock.get.mockReturnValueOnce(undefined);
+    expect(cookieConsent.isCookieSet()).toEqual(false);
+    expect(cookieMock.get).toHaveBeenCalledWith(name);
+  });
+});

--- a/src/pages/join/tests/JoinPage.test.js
+++ b/src/pages/join/tests/JoinPage.test.js
@@ -24,6 +24,7 @@ jest.mock('src/config', () => ({
   support: {
     algolia: {}
   },
+  cookieConsent: { cookie: {}},
   gaTag: 'ga101',
   links: {
     submitTicket: 'https://support.sparkpost.com/customer/portal/emails/new'

--- a/src/pages/sendingDomains/components/tests/EditBounce.test.js
+++ b/src/pages/sendingDomains/components/tests/EditBounce.test.js
@@ -13,6 +13,7 @@ jest.mock('src/config', () => ({
     domain: ''
   },
   support: { algolia: {}},
+  cookieConsent: { cookie: {}},
   bounceDomains: {
     allowDefault: false,
     cnameValue: 'sparkpostmail.com'

--- a/src/reducers/cookieConsent.js
+++ b/src/reducers/cookieConsent.js
@@ -1,0 +1,15 @@
+import helpers from 'src/helpers/cookieConsent';
+
+const initialState = {
+  cookieSet: helpers.isCookieSet()
+};
+
+export default (state = initialState, { type, payload }) => {
+  switch (type) {
+    case 'GIVE_COOKIE_CONSENT':
+      return { ...state, cookieSet: true };
+
+    default:
+      return state;
+  }
+};

--- a/src/reducers/currentUser.js
+++ b/src/reducers/currentUser.js
@@ -3,13 +3,14 @@ const initialState = {
   verifyingEmail: null,
   emailError: null,
   verifyingToken: null,
-  tokenError: null
+  tokenError: null,
+  storingCookieConsent: null
 };
 
 export default (state = initialState, { type, payload }) => {
   switch (type) {
     case 'GET_CURRENT_USER_SUCCESS':
-      return { ...state, ...payload };
+      return { ...state, ...payload, cookie_consent: !!payload.cookie_consent };
 
     case 'GET_GRANTS_SUCCESS':
       return { ...state, grants: payload };
@@ -34,6 +35,15 @@ export default (state = initialState, { type, payload }) => {
 
     case 'VERIFY_EMAIL_TOKEN_FAIL':
       return { ...state, tokenError: payload, verifyingToken: false };
+
+    case 'USER_GIVES_COOKIE_CONSENT_PENDING':
+      return { ...state, storingCookieConsent: true };
+
+    case 'USER_GIVES_COOKIE_CONSENT_FAIL':
+      return { ...state, storingCookieConsent: false };
+
+    case 'USER_GIVES_COOKIE_CONSENT_SUCCESS':
+      return { ...state, storingCookieConsent: false, cookie_consent: true };
 
     default:
       return state;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import apiKeys from './api-keys';
 import auth from './auth';
 import billing from './billing';
 import bounceReport from './bounceReport';
+import cookieConsent from './cookieConsent';
 import delayReport from './delayReport';
 import engagementReport from './engagementReport';
 import rejectionReport from './rejectionReport';
@@ -39,6 +40,7 @@ const appReducer = combineReducers({
   auth,
   billing,
   bounceReport,
+  cookieConsent,
   delayReport,
   engagementReport,
   rejectionReport,

--- a/src/selectors/cookieConsent.js
+++ b/src/selectors/cookieConsent.js
@@ -1,9 +1,8 @@
 import { createSelector } from 'reselect';
-import helpers from 'src/helpers/cookieConsent';
 
 import { userCookieConsentFlagSelector } from './currentUser';
 
-export const consentCookieSetSelector = helpers.isCookieSet;
+export const consentCookieSetSelector = (state) => state.cookieConsent.cookieSet;
 
 export const cookieConsentGivenSelector = createSelector(
   [ consentCookieSetSelector, userCookieConsentFlagSelector ],

--- a/src/selectors/cookieConsent.js
+++ b/src/selectors/cookieConsent.js
@@ -1,0 +1,11 @@
+import { createSelector } from 'reselect';
+import helpers from 'src/helpers/cookieConsent';
+
+import { userCookieConsentFlagSelector } from './currentUser';
+
+export const consentCookieSetSelector = helpers.isCookieSet;
+
+export const cookieConsentGivenSelector = createSelector(
+  [ consentCookieSetSelector, userCookieConsentFlagSelector ],
+  (cookieSet, userConsentGiven) => cookieSet || userConsentGiven
+);

--- a/src/selectors/currentUser.js
+++ b/src/selectors/currentUser.js
@@ -1,0 +1,1 @@
+export const userCookieConsentFlagSelector = (state) => !!state.currentUser.cookie_consent;

--- a/src/selectors/tests/cookieConsent.test.js
+++ b/src/selectors/tests/cookieConsent.test.js
@@ -1,29 +1,24 @@
 import * as selectors from '../cookieConsent';
-import helpers from 'src/helpers/cookieConsent';
 import * as currentUserSelectors from '../currentUser';
 
-jest.mock('src/helpers/cookieConsent');
 jest.mock('../currentUser');
 
 describe('Selector: Cookie Consent', () => {
   describe('consentCookieSetSelector', () => {
     it('should select cookie state', () => {
-      selectors.consentCookieSetSelector({});
-      expect(helpers.isCookieSet).toHaveBeenCalledTimes(1);
+      expect(selectors.consentCookieSetSelector({ cookieConsent: { cookieSet: true }})).toEqual(true);
     });
   });
 
   describe('cookieConsentGivenSelector', () => {
     it('should include cookie state', () => {
       currentUserSelectors.userCookieConsentFlagSelector.mockReturnValueOnce(false);
-      helpers.isCookieSet.mockReturnValueOnce(true);
-      expect(selectors.cookieConsentGivenSelector({})).toEqual(true);
+      expect(selectors.cookieConsentGivenSelector({ cookieConsent: { cookieSet: true }})).toEqual(true);
     });
 
     it('should include user flag state', () => {
       currentUserSelectors.userCookieConsentFlagSelector.mockReturnValueOnce(true);
-      helpers.isCookieSet.mockReturnValueOnce(false);
-      expect(selectors.cookieConsentGivenSelector({})).toEqual(true);
+      expect(selectors.cookieConsentGivenSelector({ cookieConsent: { cookieSet: false }})).toEqual(true);
     });
   });
 });

--- a/src/selectors/tests/cookieConsent.test.js
+++ b/src/selectors/tests/cookieConsent.test.js
@@ -1,0 +1,30 @@
+import * as selectors from '../cookieConsent';
+import helpers from 'src/helpers/cookieConsent';
+import * as currentUserSelectors from '../currentUser';
+
+jest.mock('src/helpers/cookieConsent');
+jest.mock('../currentUser');
+
+describe('Selector: Cookie Consent', () => {
+  describe('consentCookieSetSelector', () => {
+    it('should select cookie state', () => {
+      selectors.consentCookieSetSelector({});
+      expect(helpers.isCookieSet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cookieConsentGivenSelector', () => {
+    it('should include cookie state', () => {
+      currentUserSelectors.userCookieConsentFlagSelector.mockReturnValueOnce(false);
+      helpers.isCookieSet.mockReturnValueOnce(true);
+      expect(selectors.cookieConsentGivenSelector({})).toEqual(true);
+    });
+
+    it('should include user flag state', () => {
+      currentUserSelectors.userCookieConsentFlagSelector.mockReturnValueOnce(true);
+      helpers.isCookieSet.mockReturnValueOnce(false);
+      expect(selectors.cookieConsentGivenSelector({})).toEqual(true);
+    });
+  });
+});
+


### PR DESCRIPTION
- Main component is under `src/components/cookieBanner`
- App.js loads CookieConsent, making it visible e-v-e-r-y-w-h-e-r-e
 - Banner shows only if `consent` has not been given
 - Dismissing the banner gives consent
 - Consent is stored in 2 places:
    1. in a `cookieConsent` cookie (with absolutely no irony)
    1. `PUT /user/{username}` `{ "cookie_consent": true }`

**Note: test config sets a cookie on `.sparkpost.test` so use `app.sparkpost.test:3100` or similar to access the app locally on your machine.**

## Remaining Work
- [x] ~The div holding the banner is transparent but blocks input to items "under" it.~
- [x] Handle logged out cases
    - ~Avoid blocking page content~ - slightly better with wider banner
    - ~Don't rely on post-auth content~
 - [x] ~Wait for `currentUser` load before making decisions~