### PR TITLE
FE-295: Fix Suppression delete operation

### DIFF
--- a/src/pages/suppressions/components/Results.js
+++ b/src/pages/suppressions/components/Results.js
@@ -35,28 +35,6 @@ export class Results extends Component {
     );
   }
 
-  deleteSuppression = () => {
-    const { showAlert, deleteSuppression } = this.props;
-    const { data } = this.state.del;
-
-    return deleteSuppression(data)
-      .then(() => {
-        this.toggleDeleteModal();
-        return showAlert({ type: 'success', message: `${data.recipient} was successfully deleted from the suppression list` });
-      });
-  }
-
-  toggleDetailModal = (row) => {
-    const { detail } = this.state;
-
-    this.setState({
-      detail: {
-        open: !detail.open,
-        data: row
-      }
-    });
-  }
-
   getRowData = (row) => {
     const { recipient, type, source, subaccount_id: subaccountId } = row;
     const { subaccounts: allSubaccounts, hasSubaccounts } = this.props;
@@ -99,6 +77,17 @@ export class Results extends Component {
     return columns;
   }
 
+  toggleDetailModal = (row) => {
+    const { detail } = this.state;
+
+    this.setState({
+      detail: {
+        open: !detail.open,
+        data: row
+      }
+    });
+  }
+
   renderDetailModal = () => {
     const { open, data } = this.state.detail;
     const { subaccounts, hasSubaccounts } = this.props;
@@ -108,14 +97,24 @@ export class Results extends Component {
     );
   }
 
+  deleteSuppression = () => {
+    const { showAlert, deleteSuppression } = this.props;
+    const { data } = this.state.del;
+
+    return deleteSuppression(data)
+      .then(() => {
+        this.toggleDeleteModal();
+        return showAlert({ type: 'success', message: `${data.recipient} was successfully deleted from the suppression list` });
+      });
+  }
+
   toggleDeleteModal = (row) => {
     const { del } = this.state;
+    const open = !del.open;
+    const data = open ? row : {};
 
     this.setState({
-      del: {
-        open: !del.open,
-        data: row
-      }
+      del: { open, data }
     });
   }
 

--- a/src/pages/suppressions/components/tests/Results.test.js
+++ b/src/pages/suppressions/components/tests/Results.test.js
@@ -113,7 +113,7 @@ describe('Results', () => {
       instance.toggleDeleteModal();
       del = wrapper.state().del;
       expect(del.open).toBe(false);
-      expect(del.data).toEqual(undefined);
+      expect(del.data).toEqual({});
     });
   });
 


### PR DESCRIPTION
## Issue 1: Deleting a master account suppression throws
Cause: Delete modal expects the suppression item to exist after deletion
Solution: Make delete modal resilient to missing state

## Issue 2: Deleting a subaccount suppression causes 401 which logs the user out
No solution yet