### PR TITLE
FAD-6395: Users are unable to open links when previewing a template in certain browsers

### DIFF
--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -56,9 +56,9 @@ export default class PreviewFrame extends Component {
 
   // The sandboxed iframe enables an extra set of security restriction.
   // The "allow-same-origin" restriction must be lifted to load the content from the same origin.
-  // The "allow-top-navigation-by-user-activation" restriction must be lifted to work in
-  // conjunction with the target override in .onLoad to avoid loading links in the iframe,
-  // instead loading subsequent pages in the current browser tab for a better user experience.
+  // The "allow-top-navigation" restriction must be lifted to work in conjunction with the target
+  // override in .onLoad to avoid loading links in the iframe, instead loading subsequent pages in
+  // the current browser tab for a better user experience.
   //
   // @todo srcDoc or Shadow DOM would be better solutions if they had better browser support
   // @see https://developer.mozilla.org/en-US/docs/Web/Web_Components/Shadow_DOM
@@ -72,7 +72,7 @@ export default class PreviewFrame extends Component {
         height={this.state.height}
         ref={this.setRef}
         onLoad={this.onLoad}
-        sandbox="allow-same-origin allow-top-navigation-by-user-activation"
+        sandbox="allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation"
         title="preview email template frame"
       />
     );

--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -72,7 +72,7 @@ export default class PreviewFrame extends Component {
         height={this.state.height}
         ref={this.setRef}
         onLoad={this.onLoad}
-        sandbox="allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation"
+        sandbox="allow-same-origin allow-top-navigation"
         title="preview email template frame"
       />
     );

--- a/src/pages/templates/components/tests/__snapshots__/PreviewFrame.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewFrame.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders an iframe 1`] = `
 >
   <iframe
     onLoad={[Function]}
-    sandbox="allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation"
+    sandbox="allow-same-origin allow-top-navigation"
     title="preview email template frame"
   />
 </PreviewFrame>
@@ -19,7 +19,7 @@ exports[`sets iframe height after it loads 1`] = `
   <iframe
     height="99px"
     onLoad={[Function]}
-    sandbox="allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation"
+    sandbox="allow-same-origin allow-top-navigation"
     title="preview email template frame"
   />
 </PreviewFrame>

--- a/src/pages/templates/components/tests/__snapshots__/PreviewFrame.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewFrame.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders an iframe 1`] = `
 >
   <iframe
     onLoad={[Function]}
-    sandbox="allow-same-origin allow-top-navigation-by-user-activation"
+    sandbox="allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation"
     title="preview email template frame"
   />
 </PreviewFrame>
@@ -19,7 +19,7 @@ exports[`sets iframe height after it loads 1`] = `
   <iframe
     height="99px"
     onLoad={[Function]}
-    sandbox="allow-same-origin allow-top-navigation-by-user-activation"
+    sandbox="allow-same-origin allow-top-navigation allow-top-navigation-by-user-activation"
     title="preview email template frame"
   />
 </PreviewFrame>


### PR DESCRIPTION
Refer to [FAD-6395](https://jira.int.messagesystems.com/browse/FAD-6395).

