### PR TITLE
FAD-6500 sends country with card info for AVS rule decision in gateway

### DIFF
--- a/src/helpers/billing.js
+++ b/src/helpers/billing.js
@@ -42,7 +42,8 @@ export function formatDataForCors(values) {
         zipCode: billingAddress.zip,
         addressLine1: null,
         addressLine2: null,
-        city: null
+        city: null,
+        country: billingAddress.country // must send country so gateway knows which AVS rules to apply
       }
     }
   };

--- a/src/helpers/tests/__snapshots__/billing.test.js.snap
+++ b/src/helpers/tests/__snapshots__/billing.test.js.snap
@@ -55,6 +55,50 @@ Array [
 ]
 `;
 
+exports[`Billing Helpers formatDataForCors should return the correctly formatted values 1`] = `
+Object {
+  "billingData": Object {
+    "billToContact": Object {
+      "country": "US",
+      "firstName": "Person",
+      "lastName": "Head",
+      "state": "MD",
+      "workEmail": "someemail@example.com",
+      "zipCode": "21234",
+    },
+    "billingId": "testBillingId135",
+    "creditCard": Object {
+      "cardHolderInfo": Object {
+        "addressLine1": null,
+        "addressLine2": null,
+        "cardHolderName": "Person Face",
+        "city": null,
+        "country": "US",
+        "zipCode": "21234",
+      },
+      "cardNumber": "4123512361237123",
+      "cardType": "CardType",
+      "expirationMonth": 4,
+      "expirationYear": 2050,
+      "securityCode": 123,
+    },
+  },
+  "corsData": Object {
+    "address1": null,
+    "address2": null,
+    "bin": "412351",
+    "cardholder_name": "Person Face",
+    "city": null,
+    "country": "US",
+    "email": "someemail@example.com",
+    "last_four": "7123",
+    "plan_id": "testBillingId135",
+    "state": "MD",
+    "zip_code": "21234",
+  },
+}
+`;
+
 exports[`Billing Helpers getPlanPrice returns price info correctly for hourly plan 1`] = `
 Object {
   "intervalLong": "hourly",

--- a/src/helpers/tests/billing.test.js
+++ b/src/helpers/tests/billing.test.js
@@ -1,6 +1,46 @@
-import { formatCountries, formatCardTypes, getPlanPrice } from '../billing';
+import {
+  formatCountries,
+  formatCardTypes,
+  formatDataForCors,
+  getPlanPrice
+} from '../billing';
 
 describe('Billing Helpers', () => {
+
+  describe('formatDataForCors', () => {
+    const card = {
+      number: '4123512361237123',
+      name: 'Person Face',
+      type: 'CardType',
+      expMonth: 4,
+      expYear: 2050,
+      securityCode: 123
+    };
+    const billingAddress = {
+      state: 'MD',
+      country: 'US',
+      zip: '21234',
+      firstName: 'Person',
+      lastName: 'Head'
+    };
+    const planpicker = {
+      billingId: 'testBillingId135'
+    };
+    const values = {
+      email: 'someemail@example.com',
+      planpicker,
+      card,
+      billingAddress
+    };
+
+    it('should return the correctly formatted values', () => {
+      const formatted = formatDataForCors(values);
+      expect(formatted).toMatchSnapshot();
+      // country is especially important here for AVS, see FAD-6500
+      expect(formatted.billingData.creditCard.cardHolderInfo.country).toEqual('US');
+    });
+  });
+
   describe('formatCountries', () => {
     const countries = [
       { code: 'GG', name: 'gg' },


### PR DESCRIPTION
To test this, we can use the Braintree payment gateway AVS test data seen here:
https://developers.braintreepayments.com/reference/general/testing/node#avs-postal-code-responses

Specifically, that means using the postal code `20000` which will auto-trigger an `'N'` AVS response. In Braintree, we have it configured so that the `'N'` AVS response fails a transaction for a US-based card but is ignored for any other non-US card. So to test:

1. Sign up for a new account and upgrade from free to paid (in the onboarding flow or from the billing page after sign up, both ways should use the same exact code paths)
1. While upgrading, first use country: `United States`, zip/postal: `20000`
1. Observe the AVS failure in the red error bar (see screenshot)
1. Next, use country `United Kingdom`, zip/postal: `20000`
1. In UAT/or in master/develop, this will _also_ fail with the same AVS failure
1. In this branch, this will succeed for any country that isn't "United States"

I also added a test for this `formatDataForCors` method.

AVS error you will see:
![screen shot red 2018-04-09 at 4 05 02 pm](https://user-images.githubusercontent.com/159370/38522375-5c014184-3c16-11e8-88f9-7ff2c2628821.png)

