### PR TITLE
FAD-6288 Suspended User Experience

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -54,7 +54,7 @@ Routes should all be set up in `src/config/routes.js`, and look like this:
   {
     path: '/some/other/path',
     component: SomeOtherPage,
-    condition: composeConditions(hasGrants('some/other', 'also/this'), anotherHelper('some argument'))
+    condition: all(hasGrants('some/other', 'also/this'), anotherHelper('some argument'))
   }
 ]
 ```
@@ -97,18 +97,48 @@ This makes conditions more readable and easier to compose.
 
 #### Condition composition
 
-You can compose multiple condition helpers together by using the `composeConditions` helper. For example, if you need to make a route's access dependent on grants _and_ a config flag:
+You can compose multiple condition helpers together by using the compose helpers. For example, if you need to make a route's access dependent on grants _and_ a config flag:
 
 ```js
-import { hasGrants, configFlag, composeConditions } from 'src/helpers/conditions';
+import { hasGrants, configFlag, all } from 'src/helpers/conditions';
 
 export default [
   {
     path: '/reports/summary',
-    condition: composeConditions(hasGrants('metrics/view'), configFlag('summaryChart.enabled'))
+    condition: all(hasGrants('metrics/view'), configFlag('summaryChart.enabled'))
   }
 ]
 ```
+
+If instead you need to check an "OR" condition, you can use the `any` composition helper:
+
+```js
+import { configEquals, configFlag, any } from 'src/helpers/conditions';
+
+export default [
+  {
+    path: '/account/billing',
+    condition: any(configEquals('account.plan', 'free1'), configFlag('account.billing.enabled'))
+  }
+]
+```
+
+#### Reversing a condition
+
+Try to always create conditions in the positive direction, which can then be reversed using the `not` helper:
+
+```js
+import { not, all } from 'src/helpers/conditions';
+import { onPlan } from 'src/helpers/conditions/account';
+
+export default [
+  {
+    path: '/account/billing/plan',
+    condition: all(not(onPlan('free1')), not(onPlan('ccfree1')))
+  }
+]
+```
+
 
 ## Access Condition Selector
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,9 +132,9 @@
       }
     },
     "@sparkpost/matchbox": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-2.3.5.tgz",
-      "integrity": "sha512-tJoZJ+FQkE6a+IdSNDvJ6JCORzzUCGC5iIqZDQmOuoYb2gAVdXfd3QhYtCbPWlKs5xp8dAih7YkNA+O7C+Adxw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-2.4.0.tgz",
+      "integrity": "sha512-LIWUSx+G7xstUx2pYec3kzEMlJWpvS84H8G/bL5qzh7XMefpwvPlINv4xILyR4e/g9g9AyWQDpt6XXuSHEIggg==",
       "requires": {
         "classnames": "2.2.5",
         "react": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/SparkPost/2web2ui/issues"
   },
   "dependencies": {
-    "@sparkpost/matchbox": "^2.3.5",
+    "@sparkpost/matchbox": "^2.4.0",
     "axios": "^0.17.1",
     "chart.js": "^2.6.0",
     "classnames": "^2.2.5",

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -111,7 +111,7 @@ export function createZuoraAccount({ data, token, signature }) {
 export function billingCreate(values) {
   const { corsData, billingData } = formatDataForCors(values);
 
-  return (dispatch) =>
+  return (dispatch, getState) =>
 
     // get CORS data for the create account context
     dispatch(cors('create-account', corsData))
@@ -119,7 +119,12 @@ export function billingCreate(values) {
       // create the Zuora account
       .then((results) => {
         const { token, signature } = results;
+        const { currentUser } = getState();
         const data = formatCreateData({ ...results, ...billingData });
+
+        // add user's email when creating account
+        data.billToContact.workEmail = currentUser.email;
+
         return dispatch(createZuoraAccount({ data, token, signature }));
       })
 

--- a/src/actions/globalAlert.js
+++ b/src/actions/globalAlert.js
@@ -1,8 +1,19 @@
 export function showAlert(alert) {
   return {
     type: 'SHOW_GLOBAL_ALERT',
-    payload: { ...alert }
+    payload: alert
   };
+}
+
+export function showSuspensionAlert(overrides = {}) {
+  return showAlert({
+    type: 'warning',
+    message: 'This account is currently suspended',
+    details: 'For more information about account suspension, please email compliance@sparkpost.com',
+    maxWidth: 800,
+    dedupeId: 'SUSPENSION_NOTICE',
+    ...overrides
+  });
 }
 
 export function clear(id) {

--- a/src/actions/helpers/sparkpostApiRequest.js
+++ b/src/actions/helpers/sparkpostApiRequest.js
@@ -1,6 +1,6 @@
 import requestHelperFactory from 'src/actions/helpers/requestHelperFactory';
 import { refresh, logout } from 'src/actions/auth';
-import { showAlert } from 'src/actions/globalAlert';
+import { showAlert, showSuspensionAlert } from 'src/actions/globalAlert';
 import { useRefreshToken } from 'src/helpers/http';
 import { resolveOnCondition } from 'src/helpers/promise';
 import _ from 'lodash';
@@ -37,9 +37,12 @@ const sparkpostRequest = requestHelperFactory({
     return results;
   },
   onFail: ({ types, err, dispatch, meta, action, getState }) => {
+    // TODO: Move this error transformation into an axios interceptor in the
+    // sparkpost axios instance, so all sparkpost API errors look the same
+    // (even those that don't use this helper because the request is not authenticated)
     const apiError = new SparkpostApiError(err);
     const { message, response = {}} = apiError;
-    const { auth } = getState();
+    const { auth, account } = getState();
     const { retries = 0 } = meta;
 
     // NOTE: if this is a 401 and we have a refresh token, we need to do a
@@ -79,7 +82,7 @@ const sparkpostRequest = requestHelperFactory({
     }
 
     // If we have a 403 or a 401 and we're not refreshing, log the user out silently
-    if (response.status === 401 || response.status === 403) {
+    if (account.status === 'active' && (response.status === 401 || response.status === 403)) {
       dispatch(logout());
       throw apiError;
     }
@@ -91,10 +94,17 @@ const sparkpostRequest = requestHelperFactory({
       meta
     });
 
-    if (response.status >= 500) {
-      dispatch(showAlert({ type: 'error', message: 'Something went wrong.', details: message }));
+    // if the account is suspended, a 403 should not log the user out
+    if (response.status === 403 && account.status === 'suspended') {
+      dispatch(showSuspensionAlert());
+      // TODO: dispatch(getAccount());
     }
 
+    if (response.status >= 500) {
+      dispatch(showAlert({ type: 'error', message: 'Something went wrong', details: message }));
+    }
+
+    // TODO: Remove this once we unchain all actions
     throw apiError;
   }
 });

--- a/src/actions/helpers/tests/__snapshots__/sparkpostApiRequest.test.js.snap
+++ b/src/actions/helpers/tests/__snapshots__/sparkpostApiRequest.test.js.snap
@@ -55,6 +55,9 @@ Array [
     },
     "type": "TEST_FAIL",
   },
+  Object {
+    "type": "SHOW_ALERT",
+  },
 ]
 `;
 
@@ -82,6 +85,37 @@ Array [
       },
     },
     "type": "TEST_FAIL",
