### PR TITLE
FAD-6286: fixes

### DIFF
--- a/src/components/cookieConsent/CookieConsent.js
+++ b/src/components/cookieConsent/CookieConsent.js
@@ -40,11 +40,7 @@ export class CookieConsent extends React.Component {
   }
 
   render() {
-    const { accessControlReady, consentGiven } = this.props;
-
-    if (!accessControlReady) {
-      return null;
-    }
+    const { consentGiven } = this.props;
 
     if (consentGiven) {
       return null;

--- a/src/components/cookieConsent/tests/CookieConsent.test.js
+++ b/src/components/cookieConsent/tests/CookieConsent.test.js
@@ -21,11 +21,6 @@ describe('Component: CookieConsent', () => {
     wrapper = shallow(<CookieConsent {...props} />);
   });
 
-  it('should not render until access control is ready', () => {
-    wrapper.setProps({ accessControlReady: false });
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('should render the banner without consent', () => {
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
+++ b/src/components/cookieConsent/tests/__snapshots__/CookieConsent.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Component: CookieConsent should not render the banner with consent 1`] = `""`;
 
-exports[`Component: CookieConsent should not render until access control is ready 1`] = `""`;
-
 exports[`Component: CookieConsent should render the banner without consent 1`] = `
 <Component
   onDismiss={[Function]}

--- a/src/reducers/cookieConsent.js
+++ b/src/reducers/cookieConsent.js
@@ -9,6 +9,9 @@ export default (state = initialState, { type, payload }) => {
     case 'GIVE_COOKIE_CONSENT':
       return { ...state, cookieSet: true };
 
+    case 'LOGOUT':
+      return { ...state, cookieSet: helpers.isCookieSet() };
+
     default:
       return state;
   }


### PR DESCRIPTION
 - Show the banner before `state.accessControlReady` since we want to show it on `/auth` and `/join`
 - Reinstate `state.cookieConsent.cookieSet` from the cookie on `LOGOUT` to avoid showing the banner to a consenting user after logout
- [x] tests