### PR TITLE
FAD-6386 Legacy ccfree1 users can't update billing information

### DIFF
--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -1,10 +1,12 @@
 import { createSelector } from 'reselect';
 import _ from 'lodash';
+import { onPlan } from 'src/helpers/conditions/account';
 
 const suspendedSelector = (state) => state.account.isSuspendedForBilling;
 const pendingSubscriptionSelector = (state) => state.account.pending_subscription;
 const plansSelector = (state) => state.billing.plans || [];
 const accountBillingSelector = (state) => state.account.billing;
+const isFreeLegacyPlanSelector = (state) => onPlan('ccfree1')(state);
 
 export const currentSubscriptionSelector = (state) => state.account.subscription;
 
@@ -57,8 +59,10 @@ export const isAWSAccountSelector = createSelector(
  * Returns true if user has billing account and they are on a paid plan
  */
 export const canUpdateBillingInfoSelector = createSelector(
-  [currentPlanSelector, accountBillingSelector],
-  (currentPlan, accountBilling) => (accountBilling && !currentPlan.isFree)
+  [currentPlanSelector, accountBillingSelector, isFreeLegacyPlanSelector],
+  (currentPlan, accountBilling, isFreeLegacyPlan) => (
+    accountBilling && (isFreeLegacyPlan || !currentPlan.isFree)
+  )
 );
 
 /**

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -53,18 +53,34 @@ describe('Selector: current plan', () => {
 });
 
 describe('Selector: can update billing info', () => {
-  const state = {
-    account: { subscription: { code: 'qwe' }, billing: {}},
-    billing: {
-      plans: [
-        { status: 'public', code: '123' },
-        { status: 'public', code: 'qwe', isFree: false }
-      ]
-    }
-  };
+  let state;
+
+  beforeEach(() => {
+    state = {
+      account: { subscription: { code: 'paid' }, billing: {}},
+      billing: {
+        plans: [
+          { status: 'public', code: '123' },
+          { status: 'public', code: 'paid', isFree: false },
+          { status: 'public', code: 'free', isFree: true },
+          { status: 'public', code: 'ccfree1', isFree: true }
+        ]
+      }
+    };
+  });
 
   it('should return true if on paid plan', () => {
     expect(billingInfo.canUpdateBillingInfoSelector(state)).toEqual(true);
+  });
+
+  it('should return true if on free legacy plan', () => {
+    state.account.subscription.code = 'ccfree1';
+    expect(billingInfo.canUpdateBillingInfoSelector(state)).toEqual(true);
+  });
+
+  it('should return false if on free plan', () => {
+    state.account.subscription.code = 'free';
+    expect(billingInfo.canUpdateBillingInfoSelector(state)).toEqual(false);
   });
 });
 


### PR DESCRIPTION
**Test Cases**
- For ccfree1 account, confirm billing info is visible and can be updated
- For free account, confirm billing info is hidden
- For paid account, confirm billing info is visible and can be updated