### PR TITLE
FAD-6437 Don't log out on 403s, force logout terminated customers

### DIFF
--- a/src/actions/helpers/tests/__snapshots__/sparkpostApiRequest.test.js.snap
+++ b/src/actions/helpers/tests/__snapshots__/sparkpostApiRequest.test.js.snap
@@ -12,20 +12,26 @@ Array [
   Object {
     "type": "LOGOUT",
   },
-]
-`;
-
-exports[`Helper: SparkPost API Request failure cases should dispatch a logout action on a 403 response 1`] = `
-Array [
   Object {
     "meta": Object {
       "method": "GET",
       "url": "/some/path",
     },
-    "type": "TEST_PENDING",
+    "payload": Object {
+      "message": "API call failed",
+      "response": Object {
+        "data": Object {
+          "results": Array [],
+        },
+        "status": 401,
+      },
+    },
+    "type": "TEST_FAIL",
   },
   Object {
-    "type": "LOGOUT",
+    "details": "API call failed",
+    "message": "Something went wrong.",
+    "type": "error",
   },
 ]
 `;
@@ -51,6 +57,42 @@ Array [
           "results": Array [],
         },
         "status": 500,
+      },
+    },
+    "type": "TEST_FAIL",
+  },
+  Object {
+    "details": "API call failed",
+    "message": "Something went wrong.",
+    "type": "error",
+  },
+]
+`;
+
+exports[`Helper: SparkPost API Request failure cases should fetch account on a 403 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "url": "/some/path",
+    },
+    "type": "TEST_PENDING",
+  },
+  Object {
+    "type": "FETCH_ACCOUNT",
+  },
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "url": "/some/path",
+    },
+    "payload": Object {
+      "message": "API call failed",
+      "response": Object {
+        "data": Object {
+          "results": Array [],
+        },
+        "status": 403,
       },
     },
     "type": "TEST_FAIL",
@@ -92,39 +134,6 @@ Array [
     "details": "API call failed",
     "message": "Something went wrong.",
     "type": "error",
-  },
-]
-`;
-
-exports[`Helper: SparkPost API Request failure cases should log out on 403 when account status is unknown 1`] = `
-Array [
-  Object {
-    "meta": Object {
-      "method": "GET",
-      "url": "/some/path",
-    },
-    "type": "TEST_PENDING",
-  },
-  Object {
-    "type": "LOGOUT",
-  },
-]
-`;
-
-exports[`Helper: SparkPost API Request failure cases should not log out on a 403 while suspended 1`] = `
-Array [
-  Object {
-    "meta": Object {
-      "method": "GET",
-      "url": "/some/path",
-    },
-    "type": "TEST_PENDING",
-  },
-  Object {
-    "type": "SHOW_SUSPENSION_ALERT",
-  },
-  Object {
-    "type": "FETCH_ACCOUNT",
   },
 ]
 `;
@@ -260,6 +269,26 @@ Array [
   Object {
     "type": "LOGOUT",
   },
+  Object {
+    "meta": Object {
+      "retries": 3,
+    },
+    "payload": Object {
+      "message": "API call failed",
+      "response": Object {
+        "data": Object {
+          "results": Array [],
+        },
+        "status": 401,
+      },
+    },
+    "type": "TEST_MAX_RETRIES_FAIL",
+  },
+  Object {
+    "details": "API call failed",
+    "message": "Something went wrong.",
+    "type": "error",
+  },
 ]
 `;
 
@@ -294,6 +323,26 @@ Array [
   },
   Object {
     "type": "LOGOUT",
+  },
+  Object {
+    "meta": Object {
+      "retries": 3,
+    },
+    "payload": Object {
+      "message": "API call failed",
+      "response": Object {
+        "data": Object {
+          "results": Array [],
+        },
+        "status": 401,
+      },
+    },
+    "type": "TEST_ONE_RETRY_PER_TOKEN_FAIL",
+  },
+  Object {
+    "details": "API call failed",
+    "message": "Something went wrong.",
+    "type": "error",
   },
 ]
 `;

--- a/src/actions/helpers/tests/sparkpostApiRequest.test.js
+++ b/src/actions/helpers/tests/sparkpostApiRequest.test.js
@@ -37,7 +37,6 @@ describe('Helper: SparkPost API Request', () => {
 
     axiosMocks.sparkpost.mockImplementation(() => Promise.resolve({ data: { results }}));
     globalAlertMock.showAlert = jest.fn(() => ({ type: 'SHOW_ALERT' }));
-    globalAlertMock.showSuspensionAlert = jest.fn(() => ({ type: 'SHOW_SUSPENSION_ALERT' }));
     accountActions.fetch = jest.fn(() => ({ type: 'FETCH_ACCOUNT' }));
   });
 
@@ -103,41 +102,14 @@ describe('Helper: SparkPost API Request', () => {
       expect(mockStore.getActions()).toMatchSnapshot();
     });
 
-    it('should dispatch a logout action on a 403 response', async() => {
+    it('should fetch account on a 403', async() => {
       apiErr.response.status = 403;
-
-      await expect(mockStore.dispatch(sparkpostApiRequest(action))).rejects.toThrow(apiErr);
-      expect(authMock.logout).toHaveBeenCalledTimes(1);
-      expect(mockStore.getActions()).toMatchSnapshot();
-    });
-
-    it('should not log out on a 403 while suspended', async() => {
-      jest.spyOn(globalAlertMock, 'showSuspensionAlert');
-      apiErr.response.status = 403;
-      state.account.status = 'suspended';
-      expect(globalAlertMock.showSuspensionAlert).not.toHaveBeenCalled();
       try {
         await mockStore.dispatch(sparkpostApiRequest(action));
       } catch (err) {
         expect(err).toEqual(apiErr);
         expect(authMock.logout).not.toHaveBeenCalled();
-        expect(globalAlertMock.showSuspensionAlert).toHaveBeenCalledTimes(1);
         expect(accountActions.fetch).toHaveBeenCalledTimes(1);
-        expect(mockStore.getActions()).toMatchSnapshot();
-      }
-    });
-
-    it('should log out on 403 when account status is unknown', async() => {
-      jest.spyOn(globalAlertMock, 'showSuspensionAlert');
-      apiErr.response.status = 403;
-      delete state.account.status;
-      expect(globalAlertMock.showSuspensionAlert).not.toHaveBeenCalled();
-      try {
-        await mockStore.dispatch(sparkpostApiRequest(action));
-      } catch (err) {
-        expect(err).toEqual(apiErr);
-        expect(authMock.logout).toHaveBeenCalled();
-        expect(globalAlertMock.showSuspensionAlert).not.toHaveBeenCalled();
         expect(mockStore.getActions()).toMatchSnapshot();
       }
     });

--- a/src/components/auth/AuthenticationGate.js
+++ b/src/components/auth/AuthenticationGate.js
@@ -4,6 +4,8 @@ import { withRouter } from 'react-router-dom';
 import authCookie from 'src/helpers/authCookie';
 import { login } from 'src/actions/auth';
 import { getGrantsFromCookie } from 'src/actions/currentUser';
+import { showSuspensionAlert } from 'src/actions/globalAlert';
+import { logout } from 'src/actions/auth';
 
 export class AuthenticationGate extends Component {
   componentWillMount() {
@@ -20,10 +22,18 @@ export class AuthenticationGate extends Component {
   }
 
   componentDidUpdate(oldProps) {
-    const { auth, history, location = {}} = this.props;
+    const { account, auth, history, location = {}, showSuspensionAlert, logout } = this.props;
     // if logging out
     if (location.pathname !== '/auth' && oldProps.auth.loggedIn && !auth.loggedIn) {
       history.push('/auth');
+    }
+
+    if (oldProps.account.status !== 'terminated' && account.status === 'terminated') {
+      logout();
+    }
+
+    if (oldProps.account.status !== 'suspended' && account.status === 'suspended') {
+      showSuspensionAlert({ autoDismiss: false });
     }
   }
 
@@ -32,4 +42,4 @@ export class AuthenticationGate extends Component {
   }
 }
 
-export default withRouter(connect(({ auth }) => ({ auth }), { login, getGrantsFromCookie })(AuthenticationGate));
+export default withRouter(connect(({ auth, account }) => ({ auth, account }), { login, logout, getGrantsFromCookie, showSuspensionAlert })(AuthenticationGate));

--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -2,16 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Redirect, Route } from 'react-router-dom';
 import { AccessControl } from 'src/components/auth';
-import { showSuspensionAlert } from 'src/actions/globalAlert';
 import _ from 'lodash';
 
 export class ProtectedRoute extends Component {
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.accountStatus !== 'suspended' && this.props.accountStatus === 'suspended') {
-      this.props.showSuspensionAlert({ autoDismiss: false });
-    }
-  }
 
   renderComponent(reactRouterProps) {
     const { component: Component, condition } = this.props;
@@ -42,4 +35,4 @@ const mapStateToProps = ({ auth, account }) => ({
   auth,
   accountStatus: account.status
 });
-export default connect(mapStateToProps, { showSuspensionAlert })(ProtectedRoute);
+export default connect(mapStateToProps, {})(ProtectedRoute);

--- a/src/components/auth/tests/AuthenticationGate.test.js
+++ b/src/components/auth/tests/AuthenticationGate.test.js
@@ -20,11 +20,16 @@ describe('Component: AuthenticationGate', () => {
         token: null,
         loggedIn: false
       },
+      account: {
+        status: 'active'
+      },
       login: jest.fn(),
       getGrantsFromCookie: jest.fn(),
       history: {
         push: jest.fn()
-      }
+      },
+      logout: jest.fn(),
+      showSuspensionAlert: jest.fn()
     };
 
     wrapper = shallow(<AuthenticationGate {...props} />);
@@ -70,14 +75,26 @@ describe('Component: AuthenticationGate', () => {
   describe('componentDidUpdate', () => {
     it('should redirect to auth on logout', () => {
       wrapper.setProps({ location: { pathname: '/report/summary' }, auth: { loggedIn: false }});
-      wrapper.instance().componentDidUpdate({ auth: { loggedIn: true }});
+      wrapper.instance().componentDidUpdate({ account: {}, auth: { loggedIn: true }});
       expect(wrapper.instance().props.history.push).toHaveBeenCalledWith('/auth');
     });
 
     it('should do nothing you aren\'t on auth and logged in', () => {
       wrapper.setProps({ location: { pathname: '/report/summary' }, auth: { loggedIn: true }});
-      wrapper.instance().componentDidUpdate({ auth: { loggedIn: true }});
+      wrapper.instance().componentDidUpdate({ account: {}, auth: { loggedIn: true }});
       expect(wrapper.instance().props.history.push).not.toHaveBeenCalled();
+    });
+
+    it('should dispatch a logout action if account terminated', async() => {
+      wrapper.setProps({ account: { status: 'terminated' }});
+      wrapper.instance().componentDidUpdate({ account: { status: 'active' }, auth: {}});
+      expect(wrapper.instance().props.logout).toHaveBeenCalled();
+    });
+
+    it('should show suspension alert if account suspended', async() => {
+      wrapper.setProps({ account: { status: 'suspended' }});
+      wrapper.instance().componentDidUpdate({ account: { status: 'active' }, auth: {}});
+      expect(wrapper.instance().props.showSuspensionAlert).toHaveBeenCalledWith({ autoDismiss: false });
     });
   });
 });


### PR DESCRIPTION
Functionally, the only differences here should be the following:
1) A user should no longer be immediately logged out on any 403
2) A user will see a one-time dismissible suspended account alert if their account status changes to 'suspended' at anytime, including initial login and page refresh. Account status is fetched after any 403 (usually from PUT, POST, or DELETE requests).
3) The generic error alert will display the error (e.g. 'Forbidden' if caused by suspension) if a request returns a 401 or 403.
4) All 401's result in a logout (unless it's a token refresh)