### PR TITLE
FAD-6462: Suppress Sentry errors from Chrome and Firefox extensions

### DIFF
--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -74,6 +74,10 @@ class ErrorTracker {
     const options = {
       breadcrumbCallback,
       dataCallback: getEnricherOrDieTryin(store),
+      ignoreUrls: [
+        /^chrome-extension:\/\//i,
+        /^chrome:\/\//i
+      ],
       release,
       tags: { tenant }
     };

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -21,6 +21,9 @@ const BLACKLIST = new Set([
   '@@redux-form/SET_SUBMIT_FAILED'
 ]);
 
+// Chrome and Firefox extensions
+export const BROWSER_EXTENSION_REGEX = new RegExp('^(chrome|chrome-extension|resource)://', 'i');
+
 /**
  * Filter out blacklisted breadcrumbs
  *
@@ -75,8 +78,7 @@ class ErrorTracker {
       breadcrumbCallback,
       dataCallback: getEnricherOrDieTryin(store),
       ignoreUrls: [
-        /^chrome-extension:\/\//i,
-        /^chrome:\/\//i
+        BROWSER_EXTENSION_REGEX
       ],
       release,
       tags: { tenant }

--- a/src/helpers/tests/errorTracker.test.js
+++ b/src/helpers/tests/errorTracker.test.js
@@ -1,4 +1,6 @@
-import ErrorTracker, { breadcrumbCallback, getEnricherOrDieTryin } from '../errorTracker';
+import ErrorTracker, {
+  breadcrumbCallback, getEnricherOrDieTryin, BROWSER_EXTENSION_REGEX
+} from '../errorTracker';
 import * as mockRaven from 'raven-js';
 
 jest.mock('raven-js');
@@ -90,5 +92,19 @@ describe('.report', () => {
     isSetup.mockReturnValue(true);
     ErrorTracker.report('test-logger', error);
     expect(captureException).toHaveBeenCalledWith(error, { logger: 'test-logger' });
+  });
+});
+
+describe('BROWSER_EXTENSION_REGEX', () => {
+  it('should match Chrome files', () => {
+    expect('chrome://example/test.js').toMatch(BROWSER_EXTENSION_REGEX);
+  });
+
+  it('should match Chrome extension files', () => {
+    expect('chrome-extension://example/test.js').toMatch(BROWSER_EXTENSION_REGEX);
+  });
+
+  it('should match Firefox extension files', () => {
+    expect('resource://example/test.js').toMatch(BROWSER_EXTENSION_REGEX);
   });
 });


### PR DESCRIPTION
I used [Ferdinand](https://gist.github.com/bkemper/4c1e9a87f4b0b921711ea6791c265cc0) to test.