### PR TITLE
FAD-6389: Allow saving to CSV on collections smaller than 1 page

### DIFF
--- a/src/components/collection/Pagination.js
+++ b/src/components/collection/Pagination.js
@@ -17,14 +17,13 @@ class CollectionPagination extends Component {
   }
 
   renderCSVSave() {
-    const { saveCsv, data, perPageButtons } = this.props;
-
-    // do not show save as csv if only 1 page of smallest per page increment
-    if (!saveCsv || data.length <= Math.min(...perPageButtons)) { return null; }
-
     const now = Math.floor(Date.now() / 1000);
-    return <Button download={`sparkpost-csv-${now}.csv`} to={this.formatToCsv()}>Save As CSV</Button>;
 
+    if (!this.props.saveCsv) {
+      return null;
+    }
+
+    return <Button download={`sparkpost-csv-${now}.csv`} to={this.formatToCsv()}>Save As CSV</Button>;
   }
 
   renderPageButtons() {

--- a/src/components/collection/tests/__snapshots__/Pagination.test.js.snap
+++ b/src/components/collection/tests/__snapshots__/Pagination.test.js.snap
@@ -3,7 +3,15 @@
 exports[`Collection Pagination Component should hide pagination if data is less than per page 1`] = `
 <div>
   <div />
-  <div />
+  <div>
+    <Button
+      download="sparkpost-csv-1512509841.csv"
+      size="default"
+      to="data:text/csv;charset=utf-8,mydata"
+    >
+      Save As CSV
+    </Button>
+  </div>
 </div>
 `;
 
@@ -134,6 +142,14 @@ exports[`Collection Pagination Component should render without perPageButtons 1`
       pages={3}
     />
   </div>
-  <div />
+  <div>
+    <Button
+      download="sparkpost-csv-1512509841.csv"
+      size="default"
+      to="data:text/csv;charset=utf-8,mydata"
+    >
+      Save As CSV
+    </Button>
+  </div>
 </div>
 `;


### PR DESCRIPTION
_Refer to [FAD-6389](https://jira.int.messagesystems.com/browse/FAD-6389) for AC._

<img width="1386" alt="screen shot 2018-03-30 at 2 11 11 pm" src="https://user-images.githubusercontent.com/1335605/38148373-3d7e0b88-3424-11e8-9f48-7536698835bc.png">

**What to test?**
- The "Save as CSV" button is always visible at the bottom of the table collection.
- The table collection itself is not visible when there are no results.