### PR TITLE
FAD-6475 Message events reports filter does not handle + in email addresses properly

### DIFF
--- a/src/pages/reports/components/ShareModal.js
+++ b/src/pages/reports/components/ShareModal.js
@@ -26,7 +26,7 @@ export class ShareModal extends Component {
 
   updateLink = () => {
     const { searchOptions, history, location } = this.props;
-    const search = qs.stringify(searchOptions, { encode: false });
+    const search = qs.stringify(searchOptions);
 
     history.replace({ pathname: location.pathname, search });
   }
@@ -45,7 +45,7 @@ export class ShareModal extends Component {
       delete modifiedQuery.to;
     }
 
-    const search = qs.stringify(modifiedQuery, { encode: false });
+    const search = qs.stringify(modifiedQuery);
     const url = window.location.href.split('?')[0];
 
     return `${url}?${search}`;

--- a/src/pages/reports/components/tests/ShareModal.test.js
+++ b/src/pages/reports/components/tests/ShareModal.test.js
@@ -18,7 +18,8 @@ describe('Component: ShareModal', () => {
     testProps = {
       handleToggle: jest.fn(),
       searchOptions: {
-        range: 'valid'
+        range: 'valid',
+        recipients: ['one@test.com', 'two+2@test.com']
       },
       location: {
         pathname: '/route'
@@ -32,7 +33,10 @@ describe('Component: ShareModal', () => {
 
   it('should render correctly when not open', () => {
     expect(wrapper.find('Modal').props().open).toBe(false);
-    expect(testProps.history.replace).toHaveBeenCalledWith({ pathname: '/route', search: 'range=valid' });
+    expect(testProps.history.replace).toHaveBeenCalledWith({
+      pathname: '/route',
+      search: 'range=valid&recipients=one%40test.com&recipients=two%2B2%40test.com'
+    });
   });
 
   it('updates the link if options are changed', () => {
@@ -53,10 +57,10 @@ describe('Component: ShareModal', () => {
 
   it('should unpin when clicking the checkbox', () => {
     expect(wrapper.state('pinned')).toEqual(true);
-    expect(wrapper.find('CopyField').props().value).toEqual('http://phoenix.test/?range=custom');
+    expect(wrapper.find('CopyField').props().value).toMatchSnapshot();
     wrapper.find('#pin-relative-link').simulate('change');
     expect(wrapper.state('pinned')).toEqual(false);
-    expect(wrapper.find('CopyField').props().value).toEqual('http://phoenix.test/?range=valid');
+    expect(wrapper.find('CopyField').props().value).toMatchSnapshot();
   });
 
   it('should handle keydown events correctly', () => {

--- a/src/pages/reports/components/tests/__snapshots__/ShareModal.test.js.snap
+++ b/src/pages/reports/components/tests/__snapshots__/ShareModal.test.js.snap
@@ -23,7 +23,7 @@ exports[`Component: ShareModal should render correctly when open 1`] = `
       <Panel.Section>
         <CopyField
           hideCopy={false}
-          value="http://phoenix.test/?range=custom"
+          value="http://phoenix.test/?range=custom&recipients=one%40test.com&recipients=two%2B2%40test.com"
         />
         <Checkbox
           checked={true}
@@ -71,7 +71,7 @@ exports[`Component: ShareModal should render with a valid relative range 1`] = `
       <Panel.Section>
         <CopyField
           hideCopy={false}
-          value="http://phoenix.test/?range=custom"
+          value="http://phoenix.test/?range=custom&recipients=one%40test.com&recipients=two%2B2%40test.com"
         />
         <Checkbox
           checked={true}
@@ -99,3 +99,7 @@ exports[`Component: ShareModal should render with a valid relative range 1`] = `
   </Modal>
 </React.Fragment>
 `;
+
+exports[`Component: ShareModal should unpin when clicking the checkbox 1`] = `"http://phoenix.test/?range=custom&recipients=one%40test.com&recipients=two%2B2%40test.com"`;
+
+exports[`Component: ShareModal should unpin when clicking the checkbox 2`] = `"http://phoenix.test/?range=valid&recipients=one%40test.com&recipients=two%2B2%40test.com"`;


### PR DESCRIPTION
To verify:
- Go to message events list
- Add an email to recipients filter with a `+`, like `1+2@test.com`
- Refresh
- Check that the active filter and request does not replace the + with a space between 1 and 2