### PR TITLE
updates readme to add npm start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ npm install npm@5 -g
 
 Then `npm install` to install deps.
 
-This will start a dev server backed by api.sparkpost.dev with live reload on http://localhost:3100/
+## Local development
+
+`npm start` will start a dev server backed by api.sparkpost.dev with live reload on http://localhost:3100/
 
 ## Tests
 


### PR DESCRIPTION
The readme said `npm install` will start a local dev server, but the command is actually `npm start` (if I'm reading the scripts right).