### PR TITLE
FAD-6343 and friends

### DIFF
--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -43,7 +43,7 @@ export class JoinPage extends Component {
 
   registerSubmit = (values) => {
     this.setState({ formData: values });
-    const { register, authenticate } = this.props;
+    const { params: { plan }, register, authenticate } = this.props;
     const attributionData = this.getAndSetAttributionData();
     const salesforceData = { ...attributionData, email_opt_out: !values.email_opt_in };
     const accountFields = _.omit(values, 'email_opt_in');
@@ -59,7 +59,7 @@ export class JoinPage extends Component {
         addEvent('Completed form', 'create account', { form_type: 'create account' });
         return authenticate(accountData.username, values.password);
       })
-      .then(() => this.props.history.push(AFTER_JOIN_REDIRECT_ROUTE));
+      .then(() => this.props.history.push(AFTER_JOIN_REDIRECT_ROUTE, { plan }));
   };
 
   render() {

--- a/src/pages/join/tests/JoinPage.test.js
+++ b/src/pages/join/tests/JoinPage.test.js
@@ -32,6 +32,7 @@ jest.mock('src/helpers/googleAnalytics');
 describe('JoinPage', () => {
   beforeEach(() => {
     props = {
+      params: {},
       account: {
         createError: null
       },
@@ -126,7 +127,14 @@ describe('JoinPage', () => {
 
     it('redirects to correct url upon auth', async() => {
       await instance.registerSubmit(formValues);
-      expect(props.history.push).toHaveBeenCalledWith(AFTER_JOIN_REDIRECT_ROUTE);
+      expect(props.history.push).toHaveBeenCalledWith(AFTER_JOIN_REDIRECT_ROUTE, { plan: undefined });
+    });
+
+    it('Preserves plan for later onboarding phases', async() => {
+      const plan = 'a-man';
+      wrapper.setProps({ params: { plan }});
+      await instance.registerSubmit(formValues);
+      expect(props.history.push).toHaveBeenCalledWith(AFTER_JOIN_REDIRECT_ROUTE, { plan });
     });
 
     it('does not swallow exceptions', async() => {

--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -113,13 +113,13 @@ export class OnboardingPlanPage extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
   const selector = formValueSelector(FORM_NAME);
   return {
     loading: Boolean(state.account.loading || state.billing.plansLoading || state.billing.countriesLoading),
     billing: state.billing,
     plans: getPlansSelector(state),
-    initialValues: onboardingInitialValues(state),
+    initialValues: onboardingInitialValues(state, ownProps),
     selectedPlan: selector(state, 'planpicker'),
     hasError: state.billing.plansError || state.billing.countriesError,
     isAWSAccount: isAWSAccountSelector(state)

--- a/src/pages/profile/components/DisableTfaModal.js
+++ b/src/pages/profile/components/DisableTfaModal.js
@@ -47,10 +47,10 @@ export default class DisableTfaModal extends Component {
               </Grid>
             </Panel.Section>
             <Panel.Section>
-              <Button type='submit' primary onClick={() => this.props.disable(this.state.password)}>
+              <Button type='submit' primary disabled={togglePending} onClick={() => this.props.disable(this.state.password)}>
                 {togglePending ? 'Disabling...' : 'Disable 2FA'}
               </Button>
-              <Button onClick={onClose} className={styles.Cancel}>Cancel</Button>
+              <Button disabled={togglePending} onClick={onClose} className={styles.Cancel}>Cancel</Button>
             </Panel.Section>
           </form>
         </Panel>

--- a/src/pages/profile/components/EnableTfaModal.js
+++ b/src/pages/profile/components/EnableTfaModal.js
@@ -76,10 +76,10 @@ export default class EnableTfaModal extends Component {
           </Grid>
         </Panel.Section>
         <Panel.Section>
-          <Button type='submit' primary onClick={this.enable}>
+          <Button type='submit' primary disabled={togglePending} onClick={this.enable}>
             {togglePending ? 'Verifying Code...' : 'Enable 2FA'}
           </Button>
-          <Button onClick={onClose} className={styles.Cancel}>Cancel</Button>
+          <Button disabled={togglePending} onClick={onClose} className={styles.Cancel}>Cancel</Button>
         </Panel.Section>
       </form>
     );

--- a/src/pages/profile/components/TfaManager.js
+++ b/src/pages/profile/components/TfaManager.js
@@ -29,8 +29,13 @@ export class TfaManager extends Component {
     this.props.clearBackupCodes();
   };
 
-  enable = (code) => this.props.toggleTfa({ enabled: true, code });
+  enable = (code) => this.props.toggleTfa({ enabled: true, code })
+    .then(this.props.getTfaBackupStatus);
+
   disable = (password) => this.props.toggleTfa({ enabled: false, password });
+
+  generateBackupCodes = (password) => this.props.generateBackupCodes(password)
+    .then(this.props.getTfaBackupStatus);
 
   renderBackupCodesStatus() {
     const { enabled, backupCodes } = this.props;
@@ -48,7 +53,7 @@ export class TfaManager extends Component {
   }
 
   render() {
-    const { enabled, generateBackupCodes } = this.props;
+    const { enabled } = this.props;
 
     if (this.props.statusUnknown) {
       return <PanelLoading minHeight='100px' />;
@@ -81,7 +86,7 @@ export class TfaManager extends Component {
           open={this.state.openModal === 'backupCodes'}
           onClose={this.closeBackupModal}
           {...this.props.backupCodes}
-          generate={generateBackupCodes}
+          generate={this.generateBackupCodes}
         />
         <EnableTfaModal
           open={this.state.openModal === 'enable'}

--- a/src/pages/profile/components/tests/TfaManager.test.js
+++ b/src/pages/profile/components/tests/TfaManager.test.js
@@ -14,8 +14,8 @@ describe('EnableTfaModal tests', () => {
       getTfaStatus: jest.fn(),
       getTfaSecret: jest.fn(),
       clearBackupCodes: jest.fn(),
-      generateBackupCodes: jest.fn(),
-      toggleTfa: jest.fn(),
+      generateBackupCodes: jest.fn().mockImplementation(() => Promise.resolve(null)),
+      toggleTfa: jest.fn().mockImplementation(() => Promise.resolve(null)),
       enabled: false,
       secret: 'shhh',
       username: 'kevin-mitnick',
@@ -77,7 +77,7 @@ describe('EnableTfaModal tests', () => {
 
   it('should generate back codes on request', () => {
     instance.generateBackupCodes('password');
-    expect(instance.props.generateBackupCode).toHaveBeenCalled();
+    expect(instance.props.generateBackupCodes).toHaveBeenCalled();
   });
 
   it('should refresh backup code status after generation', () => {

--- a/src/pages/profile/components/tests/TfaManager.test.js
+++ b/src/pages/profile/components/tests/TfaManager.test.js
@@ -64,10 +64,25 @@ describe('EnableTfaModal tests', () => {
     expect(instance.props.toggleTfa).toHaveBeenCalledWith({ enabled: true, code: 'code' });
   });
 
+  it('should refresh backup code status after enable', () => {
+    instance.enable('code');
+    expect(instance.props.getTfaBackupStatus).toHaveBeenCalled();
+  });
+
   it('should toggleTfa on disable', () => {
     instance.disable('pw');
     expect(instance.props.toggleTfa).toHaveBeenCalledWith({ enabled: false, password: 'pw' });
 
+  });
+
+  it('should generate back codes on request', () => {
+    instance.generateBackupCodes('password');
+    expect(instance.props.generateBackupCode).toHaveBeenCalled();
+  });
+
+  it('should refresh backup code status after generation', () => {
+    instance.generateBackupCodes('code');
+    expect(instance.props.getTfaBackupStatus).toHaveBeenCalled();
   });
 
   it('should close modal and clear codes when closing backup modal', () => {

--- a/src/pages/profile/components/tests/__snapshots__/DisableTfaModal.test.js.snap
+++ b/src/pages/profile/components/tests/__snapshots__/DisableTfaModal.test.js.snap
@@ -34,6 +34,7 @@ exports[`DisableTfaModal tests should render correctly 1`] = `
       </Panel.Section>
       <Panel.Section>
         <Button
+          disabled={false}
           onClick={[Function]}
           primary={true}
           size="default"
@@ -42,6 +43,7 @@ exports[`DisableTfaModal tests should render correctly 1`] = `
           Disable 2FA
         </Button>
         <Button
+          disabled={false}
           onClick={[MockFunction]}
           size="default"
         >
@@ -87,6 +89,7 @@ exports[`DisableTfaModal tests should show disabling as button text when toggleP
       </Panel.Section>
       <Panel.Section>
         <Button
+          disabled={true}
           onClick={[Function]}
           primary={true}
           size="default"
@@ -95,6 +98,7 @@ exports[`DisableTfaModal tests should show disabling as button text when toggleP
           Disabling...
         </Button>
         <Button
+          disabled={true}
           onClick={[MockFunction]}
           size="default"
         >
@@ -140,6 +144,7 @@ exports[`DisableTfaModal tests should show error on TextField when toggleError a
       </Panel.Section>
       <Panel.Section>
         <Button
+          disabled={false}
           onClick={[Function]}
           primary={true}
           size="default"
@@ -148,6 +153,7 @@ exports[`DisableTfaModal tests should show error on TextField when toggleError a
           Disable 2FA
         </Button>
         <Button
+          disabled={false}
           onClick={[MockFunction]}
           size="default"
         >

--- a/src/pages/profile/components/tests/__snapshots__/EnableTfaModal.test.js.snap
+++ b/src/pages/profile/components/tests/__snapshots__/EnableTfaModal.test.js.snap
@@ -90,6 +90,7 @@ exports[`EnableTfaModal tests should render correctly 1`] = `
       </Panel.Section>
       <Panel.Section>
         <Button
+          disabled={false}
           onClick={[Function]}
           primary={true}
           size="default"
@@ -98,6 +99,7 @@ exports[`EnableTfaModal tests should render correctly 1`] = `
           Enable 2FA
         </Button>
         <Button
+          disabled={false}
           onClick={[MockFunction]}
           size="default"
         >
@@ -199,6 +201,7 @@ exports[`EnableTfaModal tests should show error on TextField when toggleError an
       </Panel.Section>
       <Panel.Section>
         <Button
+          disabled={false}
           onClick={[MockFunction]}
           primary={true}
           size="default"
@@ -207,6 +210,7 @@ exports[`EnableTfaModal tests should show error on TextField when toggleError an
           Enable 2FA
         </Button>
         <Button
+          disabled={false}
           onClick={
             [MockFunction] {
               "calls": Array [
@@ -330,6 +334,7 @@ exports[`EnableTfaModal tests should show verifying as button text when togglePe
       </Panel.Section>
       <Panel.Section>
         <Button
+          disabled={true}
           onClick={[MockFunction]}
           primary={true}
           size="default"
@@ -338,6 +343,7 @@ exports[`EnableTfaModal tests should show verifying as button text when togglePe
           Verifying Code...
         </Button>
         <Button
+          disabled={true}
           onClick={
             [MockFunction] {
               "calls": Array [

--- a/src/pages/profile/components/tests/__snapshots__/TfaManager.test.js.snap
+++ b/src/pages/profile/components/tests/__snapshots__/TfaManager.test.js.snap
@@ -27,7 +27,7 @@ exports[`EnableTfaModal tests should render correctly 1`] = `
   </LabelledValue>
   <BackupCodesModal
     activeCount={1}
-    generate={[MockFunction]}
+    generate={[Function]}
     onClose={[Function]}
     open={false}
   />

--- a/src/pages/reports/components/tests/Typeahead.test.js
+++ b/src/pages/reports/components/tests/Typeahead.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Typeahead from '../Typeahead';
+import _ from 'lodash';
 
 describe('Component: Typeahead', () => {
   let props;
@@ -13,11 +14,19 @@ describe('Component: Typeahead', () => {
       onSelect: jest.fn(),
       placeholder: ''
     };
+
+    jest.spyOn(_, 'debounce').mockImplementation((fn) => (...args) => fn(...args));
+
     wrapper = shallow(<Typeahead {...props} />);
   });
 
   it('should render ok by default', () => {
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should update matches on field change', () => {
+    wrapper.instance().handleFieldChange({ target: { value: 'cros' }});
+    expect(wrapper.state()).toMatchSnapshot();
   });
 
   it('should produce matches on search', () => {

--- a/src/pages/reports/components/tests/Typeahead.test.js
+++ b/src/pages/reports/components/tests/Typeahead.test.js
@@ -2,16 +2,61 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Typeahead from '../Typeahead';
 
-jest.mock('src/helpers/sortMatch', () => ([]));
-
 describe('Component: Typeahead', () => {
-  it('should render ok by default', () => {
-    const props = {
-      items: [],
+  let props;
+  let wrapper;
+
+  beforeEach(() => {
+    props = {
+      items: [{ type: 'X', value: 'cross' }, { type: 'X', value: 'treasure' }],
+      matches: [],
       onSelect: jest.fn(),
-      placeholder: 'a placeholder'
+      placeholder: ''
     };
-    const wrapper = shallow(<Typeahead {...props} />);
+    wrapper = shallow(<Typeahead {...props} />);
+  });
+
+  it('should render ok by default', () => {
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should produce matches on search', () => {
+    const value = 'cross';
+    wrapper.instance().updateMatches(value);
+    expect(wrapper.state()).toMatchSnapshot();
+  });
+
+  it('should produce no matches on empty query', () => {
+    const value = '';
+    wrapper.instance().updateMatches(value);
+    expect(wrapper.state()).toMatchSnapshot();
+  });
+
+  it('should render with matches', () => {
+    const value = 'cross';
+    const downshiftHelpers = {
+      getInputProps: jest.fn(),
+      getItemProps: jest.fn(),
+      isOpen: true,
+      inputValue: value,
+      selectedItem: null,
+      highlightedIndex: 0,
+      clearSelection: jest.fn()
+    };
+
+    wrapper.instance().updateMatches(value);
+    const TypeaheadRender = wrapper.instance().onTypeahead;
+    expect(shallow(<TypeaheadRender {...downshiftHelpers} {...props} />)).toMatchSnapshot();
+  });
+
+  it('should call onSelect on change', () => {
+    const value = { type: 'X', value: 'treasure' };
+    wrapper.instance().handleDownshiftChange(value);
+    expect(props.onSelect).toHaveBeenCalledWith(value);
+  });
+
+  it('should not call onSelect on clear', () => {
+    wrapper.instance().handleDownshiftChange(null);
+    expect(props.onSelect).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/reports/components/tests/TypeaheadItem.test.js
+++ b/src/pages/reports/components/tests/TypeaheadItem.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import TypeaheadItem from '../TypeaheadItem';
+
+describe('Component: TypeaheadItem', () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      value: 'found'
+    };
+    wrapper = shallow(<TypeaheadItem {...props} />);
+  });
+
+  it('should render', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render help text', () => {
+    wrapper.setProps({ helpText: 'I am helping!' });
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/reports/components/tests/__snapshots__/Typeahead.test.js.snap
+++ b/src/pages/reports/components/tests/__snapshots__/Typeahead.test.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: Typeahead should produce matches on search 1`] = `
+Object {
+  "calculatingMatches": false,
+  "inputValue": "",
+  "matches": Array [
+    Object {
+      "type": "X",
+      "value": "cross",
+    },
+  ],
+}
+`;
+
+exports[`Component: Typeahead should produce no matches on empty query 1`] = `
+Object {
+  "calculatingMatches": false,
+  "inputValue": "",
+  "matches": Array [],
+}
+`;
+
 exports[`Component: Typeahead should render ok by default 1`] = `
 <Downshift
   breakingChanges={Object {}}
@@ -11,7 +32,7 @@ exports[`Component: Typeahead should render ok by default 1`] = `
   getA11yStatusMessage={[Function]}
   id="downshift-1"
   itemToString={[Function]}
-  onChange={[MockFunction]}
+  onChange={[Function]}
   onInputValueChange={[Function]}
   onOuterClick={[Function]}
   onSelect={[Function]}
@@ -20,4 +41,32 @@ exports[`Component: Typeahead should render ok by default 1`] = `
   selectedItemChanged={[Function]}
   stateReducer={[Function]}
 />
+`;
+
+exports[`Component: Typeahead should render with matches 1`] = `
+<div>
+  <div
+    className=""
+  >
+    <ActionList
+      actions={
+        Array [
+          Object {
+            "className": "",
+            "content": <TypeaheadItem
+              helpText="X"
+              value="cross"
+            />,
+            "highlighted": true,
+          },
+        ]
+      }
+    />
+  </div>
+  <TextField
+    required={false}
+    resize="both"
+    type="text"
+  />
+</div>
 `;

--- a/src/pages/reports/components/tests/__snapshots__/Typeahead.test.js.snap
+++ b/src/pages/reports/components/tests/__snapshots__/Typeahead.test.js.snap
@@ -70,3 +70,16 @@ exports[`Component: Typeahead should render with matches 1`] = `
   />
 </div>
 `;
+
+exports[`Component: Typeahead should update matches on field change 1`] = `
+Object {
+  "calculatingMatches": false,
+  "inputValue": "",
+  "matches": Array [
+    Object {
+      "type": "X",
+      "value": "cross",
+    },
+  ],
+}
+`;

--- a/src/pages/reports/components/tests/__snapshots__/TypeaheadItem.test.js.snap
+++ b/src/pages/reports/components/tests/__snapshots__/TypeaheadItem.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: TypeaheadItem should render 1`] = `
+<div>
+  <span>
+    found
+  </span>
+</div>
+`;
+
+exports[`Component: TypeaheadItem should render help text 1`] = `
+<div>
+  <span>
+    found
+  </span>
+  <span>
+    I am helping!
+  </span>
+</div>
+`;

--- a/src/selectors/accountBillingForms.js
+++ b/src/selectors/accountBillingForms.js
@@ -1,8 +1,8 @@
-import { publicPlansSelector, currentPlanSelector, getPlansSelector, isSelfServeOrAWSSelector } from './accountBillingInfo';
+import { currentPlanSelector, getPlansSelector, isSelfServeOrAWSSelector } from './accountBillingInfo';
 import _ from 'lodash';
 
 export function onboardingInitialValues(state, props) {
-  const plans = publicPlansSelector(state);
+  const plans = getPlansSelector(state);
   const { location: { state: locationState = {}}} = props;
   const planCode = locationState.plan;
   const selectedPlan = planCode ? _.find(plans, { code: planCode }) : null;

--- a/src/selectors/accountBillingForms.js
+++ b/src/selectors/accountBillingForms.js
@@ -1,11 +1,14 @@
-import { currentPlanSelector, getPlansSelector, isSelfServeOrAWSSelector } from './accountBillingInfo';
+import { publicPlansSelector, currentPlanSelector, getPlansSelector, isSelfServeOrAWSSelector } from './accountBillingInfo';
 import _ from 'lodash';
 
-export function onboardingInitialValues(state) {
-  const plans = getPlansSelector(state);
+export function onboardingInitialValues(state, props) {
+  const plans = publicPlansSelector(state);
+  const { location: { state: locationState = {}}} = props;
+  const planCode = locationState.plan;
+  const selectedPlan = planCode ? _.find(plans, { code: planCode }) : null;
 
   return {
-    planpicker: _.first(plans),
+    planpicker: selectedPlan ? selectedPlan : _.first(plans),
     billingAddress: {
       firstName: state.currentUser.first_name,
       lastName: state.currentUser.last_name

--- a/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
+++ b/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Billing Initial Values changePlanInitialValues should return change plan values: with a billing id 1`] = `
+exports[`Selector: Account billing form Onboarding Initial Values should set reasonable defaults 1`] = `
+Object {
+  "billingAddress": Object {
+    "firstName": "ann",
+    "lastName": "perkins",
+  },
+  "planpicker": undefined,
+}
+`;
+
+exports[`Selector: Account billing form changePlanInitialValues should return change plan values: with a billing id 1`] = `
 Object {
   "billingAddress": Object {
     "firstName": "ann",
@@ -14,7 +24,7 @@ Object {
 }
 `;
 
-exports[`Billing Initial Values changePlanInitialValues should return change plan values: without billing id 1`] = `
+exports[`Selector: Account billing form changePlanInitialValues should return change plan values: without billing id 1`] = `
 Object {
   "billingAddress": Object {
     "firstName": "ann",
@@ -28,7 +38,27 @@ Object {
 }
 `;
 
-exports[`Billing Initial Values should return update contact values 1`] = `
+exports[`Selector: Account billing form onboardingInitialValues should gracefully handle invalid plan values from /join 1`] = `
+Object {
+  "billingAddress": Object {
+    "firstName": "ann",
+    "lastName": "perkins",
+  },
+  "planpicker": undefined,
+}
+`;
+
+exports[`Selector: Account billing form onboardingInitialValues should set the plan picker to the plan specified by /join 1`] = `
+Object {
+  "billingAddress": Object {
+    "firstName": "ann",
+    "lastName": "perkins",
+  },
+  "planpicker": undefined,
+}
+`;
+
+exports[`Selector: Account billing form updatePaymentInitialValues should return update contact values 1`] = `
 Object {
   "billingContact": Object {
     "country": "GG",
@@ -41,7 +71,7 @@ Object {
 }
 `;
 
-exports[`Billing Initial Values should return update payment values 1`] = `
+exports[`Selector: Account billing form updatePaymentInitialValues should return update payment values 1`] = `
 Object {
   "billingAddress": Object {
     "firstName": "ann",

--- a/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
+++ b/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Selector: Account billing form Onboarding Initial Values should set reasonable defaults 1`] = `
-Object {
-  "billingAddress": Object {
-    "firstName": "ann",
-    "lastName": "perkins",
-  },
-  "planpicker": undefined,
-}
-`;
-
 exports[`Selector: Account billing form changePlanInitialValues should return change plan values: with a billing id 1`] = `
 Object {
   "billingAddress": Object {
@@ -44,7 +34,23 @@ Object {
     "firstName": "ann",
     "lastName": "perkins",
   },
-  "planpicker": undefined,
+  "planpicker": Object {
+    "code": "im free",
+    "isFree": true,
+  },
+}
+`;
+
+exports[`Selector: Account billing form onboardingInitialValues should set reasonable defaults 1`] = `
+Object {
+  "billingAddress": Object {
+    "firstName": "ann",
+    "lastName": "perkins",
+  },
+  "planpicker": Object {
+    "code": "im free",
+    "isFree": true,
+  },
 }
 `;
 
@@ -54,11 +60,14 @@ Object {
     "firstName": "ann",
     "lastName": "perkins",
   },
-  "planpicker": undefined,
+  "planpicker": Object {
+    "code": "im not free",
+    "isFree": false,
+  },
 }
 `;
 
-exports[`Selector: Account billing form updatePaymentInitialValues should return update contact values 1`] = `
+exports[`Selector: Account billing form updateConteactInitialValues should return update contact values 1`] = `
 Object {
   "billingContact": Object {
     "country": "GG",

--- a/src/selectors/tests/accountBillingForms.test.js
+++ b/src/selectors/tests/accountBillingForms.test.js
@@ -22,7 +22,7 @@ describe('Selector: Account billing form', () => {
   let props;
 
   beforeEach(() => {
-    plans = Object.assign({}, basePlans);
+    plans = basePlans.slice();
     user = Object.assign({}, baseUser);
     store = { currentUser: user };
     props = { location: {}};
@@ -53,8 +53,11 @@ describe('Selector: Account billing form', () => {
   });
 
   describe('onboardingInitialValues', () => {
+    beforeEach(() => {
+      billingInfo.getPlansSelector = jest.fn(() => plans);
+    });
+
     it('should set reasonable defaults', () => {
-      billingInfo.publicPlansSelector = jest.fn(() => plans);
       expect(onboardingInitialValues(store, props)).toMatchSnapshot();
     });
 

--- a/src/selectors/tests/accountBillingForms.test.js
+++ b/src/selectors/tests/accountBillingForms.test.js
@@ -28,13 +28,6 @@ describe('Selector: Account billing form', () => {
     props = { location: {}};
   });
 
-  describe('Onboarding Initial Values', () => {
-    it('should set reasonable defaults', () => {
-      billingInfo.publicPlansSelector = jest.fn(() => plans);
-      expect(onboardingInitialValues(store, props)).toMatchSnapshot();
-    });
-  });
-
   describe('changePlanInitialValues', () => {
     beforeEach(() => {
       billingInfo.currentPlanSelector = jest.fn();
@@ -60,6 +53,11 @@ describe('Selector: Account billing form', () => {
   });
 
   describe('onboardingInitialValues', () => {
+    it('should set reasonable defaults', () => {
+      billingInfo.publicPlansSelector = jest.fn(() => plans);
+      expect(onboardingInitialValues(store, props)).toMatchSnapshot();
+    });
+
     it('should set the plan picker to the plan specified by /join', () => {
       props.location = { state: { plan: 'im not free' }};
       expect(onboardingInitialValues(store, props)).toMatchSnapshot();
@@ -76,7 +74,9 @@ describe('Selector: Account billing form', () => {
       const store = { currentUser: Object.assign({}, baseUser) };
       expect(updatePaymentInitialValues(store)).toMatchSnapshot();
     });
+  });
 
+  describe('updateConteactInitialValues', () => {
     it('should return update contact values', () => {
       const store = { account: { billing: Object.assign({}, baseUser) }};
       expect(updateContactInitialValues(store)).toMatchSnapshot();

--- a/src/selectors/tests/accountBillingForms.test.js
+++ b/src/selectors/tests/accountBillingForms.test.js
@@ -1,30 +1,42 @@
-import { changePlanInitialValues, updatePaymentInitialValues, updateContactInitialValues } from '../accountBillingForms';
+import { onboardingInitialValues, changePlanInitialValues, updatePaymentInitialValues, updateContactInitialValues } from '../accountBillingForms';
 import * as billingInfo from '../accountBillingInfo';
 
-describe('Billing Initial Values', () => {
-  const user = {
-    first_name: 'ann',
-    last_name: 'perkins',
-    email: 'ann@perkins.com',
-    country_code: 'GG',
-    state: 'EZ',
-    zip_code: '54321'
-  };
+const basePlans = [
+  { isFree: true, code: 'im free' },
+  { isFree: false, code: 'im not free' }
+];
+
+const baseUser = {
+  first_name: 'ann',
+  last_name: 'perkins',
+  email: 'ann@perkins.com',
+  country_code: 'GG',
+  state: 'EZ',
+  zip_code: '54321'
+};
+
+describe('Selector: Account billing form', () => {
+  let plans;
+  let user;
+  let store;
+  let props;
+
+  beforeEach(() => {
+    plans = Object.assign({}, basePlans);
+    user = Object.assign({}, baseUser);
+    store = { currentUser: user };
+    props = { location: {}};
+  });
+
+  describe('Onboarding Initial Values', () => {
+    it('should set reasonable defaults', () => {
+      billingInfo.publicPlansSelector = jest.fn(() => plans);
+      expect(onboardingInitialValues(store, props)).toMatchSnapshot();
+    });
+  });
 
   describe('changePlanInitialValues', () => {
-    let user;
-    let store;
-
     beforeEach(() => {
-      user = {
-        first_name: 'ann',
-        last_name: 'perkins',
-        email: 'ann@perkins.com',
-        country_code: 'GG',
-        state: 'EZ',
-        zip_code: '54321'
-      };
-      store = { currentUser: user };
       billingInfo.currentPlanSelector = jest.fn();
       billingInfo.publicPlansSelector = jest.fn();
       billingInfo.isSelfServeOrAWSSelector = jest.fn(() => false);
@@ -47,14 +59,27 @@ describe('Billing Initial Values', () => {
     });
   });
 
+  describe('onboardingInitialValues', () => {
+    it('should set the plan picker to the plan specified by /join', () => {
+      props.location = { state: { plan: 'im not free' }};
+      expect(onboardingInitialValues(store, props)).toMatchSnapshot();
+    });
 
-  it('should return update payment values', () => {
-    const store = { currentUser: user };
-    expect(updatePaymentInitialValues(store)).toMatchSnapshot();
+    it('should gracefully handle invalid plan values from /join', () => {
+      props.location = { state: { plan: 'im not even a real plan' }};
+      expect(onboardingInitialValues(store, props)).toMatchSnapshot();
+    });
   });
 
-  it('should return update contact values', () => {
-    const store = { account: { billing: user }};
-    expect(updateContactInitialValues(store)).toMatchSnapshot();
+  describe('updatePaymentInitialValues', () => {
+    it('should return update payment values', () => {
+      const store = { currentUser: Object.assign({}, baseUser) };
+      expect(updatePaymentInitialValues(store)).toMatchSnapshot();
+    });
+
+    it('should return update contact values', () => {
+      const store = { account: { billing: Object.assign({}, baseUser) }};
+      expect(updateContactInitialValues(store)).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
## FAD-6243: Reports: typeahead filters apply only on first use
Issue: Downshift had a hidden current selection prop.
 - We now clear that state with `clearSelection()` on focus of the typeahead `TextField`.
 - Also added to Typeahead tests

#### Testing
1. Visit a report
1. Type `gmail.com` into the filter typeahead and hit return
1. Note the added filter
1. Remove the `gmail.com` filter
1. Re-add it using the typeahead

## FAD-6336: Handle incoming plan query parameter during sign up
Issue: External links to `/join` sometimes include a `plan=...` query param which we should use to pre-populate the plan picker during the onboarding flow.
 - `/join` stashes the `plan` param in router state with `history.push(route, {plan: whatever})`
 - `/onboarding/plan` extracts `plan` from `props.location.state` and sets the plan picker initial value
 - I took some care to deal with invalid values of `plan` since its tainted
#### Testing
Note: I didn't bother creating accounts each time I tested this. I put a link for testing on the dashboard like this: `<Link to={{ pathname: '/onboarding/plan' state: { plan: '500K-0817' } }}>TESTME</Link>`
1. Sign up with `/join?plan=500K-0817`  (or follow a test link from ☝️)
1. Verify that the plan picker is preset to the plan from the URL

## FAD-6339: TFA Shows Incorrect Active Code Count After Closing Modal
Issue: We don't refresh TFA backup code state after generating backup codes or enabling TFA when there already are backup codes available.
 - Update backup code state at appropriate times
#### Testing
1. Enable TFA
1. Generate backup codes
1. Verify that the backup code count on the profile page is correct (without refreshing the page)
1. Disable and re-enable TFA
1. Verify that the backup code count on the profile page is correct (without refreshing the page)
