### PR TITLE
FAD-6126: Template list/preview access for reporting users

### DIFF
--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -236,7 +236,7 @@ const routes = [
   {
     path: '/templates',
     component: templates.ListPage,
-    condition: all(hasGrants('templates/modify'), ({ account }) => account.status === 'active'),
+    condition: hasGrants('templates/view'),
     layout: App
   },
   {
@@ -248,13 +248,13 @@ const routes = [
   {
     path: '/templates/edit/:id',
     component: templates.EditPage,
-    condition: hasGrants('templates/modify'),
+    condition: hasGrants('templates/view'),
     layout: App
   },
   {
     path: '/templates/edit/:id/published',
     component: templates.PublishedPage,
-    condition: hasGrants('templates/modify'),
+    condition: hasGrants('templates/view'),
     layout: App
   },
   {

--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -121,7 +121,7 @@ export default class EditPage extends Component {
   }
 
   render() {
-    const { loading, formName, subaccountId } = this.props;
+    const { canModify, loading, formName, subaccountId } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -131,10 +131,10 @@ export default class EditPage extends Component {
       <Page {...this.getPageProps()}>
         <Grid>
           <Grid.Column xs={12} lg={4}>
-            <Form name={formName} subaccountId={subaccountId} />
+            <Form name={formName} subaccountId={subaccountId} readOnly={!canModify} />
           </Grid.Column>
           <Grid.Column xs={12} lg={8}>
-            <Editor name={formName} />
+            <Editor name={formName} readOnly={!canModify} />
           </Grid.Column>
         </Grid>
         <DeleteModal

--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -65,7 +65,7 @@ export default class EditPage extends Component {
   }
 
   getPageProps() {
-    const { handleSubmit, template, match, submitting, subaccountId } = this.props;
+    const { canModify, handleSubmit, template, match, submitting, subaccountId } = this.props;
     const published = template.published;
 
     const primaryAction = {
@@ -78,21 +78,33 @@ export default class EditPage extends Component {
       {
         content: 'View Published',
         Component: Link,
-        to: `/templates/edit/${match.params.id}/published${setSubaccountQuery(subaccountId)}`
+        to: `/templates/edit/${match.params.id}/published${setSubaccountQuery(subaccountId)}`,
+        visible: published
       },
       {
         content: 'Save as Draft',
         onClick: handleSubmit(this.handleSave),
-        disabled: submitting
+        disabled: submitting,
+        visible: canModify
       },
-      { content: 'Delete', onClick: this.handleDeleteModalToggle },
-      { content: 'Duplicate', Component: Link, to: `/templates/create/${match.params.id}` },
-      { content: 'Preview & Send', Component: Link, to: `/templates/preview/${match.params.id}${setSubaccountQuery(subaccountId)}` }
+      { content: 'Delete', onClick: this.handleDeleteModalToggle, visible: canModify },
+      {
+        content: 'Duplicate',
+        Component: Link,
+        to: `/templates/create/${match.params.id}`,
+        visible: canModify
+      },
+      {
+        content: 'Preview & Send',
+        Component: Link,
+        to: `/templates/preview/${match.params.id}${setSubaccountQuery(subaccountId)}`,
+        visible: true
+      }
     ];
 
-    if (!published) {
-      secondaryActions.shift();
-    }
+    const visibleSecondaryActions = secondaryActions.reduce((result, { visible, ...action }) => (
+      visible ? [...result, action] : result
+    ), []);
 
     const breadcrumbAction = {
       content: 'Templates',
@@ -101,8 +113,8 @@ export default class EditPage extends Component {
     };
 
     return {
-      secondaryActions,
-      primaryAction,
+      secondaryActions: visibleSecondaryActions,
+      primaryAction: canModify ? primaryAction : undefined,
       breadcrumbAction,
       title: `${match.params.id} (Draft)`
     };

--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -60,6 +60,13 @@ export default class EditPage extends Component {
     });
   }
 
+  handlePreview = ({ testData }) => {
+    const { setTestData, match: { params: { id }}, subaccountId, history } = this.props;
+    setTestData({ id, data: testData, mode: 'draft' }).then(
+      () => history.push(`/templates/preview/${id}${setSubaccountQuery(subaccountId)}`)
+    );
+  };
+
   handleDeleteModalToggle = () => {
     this.setState({ deleteOpen: !this.state.deleteOpen });
   }
@@ -99,8 +106,7 @@ export default class EditPage extends Component {
       },
       {
         content: canModify ? 'Preview & Send' : 'Preview',
-        Component: Link,
-        to: `/templates/preview/${match.params.id}${setSubaccountQuery(subaccountId)}`,
+        onClick: handleSubmit(this.handlePreview),
         visible: true
       }
     ]);

--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -74,7 +74,10 @@ export default class EditPage extends Component {
       disabled: submitting
     };
 
-    const secondaryActions = [
+    const filterVisibleActions = (actions) =>
+      actions.filter((action) => action.visible).map(({ visible, ...action }) => action);
+
+    const secondaryActions = filterVisibleActions([
       {
         content: 'View Published',
         Component: Link,
@@ -95,16 +98,12 @@ export default class EditPage extends Component {
         visible: canModify
       },
       {
-        content: 'Preview & Send',
+        content: canModify ? 'Preview & Send' : 'Preview',
         Component: Link,
         to: `/templates/preview/${match.params.id}${setSubaccountQuery(subaccountId)}`,
         visible: true
       }
-    ];
-
-    const visibleSecondaryActions = secondaryActions.reduce((result, { visible, ...action }) => (
-      visible ? [...result, action] : result
-    ), []);
+    ]);
 
     const breadcrumbAction = {
       content: 'Templates',
@@ -113,7 +112,7 @@ export default class EditPage extends Component {
     };
 
     return {
-      secondaryActions: visibleSecondaryActions,
+      secondaryActions,
       primaryAction: canModify ? primaryAction : undefined,
       breadcrumbAction,
       title: `${match.params.id} (Draft)`

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -83,7 +83,7 @@ export default class ListPage extends Component {
   }
 
   render() {
-    const { count, loading, error } = this.props;
+    const { canModify, count, loading, error } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -91,7 +91,7 @@ export default class ListPage extends Component {
 
     return (
       <Page
-        primaryAction={primaryAction}
+        primaryAction={canModify ? primaryAction : undefined}
         title='Templates'
         empty={{
           show: count === 0,

--- a/src/pages/templates/PreviewPage.js
+++ b/src/pages/templates/PreviewPage.js
@@ -72,7 +72,7 @@ export default class PreviewPage extends Component {
   }
 
   render() {
-    const { mode, preview, returnPath, template } = this.props;
+    const { canModify, mode, preview, returnPath, template } = this.props;
     const { loading, loadingError, sending, to, validationError } = this.state;
 
     if (loading) {
@@ -82,14 +82,14 @@ export default class PreviewPage extends Component {
     const pageProps = {
       breadcrumbAction: {
         Component: Link,
-        content: 'Edit Template',
+        content: canModify ? 'Edit Template' : 'Back To Template',
         to: returnPath
       },
-      primaryAction: {
+      primaryAction: canModify ? {
         content: 'Send Email',
         disabled: sending || !!loadingError,
         onClick: this.onSend
-      },
+      } : undefined,
       title: `${template.name || ''} (${_.capitalize(mode)})`
     };
 
@@ -105,14 +105,16 @@ export default class PreviewPage extends Component {
           />
         )}
         <Panel sectioned>
-          <TextField
-            disabled={!!loadingError}
-            error={validationError}
-            label="To"
-            placeholder="Send to recipient email addresses"
-            onChange={this.onTextChange}
-            value={to}
-          />
+          { canModify &&
+              <TextField
+                disabled={!!loadingError}
+                error={validationError}
+                label="To"
+                placeholder="Send to recipient email addresses"
+                onChange={this.onTextChange}
+                value={to}
+              />
+          }
           <TextField disabled label="From" value={name ? `${name} <${email}>` : email} />
           <TextField disabled label="Subject" value={preview.subject} />
           <PreviewPanel html={preview.html} text={preview.text} />

--- a/src/pages/templates/PublishedPage.js
+++ b/src/pages/templates/PublishedPage.js
@@ -13,8 +13,17 @@ export default class PublishedPage extends Component {
     getTestData({ id: match.params.id, mode: 'published' });
   }
 
+  handlePreview = ({ testData }) => {
+    const { setTestData, match: { params: { id }}, history, subaccountId } = this.props;
+    const query = setSubaccountQuery(subaccountId);
+
+    setTestData({ id, data: testData, mode: 'published' }).then(
+      () => history.push(`/templates/preview/${id}/published${query}`)
+    );
+  };
+
   getPageProps() {
-    const { canModify, match, subaccountId } = this.props;
+    const { canModify, handleSubmit, match, subaccountId } = this.props;
     const query = setSubaccountQuery(subaccountId);
 
     const secondaryActions = [
@@ -25,8 +34,7 @@ export default class PublishedPage extends Component {
       },
       {
         content: canModify ? 'Preview & Send' : 'Preview',
-        Component: Link,
-        to: `/templates/preview/${match.params.id}/published${query}`
+        onClick: handleSubmit(this.handlePreview)
       }
     ];
 

--- a/src/pages/templates/PublishedPage.js
+++ b/src/pages/templates/PublishedPage.js
@@ -14,7 +14,7 @@ export default class PublishedPage extends Component {
   }
 
   getPageProps() {
-    const { match, subaccountId } = this.props;
+    const { canModify, match, subaccountId } = this.props;
     const query = setSubaccountQuery(subaccountId);
 
     const secondaryActions = [
@@ -24,7 +24,7 @@ export default class PublishedPage extends Component {
         to: `/templates/edit/${match.params.id}${query}`
       },
       {
-        content: 'Preview & Send',
+        content: canModify ? 'Preview & Send' : 'Preview',
         Component: Link,
         to: `/templates/preview/${match.params.id}/published${query}`
       }

--- a/src/pages/templates/PublishedPage.js
+++ b/src/pages/templates/PublishedPage.js
@@ -50,10 +50,10 @@ export default class PublishedPage extends Component {
       <Page {...this.getPageProps()}>
         <Grid>
           <Grid.Column xs={12} lg={4}>
-            <Form name={formName} published />
+            <Form name={formName} readOnly />
           </Grid.Column>
           <Grid.Column xs={12} lg={8}>
-            <Editor name={formName} published />
+            <Editor name={formName} readOnly />
           </Grid.Column>
         </Grid>
       </Page>

--- a/src/pages/templates/components/Form.js
+++ b/src/pages/templates/components/Form.js
@@ -74,7 +74,7 @@ export default class Form extends Component {
   }
 
   render() {
-    const { newTemplate, published, domains, hasSubaccounts, name } = this.props;
+    const { newTemplate, readOnly, domains, hasSubaccounts, name } = this.props;
 
     return (
       <div>
@@ -85,7 +85,7 @@ export default class Form extends Component {
               component={TextFieldWrapper}
               label='Template Name'
               onChange={this.handleIdFill}
-              disabled={published}
+              disabled={readOnly}
               validate={required}
             />
 
@@ -94,11 +94,11 @@ export default class Form extends Component {
               component={TextFieldWrapper}
               label='Template ID'
               helpText={newTemplate ? 'A Unique ID for your template, we\'ll fill this in for you.' : null}
-              disabled={!newTemplate || published}
+              disabled={!newTemplate || readOnly}
               validate={newTemplate ? [required, idSyntax] : null}
             />
           </Panel.Section>
-          { hasSubaccounts && <SubaccountSection newTemplate={newTemplate} formName={name} disabled={published} /> }
+          { hasSubaccounts && <SubaccountSection newTemplate={newTemplate} formName={name} disabled={readOnly} /> }
         </Panel>
         <Panel>
           <Panel.Section>
@@ -106,7 +106,7 @@ export default class Form extends Component {
               name='content.subject'
               component={TextFieldWrapper}
               label='Subject'
-              disabled={published}
+              disabled={readOnly}
               validate={required}
             />
 
@@ -115,7 +115,7 @@ export default class Form extends Component {
               component={FromEmailWrapper}
               placeholder='example@email.com'
               label='From Email'
-              disabled={!domains.length || published}
+              disabled={!domains.length || readOnly}
               validate={[required, emailOrSubstitution, this.validateDomain]}
               domains={domains}
               helpText={this.fromEmailWarning()}
@@ -126,7 +126,7 @@ export default class Form extends Component {
               component={TextFieldWrapper}
               label='From Name'
               helpText='A friendly from for your recipients.'
-              disabled={published}
+              disabled={readOnly}
             />
 
             <Field
@@ -134,7 +134,7 @@ export default class Form extends Component {
               component={TextFieldWrapper}
               label='Reply To'
               helpText='An email address recipients can reply to.'
-              disabled={published}
+              disabled={readOnly}
               validate={emailOrSubstitution}
             />
 
@@ -143,7 +143,7 @@ export default class Form extends Component {
               component={TextFieldWrapper}
               label='Description'
               helpText='Not visible to recipients.'
-              disabled={published}
+              disabled={readOnly}
             />
           </Panel.Section>
         </Panel>
@@ -155,7 +155,7 @@ export default class Form extends Component {
               label='Track Opens'
               type='checkbox'
               parse={this.parseToggle}
-              disabled={published}
+              disabled={readOnly}
             />
 
             <Field
@@ -164,7 +164,7 @@ export default class Form extends Component {
               label='Track Clicks'
               type='checkbox'
               parse={this.parseToggle}
-              disabled={published}
+              disabled={readOnly}
             />
           </Panel.Section>
 
@@ -176,7 +176,7 @@ export default class Form extends Component {
               type='checkbox'
               parse={this.parseToggle}
               helpText='Transactional messages are triggered by a user’s actions on the website, like requesting a password reset, signing up, or making a purchase.'
-              disabled={published}
+              disabled={readOnly}
             />
           </Panel.Section>
         </Panel>

--- a/src/pages/templates/components/async/Editor.js
+++ b/src/pages/templates/components/async/Editor.js
@@ -28,7 +28,7 @@ class Editor extends Component {
   }
 
   render() {
-    const { published } = this.props;
+    const { readOnly } = this.props;
     const { selectedTab } = this.state;
 
     const tabs = fields.map(({ content }, i) => ({ content, onClick: () => this.handleTab(i) }));
@@ -41,7 +41,7 @@ class Editor extends Component {
             name={fields[selectedTab].name}
             mode={fields[selectedTab].mode}
             component={AceWrapper}
-            readOnly={published && selectedTab !== 2}
+            readOnly={readOnly && selectedTab !== 2}
             validate={[contentRequired, validJson]}
           />
         </Panel>

--- a/src/pages/templates/components/tests/Form.test.js
+++ b/src/pages/templates/components/tests/Form.test.js
@@ -16,7 +16,7 @@ describe('Template Form', () => {
       listDomains: jest.fn(),
       change: jest.fn(),
       newTemplate: false,
-      published: false,
+      readOnly: false,
       name: 'form-name',
       hasSubaccounts: false
     };
@@ -40,8 +40,8 @@ describe('Template Form', () => {
     expect(wrapper.find(SubaccountSection)).toMatchSnapshot();
   });
 
-  it('should disable fields on published', () => {
-    wrapper.setProps({ published: true });
+  it('should disable fields for read-only users', () => {
+    wrapper.setProps({ readOnly: true });
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/templates/components/tests/__snapshots__/Form.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/Form.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Template Form should disable fields on published 1`] = `
+exports[`Template Form should disable fields for read-only users 1`] = `
 <div>
   <Panel>
     <Panel.Section>

--- a/src/pages/templates/containers/EditPage.container.js
+++ b/src/pages/templates/containers/EditPage.container.js
@@ -2,7 +2,7 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
 
-import { getDraft, getPublished, update, deleteTemplate, publish, getTestData } from 'src/actions/templates';
+import { getDraft, getPublished, update, deleteTemplate, publish, getTestData, setTestData } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 import { hasGrants } from 'src/helpers/conditions';
 import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
@@ -43,6 +43,7 @@ const mapDispatchToProps = {
   getDraft,
   getPublished,
   getTestData,
+  setTestData,
   update,
   deleteTemplate,
   publish,

--- a/src/pages/templates/containers/EditPage.container.js
+++ b/src/pages/templates/containers/EditPage.container.js
@@ -4,6 +4,7 @@ import { reduxForm } from 'redux-form';
 
 import { getDraft, getPublished, update, deleteTemplate, publish, getTestData } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
+import { hasGrants } from 'src/helpers/conditions';
 import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, hasSubaccounts, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 
@@ -14,12 +15,14 @@ const FORM_NAME = 'templateEdit';
 const mapStateToProps = (state, props) => {
   const template = selectTemplateById(state, props);
   const values = template.draft || template.published; // For templates with published but no draft, pull in published values
+  const canModify = hasGrants('template/modify')(state);
 
   return {
     loading: state.templates.getLoading,
     template,
     subaccountId: selectSubaccountIdFromQuery(state, props),
     hasSubaccounts: hasSubaccounts(state),
+    canModify,
 
     // Redux Form
     formName: FORM_NAME,

--- a/src/pages/templates/containers/ListPage.container.js
+++ b/src/pages/templates/containers/ListPage.container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { listTemplates } from 'src/actions/templates';
+import { hasGrants } from 'src/helpers/conditions';
 import { selectTemplates } from 'src/selectors/templates';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 
@@ -8,12 +9,15 @@ import ListPage from '../ListPage';
 
 function mapStateToProps(state) {
   const templates = selectTemplates(state);
+  const canModify = hasGrants('template/modify')(state);
+
   return {
     count: templates.length,
     templates,
     hasSubaccounts: hasSubaccounts(state),
     loading: state.templates.listLoading,
-    error: state.templates.listError
+    error: state.templates.listError,
+    canModify
   };
 }
 

--- a/src/pages/templates/containers/PreviewDraftPage.container.js
+++ b/src/pages/templates/containers/PreviewDraftPage.container.js
@@ -6,12 +6,14 @@ import { getDraftAndPreview, sendPreview } from 'src/actions/templates';
 import { selectDraftTemplate, selectDraftTemplatePreview } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery } from 'src/selectors/subaccounts';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
+import { hasGrants } from 'src/helpers/conditions';
 import PreviewPage from '../PreviewPage';
 
 export const mapStateToProps = (state, props) => {
   const subaccountId = selectSubaccountIdFromQuery(state, props);
   return {
     mode: 'draft',
+    canModify: hasGrants('template/modify')(state),
     returnPath: `/templates/edit/${props.match.params.id}${setSubaccountQuery(subaccountId)}`,
     preview: selectDraftTemplatePreview(state, props.match.params.id),
     template: selectDraftTemplate(state, props.match.params.id),

--- a/src/pages/templates/containers/PreviewPublishedPage.container.js
+++ b/src/pages/templates/containers/PreviewPublishedPage.container.js
@@ -6,12 +6,14 @@ import { getPublishedAndPreview, sendPreview } from 'src/actions/templates';
 import { selectPublishedTemplate, selectPublishedTemplatePreview } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery } from 'src/selectors/subaccounts';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
+import { hasGrants } from 'src/helpers/conditions';
 import PreviewPage from '../PreviewPage';
 
 export const mapStateToProps = (state, props) => {
   const subaccountId = selectSubaccountIdFromQuery(state, props);
   return {
     mode: 'published',
+    canModify: hasGrants('template/modify')(state),
     returnPath: `/templates/edit/${props.match.params.id}/published${setSubaccountQuery(subaccountId)}`,
     preview: selectPublishedTemplatePreview(state, props.match.params.id),
     template: selectPublishedTemplate(state, props.match.params.id),

--- a/src/pages/templates/containers/PublishedPage.container.js
+++ b/src/pages/templates/containers/PublishedPage.container.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
 
 import { getPublished, getTestData } from 'src/actions/templates';
+import { hasGrants } from 'src/helpers/conditions';
 import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
@@ -13,6 +14,7 @@ const FORM_NAME = 'templatePublished';
 
 const mapStateToProps = (state, props) => ({
   loading: state.templates.getLoading,
+  canModify: hasGrants('template/modify')(state),
   subaccountId: selectSubaccountIdFromQuery(state, props),
   hasSubaccounts: hasSubaccounts(state),
   formName: FORM_NAME,

--- a/src/pages/templates/containers/PublishedPage.container.js
+++ b/src/pages/templates/containers/PublishedPage.container.js
@@ -2,7 +2,7 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
 
-import { getPublished, getTestData } from 'src/actions/templates';
+import { getPublished, getTestData, setTestData } from 'src/actions/templates';
 import { hasGrants } from 'src/helpers/conditions';
 import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
@@ -30,4 +30,4 @@ const formOptions = {
   enableReinitialize: true // required to update initial values from redux state
 };
 
-export default withRouter(connect(mapStateToProps, { getPublished, getTestData })(reduxForm(formOptions)(PublishedPage)));
+export default withRouter(connect(mapStateToProps, { getPublished, getTestData, setTestData })(reduxForm(formOptions)(PublishedPage)));

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -25,7 +25,8 @@ describe('Template EditPage', () => {
         push: jest.fn()
       },
       subaccountId: 101,
-      formName: 'templateEdit'
+      formName: 'templateEdit',
+      canModify: true
     };
 
     wrapper = shallow(<EditPage {...props} />);
@@ -40,6 +41,11 @@ describe('Template EditPage', () => {
     expect(props.getTestData).toHaveBeenCalledWith({ id: 'id', mode: 'draft' });
     expect(props.getDraft).toHaveBeenCalledWith('id', props.subaccountId);
     expect(props.getPublished).toHaveBeenCalledWith('id', props.subaccountId);
+  });
+
+  it('should render without delete, duplicate, publish, and save action buttons', () => {
+    wrapper.setProps({ canModify: false });
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should catch 404s on both published and draft', async() => {

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -43,7 +43,7 @@ describe('Template EditPage', () => {
     expect(props.getPublished).toHaveBeenCalledWith('id', props.subaccountId);
   });
 
-  it('should render without delete, duplicate, publish, and save action buttons', () => {
+  it('should render correctly for read-only users', () => {
     wrapper.setProps({ canModify: false });
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/templates/tests/ListPage.test.js
+++ b/src/pages/templates/tests/ListPage.test.js
@@ -18,7 +18,8 @@ const props = {
     {
       name: 'Temp 2'
     }
-  ]
+  ],
+  canModify: true
 };
 
 let wrapper;
@@ -35,6 +36,11 @@ afterEach(() => {
 it('renders correctly', () => {
   expect(wrapper).toMatchSnapshot();
   expect(props.listTemplates).toHaveBeenCalled();
+});
+
+it('renders without primary action for read-only users', () => {
+  wrapper.setProps({ canModify: false });
+  expect(wrapper).toMatchSnapshot();
 });
 
 it('renders columns correctly with subaccounts', () => {

--- a/src/pages/templates/tests/PreviewPage.test.js
+++ b/src/pages/templates/tests/PreviewPage.test.js
@@ -7,6 +7,7 @@ import PreviewPage from '../PreviewPage';
 // Load a preview page with a test template and return for additional operations
 const loadPreviewPage = async(overrides = {}) => {
   const props = {
+    canModify: true,
     match: { params: { id: 'test-template' }},
     mode: 'draft',
     onLoad: () => Promise.resolve(),
@@ -35,6 +36,11 @@ const loadPreviewPage = async(overrides = {}) => {
 
 it('renders preview page with template', async() => {
   const wrapper = await loadPreviewPage();
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('renders preview page with read-only template', async() => {
+  const wrapper = await loadPreviewPage({ canModify: false });
   expect(wrapper).toMatchSnapshot();
 });
 

--- a/src/pages/templates/tests/PublishedPage.test.js
+++ b/src/pages/templates/tests/PublishedPage.test.js
@@ -14,13 +14,23 @@ describe('Template PublishedPage', () => {
       },
       getPublished: jest.fn(() => Promise.resolve()),
       getTestData: jest.fn(),
-      formName: 'templatePublished'
+      formName: 'templatePublished',
+      canModify: true
     };
   });
 
   it('should render correctly', () => {
     wrapper = shallow(<PublishedPage {...props} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render read-only correctly', () => {
+    wrapper = shallow(<PublishedPage {...props} canModify={false} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should load template content', () => {
+    wrapper = shallow(<PublishedPage {...props} />);
     expect(props.getTestData).toHaveBeenCalledWith({ id: 'id', mode: 'published' });
     expect(props.getPublished).toHaveBeenCalledWith('id', props.subaccountId);
   });

--- a/src/pages/templates/tests/PublishedPage.test.js
+++ b/src/pages/templates/tests/PublishedPage.test.js
@@ -14,7 +14,9 @@ describe('Template PublishedPage', () => {
       },
       getPublished: jest.fn(() => Promise.resolve()),
       getTestData: jest.fn(),
+      setTestData: jest.fn(),
       formName: 'templatePublished',
+      handleSubmit: jest.fn(),
       canModify: true
     };
   });

--- a/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
@@ -103,3 +103,62 @@ exports[`Template EditPage should render correctly 1`] = `
   />
 </Page>
 `;
+
+exports[`Template EditPage should render without delete, duplicate, publish, and save action buttons 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "Component": [Function],
+      "content": "Templates",
+      "to": "/templates",
+    }
+  }
+  empty={Object {}}
+  secondaryActions={
+    Array [
+      Object {
+        "Component": [Function],
+        "content": "View Published",
+        "to": "/templates/edit/id/published?subaccount=101",
+      },
+      Object {
+        "Component": [Function],
+        "content": "Preview & Send",
+        "to": "/templates/preview/id?subaccount=101",
+      },
+    ]
+  }
+  title="id (Draft)"
+>
+  <Grid>
+    <Grid.Column
+      lg={4}
+      xs={12}
+    >
+      <Connect(Form)
+        name="templateEdit"
+        subaccountId={101}
+      />
+    </Grid.Column>
+    <Grid.Column
+      lg={8}
+      xs={12}
+    >
+      <LoadableComponent
+        name="templateEdit"
+      />
+    </Grid.Column>
+  </Grid>
+  <DeleteModal
+    content={
+      <p>
+        Both the draft and published versions of this template will be deleted.
+      </p>
+    }
+    onCancel={[Function]}
+    onDelete={[Function]}
+    open={false}
+    title="Are you sure you want to delete this template?"
+  />
+</Page>
+`;

--- a/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
@@ -17,9 +17,8 @@ Array [
     "to": "/templates/create/id",
   },
   Object {
-    "Component": [Function],
     "content": "Preview & Send",
-    "to": "/templates/preview/id?subaccount=101",
+    "onClick": undefined,
   },
 ]
 `;
@@ -63,9 +62,8 @@ exports[`Template EditPage should render correctly 1`] = `
         "to": "/templates/create/id",
       },
       Object {
-        "Component": [Function],
         "content": "Preview & Send",
-        "to": "/templates/preview/id?subaccount=101",
+        "onClick": undefined,
       },
     ]
   }
@@ -124,9 +122,8 @@ exports[`Template EditPage should render correctly for read-only users 1`] = `
         "to": "/templates/edit/id/published?subaccount=101",
       },
       Object {
-        "Component": [Function],
         "content": "Preview",
-        "to": "/templates/preview/id?subaccount=101",
+        "onClick": undefined,
       },
     ]
   }

--- a/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
@@ -125,7 +125,7 @@ exports[`Template EditPage should render correctly for read-only users 1`] = `
       },
       Object {
         "Component": [Function],
-        "content": "Preview & Send",
+        "content": "Preview",
         "to": "/templates/preview/id?subaccount=101",
       },
     ]

--- a/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
@@ -78,6 +78,7 @@ exports[`Template EditPage should render correctly 1`] = `
     >
       <Connect(Form)
         name="templateEdit"
+        readOnly={false}
         subaccountId={101}
       />
     </Grid.Column>
@@ -87,6 +88,7 @@ exports[`Template EditPage should render correctly 1`] = `
     >
       <LoadableComponent
         name="templateEdit"
+        readOnly={false}
       />
     </Grid.Column>
   </Grid>
@@ -104,7 +106,7 @@ exports[`Template EditPage should render correctly 1`] = `
 </Page>
 `;
 
-exports[`Template EditPage should render without delete, duplicate, publish, and save action buttons 1`] = `
+exports[`Template EditPage should render correctly for read-only users 1`] = `
 <Page
   breadcrumbAction={
     Object {
@@ -137,6 +139,7 @@ exports[`Template EditPage should render without delete, duplicate, publish, and
     >
       <Connect(Form)
         name="templateEdit"
+        readOnly={true}
         subaccountId={101}
       />
     </Grid.Column>
@@ -146,6 +149,7 @@ exports[`Template EditPage should render without delete, duplicate, publish, and
     >
       <LoadableComponent
         name="templateEdit"
+        readOnly={true}
       />
     </Grid.Column>
   </Grid>

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -206,3 +206,73 @@ Array [
   ],
 ]
 `;
+
+exports[`renders without primary action for read-only users 1`] = `
+<Page
+  empty={
+    Object {
+      "content": <p>
+        Build, test, preview and send your transmissions.
+      </p>,
+      "image": "Templates",
+      "show": false,
+      "title": "Manage your email templates",
+    }
+  }
+  title="Templates"
+>
+  <TableCollection
+    columns={
+      Array [
+        Object {
+          "label": "Name",
+          "sortKey": "name",
+          "width": "22%",
+        },
+        Object {
+          "label": "ID",
+          "sortKey": "id",
+          "width": "22%",
+        },
+        Object {
+          "label": "Status",
+          "sortKey": "published",
+          "width": "15%",
+        },
+        Object {
+          "label": "Updated",
+          "sortKey": "last_update_time",
+        },
+      ]
+    }
+    defaultSortColumn="name"
+    defaultSortDirection="asc"
+    filterBox={
+      Object {
+        "exampleModifiers": Array [
+          "id",
+          "name",
+        ],
+        "itemToStringKeys": Array [
+          "name",
+          "id",
+          "subaccount_id",
+        ],
+        "show": true,
+      }
+    }
+    getRowData={[Function]}
+    pagination={true}
+    rows={
+      Array [
+        Object {
+          "name": "Temp 1",
+        },
+        Object {
+          "name": "Temp 2",
+        },
+      ]
+    }
+  />
+</Page>
+`;

--- a/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
@@ -73,6 +73,45 @@ exports[`renders loading error 1`] = `
 
 exports[`renders loading page and makes request for preview 1`] = `<Loading />`;
 
+exports[`renders preview page with read-only template 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "Component": [Function],
+      "content": "Back To Template",
+      "to": "/path/to/return",
+    }
+  }
+  empty={Object {}}
+  title="Test Template (Draft)"
+>
+  <Panel
+    sectioned={true}
+  >
+    <TextField
+      disabled={true}
+      label="From"
+      required={false}
+      resize="both"
+      type="text"
+      value="test@example.com"
+    />
+    <TextField
+      disabled={true}
+      label="Subject"
+      required={false}
+      resize="both"
+      type="text"
+      value="Test Template"
+    />
+    <PreviewPanel
+      html="<h1>Test Template</h1>"
+      text=""
+    />
+  </Panel>
+</Page>
+`;
+
 exports[`renders preview page with template 1`] = `
 <Page
   breadcrumbAction={

--- a/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
@@ -33,7 +33,7 @@ exports[`Template PublishedPage should render correctly 1`] = `
     >
       <Connect(Form)
         name="templatePublished"
-        published={true}
+        readOnly={true}
       />
     </Grid.Column>
     <Grid.Column
@@ -42,7 +42,7 @@ exports[`Template PublishedPage should render correctly 1`] = `
     >
       <LoadableComponent
         name="templatePublished"
-        published={true}
+        readOnly={true}
       />
     </Grid.Column>
   </Grid>

--- a/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
@@ -48,3 +48,52 @@ exports[`Template PublishedPage should render correctly 1`] = `
   </Grid>
 </Page>
 `;
+
+exports[`Template PublishedPage should render read-only correctly 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "Component": [Function],
+      "content": "Templates",
+      "to": "/templates",
+    }
+  }
+  empty={Object {}}
+  secondaryActions={
+    Array [
+      Object {
+        "Component": [Function],
+        "content": "View Draft",
+        "to": "/templates/edit/id",
+      },
+      Object {
+        "Component": [Function],
+        "content": "Preview",
+        "to": "/templates/preview/id/published",
+      },
+    ]
+  }
+  title="id (Published)"
+>
+  <Grid>
+    <Grid.Column
+      lg={4}
+      xs={12}
+    >
+      <Connect(Form)
+        name="templatePublished"
+        readOnly={true}
+      />
+    </Grid.Column>
+    <Grid.Column
+      lg={8}
+      xs={12}
+    >
+      <LoadableComponent
+        name="templatePublished"
+        readOnly={true}
+      />
+    </Grid.Column>
+  </Grid>
+</Page>
+`;

--- a/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
@@ -18,9 +18,8 @@ exports[`Template PublishedPage should render correctly 1`] = `
         "to": "/templates/edit/id",
       },
       Object {
-        "Component": [Function],
         "content": "Preview & Send",
-        "to": "/templates/preview/id/published",
+        "onClick": undefined,
       },
     ]
   }
@@ -67,9 +66,8 @@ exports[`Template PublishedPage should render read-only correctly 1`] = `
         "to": "/templates/edit/id",
       },
       Object {
-        "Component": [Function],
         "content": "Preview",
-        "to": "/templates/preview/id/published",
+        "onClick": undefined,
       },
     ]
   }


### PR DESCRIPTION
_Refer to [FAD-6126](https://jira.int.messagesystems.com/browse/FAD-6126)_

**Todo**
- [x] Visible template navigation link
- [x] Load template list page
- [x] Hide create template button on list page
- [x] Hide delete, duplicate, publish, and save buttons on edit page
- [x] Disabled form and editor for edit page (only needed for drafts, published are already disabled)
- [x] Hide send button and to field on preview page 
- [x] Save substitution data when click preview and send button
