### PR TITLE
FAD-5564 Restricts editing API keys to owners only

### DIFF
--- a/src/components/collection/FilterBox.js
+++ b/src/components/collection/FilterBox.js
@@ -1,17 +1,21 @@
 import React from 'react';
 import { TextField, Icon } from '@sparkpost/matchbox';
+import _ from 'lodash';
 
-export default function CollectionFilterBox({ onChange, rows, exampleModifiers = Object.keys(rows[0]) }) {
+export default function CollectionFilterBox({ onChange, rows, exampleModifiers = Object.keys(rows[0]), keyMap = {}}) {
   function handleChange(e) {
     onChange(e.target.value);
   }
 
-  const first = exampleModifiers[0];
-  const second = exampleModifiers[1] || first;
-  const placeholder = `Filter results by ${exampleModifiers.slice(0, 3).join(', ')}, etc...`;
-  const helpText = <span>Advanced filtering: try using modifiers such as <strong>{first}:some-{first}</strong> or <strong>{second}:&#8220;some {second}&#8221;</strong></span>;
+  const exampleString = exampleModifiers.reduce((examples, modifier) => {
+    const realKey = keyMap[modifier] || modifier;
+    const rowWithValue = _.find(rows, realKey) || {};
+    const value = rowWithValue[realKey];
+    return [ ...examples, `${modifier}:${value}` ];
+  }, []).join(' ');
+  const placeholder = `Filter results e.g. ${exampleString}`;
 
   return (
-    <TextField prefix={<Icon name='Search' />} placeholder={placeholder} helpText={helpText} onChange={handleChange} />
+    <TextField prefix={<Icon name='Search' />} placeholder={placeholder} onChange={handleChange} />
   );
 }

--- a/src/pages/api-keys/DetailsPage.js
+++ b/src/pages/api-keys/DetailsPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link, withRouter } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { Page, Panel } from '@sparkpost/matchbox';
 
 import { deleteApiKey, getApiKey, updateApiKey, listGrants, listSubaccountGrants } from 'src/actions/api-keys';
@@ -61,10 +61,14 @@ export class ApiKeysDetailsPage extends Component {
   };
 
   render() {
-    const { apiKey, loading } = this.props;
+    const { apiKey, error, loading } = this.props;
 
     if (loading) {
       return <Loading />;
+    }
+
+    if (error) {
+      return <Redirect to='/account/api-keys' />;
     }
 
     return (
@@ -101,6 +105,4 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, { getApiKey, updateApiKey, listGrants, listSubaccountGrants, deleteApiKey, showAlert })(ApiKeysDetailsPage)
-);
+export default connect(mapStateToProps, { getApiKey, updateApiKey, listGrants, listSubaccountGrants, deleteApiKey, showAlert })(ApiKeysDetailsPage);

--- a/src/pages/api-keys/tableConfig.js
+++ b/src/pages/api-keys/tableConfig.js
@@ -1,6 +1,6 @@
 export const filterBoxConfig = {
   show: true,
-  keyMap: { name: 'label', key: 'short_key' },
+  keyMap: { name: 'label', key: 'short_key', owner: 'username' },
   itemToStringKeys: ['label', 'short_key', 'id'],
   exampleModifiers: ['key', 'name', 'id']
 };

