### PR TITLE
FE-290 Fix summary tooltip overlap

### DIFF
--- a/src/pages/reports/summary/components/async/LineChart.scss
+++ b/src/pages/reports/summary/components/async/LineChart.scss
@@ -87,7 +87,9 @@
          position: relative;
 
         .recharts-tooltip-item-name {}
-        .recharts-tooltip-item-separator {}
+        .recharts-tooltip-item-separator {
+          padding-right: rem(50);
+        }
         .recharts-tooltip-item-value {
           font-weight: 600;
           position: absolute;


### PR DESCRIPTION
Bug was introduced in https://github.com/SparkPost/2web2ui/pull/417.

Tested in FF as well.

