### PR TITLE
FAD-6423 Collect payments after updating payment info

### DIFF
--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -149,7 +149,6 @@ export function billingCreate(values) {
 
 /**
  * attempts to collect payments (like when payment method is updated) to make sure pending payments are charged
- * should suppress 400 from api as they are good here (means nothing to collect)
  */
 
 export function collectPayments() {

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -1,4 +1,4 @@
-/* eslint max-lines: ["error", 200] */
+/* eslint max-lines: ["error", 215] */
 import { formatDataForCors, formatCreateData, formatUpdateData, formatContactData } from 'src/helpers/billing';
 import { fetch as fetchAccount } from './account';
 import { list as getSendingIps } from './sendingIps';
@@ -147,6 +147,21 @@ export function billingCreate(values) {
   };
 }
 
+/**
+ * attempts to collect payments (like when payment method is updated) to make sure pending payments are charged
+ * should suppress 400 from api as they are good here (means nothing to collect)
+ */
+
+export function collectPayments() {
+  return sparkpostApiRequest({
+    type: 'COLLECT_PAYMENTS',
+    meta: {
+      method: 'POST',
+      url: '/account/billing/collect'
+    }
+  });
+}
+
 // note: this action creator should detect
 // 1. if payment info is present, contact zuora first
 // 2. otherwise it's just a call to our API + sync + refetch
@@ -174,6 +189,8 @@ export function billingUpdate(values) {
 
       // sync our db with new Zuora state
       .then(() => dispatch(syncSubscription()))
+
+      .then(() => dispatch(collectPayments()))
 
       // refetch the account
       .then(() => dispatch(fetchAccount({ include: 'usage,billing' })));

--- a/src/actions/tests/__snapshots__/billing.test.js.snap
+++ b/src/actions/tests/__snapshots__/billing.test.js.snap
@@ -46,6 +46,16 @@ Array [
 ]
 `;
 
+exports[`Action Creator: Billing collectPayments dispatches a collection action 1`] = `
+Object {
+  "meta": Object {
+    "method": "POST",
+    "url": "/account/billing/collect",
+  },
+  "type": "COLLECT_PAYMENTS",
+}
+`;
+
 exports[`Action Creator: Billing should dispatch a chained billing create action 1`] = `
 Array [
   Object {
@@ -155,6 +165,13 @@ Array [
       "url": "/account/subscription/check",
     },
     "type": "SYNC_SUBSCRIPTION",
+  },
+  Object {
+    "meta": Object {
+      "method": "POST",
+      "url": "/account/billing/collect",
+    },
+    "type": "COLLECT_PAYMENTS",
   },
   Object {
     "meta": Object {

--- a/src/actions/tests/billing.test.js
+++ b/src/actions/tests/billing.test.js
@@ -139,4 +139,11 @@ describe('Action Creator: Billing', () => {
     });
   });
 
+  describe('collectPayments', () => {
+    it('dispatches a collection action', async() => {
+      expect(billing.collectPayments()).toMatchSnapshot();
+    });
+
+  });
+
 });


### PR DESCRIPTION
How to test:
- Go to /billing; open your console
- Click `Update Payment Information`
- Put the new credit card info
- Submit the form. You should see a request to `/collect` endpoint


Notes:
- Contrary to what ticket said, seems api doesn't respond with 400 when nothing to be collected. Seems API now responds a 200 with a description. [See](https://github.com/SparkPost/accusers-api/blob/master/api/resources/account-controller.js#L878-L880)
- [Test credit cards](https://developer.merchante-solutions.com/#/payment-gateway-testing#validation)