### PR TITLE
FAD-6372 and friends

### DIFF
--- a/src/components/smtpDetails/SmtpDetails.js
+++ b/src/components/smtpDetails/SmtpDetails.js
@@ -23,7 +23,7 @@ class SmtpDetails extends Component {
 
     const passwordContent = apiKey
       ? <CopyField value={apiKey} helpText='For security, this key will never be displayed in full again. Make sure you copy it somewhere safe!'/>
-      : <p>The password is an API key with <strong>Send via SMTP</strong><em>(smtp/inject)</em> permisions.  <UnstyledLink to='/account/api-keys' Component={Link}>Manage API Keys</UnstyledLink></p>;
+      : <p>The password is an API key with <strong>Send via SMTP</strong> permissions.  <UnstyledLink to='/account/api-keys' Component={Link}>Manage API Keys</UnstyledLink></p>;
 
     return (
       <Fragment>

--- a/src/components/smtpDetails/tests/__snapshots__/SmtpDetails.test.js.snap
+++ b/src/components/smtpDetails/tests/__snapshots__/SmtpDetails.test.js.snap
@@ -78,10 +78,7 @@ exports[`Smtp component: Smtp Details should render page correctly with defaults
       <strong>
         Send via SMTP
       </strong>
-      <em>
-        (smtp/inject)
-      </em>
-       permisions.  
+       permissions.  
       <UnstyledLink
         Component={[Function]}
         to="/account/api-keys"

--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -56,6 +56,7 @@ export default class BillingSummary extends Component {
       count={this.props.sendingIps.length}
       plan={this.props.currentPlan}
       onClick={this.handleIpModal}
+      isAWSAccount={this.props.isAWSAccount}
     />
   );
 

--- a/src/pages/billing/components/DedicatedIpCost.js
+++ b/src/pages/billing/components/DedicatedIpCost.js
@@ -1,7 +1,7 @@
 import config from 'src/config';
 
-export default function DedicatedIpCost({ plan, quantity }) {
-  return plan.isAwsAccount
+export default function DedicatedIpCost({ quantity, isAWSAccount }) {
+  return isAWSAccount
     ? `$${(config.sendingIps.awsPricePerIp * quantity).toFixed(3)} per hour`
     : `$${(config.sendingIps.pricePerIp * quantity).toFixed(2)} per month`;
 }

--- a/src/pages/billing/components/DedicatedIpSummarySection.js
+++ b/src/pages/billing/components/DedicatedIpSummarySection.js
@@ -7,7 +7,7 @@ import config from 'src/config';
 import { LabelledValue } from 'src/components';
 import DedicatedIpCost from './DedicatedIpCost';
 
-export default function DedicatedIpSummarySection({ count = 0, plan = {}, onClick = _.noop }) {
+export default function DedicatedIpSummarySection({ count = 0, plan = {}, onClick = _.noop , isAWSAccount }) {
   const hasReachedMax = count >= config.sendingIps.maxPerAccount;
   const ipCtaContent = (count === 0 && plan.includesIp) ? 'Claim Your Free Dedicated IP' : 'Add Dedicated IPs';
 
@@ -21,7 +21,7 @@ export default function DedicatedIpSummarySection({ count = 0, plan = {}, onClic
 
   const summary = count === 0
     ? <h6>0</h6>
-    : <h6>{count} for <DedicatedIpCost plan={plan} quantity={billableCount} /></h6>;
+    : <h6>{count} for <DedicatedIpCost quantity={billableCount} isAWSAccount={isAWSAccount}/></h6>;
 
   return (
     <Panel.Section actions={[action]}>

--- a/src/pages/billing/components/tests/DedicatedIpCost.test.js
+++ b/src/pages/billing/components/tests/DedicatedIpCost.test.js
@@ -10,17 +10,21 @@ jest.mock('src/config', () => ({
 }));
 
 describe('Component: Dedicated IP Cost', () => {
-
-  it('should render an AWS price', () => {
-    const plan = {
-      isAwsAccount: true
+  let wrapper;
+  beforeEach(() => {
+    const props = {
+      quantity: 2,
+      isAWSAccount: false
     };
-    expect(shallow(<DedicatedIpCost quantity={2} plan={plan} />).text()).toEqual('$0.020 per hour');
+    wrapper = shallow(<DedicatedIpCost {...props}/>);
+  });
+  it('should render an AWS price', () => {
+    wrapper.setProps({ isAWSAccount: true });
+    expect(wrapper.text()).toEqual('$0.020 per hour');
   });
 
   it('should render a regular price', () => {
-    const plan = {};
-    expect(shallow(<DedicatedIpCost quantity={2} plan={plan} />).text()).toEqual('$40.00 per month');
+    expect(wrapper.text()).toEqual('$40.00 per month');
   });
 
 });

--- a/src/pages/billing/components/tests/DedicatedIpSummarySection.test.js
+++ b/src/pages/billing/components/tests/DedicatedIpSummarySection.test.js
@@ -8,15 +8,28 @@ const TEST_CASES = {
   'renders upgrade button and zero count': {},
   'renders zero count and first is free notice': {
     count: 0,
-    plan: { canPurchaseIps: true, includesIp: true }
+    plan: { canPurchaseIps: true, includesIp: true },
+    isAWSAccount: false
   },
   'renders count and zero cost': {
     count: 1,
-    plan: { canPurchaseIps: true, includesIp: true }
+    plan: { canPurchaseIps: true, includesIp: true },
+    isAWSAccount: false
   },
   'renders disabled add button, count, cost, and max plan notice': {
     count: 4, // configuration default
-    plan: { canPurchaseIps: true }
+    plan: { canPurchaseIps: true },
+    isAWSAccount: false
+  },
+  'renders count and cost for aws customers': {
+    count: 2,
+    plan: {},
+    isAWSAccount: true
+  },
+  'renders count and cost for aws customers with free ip': {
+    count: 3,
+    plan: { includesIp: true },
+    isAWSAccount: true
   }
 };
 

--- a/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DedicatedIpSummarySection renders count and cost for aws customers 1`] = `
+<Panel.Section
+  actions={
+    Array [
+      Object {
+        "Component": [Function],
+        "content": "Upgrade Now",
+        "to": "/account/billing/plan",
+      },
+    ]
+  }
+>
+  <LabelledValue
+    label="Dedicated IPs"
+  >
+    <h6>
+      2
+       for 
+      <DedicatedIpCost
+        isAWSAccount={true}
+        quantity={2}
+      />
+    </h6>
+  </LabelledValue>
+</Panel.Section>
+`;
+
+exports[`DedicatedIpSummarySection renders count and cost for aws customers with free ip 1`] = `
+<Panel.Section
+  actions={
+    Array [
+      Object {
+        "Component": [Function],
+        "content": "Upgrade Now",
+        "to": "/account/billing/plan",
+      },
+    ]
+  }
+>
+  <LabelledValue
+    label="Dedicated IPs"
+  >
+    <h6>
+      3
+       for 
+      <DedicatedIpCost
+        isAWSAccount={true}
+        quantity={2}
+      />
+    </h6>
+  </LabelledValue>
+</Panel.Section>
+`;
+
 exports[`DedicatedIpSummarySection renders count and zero cost 1`] = `
 <Panel.Section
   actions={
@@ -19,12 +73,7 @@ exports[`DedicatedIpSummarySection renders count and zero cost 1`] = `
       1
        for 
       <DedicatedIpCost
-        plan={
-          Object {
-            "canPurchaseIps": true,
-            "includesIp": true,
-          }
-        }
+        isAWSAccount={false}
         quantity={0}
       />
     </h6>
@@ -51,11 +100,7 @@ exports[`DedicatedIpSummarySection renders disabled add button, count, cost, and
       4
        for 
       <DedicatedIpCost
-        plan={
-          Object {
-            "canPurchaseIps": true,
-          }
-        }
+        isAWSAccount={false}
         quantity={4}
       />
     </h6>

--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -35,9 +35,11 @@ export default class PreviewFrame extends Component {
     );
 
     // Avoid loading links in iframe
-    for (const a of this.iframe.contentDocument.getElementsByTagName('a')) {
-      a.setAttribute('target', '_parent');
-    }
+    const anchorHTMLCollection = this.iframe.contentDocument.getElementsByTagName('a');
+
+    // ...because DOM collections only array-like
+    const anchors = [...anchorHTMLCollection];
+    anchors.forEach((a) => a.setAttribute('target', '_parent'));
 
     this.setState({ height: `${height + PADDING}px` });
   }

--- a/src/pages/webhooks/components/Fields.js
+++ b/src/pages/webhooks/components/Fields.js
@@ -65,14 +65,16 @@ const AuthDropDown = () => (
   />
 );
 
-const ActiveField = () => (
-  <Field
+const ActiveField = () => {
+  // Artificially set a checked prop so the underlying input displays properly.
+  const CheckableCheckbox = ({ input, ...rest }) => <CheckboxWrapper input={input} {...rest} checked={Boolean(input.value)} />;
+  return <Field
     name='active'
     label='Active'
-    component={CheckboxWrapper}
+    component={CheckableCheckbox}
     helpText='An inactive webhook will not transmit any data.'
-  />
-);
+  />;
+};
 
 export {
   NameField,

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -88,13 +88,15 @@ export const selectBillingInfo = createSelector(
     canChangePlanSelector,
     canPurchaseIps,
     currentPlanSelector,
-    getPlansSelector
+    getPlansSelector,
+    isAWSAccountSelector
   ],
-  (canUpdateBillingInfo, canChangePlan, canPurchaseIps, currentPlan, plans) => ({
+  (canUpdateBillingInfo, canChangePlan, canPurchaseIps, currentPlan, plans, isAWSAccount) => ({
     canUpdateBillingInfo,
     canChangePlan,
     canPurchaseIps,
     currentPlan,
-    plans
+    plans,
+    isAWSAccount
   })
 );

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -117,7 +117,8 @@ describe('selectBillingInfo', () => {
       'canChangePlan',
       'canPurchaseIps',
       'currentPlan',
-      'plans'
+      'plans',
+      'isAWSAccount'
     ]);
   });
 


### PR DESCRIPTION
### FAD-6372: For ... of
Issue: for...of isn't well supported on DOM collections
Fix: Use `[...collection].forEach()`

Testing: Use Edge (!) or an old Safari to preview a template containing a link. Or just eyeball the patch in this PR.

###  FAD-6385: AWS users should see hourly dedicates IP pricing
Issue: we show AWS users incorrect monthly IP pricing in the billing summary
Fix: Pull the AWS account state from subscription details and the correct pricing from config

Testing: Use React dev tools to set isAWSAccount on the BillingSummary under `/account/billing` and voila.

Also fixed a type on `/account/smtp`.

### FAD-6377: Webhooks "active" checkbox state doesn't match underlying `active` field
Issue: Active webhooks appear inactive in our edit form and confuse the rest of the form's `dirty` state.
Fix: Tie our `<Checkbox />` `checked` state to `input.value` from redux-form.

Testing: Visit an active webhook and verify:
 - the active checkbox shows the correct initial state
 - the submit button goes active when unchecking active
 - the submit button goes inactive when re-checked active