+  },
+]
+`;
+
+exports[`Helper: SparkPost API Request failure cases should not log out on a 403 while suspended 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "url": "/some/path",
+    },
+    "type": "TEST_PENDING",
+  },
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "url": "/some/path",
+    },
+    "payload": Object {
+      "message": "API call failed",
+      "response": Object {
+        "data": Object {
+          "results": Array [],
+        },
+        "status": 403,
+      },
+    },
+    "type": "TEST_FAIL",
+  },
+  Object {
+    "type": "SHOW_SUSPENSION_ALERT",
   },
 ]
 `;

--- a/src/actions/tests/__snapshots__/billing.test.js.snap
+++ b/src/actions/tests/__snapshots__/billing.test.js.snap
@@ -18,7 +18,11 @@ Array [
   Object {
     "meta": Object {
       "data": Object {
-        "formatted": "data",
+        "billToContact": Object {
+          "workEmail": "sparkpost-user-email@example.com",
+        },
+        "creditCard": Object {},
+        "subscription": Object {},
       },
       "headers": Object {
         "signature": undefined,

--- a/src/actions/tests/billing.test.js
+++ b/src/actions/tests/billing.test.js
@@ -12,6 +12,12 @@ describe('Action Creator: Billing', () => {
   let mockStore;
   let token;
   let signature;
+  let corsData;
+  let billingData;
+  let accountKey;
+  let dispatchMock;
+  let getStateMock;
+  let testState;
 
   function snapActions() {
     expect(mockStore.getActions()).toMatchSnapshot();
@@ -21,6 +27,25 @@ describe('Action Creator: Billing', () => {
     mockStore = createMockStore({});
     token = 'SOME$%TEST#*TOKEN';
     signature = 'some-test-signature';
+    corsData = { some: 'test-cors-data' };
+    billingData = { some: 'test-billing-data', billToContact: {}};
+    accountKey = { some: 'test-billing-data' };
+    testState = {
+      currentUser: {
+        email: 'sparkpost-user-email@example.com'
+      }
+    };
+
+    dispatchMock = jest.fn((a) => Promise.resolve(a));
+    getStateMock = jest.fn(() => testState);
+
+    billingHelpers.formatDataForCors = jest.fn((values) => ({ values, corsData, billingData }));
+    billingHelpers.formatCreateData = jest.fn(() => ({
+      billToContact: {},
+      creditCard: {},
+      subscription: {}
+    }));
+    billingHelpers.formatUpdateData = jest.fn((values) => ({ accountKey }));
   });
 
   it('should dispatch a subscription sync action', () => {
@@ -30,8 +55,7 @@ describe('Action Creator: Billing', () => {
 
   it('should dispatch an update subscription action', async() => {
     const dispatchMock = jest.fn((a) => Promise.resolve(a));
-    const thunk = billing.updateSubscription('test-code');
-    await thunk(dispatchMock);
+    await billing.updateSubscription('test-code')(dispatchMock);
     expect(_.flatten(dispatchMock.mock.calls)).toMatchSnapshot();
   });
 
@@ -42,7 +66,6 @@ describe('Action Creator: Billing', () => {
 
   it('should dispatch an update credit card action', () => {
     const data = { some: 'credit-card-data' };
-
     mockStore.dispatch(billing.updateCreditCard({ data, token, signature }));
     snapActions();
   });
@@ -54,27 +77,13 @@ describe('Action Creator: Billing', () => {
   });
 
   it('should dispatch a chained billing create action', async() => {
-    const dispatchMock = jest.fn((a) => Promise.resolve(a));
-    const corsData = { some: 'test-cors-data' };
-    const billingData = { some: 'test-billing-data' };
     billing.cors = jest.fn(() => ({ token, signature }));
-    billingHelpers.formatDataForCors = jest.fn((values) => ({ values, corsData, billingData }));
-    billingHelpers.formatCreateData = jest.fn(() => ({ formatted: 'data' }));
-
-    const thunk = billing.billingCreate({ some: 'test-values' });
-    await thunk(dispatchMock);
-
+    await billing.billingCreate({ some: 'test-values' })(dispatchMock, getStateMock);
     expect(_.flatten(dispatchMock.mock.calls)).toMatchSnapshot();
   });
 
   it('should dispatch a chained billing update action', async() => {
-    const dispatchMock = jest.fn((a) => Promise.resolve(a));
-    const accountKey = { some: 'test-billing-data' };
-    billingHelpers.formatUpdateData = jest.fn((values) => ({ accountKey }));
-
-    const thunk = billing.billingUpdate({ planpicker: { code: 'test-plan' }});
-    await thunk(dispatchMock);
-
+    await billing.billingUpdate({ planpicker: { code: 'test-plan' }})(dispatchMock);
     expect(_.flatten(dispatchMock.mock.calls)).toMatchSnapshot();
   });
 

--- a/src/components/auth/ConditionSwitch.js
+++ b/src/components/auth/ConditionSwitch.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import selectAccessConditionState from 'src/selectors/accessConditionState';
+
+export const defaultCase = () => true;
+
+/**
+ * Returns the first child whose condition prop returns true
+ *
+ * Patterned after the React Router <Switch> element
+ */
+export const ConditionSwitch = function({ children, ready, accessConditionState }) {
+  if (!ready) {
+    return null;
+  }
+
+  let output = null;
+
+  React.Children.forEach(children, (child) => {
+    const { props = {}} = child;
+    if (
+      output === null &&
+      React.isValidElement(child) &&
+      typeof props.condition === 'function' &&
+      props.condition(accessConditionState)
+    ) {
+      output = child;
+    }
+  });
+
+  return output;
+};
+
+const mapStateToProps = (state, { wait = true }) => ({
+  ready: !wait || state.accessControlReady,
+  accessConditionState: selectAccessConditionState(state)
+});
+
+export default connect(mapStateToProps)(ConditionSwitch);

--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -2,9 +2,16 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Redirect, Route } from 'react-router-dom';
 import { AccessControl } from 'src/components/auth';
+import { showSuspensionAlert } from 'src/actions/globalAlert';
 import _ from 'lodash';
 
 export class ProtectedRoute extends Component {
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.accountStatus !== 'suspended' && this.props.accountStatus === 'suspended') {
+      this.props.showSuspensionAlert({ autoDismiss: false });
+    }
+  }
 
   renderComponent(reactRouterProps) {
     const { component: Component, condition } = this.props;
@@ -36,7 +43,8 @@ export class ProtectedRoute extends Component {
   }
 }
 
-const mapStateToProps = ({ auth }) => ({
-  auth
+const mapStateToProps = ({ auth, account }) => ({
+  auth,
+  accountStatus: account.status
 });
-export default connect(mapStateToProps)(ProtectedRoute);
+export default connect(mapStateToProps, { showSuspensionAlert })(ProtectedRoute);

--- a/src/components/globalAlert/Alert.js
+++ b/src/components/globalAlert/Alert.js
@@ -16,7 +16,7 @@ class Alert extends Component {
   static defaultProps = {
     autoDismiss: true,
     type: 'default',
-    timeoutInterval: 3000
+    timeoutInterval: 15000
   }
 
   state = {

--- a/src/components/globalAlert/Alert.js
+++ b/src/components/globalAlert/Alert.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Snackbar } from '@sparkpost/matchbox';
+import styles from './Alert.module.scss';
 
 class Alert extends Component {
   static propTypes = {
     autoDismiss: PropTypes.bool,
     message: PropTypes.string.isRequired,
-    type: PropTypes.oneOf(['default', 'success', 'error', 'danger']),
+    type: PropTypes.string,
     details: PropTypes.string,
     timeoutInterval: PropTypes.number,
     onDismiss: PropTypes.func.isRequired
@@ -15,7 +16,7 @@ class Alert extends Component {
   static defaultProps = {
     autoDismiss: true,
     type: 'default',
-    timeoutInterval: 15000
+    timeoutInterval: 3000
   }
 
   state = {
@@ -58,16 +59,15 @@ class Alert extends Component {
 
     const markup = showDetails
       ? <div>{ details }</div>
-      : <div>{ message } { detailsLink }</div>;
+      : <div>{ message } <span className={styles.Details}>{detailsLink}</span></div>;
 
     return <div>{ markup }</div>;
   }
 
   render() {
-    const { type } = this.props;
-    const status = type === 'error' ? 'danger' : type;
+    const { type, maxWidth } = this.props;
 
-    return <Snackbar status={status} onDismiss={this.handleDismiss}>{ this.renderMessage() }</Snackbar>;
+    return <Snackbar status={type} onDismiss={this.handleDismiss} maxWidth={maxWidth}>{this.renderMessage()}</Snackbar>;
   }
 }
 

--- a/src/components/globalAlert/Alert.module.scss
+++ b/src/components/globalAlert/Alert.module.scss
@@ -1,0 +1,3 @@
+.Details {
+  padding-left: 20px;
+}

--- a/src/components/globalAlert/GlobalAlertWrapper.js
+++ b/src/components/globalAlert/GlobalAlertWrapper.js
@@ -18,7 +18,7 @@ export const GlobalAlertWrapper = ({
         { alerts.map((alert, i) => (
           <Animator key={alert.id}>
             <div className={styles.Alert}>
-              <Alert onDismiss={() => clear(alert.id)} {...alert}></Alert>
+              <Alert onDismiss={() => clear(alert.id)} {...alert} />
             </div>
           </Animator>
         ))}

--- a/src/components/globalAlert/tests/__snapshots__/Alert.test.js.snap
+++ b/src/components/globalAlert/tests/__snapshots__/Alert.test.js.snap
@@ -2,8 +2,9 @@
 
 exports[`Alert should handle details click 1`] = `
 <Snackbar
+  maxWidth={380}
   onDismiss={[Function]}
-  status="danger"
+  status="error"
 >
   <div>
     <div>
@@ -15,18 +16,21 @@ exports[`Alert should handle details click 1`] = `
 
 exports[`Alert should render with all props 1`] = `
 <Snackbar
+  maxWidth={380}
   onDismiss={[Function]}
-  status="danger"
+  status="error"
 >
   <div>
     <div>
       message
        
-      <a
-        onClick={[Function]}
-      >
-        View Details
-      </a>
+      <span>
+        <a
+          onClick={[Function]}
+        >
+          View Details
+        </a>
+      </span>
     </div>
   </div>
 </Snackbar>

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -29,9 +29,10 @@ import { default as emailVerification } from 'src/components/emailVerification/E
 
 import {
   hasGrants,
-  composeConditions
+  all,
+  not
 } from 'src/helpers/conditions';
-import { notEnterprise } from 'src/helpers/conditions/account';
+import { isEnterprise } from 'src/helpers/conditions/account';
 import { configFlag, configEquals } from 'src/helpers/conditions/config';
 import App from 'src/components/layout/App';
 
