### PR TITLE
FAD-6476 Subaccount Default tag for sending domains, plus bugfix

### DIFF
--- a/src/components/domainStatus/DomainStatusCell.js
+++ b/src/components/domainStatus/DomainStatusCell.js
@@ -4,14 +4,14 @@ import ReadyFor from './ReadyFor';
 import { resolveStatus, resolveReadyFor } from 'src/helpers/domains';
 
 const DomainStatusCell = ({ domain }) => {
-  const { status, is_default_bounce_domain } = domain;
+  const { status, is_default_bounce_domain, subaccount_id } = domain;
   const domainStatus = resolveStatus(status);
 
   if (domainStatus !== 'verified') {
     return <DomainStatusTag status={domainStatus} />;
   }
 
-  return <ReadyFor {...resolveReadyFor(status)} bounceDefault={is_default_bounce_domain} />;
+  return <ReadyFor {...resolveReadyFor(status)} bounceDefault={is_default_bounce_domain} subaccount={subaccount_id} />;
 
 };
 

--- a/src/components/domainStatus/ReadyFor.js
+++ b/src/components/domainStatus/ReadyFor.js
@@ -4,7 +4,7 @@ import { Tag } from '@sparkpost/matchbox';
 
 import styles from './ReadyFor.module.scss';
 
-const ReadyFor = ({ bounce, dkim, sending, bounceDefault }) => {
+const ReadyFor = ({ bounce, dkim, sending, bounceDefault, subaccount }) => {
   let bounceMarkup = null;
 
   if (!bounce && !dkim && !sending) {
@@ -13,7 +13,7 @@ const ReadyFor = ({ bounce, dkim, sending, bounceDefault }) => {
 
   if (bounce) {
     bounceMarkup = bounceDefault
-      ? <Tag color='orange'>Bounce (Default)</Tag>
+      ? <Tag color='orange'>Bounce ({subaccount ? 'Subaccount ' : '' }Default)</Tag>
       : <Tag>Bounce</Tag>;
   }
 

--- a/src/components/domainStatus/tests/ReadyFor.test.js
+++ b/src/components/domainStatus/tests/ReadyFor.test.js
@@ -20,4 +20,8 @@ describe('Component: Ready For', () => {
   it('should render bounce as default ready', () => {
     expect(shallow(<ReadyFor bounce bounceDefault/>)).toMatchSnapshot();
   });
+
+  it('should render bounce as subaccount default ready', () => {
+    expect(shallow(<ReadyFor bounce bounceDefault subaccount={101} />)).toMatchSnapshot();
+  });
 });

--- a/src/components/domainStatus/tests/__snapshots__/ReadyFor.test.js.snap
+++ b/src/components/domainStatus/tests/__snapshots__/ReadyFor.test.js.snap
@@ -8,7 +8,23 @@ exports[`Component: Ready For should render bounce as default ready 1`] = `
   <Tag
     color="orange"
   >
-    Bounce (Default)
+    Bounce (
+    Default)
+  </Tag>
+</span>
+`;
+
+exports[`Component: Ready For should render bounce as subaccount default ready 1`] = `
+<span>
+  <small>
+    Ready For:
+  </small>
+  <Tag
+    color="orange"
+  >
+    Bounce (
+    Subaccount 
+    Default)
   </Tag>
 </span>
 `;

--- a/src/pages/sendingDomains/ListPage.js
+++ b/src/pages/sendingDomains/ListPage.js
@@ -60,7 +60,8 @@ export class ListPage extends Component {
         filterBox={{
           show: true,
           itemToStringKeys: ['domain'],
-          exampleModifiers: ['domain', 'subaccount_id']
+          keyMap: { default: 'is_default_bounce_domain' },
+          exampleModifiers: ['domain', 'subaccount_id', 'default']
         }}
         defaultSortColumn='domain'
       />

--- a/src/pages/sendingDomains/components/SetupSending.js
+++ b/src/pages/sendingDomains/components/SetupSending.js
@@ -63,6 +63,7 @@ export class SetupSending extends Component {
                 id={domain.id}
                 open={this.state.open}
                 onCancel={this.toggleVerifyViaEmailModal}
+                subaccount={domain.subaccount_id}
               />
             )}
           </React.Fragment>

--- a/src/pages/sendingDomains/components/StatusDescription.js
+++ b/src/pages/sendingDomains/components/StatusDescription.js
@@ -18,7 +18,7 @@ const StatusDescription = ({ domain, readyFor, status }) => {
       <LabelledValue label={<StatusTooltipHeader />}>
         { status === 'verified' && <div><VerifiedIcon/> <strong>Verified</strong></div> }
         { status !== 'verified' && <DomainStatusTag status={status} /> }
-        <div><ReadyFor {...readyFor} bounceDefault={is_default_bounce_domain} /></div>
+        <div><ReadyFor {...readyFor} bounceDefault={is_default_bounce_domain} subaccount={subaccount_id} /></div>
       </LabelledValue>
     </Panel.Section>
     {

--- a/src/pages/sendingDomains/components/tests/__snapshots__/StatusDescription.test.js.snap
+++ b/src/pages/sendingDomains/components/tests/__snapshots__/StatusDescription.test.js.snap
@@ -37,6 +37,7 @@ exports[`StatusDescription component Shallow tests renders subaccount details 1`
           bounceDefault={false}
           dkim={false}
           sending={false}
+          subaccount={101}
         />
       </div>
     </LabelledValue>

--- a/src/pages/sendingDomains/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/sendingDomains/tests/__snapshots__/ListPage.test.js.snap
@@ -68,10 +68,14 @@ exports[`Sending Domains List Page renders correctly 1`] = `
         "exampleModifiers": Array [
           "domain",
           "subaccount_id",
+          "default",
         ],
         "itemToStringKeys": Array [
           "domain",
         ],
+        "keyMap": Object {
+          "default": "is_default_bounce_domain",
+        },
         "show": true,
       }
     }


### PR DESCRIPTION
Adds the "Subaccount" label to the "Default" tag when a sending domain is the default for a subaccount.

Also solves the bug in FAD-6508 where we weren't passing subaccount into the verify by email modal so it wasn't passing the subaccount header in the request.