--- a/src/pages/api-keys/tests/DetailsPage.test.js
+++ b/src/pages/api-keys/tests/DetailsPage.test.js
@@ -45,6 +45,11 @@ it('should render loading component while loading', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it('should render a redirect when an error is present', () => {
+  wrapper.setProps({ error: new Error('oops') });
+  expect(wrapper).toMatchSnapshot();
+});
+
 it('toggles modal', () => {
   expect(wrapper).toHaveState('showDeleteModal', false);
   wrapper.instance().onToggleDelete();

--- a/src/pages/api-keys/tests/ListPage.test.js
+++ b/src/pages/api-keys/tests/ListPage.test.js
@@ -12,19 +12,29 @@ describe('Api Keys List Page', () => {
     hideNewApiKey,
     listApiKeys,
     hasSubaccounts: false,
-    count: 30,
     keys: [
       {
         id: '123id',
         label: 'Test Key 1',
         short_key: 'ab01',
         grants: ['metrics/view'],
-        subaccount_id: 101
+        subaccount_id: 101,
+        isOwnedByCurrentUser: true
       },
       {
+        id: '456id',
         label: 'Test Key 2',
         short_key: 'fe98',
-        grants: ['smtp/inject']
+        grants: ['smtp/inject'],
+        isOwnedByCurrentUser: true
+      },
+      {
+        id: '789id',
+        label: 'Other User Key',
+        short_key: 'c00l',
+        grants: ['metrics/view'],
+        username: 'other_user',
+        isOwnedByCurrentUser: false
       }
     ]
   };
@@ -37,6 +47,15 @@ describe('Api Keys List Page', () => {
 
   it('renders correctly', () => {
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders when there are no keys', () => {
+    wrapper.setProps({ keys: []});
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('gets row data correctly', () => {
+    expect(props.keys.map(wrapper.instance().getRowData)).toMatchSnapshot();
   });
 
   it('renders errors when present', () => {

--- a/src/pages/api-keys/tests/__snapshots__/DetailsPage.test.js.snap
+++ b/src/pages/api-keys/tests/__snapshots__/DetailsPage.test.js.snap
@@ -39,4 +39,11 @@ exports[`renders correctly with no subaccounts 1`] = `
 </Page>
 `;
 
+exports[`should render a redirect when an error is present 1`] = `
+<Redirect
+  push={false}
+  to="/account/api-keys"
+/>
+`;
+
 exports[`should render loading component while loading 1`] = `<Loading />`;

--- a/src/pages/api-keys/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/api-keys/tests/__snapshots__/ListPage.test.js.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Api Keys List Page gets row data correctly 1`] = `
+Array [
+  Array [
+    <Link
+      replace={false}
+      to="/account/api-keys/details/123id?subaccount=101"
+    >
+      Test Key 1
+    </Link>,
+    <ShortKeyCode
+      shortKey="ab01"
+    />,
+  ],
+  Array [
+    <Link
+      replace={false}
+      to="/account/api-keys/details/456id"
+    >
+      Test Key 2
+    </Link>,
+    <ShortKeyCode
+      shortKey="fe98"
+    />,
+  ],
+  Array [
+    <span>
+      Other User Key
+      <br />
+      <small>
+        <Tooltip
+          bottom={true}
+          content="API keys are only editable by their owner"
+          dark={true}
+          forcePosition={false}
+          horizontalOffset="0px"
+          preferredDirection={
+            Object {
+              "bottom": true,
+              "left": false,
+              "right": true,
+              "top": false,
+            }
+          }
+          right={true}
+        >
+          (owner: 
+          other_user
+          ) 
+          <Icon
+            name="Info"
+            size={18}
+          />
+        </Tooltip>
+      </small>
+    </span>,
+    <ShortKeyCode
+      shortKey="c00l"
+    />,
+  ],
+]
+`;
+
 exports[`Api Keys List Page renders correctly 1`] = `
 <Page
   empty={
@@ -68,6 +130,7 @@ exports[`Api Keys List Page renders correctly 1`] = `
             "metrics/view",
           ],
           "id": "123id",
+          "isOwnedByCurrentUser": true,
           "label": "Test Key 1",
           "short_key": "ab01",
           "subaccount_id": 101,
@@ -76,8 +139,20 @@ exports[`Api Keys List Page renders correctly 1`] = `
           "grants": Array [
             "smtp/inject",
           ],
+          "id": "456id",
+          "isOwnedByCurrentUser": true,
           "label": "Test Key 2",
           "short_key": "fe98",
+        },
+        Object {
+          "grants": Array [
+            "metrics/view",
+          ],
+          "id": "789id",
+          "isOwnedByCurrentUser": false,
+          "label": "Other User Key",
+          "short_key": "c00l",
+          "username": "other_user",
         },
       ]
     }
@@ -114,6 +189,72 @@ exports[`Api Keys List Page renders errors when present 1`] = `
     errorDetails="Uh oh! It broke. "
     message="Sorry, we seem to have had some trouble loading your API keys."
     reload={[Function]}
+  />
+</Page>
+`;
+
+exports[`Api Keys List Page renders when there are no keys 1`] = `
+<Page
+  empty={
+    Object {
+      "content": <p>
+        Create an API key you can use to access our REST or SMTP API services.
+      </p>,
+      "image": "Setup",
+      "secondaryAction": Object {
+        "content": "View our API Docs",
+        "external": true,
+        "to": "https://developers.sparkpost.com/api",
+      },
+      "show": true,
+    }
+  }
+  primaryAction={
+    Object {
+      "Component": [Function],
+      "content": "Create API Key",
+      "to": "/account/api-keys/create",
+    }
+  }
+  title="API Keys"
+>
+  <TableCollection
+    columns={
+      Array [
+        Object {
+          "label": "Name",
+          "sortKey": "label",
+          "width": "40%",
+        },
+        Object {
+          "label": "Key",
+        },
+      ]
+    }
+    defaultSortColumn="label"
+    defaultSortDirection="desc"
+    filterBox={
+      Object {
+        "exampleModifiers": Array [
+          "key",
+          "name",
+          "id",
+        ],
+        "itemToStringKeys": Array [
+          "label",
+          "short_key",
+          "id",
+        ],
+        "keyMap": Object {
+          "key": "short_key",
+          "name": "label",
+        },
+        "show": true,
+      }
+    }
+    getRowData={[Function]}
+    pagination={true}
+    rows={Array []}
   />
 </Page>
 `;
@@ -228,6 +369,7 @@ exports[`Api Keys List Page should show api key banner on successful create 1`] 
             "metrics/view",
           ],
           "id": "123id",
+          "isOwnedByCurrentUser": true,
           "label": "Test Key 1",
           "short_key": "ab01",
           "subaccount_id": 101,
@@ -236,8 +378,20 @@ exports[`Api Keys List Page should show api key banner on successful create 1`] 
           "grants": Array [
             "smtp/inject",
           ],
+          "id": "456id",
+          "isOwnedByCurrentUser": true,
           "label": "Test Key 2",
           "short_key": "fe98",
+        },
+        Object {
+          "grants": Array [
+            "metrics/view",
+          ],
+          "id": "789id",
+          "isOwnedByCurrentUser": false,
+          "label": "Other User Key",
+          "short_key": "c00l",
+          "username": "other_user",
         },
       ]
     }

--- a/src/selectors/api-keys.js
+++ b/src/selectors/api-keys.js
@@ -10,6 +10,7 @@ const getSubaccountGrantsArray = (state) => state.apiKeys.subaccountGrants;
 export const selectApiKeyId = (props) => props.match.params.id;
 const getGrantsLoading = (state) => state.apiKeys.grantsLoading;
 const getSubaccountGrantsLoading = (state) => state.apiKeys.subaccountGrantsLoading;
+const getCurrentUsername = (state) => state.currentUser.username;
 
 // Convert grants array to an object keyed by `grant.key`
 export const getGrants = createSelector(getGrantsArray, (grants) =>
@@ -84,4 +85,9 @@ export const selectApiKeysForSending = createSelector(
 export const selectApiKeysForSmtp = createSelector(
   [getApiKeys],
   (apiKeys) => apiKeys.filter((key) => key.grants.includes('smtp/inject'))
+);
+
+export const selectKeysForAccount = createSelector(
+  [getApiKeys, getCurrentUsername],
+  (keys, currentUsername) => keys.map((key) => ({ ...key, isOwnedByCurrentUser: Boolean((key.username === currentUsername) || (!key.username && key.subaccount_id)) }))
 );

--- a/src/selectors/tests/__snapshots__/api-keys.test.js.snap
+++ b/src/selectors/tests/__snapshots__/api-keys.test.js.snap
@@ -70,3 +70,24 @@ Object {
   "sub grant two": false,
 }
 `;
+
+exports[`ApiKey Selectors should return a list of keys with ownership details 1`] = `
+Array [
+  Object {
+    "isOwnedByCurrentUser": true,
+    "username": "abc",
+  },
+  Object {
+    "isOwnedByCurrentUser": false,
+    "username": "other",
+  },
+  Object {
+    "isOwnedByCurrentUser": true,
+    "subaccount_id": 123,
+  },
+  Object {
+    "isOwnedByCurrentUser": false,
+    "lol": "wut",
+  },
+]
+`;

--- a/src/selectors/tests/api-keys.test.js
+++ b/src/selectors/tests/api-keys.test.js
@@ -112,4 +112,36 @@ describe('ApiKey Selectors', () => {
 
     expect(apiKeys.selectApiKeysForSending(store)).toMatchSnapshot();
   });
+
+  it('should return a list of keys with ownership details', () => {
+    const store = {
+      currentUser: {
+        username: 'abc'
+      },
+      apiKeys: {
+        keys: [
+          {
+            // same username
+            username: 'abc'
+          },
+          {
+            // different username
+            username: 'other'
+          },
+          {
+            // no username but has a subaccount_id
+            subaccount_id: 123
+          },
+          {
+            // no username and no subaccount_id (should never happen but should produce false if so)
+            lol: 'wut'
+          }
+        ]
+      }
+    };
+
+    const list = apiKeys.selectKeysForAccount(store);
+    expect(list.map((key) => key.isOwnedByCurrentUser)).toEqual([true, false, true, false]);
+    expect(list).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
![screen shot 2018-03-26 at 2 25 22 pm](https://user-images.githubusercontent.com/159370/37929210-5b9b9c08-310d-11e8-8a33-832faf56878b.png)

When a key belongs to another admin user on your account, the owner's name is shown and the label is no longer a link to the edit page.

![screen shot 2018-03-26 at 2 25 28 pm](https://user-images.githubusercontent.com/159370/37929235-71c96690-310d-11e8-85a3-ca20e2789c4d.png)

On hover, a tooltip describes why the label is not linked.

![screen shot 2018-03-26 at 3 51 36 pm](https://user-images.githubusercontent.com/159370/37929305-9eb9eeae-310d-11e8-91d7-d5787c6c3be7.png)

Attempting to visit the edit page for a key you don't own redirects you back to the list page with the red error alert.

---

*Added in here to improve the filterbox experience*

![screen shot 2018-03-26 at 3 48 48 pm](https://user-images.githubusercontent.com/159370/37929346-befd7316-310d-11e8-801c-cd7feba1bf12.png)

The existing FilterBox shows a placeholder _and_ help text, which is redundant. It also uses fake data like "some-id" and "some-key" instead of showing an example of real data. 

![screen shot 2018-03-26 at 3 42 31 pm](https://user-images.githubusercontent.com/159370/37929388-dec50268-310d-11e8-958e-21085d83b4ce.png)

This ticket removes the help text and improves the placeholder, adding the first value for each supplied key that it can find in the data set.