@@ -136,7 +137,7 @@ const routes = [
     path: '/dashboard',
     component: DashboardPage,
     layout: App,
-    condition: composeConditions(
+    condition: all(
       hasGrants('api_keys/manage', 'templates/modify', 'sending_domains/manage'),
       configEquals('splashPage', '/dashboard') // want to hide if not a splash page https://jira.int.messagesystems.com/browse/FAD-6046
     )
@@ -230,7 +231,7 @@ const routes = [
   {
     path: '/templates',
     component: templates.ListPage,
-    condition: composeConditions(hasGrants('templates/modify'), ({ account }) => account.status === 'active'),
+    condition: all(hasGrants('templates/modify'), ({ account }) => account.status === 'active'),
     layout: App
   },
   {
@@ -375,13 +376,13 @@ const routes = [
   {
     path: '/account/billing',
     component: billing.SummaryPage,
-    condition: composeConditions(hasGrants('account/manage'), notEnterprise()),
+    condition: all(hasGrants('account/manage'), not(isEnterprise())),
     layout: App
   },
   {
     path: '/account/billing/plan',
     component: billing.ChangePlanPage,
-    condition: composeConditions(hasGrants('account/manage'), notEnterprise()),
+    condition: all(hasGrants('account/manage'), not(isEnterprise())),
     layout: App
   },
   {

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -376,13 +376,13 @@ const routes = [
   {
     path: '/account/billing',
     component: billing.SummaryPage,
-    condition: all(hasGrants('account/manage'), not(isEnterprise())),
+    condition: all(hasGrants('account/manage'), not(isEnterprise)),
     layout: App
   },
   {
     path: '/account/billing/plan',
     component: billing.ChangePlanPage,
-    condition: all(hasGrants('account/manage'), not(isEnterprise())),
+    condition: all(hasGrants('account/manage'), not(isEnterprise)),
     layout: App
   },
   {

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -1,14 +1,16 @@
 import { any, all } from './compose';
+import _ from 'lodash';
 
 export const onPlan = (plan) => ({ account }) => account.subscription.code === plan;
 export const onServiceLevel = (level) => ({ account }) => account.service_level === level;
-export const isEnterprise = () => any(
+export const isEnterprise = any(
   onPlan('ent1'),
   onServiceLevel('enterprise')
 );
 export const hasStatus = (status) => ({ account }) => account.status === status;
 export const hasStatusReasonCategory = (category) => ({ account }) => account.status_reason_category === category;
-export const isSuspendedForBilling = () => all(
+export const isSuspendedForBilling = all(
   hasStatus('suspended'),
   hasStatusReasonCategory('100.01')
 );
+export const isSelfServeBilling = ({ account }) => _.get(account, 'subscription.self_serve', false);

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -1,10 +1,14 @@
-import composeConditions from './compose';
+import { any, all } from './compose';
 
-export const notOnPlan = (plan) => ({ account }) => account.subscription.code !== plan;
-
-export const notOnServiceLevel = (level) => ({ account }) => account.service_level !== level;
-
-export const notEnterprise = () => composeConditions(
-  notOnPlan('ent1'),
-  notOnServiceLevel('enterprise')
+export const onPlan = (plan) => ({ account }) => account.subscription.code === plan;
+export const onServiceLevel = (level) => ({ account }) => account.service_level === level;
+export const isEnterprise = () => any(
+  onPlan('ent1'),
+  onServiceLevel('enterprise')
+);
+export const hasStatus = (status) => ({ account }) => account.status === status;
+export const hasStatusReasonCategory = (category) => ({ account }) => account.status_reason_category === category;
+export const isSuspendedForBilling = () => all(
+  hasStatus('suspended'),
+  hasStatusReasonCategory('100.01')
 );

--- a/src/helpers/conditions/compose.js
+++ b/src/helpers/conditions/compose.js
@@ -1,3 +1,7 @@
-export default function(...conditions) {
+export function all(...conditions) {
   return (args) => conditions.every((condition) => condition(args));
+}
+
+export function any(...conditions) {
+  return (args) => conditions.some((condition) => condition(args));
 }

--- a/src/helpers/conditions/index.js
+++ b/src/helpers/conditions/index.js
@@ -1,2 +1,3 @@
-export { default as composeConditions } from './compose';
+export { any, all } from './compose';
 export { default as hasGrants } from './hasGrants';
+export { default as not } from './not';

--- a/src/helpers/conditions/not.js
+++ b/src/helpers/conditions/not.js
@@ -1,0 +1,3 @@
+const not = (condition) => (opts) => !condition(opts);
+
+export default not;

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -1,34 +1,34 @@
-import { notOnPlan, notOnServiceLevel, notEnterprise } from '../account';
+import { onPlan, onServiceLevel, isEnterprise, isSuspendedForBilling } from '../account';
 
-describe('Condition: notOnPlan', () => {
+describe('Condition: onPlan', () => {
 
-  it('should return a function that returns true if not on given plan', () => {
-    const condition = notOnPlan('p1');
-    expect(condition({ account: { subscription: { code: 'p2' }}})).toEqual(true);
+  it('should return a function that returns true if on given plan', () => {
+    const condition = onPlan('p1');
+    expect(condition({ account: { subscription: { code: 'p1' }}})).toEqual(true);
   });
 
-  it('should return a function that returns false if on the given plan', () => {
-    const condition = notOnPlan('p1');
-    expect(condition({ account: { subscription: { code: 'p1' }}})).toEqual(false);
-  });
-
-});
-
-describe('Condition: notOnServiceLevel', () => {
-
-  it('should return a function that returns true if not on given level', () => {
-    const condition = notOnServiceLevel('other');
-    expect(condition({ account: { service_level: 'standard' }})).toEqual(true);
-  });
-
-  it('should return a function that returns false if on the given level', () => {
-    const condition = notOnServiceLevel('other');
-    expect(condition({ account: { service_level: 'other' }})).toEqual(false);
+  it('should return a function that returns false if not on the given plan', () => {
+    const condition = onPlan('p1');
+    expect(condition({ account: { subscription: { code: 'p2' }}})).toEqual(false);
   });
 
 });
 
-describe('Condition: notEnterprise', () => {
+describe('Condition: onServiceLevel', () => {
+
+  it('should return a function that returns false if not on given level', () => {
+    const condition = onServiceLevel('other');
+    expect(condition({ account: { service_level: 'standard' }})).toEqual(false);
+  });
+
+  it('should return a function that returns true if on the given level', () => {
+    const condition = onServiceLevel('other');
+    expect(condition({ account: { service_level: 'other' }})).toEqual(true);
+  });
+
+});
+
+describe('Condition: isEnterprise', () => {
 
   let condition;
   let state;
@@ -41,21 +41,40 @@ describe('Condition: notEnterprise', () => {
         service_level: 'whatev'
       }
     };
-    condition = notEnterprise();
+    condition = isEnterprise();
   });
 
-  it('should return a function that returns false if on ent1 plan', () => {
+  it('should return a function that returns true if on ent1 plan', () => {
     state.account.subscription.code = 'ent1';
-    expect(condition(state)).toEqual(false);
-  });
-
-  it('should return a function that returns false if on enterprise service level', () => {
-    state.account.service_level = 'enterprise';
-    expect(condition(state)).toEqual(false);
-  });
-
-  it('should return a function that returns true if not on ent1 plan or enterprise service level', () => {
     expect(condition(state)).toEqual(true);
+  });
+
+  it('should return a function that returns true if on enterprise service level', () => {
+    state.account.service_level = 'enterprise';
+    expect(condition(state)).toEqual(true);
+  });
+
+  it('should return a function that returns false if not on ent1 plan OR enterprise service level', () => {
+    expect(condition(state)).toEqual(false);
+  });
+
+});
+
+describe('Condition: isSuspendedForBilling', () => {
+
+  it('should return a function that returns true if account is suspended and category is 100.01', () => {
+    const account = { status: 'suspended', status_reason_category: '100.01' };
+    expect(isSuspendedForBilling()({ account })).toEqual(true);
+  });
+
+  it('should return a function that returns false if account is NOT suspended', () => {
+    const account = { status: 'active', status_reason_category: '100.01' };
+    expect(isSuspendedForBilling()({ account })).toEqual(false);
+  });
+
+  it('should return a function that returns false if account does NOT have the right status reason category', () => {
+    const account = { status: 'suspended', status_reason_category: '200.01' };
+    expect(isSuspendedForBilling()({ account })).toEqual(false);
   });
 
 });

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -41,7 +41,7 @@ describe('Condition: isEnterprise', () => {
         service_level: 'whatev'
       }
     };
-    condition = isEnterprise();
+    condition = isEnterprise;
   });
 
   it('should return a function that returns true if on ent1 plan', () => {
@@ -64,17 +64,17 @@ describe('Condition: isSuspendedForBilling', () => {
 
   it('should return a function that returns true if account is suspended and category is 100.01', () => {
     const account = { status: 'suspended', status_reason_category: '100.01' };
-    expect(isSuspendedForBilling()({ account })).toEqual(true);
+    expect(isSuspendedForBilling({ account })).toEqual(true);
   });
 
   it('should return a function that returns false if account is NOT suspended', () => {
     const account = { status: 'active', status_reason_category: '100.01' };
-    expect(isSuspendedForBilling()({ account })).toEqual(false);
+    expect(isSuspendedForBilling({ account })).toEqual(false);
   });
 
   it('should return a function that returns false if account does NOT have the right status reason category', () => {
     const account = { status: 'suspended', status_reason_category: '200.01' };
-    expect(isSuspendedForBilling()({ account })).toEqual(false);
+    expect(isSuspendedForBilling({ account })).toEqual(false);
   });
 
 });

--- a/src/helpers/conditions/tests/compose.test.js
+++ b/src/helpers/conditions/tests/compose.test.js
@@ -1,35 +1,73 @@
-import compose from '../compose';
+import { all, any } from '../compose';
 
 describe('Condition Helper: compose conditions', () => {
 
-  it('should call all the functions with the args and return a single result', () => {
-    const c1 = jest.fn(() => true);
-    const c2 = jest.fn(() => true);
-    const c3 = jest.fn(() => true);
+  describe('all (and)', () => {
 
-    const opts = {};
-    const composed = compose(c1, c2, c3);
-    const result = composed(opts);
+    it('should call all given functions and return true when all return true', () => {
+      const c1 = jest.fn(() => true);
+      const c2 = jest.fn(() => true);
+      const c3 = jest.fn(() => true);
 
-    expect(c1).toHaveBeenCalledWith(opts);
-    expect(c2).toHaveBeenCalledWith(opts);
-    expect(c3).toHaveBeenCalledWith(opts);
-    expect(result).toEqual(true);
+      const opts = {};
+      const composed = all(c1, c2, c3);
+      const result = composed(opts);
+
+      expect(c1).toHaveBeenCalledWith(opts);
+      expect(c2).toHaveBeenCalledWith(opts);
+      expect(c3).toHaveBeenCalledWith(opts);
+      expect(result).toEqual(true);
+    });
+
+    it('should bail and return false when the first function returns false', () => {
+      const c1 = jest.fn(() => true);
+      const c2 = jest.fn(() => false);
+      const c3 = jest.fn(() => true);
+
+      const opts = {};
+      const composed = all(c1, c2, c3);
+      const result = composed(opts);
+
+      expect(c1).toHaveBeenCalledWith(opts);
+      expect(c2).toHaveBeenCalledWith(opts);
+      expect(c3).not.toHaveBeenCalled();
+      expect(result).toEqual(false);
+    });
+
   });
 
-  it('should stop calling functions when one returns false', () => {
-    const c1 = jest.fn(() => true);
-    const c2 = jest.fn(() => false);
-    const c3 = jest.fn(() => true);
+  describe('any (or)', () => {
 
-    const opts = {};
-    const composed = compose(c1, c2, c3);
-    const result = composed(opts);
+    it('should call all given functions and return false when all return false', () => {
+      const c1 = jest.fn(() => false);
+      const c2 = jest.fn(() => false);
+      const c3 = jest.fn(() => false);
 
-    expect(c1).toHaveBeenCalledWith(opts);
-    expect(c2).toHaveBeenCalledWith(opts);
-    expect(c3).not.toHaveBeenCalled();
-    expect(result).toEqual(false);
+      const opts = {};
+      const composed = any(c1, c2, c3);
+      const result = composed(opts);
+
+      expect(c1).toHaveBeenCalledWith(opts);
+      expect(c2).toHaveBeenCalledWith(opts);
+      expect(c3).toHaveBeenCalledWith(opts);
+      expect(result).toEqual(false);
+    });
+
+    it('should bail and return true when the first function returns true', () => {
+      const c1 = jest.fn(() => false);
+      const c2 = jest.fn(() => true);
+      const c3 = jest.fn(() => false);
+
+      const opts = {};
+      const composed = any(c1, c2, c3);
+      const result = composed(opts);
+
+      expect(c1).toHaveBeenCalledWith(opts);
+      expect(c2).toHaveBeenCalledWith(opts);
+      expect(c3).not.toHaveBeenCalled();
+      expect(result).toEqual(true);
+    });
+
   });
 
 });

--- a/src/helpers/conditions/tests/not.test.js
+++ b/src/helpers/conditions/tests/not.test.js
@@ -1,0 +1,15 @@
+import not from '../not';
+
+describe('Condition Helper: not', () => {
+
+  it('should return a function that reverses a condition', () => {
+    const isLetter = (letter) => (options) => letter === options.letter;
+
+    expect(isLetter('a')({ letter: 'a' })).toEqual(true);
+    expect(isLetter('a')({ letter: 'b' })).toEqual(false);
+
+    expect(not(isLetter('a'))({ letter: 'a' })).toEqual(false);
+    expect(not(isLetter('a'))({ letter: 'b' })).toEqual(true);
+  });
+
+});

--- a/src/pages/billing/ChangePlanPage.js
+++ b/src/pages/billing/ChangePlanPage.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-
 import { Page } from '@sparkpost/matchbox';
 import { Loading } from 'src/components';
-import { PendingPlanBanner, SuspendedBanner } from './components/Banners';
+import { PendingPlanBanner } from './components/Banners';
 import ChangePlan from './forms/ChangePlan';
-
 import { getPlans } from 'src/actions/account';
 import { getBillingCountries } from 'src/actions/billing';
 import { canChangePlanSelector } from 'src/selectors/accountBillingInfo';
@@ -26,8 +24,7 @@ export class ChangePlanPage extends Component {
     return (
       <Page breadcrumbAction={{ content: 'Back to billing', to: '/account/billing', Component: Link }}>
         <PendingPlanBanner account={this.props.account} />
-        <SuspendedBanner account={this.props.account}/>
-        { this.props.canChangePlan && <ChangePlan /> }
+        {this.props.canChangePlan && <ChangePlan />}
       </Page>
     );
   }

--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -1,28 +1,18 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
-import { Page, Panel, WindowEvent } from '@sparkpost/matchbox';
-
+import { Page } from '@sparkpost/matchbox';
 import { fetch as fetchAccount, getPlans } from 'src/actions/account';
 import { list as getSendingIps } from 'src/actions/sendingIps';
-import { shouldExposeCardSelector, canChangePlanSelector, currentPlanSelector, publicPlansSelector } from 'src/selectors/accountBillingInfo';
+import { selectBillingInfo } from 'src/selectors/accountBillingInfo';
+import ConditionSwitch, { defaultCase } from 'src/components/auth/ConditionSwitch';
+import { not } from 'src/helpers/conditions';
+import { isSuspendedForBilling, isSelfServeBilling } from 'src/helpers/conditions/account';
+import { Loading } from 'src/components';
+import { ManuallyBilledBanner } from './components/Banners';
+import BillingSummary from './components/BillingSummary';
+import SuspendedForBilling from './components/SuspendedForBilling';
 
-import { Loading, Modal, LabelledValue } from 'src/components';
-import { PremiumBanner, EnterpriseBanner, SuspendedBanner, ManuallyBilledBanner, PendingPlanBanner } from './components/Banners';
-import UpdatePayment from './forms/UpdatePayment';
-import UpdateContact from './forms/UpdateContact';
-import AddIps from './forms/AddIps';
-import DedicatedIpSummarySection from './components/DedicatedIpSummarySection';
-import { CardSummary, PlanSummary } from './components/SummarySection';
-
-const PAYMENT_MODAL = 'payment';
-const CONTACT_MODAL = 'contact';
-const IP_MODAL = 'ip';
-
-export class SummaryPage extends Component {
-  state = {
-    show: false
-  }
+export class BillingSummaryPage extends Component {
 
   componentDidMount() {
     this.props.fetchAccount({ include: 'billing' });
@@ -30,99 +20,29 @@ export class SummaryPage extends Component {
     this.props.getSendingIps();
   }
 
-  handleModal = (modal = false) => {
-    this.setState({ show: this.state.show ? false : modal });
-  }
-
-  handleEscape = (e) => {
-    if (e.key === 'Escape') {
-      this.handleModal();
-    }
-  }
-
-  renderSummary = () => {
-    const { account, currentPlan, canChangePlan, shouldExposeCard } = this.props;
-    const { show } = this.state;
-    let changePlanActions = {};
-
-    if (canChangePlan) {
-      const changePlanLabel = currentPlan.isFree ? 'Upgrade Now' : 'Change Plan';
-      changePlanActions = { actions: [{ content: changePlanLabel, to: '/account/billing/plan', Component: Link }]};
-    }
-
-    return (
-      <div>
-        <SuspendedBanner account={account} />
-        <PendingPlanBanner account={account} />
-
-        <Panel accent title='Plan Overview'>
-          <Panel.Section {...changePlanActions}>
-            <PlanSummary label='Your Plan' plan={currentPlan} />
-          </Panel.Section>
-          { shouldExposeCard && this.renderDedicatedIpSummarySection() }
-        </Panel>
-
-        { shouldExposeCard && this.renderBillingSummary() }
-
-        <PremiumBanner />
-        <EnterpriseBanner />
-
-        <Modal open={!!show}>
-          <WindowEvent event='keydown' handler={this.handleEscape} />
-          { show === PAYMENT_MODAL && <UpdatePayment onCancel={this.handleModal}/> }
-          { show === CONTACT_MODAL && <UpdateContact onCancel={this.handleModal}/> }
-          { show === IP_MODAL && <AddIps onClose={this.handleModal}/> }
-        </Modal>
-      </div>
-    );
-  }
-
-  renderBillingSummary = () => {
-    const { billing } = this.props;
-    return (
-      <Panel title='Billing'>
-        <Panel.Section actions={[{ content: 'Update Payment Information', onClick: () => this.handleModal(PAYMENT_MODAL) }]}>
-          <CardSummary label='Credit Card' billing={billing} />
-        </Panel.Section>
-        <Panel.Section actions={[{ content: 'Update Billing Contact', onClick: () => this.handleModal(CONTACT_MODAL) }]}>
-          <LabelledValue label='Billing Contact'>
-            <h6>{ billing.first_name } { billing.last_name }</h6>
-            <p>{ billing.email }</p>
-          </LabelledValue>
-        </Panel.Section>
-      </Panel>
-    );
-  }
-
-  renderDedicatedIpSummarySection = () => (
-    <DedicatedIpSummarySection
-      count={this.props.sendingIps.length}
-      plan={this.props.currentPlan}
-      onClick={() => this.handleModal(IP_MODAL)}
-    />
-  );
-
   render() {
-    if (this.props.loading) {
+    const { loading, account, billingInfo, sendingIps } = this.props;
+
+    if (loading) {
       return <Loading />;
     }
 
-    const pageMarkup = this.props.account.subscription.self_serve
-      ? this.renderSummary()
-      : <ManuallyBilledBanner account={this.props.account} />;
-
-    return <Page title='Billing'>{ pageMarkup }</Page>;
+    return (
+      <Page title='Billing'>
+        <ConditionSwitch>
+          <SuspendedForBilling condition={isSuspendedForBilling} account={account} />
+          <ManuallyBilledBanner condition={not(isSelfServeBilling)} account={account} />
+          <BillingSummary condition={defaultCase} account={account} {...billingInfo} sendingIps={sendingIps} />
+        </ConditionSwitch>
+      </Page>
+    );
   }
 }
 
 const mapStateToProps = (state) => ({
   loading: state.account.loading || state.billing.plansLoading || !state.account.subscription,
   account: state.account,
-  billing: state.account.billing,
-  shouldExposeCard: shouldExposeCardSelector(state),
-  canChangePlan: canChangePlanSelector(state),
-  currentPlan: currentPlanSelector(state),
-  plans: publicPlansSelector(state),
+  billingInfo: selectBillingInfo(state),
   sendingIps: state.sendingIps.list
 });
-export default connect(mapStateToProps, { getSendingIps, getPlans, fetchAccount })(SummaryPage);
+export default connect(mapStateToProps, { getSendingIps, getPlans, fetchAccount })(BillingSummaryPage);

--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -19,17 +19,6 @@ export const PendingPlanBanner = ({ account }) => account.pending_subscription
   : null;
 
 /**
- * Renders suspended-due-to-billing warning
- * @prop account Account state from redux store
- */
-export const SuspendedBanner = ({ account }) => account.isSuspendedForBilling
-  ? <Banner status='danger' title='Your account has been suspended due to a billing problem' >
-    <p>We sent an email notification to your current billing contact email address ({ account.billing.email }). To reactivate your account and pay your outstanding balance due, please update your payment information below.</p>
-    <p>If you have any questions, please <UnstyledLink to={`mailto:${config.contact.billingEmail}`}>contact us</UnstyledLink>.</p>
-  </Banner>
-  : null;
-
-/**
  * Renders plan information for non-self-serve users
  * @prop account Account state from redux store
  */

--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -1,0 +1,93 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Panel, WindowEvent } from '@sparkpost/matchbox';
+import { Modal, LabelledValue } from 'src/components';
+import { PremiumBanner, EnterpriseBanner, PendingPlanBanner } from './Banners';
+import UpdatePayment from '../forms/UpdatePayment';
+import UpdateContact from '../forms/UpdateContact';
+import AddIps from '../forms/AddIps';
+import DedicatedIpSummarySection from './DedicatedIpSummarySection';
+import { CardSummary, PlanSummary } from './SummarySection';
+
+const PAYMENT_MODAL = 'payment';
+const CONTACT_MODAL = 'contact';
+const IP_MODAL = 'ip';
+
+export default class BillingSummary extends Component {
+  state = {
+    show: false
+  }
+
+  handleModal = (modal = false) => {
+    this.setState({ show: this.state.show ? false : modal });
+  }
+
+  handleEscape = (e) => {
+    if (e.key === 'Escape') {
+      this.handleModal();
+    }
+  }
+
+  renderSummary = () => {
+    const { account } = this.props;
+    const { billing } = account;
+    return (
+      <Panel title='Billing'>
+        <Panel.Section actions={[{ content: 'Update Payment Information', onClick: () => this.handleModal(PAYMENT_MODAL) }]}>
+          <CardSummary label='Credit Card' billing={billing} />
+        </Panel.Section>
+        <Panel.Section actions={[{ content: 'Update Billing Contact', onClick: () => this.handleModal(CONTACT_MODAL) }]}>
+          <LabelledValue label='Billing Contact'>
+            <h6>{ billing.first_name } { billing.last_name }</h6>
+            <p>{ billing.email }</p>
+          </LabelledValue>
+        </Panel.Section>
+      </Panel>
+    );
+  }
+
+  renderDedicatedIpSummarySection = () => (
+    <DedicatedIpSummarySection
+      count={this.props.sendingIps.length}
+      plan={this.props.currentPlan}
+      onClick={() => this.handleModal(IP_MODAL)}
+    />
+  );
+
+  render() {
+    const { account, currentPlan, canChangePlan, canUpdateBillingInfo } = this.props;
+    const { show } = this.state;
+    let changePlanActions = {};
+
+    if (canChangePlan) {
+      const changePlanLabel = currentPlan.isFree ? 'Upgrade Now' : 'Change Plan';
+      changePlanActions = { actions: [{ content: changePlanLabel, to: '/account/billing/plan', Component: Link }]};
+    }
+
+    return (
+      <div>
+        <PendingPlanBanner account={account} />
+
+        <Panel accent title='Plan Overview'>
+          <Panel.Section {...changePlanActions}>
+            <PlanSummary label='Your Plan' plan={currentPlan} />
+          </Panel.Section>
+          { canUpdateBillingInfo && this.renderDedicatedIpSummarySection() }
+        </Panel>
+
+        { canUpdateBillingInfo && this.renderSummary() }
+
+        <PremiumBanner />
+        <EnterpriseBanner />
+
+        <Modal open={!!show}>
+          <WindowEvent event='keydown' handler={this.handleEscape} />
+          { show === PAYMENT_MODAL && <UpdatePayment onCancel={this.handleModal}/> }
+          { show === CONTACT_MODAL && <UpdateContact onCancel={this.handleModal}/> }
+          { show === IP_MODAL && <AddIps onClose={this.handleModal}/> }
+        </Modal>
+      </div>
+    );
+  }
+
+}

--- a/src/pages/billing/components/DedicatedIpSummarySection.js
+++ b/src/pages/billing/components/DedicatedIpSummarySection.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import { Link } from 'react-router-dom';
-import { Panel } from '@sparkpost/matchbox';
+import { Panel, Banner } from '@sparkpost/matchbox';
 
 import config from 'src/config';
 import { LabelledValue } from 'src/components';
@@ -22,11 +22,18 @@ export default function DedicatedIpSummarySection({ count = 0, plan = {}, onClic
     ? <h6>0</h6>
     : <h6>{count} for <DedicatedIpCost plan={plan} quantity={billableCount} /></h6>;
 
+  if (count === 0 && plan.includesIp) {
+    return (
+      <Banner status='info' title='Claim your free IP' action={action}>
+        Your plan includes a free dedicated IP address. Add one now!
+      </Banner>
+    );
+  }
+
   return (
     <Panel.Section actions={[action]}>
       <LabelledValue label='Dedicated IPs'>
         {summary}
-        {count === 0 && plan.includesIp && <p>First IP is free!</p>}
         {hasReachedMax && <p>You have reached the maximum allowed.</p>}
       </LabelledValue>
     </Panel.Section>

--- a/src/pages/billing/components/SuspendedForBilling.js
+++ b/src/pages/billing/components/SuspendedForBilling.js
@@ -1,0 +1,18 @@
+
+import React, { Fragment } from 'react';
+import config from 'src/config';
+import { Banner, UnstyledLink } from '@sparkpost/matchbox';
+import UpdatePaymentForm from '../forms/UpdatePayment';
+
+export default function SuspendedForBilling({ account }) {
+  const { billing } = account;
+  return (
+    <Fragment>
+      <Banner status='danger' title='Your account has been suspended due to a billing problem' >
+        <p>We sent an email notification to your current billing contact email address ({billing.email}). To reactivate your account and pay your outstanding balance due, please update your payment information below.</p>
+        <p>If you have any questions, please <UnstyledLink to={`mailto:${config.contact.billingEmail}`}>contact us</UnstyledLink>.</p>
+      </Banner>
+      <UpdatePaymentForm />
+    </Fragment>
+  );
+}

--- a/src/pages/billing/components/tests/Banners.test.js
+++ b/src/pages/billing/components/tests/Banners.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PendingPlanBanner, SuspendedBanner, ManuallyBilledBanner, PremiumBanner, EnterpriseBanner } from '../Banners';
+import { PendingPlanBanner, ManuallyBilledBanner, PremiumBanner, EnterpriseBanner } from '../Banners';
 import { shallow } from 'enzyme';
 
 describe('Billing Banners: ', () => {
@@ -10,17 +10,6 @@ describe('Billing Banners: ', () => {
       }
     };
     const wrapper = shallow(<PendingPlanBanner {...props} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('SuspendedBanner should render with isSuspendedForBilling', () => {
-    const props = {
-      account: {
-        isSuspendedForBilling: true,
-        billing: { email: 'tst' }
-      }
-    };
-    const wrapper = shallow(<SuspendedBanner {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -72,28 +72,6 @@ exports[`Billing Banners:  PendingPlanBanner should render with pending_subscrip
 </Banner>
 `;
 
-exports[`Billing Banners:  SuspendedBanner should render with isSuspendedForBilling 1`] = `
-<Banner
-  status="danger"
-  title="Your account has been suspended due to a billing problem"
->
-  <p>
-    We sent an email notification to your current billing contact email address (
-    tst
-    ). To reactivate your account and pay your outstanding balance due, please update your payment information below.
-  </p>
-  <p>
-    If you have any questions, please 
-    <UnstyledLink
-      to="mailto:billing@sparkpost.com"
-    >
-      contact us
-    </UnstyledLink>
-    .
-  </p>
-</Banner>
-`;
-
 exports[`Billing Banners:  renders Enterprise banner 1`] = `
 <Banner
   action={

--- a/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
@@ -89,26 +89,17 @@ exports[`DedicatedIpSummarySection renders upgrade button and zero count 1`] = `
 `;
 
 exports[`DedicatedIpSummarySection renders zero count and first is free notice 1`] = `
-<Panel.Section
-  actions={
-    Array [
-      Object {
-        "content": "Add Dedicated IPs",
-        "disabled": false,
-        "onClick": [Function],
-      },
-    ]
+<Banner
+  action={
+    Object {
+      "content": "Add Dedicated IPs",
+      "disabled": false,
+      "onClick": [Function],
+    }
   }
+  status="info"
+  title="Claim your free IP"
 >
-  <LabelledValue
-    label="Dedicated IPs"
-  >
-    <h6>
-      0
-    </h6>
-    <p>
-      First IP is free!
-    </p>
-  </LabelledValue>
-</Panel.Section>
+  Your plan includes a free dedicated IP address. Add one now!
+</Banner>
 `;

--- a/src/pages/billing/forms/AddIps.js
+++ b/src/pages/billing/forms/AddIps.js
@@ -2,32 +2,20 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
-import { Button, Error, Panel, UnstyledLink } from '@sparkpost/matchbox';
-
+import { Button, Error, Panel, Banner } from '@sparkpost/matchbox';
 import { addDedicatedIps } from 'src/actions/billing';
 import { showAlert } from 'src/actions/globalAlert';
 import { createPool } from 'src/actions/ipPools';
 import { TextFieldWrapper } from 'src/components';
-import Note from 'src/components/note/Note';
 import config from 'src/config';
 import IpPoolSelect from './fields/IpPoolSelect';
 import ErrorTracker from 'src/helpers/errorTracker';
 import { required, minNumber, maxNumber } from 'src/helpers/validation';
 import { currentPlanSelector } from 'src/selectors/accountBillingInfo';
 import DedicatedIpCost from '../components/DedicatedIpCost';
-import { LINKS } from 'src/constants';
-
 import styles from './Forms.module.scss';
 
 const FORM_NAME = 'add-sending-ips';
-const WarmUpArticleLink = () => (
-  <UnstyledLink
-    to={LINKS.IP_WARM_UP}
-    external
-  >
-    IP Warm-up Overview article
-  </UnstyledLink>
-);
 
 class AddIps extends Component {
   getOrCreateIpPool = async({ action, id, name }) => {
@@ -77,14 +65,13 @@ class AddIps extends Component {
 
   renderFreeIpNotice() {
     if (this.props.currentPlan.isAwsAccount) {
-      return <p>Your plan includes one free.</p>;
+      return <Banner status='info'>Your plan includes one free dedicated IP address.</Banner>;
     }
 
     return (
-      <p>
-        Your plan includes one free IP.  If used, your account statement will show a charge
-        with a matching refund.
-      </p>
+      <Banner status='info'>
+        Your plan includes one free dedicated IP address. {this.props.sendingIps.length === 0 && 'Once you\'ve purchased at least one IP, your account statement will show a charge with a matching refund.'}
+      </Banner>
     );
   }
 
@@ -104,9 +91,7 @@ class AddIps extends Component {
         <Panel title='Add Dedicated IPs' actions={[action]}>
           <Panel.Section>
             <p>
-              Dedicated IPs give you better control over your sending reputation.  You can add up
-              to { remainingCount } dedicated IPs to your plan
-              for <DedicatedIpCost plan={currentPlan} quantity='1' /> each.
+              Dedicated IPs give you better control over your sending reputation.
             </p>
             { currentPlan.includesIp && this.renderFreeIpNotice() }
             <Field
@@ -118,12 +103,10 @@ class AddIps extends Component {
               required
               type='number'
               validate={[required, minNumber(1), maxNumber(remainingCount)]}
+              autoFocus
+              helpText={<span>You can add up to {maxPerAccount} total dedicated IPs to your plan for <DedicatedIpCost plan={currentPlan} quantity='1' /> each.</span>}
             />
             <IpPoolSelect disabled={isDisabled} formName={FORM_NAME} />
-            <Note>
-              New dedicated IP addresses will need to be warmed up, so we suggest adding them to
-              an isolated pool.  Read the <WarmUpArticleLink /> for more information.
-            </Note>
           </Panel.Section>
           <Panel.Section>
             <Button type='submit' primary disabled={isDisabled}>Add Dedicated IPs</Button>

--- a/src/pages/billing/forms/ChangePlan.js
+++ b/src/pages/billing/forms/ChangePlan.js
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router-dom';
 import { billingCreate, billingUpdate, updateSubscription } from 'src/actions/billing';
 import { showAlert } from 'src/actions/globalAlert';
 import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
-import { publicPlansSelector, currentPlanSelector, shouldExposeCardSelector } from 'src/selectors/accountBillingInfo';
+import { publicPlansSelector, currentPlanSelector, canUpdateBillingInfoSelector } from 'src/selectors/accountBillingInfo';
 
 import { Panel, Grid } from '@sparkpost/matchbox';
 import { PlanPicker } from 'src/components';
@@ -26,7 +26,7 @@ export class ChangePlan extends Component {
 
   componentWillReceiveProps(nextProps) {
     // Null check to make sure this only runs once
-    if (nextProps.shouldExposeCard && this.state.useSavedCC === null) {
+    if (nextProps.canUpdateBillingInfo && this.state.useSavedCC === null) {
       this.setState({ useSavedCC: true });
     }
   }
@@ -69,7 +69,7 @@ export class ChangePlan extends Component {
       );
     }
 
-    const savedPaymentAction = this.props.shouldExposeCard
+    const savedPaymentAction = this.props.canUpdateBillingInfo
       ? [{ content: 'Use Saved Payment Method', onClick: this.handleCardToggle }]
       : null;
 
@@ -130,7 +130,7 @@ const mapStateToProps = (state) => {
   return {
     account: state.account,
     billing: state.billing,
-    shouldExposeCard: shouldExposeCardSelector(state),
+    canUpdateBillingInfo: canUpdateBillingInfoSelector(state),
     plans: publicPlansSelector(state),
     currentPlan: currentPlanSelector(state),
     selectedPlan: selector(state, 'planpicker'),

--- a/src/pages/billing/forms/UpdatePayment.js
+++ b/src/pages/billing/forms/UpdatePayment.js
@@ -21,10 +21,13 @@ export class UpdatePayment extends Component {
 
   onSubmit = (values) => {
     const { billingUpdate, onCancel, showAlert } = this.props;
-    return billingUpdate(values).then(() => {
-      showAlert({ type: 'success', message: 'Payment Information Updated' });
-      onCancel();
-    }).catch((err) => showAlert({ type: 'error', message: 'Payment Information Update Failed' }));
+    return billingUpdate(values).then(
+      () => {
+        showAlert({ type: 'success', message: 'Payment Information Updated' });
+        typeof onCancel === 'function' && onCancel();
+      },
+      (err) => showAlert({ type: 'error', message: 'Payment Information Update Failed' })
+    );
   }
 
   render() {

--- a/src/pages/billing/forms/fields/IpPoolSelect.js
+++ b/src/pages/billing/forms/fields/IpPoolSelect.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Field, formValueSelector } from 'redux-form';
-
+import { UnstyledLink } from '@sparkpost/matchbox';
 import { listPools } from 'src/actions/ipPools';
 import { RadioGroup, SelectWrapper, TextFieldWrapper } from 'src/components';
 import { required } from 'src/helpers/validation';
 import { getNonDefaultIpPools } from 'src/selectors/ipPools';
+import { LINKS } from 'src/constants';
 
 const EXISTING = 'existing';
 const NEW = 'new';
@@ -25,7 +26,7 @@ const ActionSelect = ({ disabled, ipPools, loading }) => {
   ];
 
   return (
-    <Field
+    (ipPools.length > 0) && <Field
       component={RadioGroup}
       name='ipPool.action'
       options={options}
@@ -33,6 +34,11 @@ const ActionSelect = ({ disabled, ipPools, loading }) => {
     />
   );
 };
+
+
+const WarmUpHelpText = () => (
+  <span>New dedicated IP addresses will need to be warmed up, so we require new IPs to be added to an isolated, non-default pool. Read our <UnstyledLink to={LINKS.IP_WARM_UP} external>IP Warm-up Overview</UnstyledLink> for more information.</span>
+);
 
 const ExistingIpPoolField = ({ disabled, ipPools }) => {
   const options = ipPools.map((p) => ({ label: p.name, value: p.id }));
@@ -47,6 +53,7 @@ const ExistingIpPoolField = ({ disabled, ipPools }) => {
       placeholder=' ' // needed for matchbox, treated same as empty string by redux-form
       required
       validate={required}
+      helpText={<WarmUpHelpText />}
     />
   );
 };
@@ -59,6 +66,7 @@ const NewIpPoolField = ({ disabled }) => (
     label='Name your new IP Pool'
     required
     validate={required}
+    helpText={<WarmUpHelpText />}
   />
 );
 

--- a/src/pages/billing/forms/tests/ChangePlan.test.js
+++ b/src/pages/billing/forms/tests/ChangePlan.test.js
@@ -24,7 +24,7 @@ describe('Form Container: Change Plan', () => {
     ],
     currentPlan: {},
     selectedPlan: {},
-    shouldExposeCard: false,
+    canUpdateBillingInfo: false,
     history: { push: jest.fn() },
     handleSubmit: jest.fn(),
     showAlert: jest.fn(),
@@ -56,14 +56,14 @@ describe('Form Container: Change Plan', () => {
   it('should show saved card', () => {
     const receiveSpy = jest.spyOn(wrapper.instance(), 'componentWillReceiveProps');
     expect(wrapper).toHaveState('useSavedCC', null);
-    wrapper.setProps({ shouldExposeCard: true });
-    expect(receiveSpy).toHaveBeenCalledWith({ ...props, shouldExposeCard: true }, {});
+    wrapper.setProps({ canUpdateBillingInfo: true });
+    expect(receiveSpy).toHaveBeenCalledWith({ ...props, canUpdateBillingInfo: true }, {});
     expect(wrapper).toHaveState('useSavedCC', true);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should handle toggle', () => {
-    wrapper.setProps({ shouldExposeCard: true });
+    wrapper.setProps({ canUpdateBillingInfo: true });
     expect(wrapper.find('CardSummary')).toBePresent();
     expect(wrapper.find('Connect(PaymentForm)')).not.toBePresent();
     wrapper.setState({ useSavedCC: false });

--- a/src/pages/billing/tests/SummaryPage.test.js
+++ b/src/pages/billing/tests/SummaryPage.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { SummaryPage } from '../SummaryPage';
+import { BillingSummaryPage } from '../SummaryPage';
 import { shallow } from 'enzyme';
 
-describe('Page: SummaryPage', () => {
+describe('Page: BillingSummaryPage', () => {
   let wrapper;
 
   const props = {
@@ -15,7 +15,7 @@ describe('Page: SummaryPage', () => {
     getPlans: jest.fn(),
     getBillingCountries: jest.fn(),
     getSendingIps: jest.fn(),
-    shouldExposeCard: false,
+    canUpdateBillingInfo: false,
     canChangePlan: false,
     currentPlan: {},
     plans: [],
@@ -25,7 +25,7 @@ describe('Page: SummaryPage', () => {
   };
 
   beforeEach(() => {
-    wrapper = shallow(<SummaryPage {...props} />);
+    wrapper = shallow(<BillingSummaryPage {...props} />);
   });
 
   it('gets plans, sending ips and account on mount', () => {
@@ -33,7 +33,6 @@ describe('Page: SummaryPage', () => {
     const fetchSpy = jest.spyOn(wrapper.instance().props, 'fetchAccount');
     const getSendingIpsSpy = jest.spyOn(wrapper.instance().props, 'getSendingIps');
     wrapper.instance().componentDidMount();
-    expect(wrapper).toHaveState('show', false);
     expect(plansSpy).toHaveBeenCalled();
     expect(fetchSpy).toHaveBeenCalledWith({ include: 'billing' });
     expect(getSendingIpsSpy).toHaveBeenCalled();
@@ -56,7 +55,7 @@ describe('Page: SummaryPage', () => {
   it('should render billing and dedicated IP summary if on paid plan', () => {
     wrapper.setProps({
       canChangePlan: true,
-      shouldExposeCard: true,
+      canUpdateBillingInfo: true,
       account: { subscription: { self_serve: true }},
       currentPlan: { isFree: false }
     });
@@ -66,22 +65,10 @@ describe('Page: SummaryPage', () => {
   it('should not render billing and ips if on free plan', () => {
     wrapper.setProps({
       canChangePlan: true,
-      shouldExposeCard: false,
+      canUpdateBillingInfo: false,
       account: { subscription: { self_serve: true }},
       currentPlan: { isFree: true }
     });
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should handle modal toggle', () => {
-    wrapper.setProps({
-      account: { subscription: { self_serve: true }}
-    });
-    const modalSpy = jest.spyOn(wrapper.instance(), 'handleModal');
-    wrapper.setState({ show: 'payment' });
-    expect(wrapper).toMatchSnapshot();
-    wrapper.instance().handleEscape({ key: 'Escape' });
-    expect(modalSpy).toHaveBeenCalled();
-    expect(wrapper).toHaveState('show', false);
   });
 });

--- a/src/pages/billing/tests/__snapshots__/ChangePlanPage.test.js.snap
+++ b/src/pages/billing/tests/__snapshots__/ChangePlanPage.test.js.snap
@@ -14,9 +14,6 @@ exports[`Page: ChangePlanPage should not render form if not allowed to change pl
   <Component
     account={Object {}}
   />
-  <Component
-    account={Object {}}
-  />
 </Page>
 `;
 
@@ -31,9 +28,6 @@ exports[`Page: ChangePlanPage should render form if allowed to change plan 1`] =
   }
   empty={Object {}}
 >
-  <Component
-    account={Object {}}
-  />
   <Component
     account={Object {}}
   />

--- a/src/pages/billing/tests/__snapshots__/SummaryPage.test.js.snap
+++ b/src/pages/billing/tests/__snapshots__/SummaryPage.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Page: SummaryPage should handle modal toggle 1`] = `
+exports[`Page: BillingSummaryPage should not render billing and ips if on free plan 1`] = `
 <Page
   empty={Object {}}
   title="Billing"
 >
-  <div>
-    <Component
+  <Connect(Component)>
+    <SuspendedForBilling
       account={
         Object {
           "subscription": Object {
@@ -14,8 +14,9 @@ exports[`Page: SummaryPage should handle modal toggle 1`] = `
           },
         }
       }
+      condition={[Function]}
     />
-    <Component
+    <ManuallyBilledBanner
       account={
         Object {
           "subscription": Object {
@@ -23,122 +24,124 @@ exports[`Page: SummaryPage should handle modal toggle 1`] = `
           },
         }
       }
+      condition={[Function]}
     />
-    <Panel
-      accent={true}
-      title="Plan Overview"
-    >
-      <Panel.Section>
-        <PlanSummary
-          label="Your Plan"
-          plan={Object {}}
-        />
-      </Panel.Section>
-    </Panel>
-    <Component />
-    <Component />
-    <Modal
-      open={true}
-    >
-      <WindowEvent
-        event="keydown"
-        handler={[Function]}
-      />
-      <Connect(ReduxForm)
-        onCancel={[MockFunction]}
-      />
-    </Modal>
-  </div>
+    <BillingSummary
+      account={
+        Object {
+          "subscription": Object {
+            "self_serve": true,
+          },
+        }
+      }
+      condition={[Function]}
+      sendingIps={
+        Object {
+          "list": Array [],
+        }
+      }
+    />
+  </Connect(Component)>
 </Page>
 `;
 
-exports[`Page: SummaryPage should not render billing and ips if on free plan 1`] = `
+exports[`Page: BillingSummaryPage should render banner when manually billed 1`] = `
 <Page
   empty={Object {}}
   title="Billing"
 >
-  <div>
-    <Component
+  <Connect(Component)>
+    <SuspendedForBilling
       account={
         Object {
           "subscription": Object {
-            "self_serve": true,
+            "self_serve": false,
           },
         }
       }
+      condition={[Function]}
     />
-    <Component
+    <ManuallyBilledBanner
       account={
         Object {
           "subscription": Object {
-            "self_serve": true,
+            "self_serve": false,
           },
         }
       }
+      condition={[Function]}
     />
-    <Panel
-      accent={true}
-      title="Plan Overview"
-    >
-      <Panel.Section
-        actions={
-          Array [
-            Object {
-              "Component": [Function],
-              "content": "Upgrade Now",
-              "to": "/account/billing/plan",
-            },
-          ]
+    <BillingSummary
+      account={
+        Object {
+          "subscription": Object {
+            "self_serve": false,
+          },
         }
-      >
-        <PlanSummary
-          label="Your Plan"
-          plan={
-            Object {
-              "isFree": true,
-            }
-          }
-        />
-      </Panel.Section>
-    </Panel>
-    <Component />
-    <Component />
-    <Modal
-      open={false}
-    >
-      <WindowEvent
-        event="keydown"
-        handler={[Function]}
-      />
-    </Modal>
-  </div>
+      }
+      condition={[Function]}
+      sendingIps={
+        Object {
+          "list": Array [],
+        }
+      }
+    />
+  </Connect(Component)>
 </Page>
 `;
 
-exports[`Page: SummaryPage should render banner when manually billed 1`] = `
+exports[`Page: BillingSummaryPage should render billing and dedicated IP summary if on paid plan 1`] = `
 <Page
   empty={Object {}}
   title="Billing"
 >
-  <ManuallyBilledBanner
-    account={
-      Object {
-        "subscription": Object {
-          "self_serve": false,
-        },
+  <Connect(Component)>
+    <SuspendedForBilling
+      account={
+        Object {
+          "subscription": Object {
+            "self_serve": true,
+          },
+        }
       }
-    }
-  />
+      condition={[Function]}
+    />
+    <ManuallyBilledBanner
+      account={
+        Object {
+          "subscription": Object {
+            "self_serve": true,
+          },
+        }
+      }
+      condition={[Function]}
+    />
+    <BillingSummary
+      account={
+        Object {
+          "subscription": Object {
+            "self_serve": true,
+          },
+        }
+      }
+      condition={[Function]}
+      sendingIps={
+        Object {
+          "list": Array [],
+        }
+      }
+    />
+  </Connect(Component)>
 </Page>
 `;
 
-exports[`Page: SummaryPage should render billing and dedicated IP summary if on paid plan 1`] = `
+exports[`Page: BillingSummaryPage should render upgrade on free plan 1`] = `
 <Page
   empty={Object {}}
   title="Billing"
 >
-  <div>
-    <Component
+  <Connect(Component)>
+    <SuspendedForBilling
       account={
         Object {
           "subscription": Object {
@@ -146,8 +149,9 @@ exports[`Page: SummaryPage should render billing and dedicated IP summary if on 
           },
         }
       }
+      condition={[Function]}
     />
-    <Component
+    <ManuallyBilledBanner
       account={
         Object {
           "subscription": Object {
@@ -155,99 +159,9 @@ exports[`Page: SummaryPage should render billing and dedicated IP summary if on 
           },
         }
       }
+      condition={[Function]}
     />
-    <Panel
-      accent={true}
-      title="Plan Overview"
-    >
-      <Panel.Section
-        actions={
-          Array [
-            Object {
-              "Component": [Function],
-              "content": "Change Plan",
-              "to": "/account/billing/plan",
-            },
-          ]
-        }
-      >
-        <PlanSummary
-          label="Your Plan"
-          plan={
-            Object {
-              "isFree": false,
-            }
-          }
-        />
-      </Panel.Section>
-      <DedicatedIpSummarySection
-        onClick={[Function]}
-        plan={
-          Object {
-            "isFree": false,
-          }
-        }
-      />
-    </Panel>
-    <Panel
-      title="Billing"
-    >
-      <Panel.Section
-        actions={
-          Array [
-            Object {
-              "content": "Update Payment Information",
-              "onClick": [Function],
-            },
-          ]
-        }
-      >
-        <CardSummary
-          billing={Object {}}
-          label="Credit Card"
-        />
-      </Panel.Section>
-      <Panel.Section
-        actions={
-          Array [
-            Object {
-              "content": "Update Billing Contact",
-              "onClick": [Function],
-            },
-          ]
-        }
-      >
-        <LabelledValue
-          label="Billing Contact"
-        >
-          <h6>
-             
-          </h6>
-          <p />
-        </LabelledValue>
-      </Panel.Section>
-    </Panel>
-    <Component />
-    <Component />
-    <Modal
-      open={false}
-    >
-      <WindowEvent
-        event="keydown"
-        handler={[Function]}
-      />
-    </Modal>
-  </div>
-</Page>
-`;
-
-exports[`Page: SummaryPage should render upgrade on free plan 1`] = `
-<Page
-  empty={Object {}}
-  title="Billing"
->
-  <div>
-    <Component
+    <BillingSummary
       account={
         Object {
           "subscription": Object {
@@ -255,51 +169,13 @@ exports[`Page: SummaryPage should render upgrade on free plan 1`] = `
           },
         }
       }
-    />
-    <Component
-      account={
+      condition={[Function]}
+      sendingIps={
         Object {
-          "subscription": Object {
-            "self_serve": true,
-          },
+          "list": Array [],
         }
       }
     />
-    <Panel
-      accent={true}
-      title="Plan Overview"
-    >
-      <Panel.Section
-        actions={
-          Array [
-            Object {
-              "Component": [Function],
-              "content": "Upgrade Now",
-              "to": "/account/billing/plan",
-            },
-          ]
-        }
-      >
-        <PlanSummary
-          label="Your Plan"
-          plan={
-            Object {
-              "isFree": true,
-            }
-          }
-        />
-      </Panel.Section>
-    </Panel>
-    <Component />
-    <Component />
-    <Modal
-      open={false}
-    >
-      <WindowEvent
-        event="keydown"
-        handler={[Function]}
-      />
-    </Modal>
-  </div>
+  </Connect(Component)>
 </Page>
 `;

--- a/src/pages/reports/engagement/components/EngagementTable.js
+++ b/src/pages/reports/engagement/components/EngagementTable.js
@@ -71,7 +71,7 @@ export default function EngagementTable({ data, loading }) {
   // Must include percentage in data for sorting
   const dataWithPercentage = data.map((row) => ({
     ...row,
-    percentage_clicked: formatPercent(safeRate(row.count_clicked, totalClicks))
+    percentage_clicked: safeRate(row.count_clicked, totalClicks)
   }));
 
   return (

--- a/src/pages/reports/engagement/components/tests/__snapshots__/EngagementTable.test.js.snap
+++ b/src/pages/reports/engagement/components/tests/__snapshots__/EngagementTable.test.js.snap
@@ -110,13 +110,13 @@ exports[`EngagementTable when renders table 1`] = `
         "count_clicked": 10,
         "count_raw_clicked_approx": 1,
         "link_name": "Raw URL",
-        "percentage_clicked": "33.33%",
+        "percentage_clicked": 33.33333333333333,
       },
       Object {
         "count_clicked": 20,
         "count_raw_clicked_approx": 2,
         "link_name": "Nintendo",
-        "percentage_clicked": "66.67%",
+        "percentage_clicked": 66.66666666666666,
       },
     ]
   }

--- a/src/reducers/globalAlert.js
+++ b/src/reducers/globalAlert.js
@@ -5,14 +5,22 @@ const initialState = {
 };
 
 export default (state = initialState, { type, payload }) => {
+
   switch (type) {
-    case 'SHOW_GLOBAL_ALERT':
-      return { ...state, alerts: [ ...state.alerts,
-        {
-          id: _.uniqueId('alert_'),
-          ...payload
-        }
-      ]};
+
+    case 'SHOW_GLOBAL_ALERT': {
+      const id = _.uniqueId('alert_');
+      const alerts = _.uniqBy([
+        ...state.alerts,
+        { dedupeId: id, ...payload, id } // pass in 'dedupeId' to prevent multiples of the same alert
+      ], 'dedupeId');
+
+      if (alerts.length > state.alerts.length) {
+        return { ...state, alerts };
+      } else {
+        return state;
+      }
+    }
 
     case 'CLEAR_GLOBAL_ALERT':
       return {
@@ -23,4 +31,5 @@ export default (state = initialState, { type, payload }) => {
     default:
       return state;
   }
+
 };

--- a/src/reducers/tests/globalAlert.test.js
+++ b/src/reducers/tests/globalAlert.test.js
@@ -1,0 +1,56 @@
+import globalAlertReducer from '../globalAlert';
+
+describe('Reducer: globalAlert', () => {
+
+  let action;
+  let stateA;
+
+  beforeEach(() => {
+    action = {
+      type: 'SHOW_GLOBAL_ALERT',
+      payload: { dedupeId: 'TEST' }
+    };
+    stateA = globalAlertReducer({ alerts: []}, action);
+  });
+
+  it('should add an alert to the store', () => {
+    expect(stateA.alerts).toHaveLength(1);
+  });
+
+  it('should return the same state reference if dedupeIds match existing alerts', () => {
+    const stateB = globalAlertReducer(stateA, action);
+    expect(stateB).toBe(stateA);
+    expect(stateB.alerts).toHaveLength(1);
+  });
+
+  it('should add alerts with different dedupeIds', () => {
+    action.payload.dedupeId = 'OTHER';
+    const stateC = globalAlertReducer(stateA, action);
+    expect(stateC).not.toBe(stateA);
+    expect(stateC.alerts).toHaveLength(2);
+  });
+
+  it('should add alerts with no dudupeId', () => {
+    delete action.payload.dedupeId;
+    const stateD = globalAlertReducer(stateA, action);
+    expect(stateD).not.toBe(stateA);
+    expect(stateD.alerts).toHaveLength(2);
+  });
+
+  it('should clear an alert by id but leave the others', () => {
+    delete action.payload.dedupeId;
+    const stateB = globalAlertReducer(stateA, action);
+    const stateC = globalAlertReducer(stateB, action);
+
+    expect(stateC.alerts).toHaveLength(3);
+
+    const stateD = globalAlertReducer(stateC, {
+      type: 'CLEAR_GLOBAL_ALERT',
+      payload: {
+        id: stateC.alerts[1].id
+      }
+    });
+    expect(stateD.alerts).toHaveLength(2);
+  });
+
+});

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -41,7 +41,22 @@ export const currentPlanSelector = createSelector(
 /**
  * Returns true if user has billing account and they are on a paid plan
  */
-export const shouldExposeCardSelector = createSelector(
+export const canUpdateBillingInfoSelector = createSelector(
   [currentPlanSelector, accountBillingSelector],
   (currentPlan, accountBilling) => !!accountBilling && !currentPlan.isFree
+);
+
+export const selectBillingInfo = createSelector(
+  [
+    canUpdateBillingInfoSelector,
+    canChangePlanSelector,
+    currentPlanSelector,
+    publicPlansSelector
+  ],
+  (canUpdateBillingInfo, canChangePlan, currentPlan, plans) => ({
+    canUpdateBillingInfo,
+    canChangePlan,
+    currentPlan,
+    plans
+  })
 );

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -33,7 +33,7 @@ describe('Selector: current plan', () => {
   });
 });
 
-describe('Selector: should expose card', () => {
+describe('Selector: can update billing info', () => {
   const store = {
     account: { subscription: { code: 'qwe' }, billing: {}},
     billing: {
@@ -45,7 +45,7 @@ describe('Selector: should expose card', () => {
   };
 
   it('should return true if on paid plan', () => {
-    expect(billingInfo.shouldExposeCardSelector(store)).toEqual(true);
+    expect(billingInfo.canUpdateBillingInfoSelector(store)).toEqual(true);
   });
 });
 


### PR DESCRIPTION
The work for a _suspended_ user is simple:

* A yellow banner shows up when you first log in and it does not auto-dismiss. If you try to do any non-read action while that banner is up, nothing else happens.
* Once you dismiss the initial banner, if you try to do any non-read action, the yellow banner re-appears (and auto-dismisses with the default timeout).
* While suspended, a 403 response never logs you out

For the "suspended for billing reasons" experience, I had to make more changes:

* The banner already existed, but the condition to make it appear was inaccurate. Instead of pushing a computed boolean like `isSuspendedForBilling` onto the account object via selector, I opted to lean into our access control condition logic so that these decisions all flow through one place. This involved:
  * Making condition helpers _positive_ in direction (isEnterprise instead of notEnterprise)
  * Introducing a `not()` helper that reverses a condition
  * Re-naming `composeConditions` to `all()` to represent the case where you want to grant access when _all_ of the given conditions are true
  * Introducing `any()` as a counterpart to `all()`, for the case where you want to grant access when _any one_ of the given conditions is true
  * Introducing a `<ConditionSwitch>` component, modeled after the react-router `<Switch>`, that forces only one of the given component/condition pairs to render (the first where the condition returns true), to guard against increasingly complex if/then logic in a page like Billing
* The update payment form now appears beneath the banner when you are suspended for billing

### How to test

To test these cases, you can either use the internal REST API to set your account to status = "suspended" for the regular case, and then add "status_reason" = "Suspended following payment failure in Zuora" for the "suspended for billing case".

Alternatively, use Redux Dev Tools to re-emit the "FETCH_ACCOUNT_SUCCESS" action but modify status to be "suspended" for the regular case, and add "status_reason_category" to be "100.01" for the "suspended for billing" case.
