### PR TITLE
FAD-6279 Fix error screen css

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -87,13 +87,14 @@
 
     <!-- Error screen -->
     <div id="error">
-      <svg class='logo__icon' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.5 260">
-        <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
-      </svg>
-      <h3>Oh no, SparkPost is having trouble loading.</h3>
-      <p>Please <a id='reloadLink'>try again</a> soon.</p>
-      <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
-
+      <div class="content">
+        <svg class='logo__icon' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.5 260">
+          <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
+        </svg>
+        <h3>Oh no, SparkPost is having trouble loading.</h3>
+        <p>Please <a id='reloadLink'>try again</a> soon.</p>
+        <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
+      </div>
       <script type="text/javascript">
         var reloadLink = document.getElementById('reloadLink');
         reloadLink.href = window.location.href;

--- a/public/index.html
+++ b/public/index.html
@@ -44,9 +44,9 @@
       }
 
       function handleAppLoad() {
-        document.getElementById('loading').className += ' ready'; // Kills loading screen
+        document.getElementById('loading').className += 'ready'; // Kills loading screen
         if (!window.SPARKPOST_LOADED) {
-          document.getElementById('error').className += ' show';
+          document.getElementById('error').className += 'show';
           var sentry = document.createElement('script');
           sentry.src = 'https://cdn.ravenjs.com/3.24.0/raven.min.js';
           sentry.onload = trackAppLoadError;

--- a/src/critical.scss
+++ b/src/critical.scss
@@ -58,17 +58,25 @@ html {
 
 #error {
   display: none;
-  position: absolute;
-  top: 50%;
+  position: fixed;
+  top: 0;
   left: 0;
-  right: 0;
-  padding: 0 spacing();
-  transform: translate(0, -50%);
+  width: 100vw;
+  height: 100vh;
 
-  text-align: center;
   font-family: -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, “Fira Sans”, “Droid Sans”, “Helvetica Neue”, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  .content {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    padding: 0 spacing();
+    transform: translate(0, -50%);
+    text-align: center;
+  }
 
   h3 {
     color: color(gray, 2);

--- a/src/critical.scss
+++ b/src/critical.scss
@@ -86,6 +86,10 @@ html {
     color: color(gray, 3);
   }
 
+  a, a:visited {
+    text-decoration: underline;
+  }
+
   &.show {
     display: block;
   }


### PR DESCRIPTION
Edit:
The styles seemed to break on `tst` because the main app styles still loaded while we were blocking only the main js bundle. This doesn't happen when running webpack locally because blocking bundle also means blocking css. `position: relative` was being added to `html`.

This pr will make sure `#error` works regardless of what other styles are loaded.

How I verified the build -
```
npm run build
cd build
php -S localhost:5000
```