### PR TITLE
FE-292 Allow deep linking to in-app support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,8 +64,8 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
-    <div id='support-portal'></div>
     <div id='modal-portal'></div>
+    <div id='support-portal'></div>
     <div id='alert-portal'></div>
     <!--
       This HTML file is a template.

--- a/src/actions/support.js
+++ b/src/actions/support.js
@@ -1,7 +1,7 @@
 import sparkpostApiRequest from './helpers/sparkpostApiRequest';
 import { change } from 'redux-form';
 
-export function createTicket({ subject, message }) {
+export function createTicket({ subject, message, attachment }) {
   return sparkpostApiRequest({
     type: 'CREATE_TICKET',
     meta: {
@@ -9,7 +9,8 @@ export function createTicket({ subject, message }) {
       url: '/integrations/support/ticket',
       data: {
         subject,
-        message
+        message,
+        attachment
       }
     }
   });

--- a/src/actions/support.js
+++ b/src/actions/support.js
@@ -1,7 +1,14 @@
 import sparkpostApiRequest from './helpers/sparkpostApiRequest';
 import { change } from 'redux-form';
 
-export function createTicket({ subject, message, attachment }) {
+// Toggles the support panel UI
+export function toggleSupportPanel() {
+  return {
+    type: 'TOGGLE_SUPPORT_PANEL'
+  };
+}
+
+export function createTicket({ subject, message }) {
   return sparkpostApiRequest({
     type: 'CREATE_TICKET',
     meta: {
@@ -9,8 +16,7 @@ export function createTicket({ subject, message, attachment }) {
       url: '/integrations/support/ticket',
       data: {
         subject,
-        message,
-        attachment
+        message
       }
     }
   });
@@ -22,13 +28,15 @@ export function clearTicketForm() {
   };
 }
 
+// Toggles support ticket form (algolia search shown when false)
 export function toggleTicketForm() {
   return {
     type: 'TOGGLE_TICKET_FORM'
   };
 }
 
-export function hydrateTicketForm({ message, subject }) {
+// Fills support ticket form values
+export function hydrateTicketForm({ message, subject } = {}) {
   const formName = 'supportForm'; // Must match the form name used in SupportForm component
 
   return (dispatch) => {
@@ -43,11 +51,5 @@ export function hydrateTicketForm({ message, subject }) {
     return {
       type: 'HYDRATE_TICKET_FORM'
     };
-  };
-}
-
-export function toggleSupportPanel() {
-  return {
-    type: 'TOGGLE_SUPPORT_PANEL'
   };
 }

--- a/src/actions/support.js
+++ b/src/actions/support.js
@@ -1,4 +1,5 @@
 import sparkpostApiRequest from './helpers/sparkpostApiRequest';
+import { change } from 'redux-form';
 
 export function createTicket({ subject, message }) {
   return sparkpostApiRequest({
@@ -14,9 +15,38 @@ export function createTicket({ subject, message }) {
   });
 }
 
-export function clearSupportForm() {
+export function clearTicketForm() {
   return {
-    type: 'RESET_SUPPORT_FORM'
+    type: 'RESET_TICKET_FORM'
   };
 }
 
+export function toggleTicketForm() {
+  return {
+    type: 'TOGGLE_TICKET_FORM'
+  };
+}
+
+export function hydrateTicketForm({ message, subject }) {
+  const formName = 'supportForm'; // Must match the form name used in SupportForm component
+
+  return (dispatch) => {
+    if (message) {
+      dispatch(change(formName, 'message', message));
+    }
+
+    if (subject) {
+      dispatch(change(formName, 'subject', subject));
+    }
+
+    return {
+      type: 'HYDRATE_TICKET_FORM'
+    };
+  };
+}
+
+export function toggleSupportPanel() {
+  return {
+    type: 'TOGGLE_SUPPORT_PANEL'
+  };
+}

--- a/src/actions/tests/__snapshots__/support.test.js.snap
+++ b/src/actions/tests/__snapshots__/support.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Action Creator: Support clearTicketForm should clear ticket form 1`] = `
+Object {
+  "type": "RESET_TICKET_FORM",
+}
+`;
+
+exports[`Action Creator: Support createTicket should create a ticket 1`] = `
+Object {
+  "meta": Object {
+    "data": Object {
+      "message": "mess",
+      "subject": "sub",
+    },
+    "method": "POST",
+    "url": "/integrations/support/ticket",
+  },
+  "type": "CREATE_TICKET",
+}
+`;
+
+exports[`Action Creator: Support hydrateTicketForm should not hydrate without values 1`] = `
+Object {
+  "type": "HYDRATE_TICKET_FORM",
+}
+`;
+
+exports[`Action Creator: Support toggleSupportPanel should toggle panel 1`] = `
+Object {
+  "type": "TOGGLE_SUPPORT_PANEL",
+}
+`;
+
+exports[`Action Creator: Support toggleTicketForm should toggle ticket form 1`] = `
+Object {
+  "type": "TOGGLE_TICKET_FORM",
+}
+`;

--- a/src/actions/tests/support.test.js
+++ b/src/actions/tests/support.test.js
@@ -1,0 +1,56 @@
+import * as support from '../support';
+import * as formActions from 'redux-form';
+
+jest.mock('../helpers/sparkpostApiRequest', () => jest.fn((a) => a));
+
+describe('Action Creator: Support', () => {
+  let dispatchMock;
+
+  beforeEach(() => {
+    dispatchMock = jest.fn((a) => a);
+    formActions.change = jest.fn((a) => a);
+  });
+
+  describe('toggleSupportPanel', () => {
+    it('should toggle panel', () => {
+      expect(support.toggleSupportPanel()).toMatchSnapshot();
+    });
+  });
+
+  describe('clearTicketForm', () => {
+    it('should clear ticket form', () => {
+      expect(support.clearTicketForm()).toMatchSnapshot();
+    });
+  });
+
+  describe('toggleTicketForm', () => {
+    it('should toggle ticket form', () => {
+      expect(support.toggleTicketForm()).toMatchSnapshot();
+    });
+  });
+
+  describe('hydrateTicketForm', () => {
+    it('should not hydrate without values', () => {
+      expect(support.hydrateTicketForm({})(dispatchMock)).toMatchSnapshot();
+      expect(formActions.change).not.toHaveBeenCalled();
+    });
+
+    it('should hydrate message', () => {
+      support.hydrateTicketForm({ message: 'test' })(dispatchMock);
+      expect(formActions.change).toHaveBeenCalledWith('supportForm', 'message', 'test');
+      expect(formActions.change).toHaveBeenCalledTimes(1);
+    });
+
+    it('should hydrate subject', () => {
+      support.hydrateTicketForm({ subject: 'test' })(dispatchMock);
+      expect(formActions.change).toHaveBeenCalledWith('supportForm', 'subject', 'test');
+      expect(formActions.change).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createTicket', () => {
+    it('should create a ticket', () => {
+      expect(support.createTicket({ subject: 'sub', message: 'mess' })).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -10,12 +10,6 @@ import { SearchPanel } from './components/SearchPanel';
 import styles from './Support.module.scss';
 
 export class Support extends Component {
-
-  state = {
-    showPanel: false,
-    showForm: false
-  };
-
   componentDidMount() {
     const { location, toggleSupportPanel, toggleTicketForm, hydrateTicketForm } = this.props;
     const { supportTicket, supportMessage: message, supportSubject: subject } = qs.parse(location.search);

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -4,13 +4,24 @@ import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { Portal, Icon, Popover } from '@sparkpost/matchbox';
 import { entitledToSupport } from 'src/selectors/support';
-import { createTicket, toggleSupportPanel, toggleTicketForm, hydrateTicketForm } from 'src/actions/support';
+import * as supportActions from 'src/actions/support';
 import SupportForm from './components/SupportForm';
 import { SearchPanel } from './components/SearchPanel';
 import styles from './Support.module.scss';
 
 export class Support extends Component {
   componentDidMount() {
+    this.maybeOpenTicket();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.location.search !== prevProps.location.search) {
+      this.maybeOpenTicket();
+    }
+  }
+
+  // Opens and hydrates support ticket form from query params
+  maybeOpenTicket = () => {
     const { location, toggleSupportPanel, toggleTicketForm, hydrateTicketForm } = this.props;
     const { supportTicket, supportMessage: message, supportSubject: subject } = qs.parse(location.search);
 
@@ -94,6 +105,4 @@ const mapStateToProps = (state) => ({
   showTicketForm: state.support.showTicketForm
 });
 
-const mapDispatchToProps = { createTicket, toggleSupportPanel, toggleTicketForm, hydrateTicketForm };
-
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Support));
+export default withRouter(connect(mapStateToProps, supportActions)(Support));

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import qs from 'query-string';
 import { Portal, Icon, Popover } from '@sparkpost/matchbox';
 import { entitledToSupport } from 'src/selectors/support';
-import { createTicket, clearSupportForm } from 'src/actions/support';
+import { createTicket, clearTicketForm, toggleSupportPanel, toggleTicketForm, hydrateTicketForm } from 'src/actions/support';
 import SupportForm from './components/SupportForm';
 import { SearchPanel } from './components/SearchPanel';
 import styles from './Support.module.scss';
@@ -14,6 +16,17 @@ export class Support extends Component {
     showForm: false
   };
 
+  componentDidMount() {
+    const { location, toggleSupportPanel, toggleTicketForm, hydrateTicketForm } = this.props;
+    const { supportTicket, supportMessage: message, supportSubject: subject } = qs.parse(location.search);
+
+    if (supportTicket) {
+      toggleSupportPanel();
+      toggleTicketForm();
+      hydrateTicketForm({ message, subject });
+    }
+  }
+
   onSubmit = (values) => {
     const { createTicket } = this.props;
     const { subject, message } = values;
@@ -23,29 +36,28 @@ export class Support extends Component {
   };
 
   togglePanel = () => {
-    const stateUpdates = { showPanel: !this.state.showPanel };
-    // handling reseting doc search when closed
-    if (!this.state.showPanel) {
-      stateUpdates.showForm = false;
-    }
+    const { showPanel, showTicketForm, toggleSupportPanel, toggleTicketForm } = this.props;
 
-    this.setState(stateUpdates);
+    // handling reseting doc search when closed
+    if (!showPanel && showTicketForm) {
+      toggleTicketForm();
+    }
+    toggleSupportPanel();
   }
 
   resetPanel = () => {
-    this.setState({ showPanel: false }, () => {
-      this.props.clearSupportForm();
-    });
+    this.props.toggleSupportPanel();
+    this.props.clearTicketForm();
   };
 
   toggleForm = () => {
-    this.setState({ showForm: !this.state.showForm });
+    this.props.toggleTicketForm();
   }
 
   renderPanel() {
-    const { showForm } = this.state;
+    const { showTicketForm } = this.props;
 
-    return showForm
+    return showTicketForm
       ? <SupportForm
         onSubmit={this.onSubmit}
         onCancel={this.toggleForm}
@@ -54,8 +66,7 @@ export class Support extends Component {
   }
 
   render() {
-    const { loggedIn, entitledToSupport } = this.props;
-    const { showPanel } = this.state;
+    const { loggedIn, entitledToSupport, showPanel } = this.props;
 
     if (!loggedIn || !entitledToSupport) {
       return null;
@@ -89,9 +100,11 @@ export class Support extends Component {
 
 const mapStateToProps = (state) => ({
   loggedIn: state.auth.loggedIn,
-  entitledToSupport: entitledToSupport(state)
+  entitledToSupport: entitledToSupport(state),
+  showPanel: state.support.showPanel,
+  showTicketForm: state.support.showTicketForm
 });
 
-const mapDispatchToProps = { createTicket, clearSupportForm };
+const mapDispatchToProps = { createTicket, clearTicketForm, toggleSupportPanel, toggleTicketForm, hydrateTicketForm };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Support);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Support));

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { Portal, Icon, Popover } from '@sparkpost/matchbox';
 import { entitledToSupport } from 'src/selectors/support';
-import { createTicket, clearTicketForm, toggleSupportPanel, toggleTicketForm, hydrateTicketForm } from 'src/actions/support';
+import { createTicket, toggleSupportPanel, toggleTicketForm, hydrateTicketForm } from 'src/actions/support';
 import SupportForm from './components/SupportForm';
 import { SearchPanel } from './components/SearchPanel';
 import styles from './Support.module.scss';
@@ -44,11 +44,6 @@ export class Support extends Component {
     }
     toggleSupportPanel();
   }
-
-  resetPanel = () => {
-    this.props.toggleSupportPanel();
-    this.props.clearTicketForm();
-  };
 
   toggleForm = () => {
     this.props.toggleTicketForm();
@@ -105,6 +100,6 @@ const mapStateToProps = (state) => ({
   showTicketForm: state.support.showTicketForm
 });
 
-const mapDispatchToProps = { createTicket, clearTicketForm, toggleSupportPanel, toggleTicketForm, hydrateTicketForm };
+const mapDispatchToProps = { createTicket, toggleSupportPanel, toggleTicketForm, hydrateTicketForm };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Support));

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -15,7 +15,9 @@ export class Support extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.search !== prevProps.location.search) {
+    const { location } = this.props;
+
+    if (location.search && location.search !== prevProps.location.search) {
       this.maybeOpenTicket();
     }
   }

--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -1,19 +1,13 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Field, reduxForm } from 'redux-form';
-
 import { Button, Panel } from '@sparkpost/matchbox';
-
 import { TextFieldWrapper } from 'src/components';
-
 import { required, minLength, maxFileSize } from 'src/helpers/validation';
-
 import config from 'src/config';
-
 import FileInput from './FileInput';
 
 import styles from './SupportForm.module.scss';
-
 const formName = 'supportForm';
 
 const AttachmentField = (props) => <FileInput {...props}>Attach a file</FileInput>;
@@ -105,4 +99,3 @@ const mapStateToProps = ({ support }) => ({
 
 const ReduxSupportForm = reduxForm({ form: formName })(SupportForm);
 export default connect(mapStateToProps)(ReduxSupportForm);
-

--- a/src/components/support/tests/Support.test.js
+++ b/src/components/support/tests/Support.test.js
@@ -15,7 +15,7 @@ describe('Support Component', () => {
 
   beforeEach(() => {
     const props = {
-      createTicket: jest.fn().mockImplementation(() => Promise.resolve(createTicketResult)),
+      createTicket: jest.fn(() => Promise.resolve(createTicketResult)),
       entitledToSupport: true,
       loggedIn: true,
       location: {},
@@ -58,6 +58,7 @@ describe('Support Component', () => {
   describe('on mount', () => {
     it('should open panel and hydrate form', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
+      jest.resetAllMocks(); // To clear the initial mount call
       instance.componentDidMount();
       expect(instance.props.toggleTicketForm).toHaveBeenCalledTimes(1);
       expect(instance.props.toggleSupportPanel).toHaveBeenCalledTimes(1);
@@ -67,7 +68,22 @@ describe('Support Component', () => {
     it('should not open panel or hydrate form', () => {
       expect(instance.props.toggleTicketForm).not.toHaveBeenCalled();
       expect(instance.props.toggleSupportPanel).not.toHaveBeenCalled();
-      expect(instance.props.hydrateTicketForm).not.toHaveBeenCalledWith();
+      expect(instance.props.hydrateTicketForm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on update', () => {
+    it('should open panel and hydrate form', () => {
+      wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
+      expect(instance.props.toggleTicketForm).toHaveBeenCalledTimes(1);
+      expect(instance.props.toggleSupportPanel).toHaveBeenCalledTimes(1);
+      expect(instance.props.hydrateTicketForm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not open panel or hydrate form', () => {
+      expect(instance.props.toggleTicketForm).not.toHaveBeenCalled();
+      expect(instance.props.toggleSupportPanel).not.toHaveBeenCalled();
+      expect(instance.props.hydrateTicketForm).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/support/tests/Support.test.js
+++ b/src/components/support/tests/Support.test.js
@@ -81,6 +81,12 @@ describe('Support Component', () => {
     });
 
     it('should not open panel or hydrate form', () => {
+      wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
+      jest.resetAllMocks();
+
+      // Simulate cDU twice for two negative cases
+      wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
+      wrapper.setProps({ location: { search: undefined }});
       expect(instance.props.toggleTicketForm).not.toHaveBeenCalled();
       expect(instance.props.toggleSupportPanel).not.toHaveBeenCalled();
       expect(instance.props.hydrateTicketForm).not.toHaveBeenCalled();

--- a/src/pages/auth/AuthPage.js
+++ b/src/pages/auth/AuthPage.js
@@ -50,7 +50,10 @@ export class AuthPage extends Component {
   }
 
   redirect(nextProps) {
-    const route = _.get(nextProps, 'location.state.redirectAfterLogin', DEFAULT_REDIRECT_ROUTE);
+    // Passes location state through '/' or '/auth'
+    // DefaultRedirect component handles protected routes
+    const defaultRoute = { ...this.props.location, pathname: DEFAULT_REDIRECT_ROUTE };
+    const route = _.get(nextProps, 'location.state.redirectAfterLogin', defaultRoute);
     this.props.history.push(route);
   }
 

--- a/src/pages/auth/tests/AuthPage.test.js
+++ b/src/pages/auth/tests/AuthPage.test.js
@@ -22,6 +22,9 @@ const props = {
   authenticate: jest.fn(),
   history: {
     push: jest.fn()
+  },
+  location: {
+    search: '?test=one'
   }
 };
 
@@ -53,7 +56,10 @@ it('redirects to default route after mounted when logged in ', () => {
 
 it('redirects to default route when logged in', () => {
   wrapper.setProps({ auth: { loggedIn: true }});
-  expect(props.history.push).toHaveBeenCalledWith(DEFAULT_REDIRECT_ROUTE);
+  expect(props.history.push).toHaveBeenCalledWith({
+    pathname: DEFAULT_REDIRECT_ROUTE,
+    search: '?test=one'
+  });
 });
 
 it('redirects to desired route when logged in', () => {

--- a/src/pages/auth/tests/AuthPage.test.js
+++ b/src/pages/auth/tests/AuthPage.test.js
@@ -11,9 +11,6 @@ const props = {
     loggedIn: false,
     loginPending: false
   },
-  location: {
-    search: ''
-  },
   tfa: {
     enabled: false,
     username: 'bertha',
@@ -51,7 +48,10 @@ it('renders correctly when there is a login error', () => {
 
 it('redirects to default route after mounted when logged in ', () => {
   wrapper = shallow(<AuthPage {...props} auth={{ loggedIn: true }} />);
-  expect(props.history.push).toHaveBeenCalledWith(DEFAULT_REDIRECT_ROUTE);
+  expect(props.history.push).toHaveBeenCalledWith({
+    pathname: DEFAULT_REDIRECT_ROUTE,
+    search: '?test=one'
+  });
 });
 
 it('redirects to default route when logged in', () => {

--- a/src/pages/defaultRedirect/DefaultRedirect.js
+++ b/src/pages/defaultRedirect/DefaultRedirect.js
@@ -24,7 +24,7 @@ export class DefaultRedirect extends Component {
     // if there is a redirect route set on state, we can
     // redirect there before access condition state is ready
     if (routerState.redirectAfterLogin) {
-      history.push(routerState.redirectAfterLogin, { replace: true });
+      history.push({ ...location, pathname: routerState.redirectAfterLogin }, { replace: true });
       return;
     }
 
@@ -36,12 +36,12 @@ export class DefaultRedirect extends Component {
 
     // reporting users are all sent to the summary report
     if (_.includes(allowedAccessLevels, currentUser.access_level)) {
-      history.push('/reports/summary', { replace: true });
+      history.push({ ...location, pathname: '/reports/summary' }, { replace: true });
       return;
     }
 
     // everyone else is sent to the config.splashPage route
-    history.push(config.splashPage, { replace: true });
+    history.push({ ...location, pathname: config.splashPage }, { replace: true });
   }
 
   render() {

--- a/src/pages/defaultRedirect/tests/DefaultRedirect.test.js
+++ b/src/pages/defaultRedirect/tests/DefaultRedirect.test.js
@@ -15,7 +15,8 @@ describe('Component: DefaultRedirect', () => {
   beforeEach(() => {
     props = {
       location: {
-        state: {}
+        state: {},
+        search: '?test=one'
       },
       history: {
         push: jest.fn()
@@ -39,7 +40,10 @@ describe('Component: DefaultRedirect', () => {
     props.history.push.mockClear();
     instance.handleRedirect();
     expect(props.history.push).toHaveBeenCalledTimes(1);
-    expect(props.history.push).toHaveBeenCalledWith('/test/redirect/after/login', { replace: true });
+    expect(props.history.push).toHaveBeenCalledWith({
+      pathname: '/test/redirect/after/login',
+      state: { redirectAfterLogin: '/test/redirect/after/login' }
+    }, { replace: true });
   });
 
   it('should do nothing if no redirect after login and not ready', () => {
@@ -58,7 +62,11 @@ describe('Component: DefaultRedirect', () => {
     props.history.push.mockClear();
     instance.handleRedirect();
     expect(props.history.push).toHaveBeenCalledTimes(1);
-    expect(props.history.push).toHaveBeenCalledWith('/reports/summary', { replace: true });
+    expect(props.history.push).toHaveBeenCalledWith({
+      pathname: '/reports/summary',
+      search: '?test=one',
+      state: {}
+    }, { replace: true });
   });
 
   it('should redirect based on config', () => {
@@ -66,7 +74,11 @@ describe('Component: DefaultRedirect', () => {
     props.history.push.mockClear();
     instance.handleRedirect();
     expect(props.history.push).toHaveBeenCalledTimes(1);
-    expect(props.history.push).toHaveBeenCalledWith('/config/splash', { replace: true });
+    expect(props.history.push).toHaveBeenCalledWith({
+      pathname: '/config/splash',
+      search: '?test=one',
+      state: {}
+    }, { replace: true });
   });
 
   it('should handle a redirect on mount', () => {

--- a/src/reducers/support.js
+++ b/src/reducers/support.js
@@ -1,5 +1,7 @@
 const initialState = {
-  ticketId: null
+  ticketId: null,
+  showTicketForm: false,
+  showPanel: false
 };
 
 export default (state = initialState, action) => {
@@ -7,11 +9,16 @@ export default (state = initialState, action) => {
     case 'CREATE_TICKET_SUCCESS':
       return { ...state, ticketId: action.payload.ticket_id };
 
-    case 'RESET_SUPPORT_FORM':
+    case 'RESET_TICKET_FORM':
       return { ...initialState };
+
+    case 'TOGGLE_TICKET_FORM':
+      return { ...state, showTicketForm: !state.showTicketForm };
+
+    case 'TOGGLE_SUPPORT_PANEL':
+      return { ...state, showPanel: !state.showPanel };
 
     default:
       return state;
   }
 };
-


### PR DESCRIPTION
Jira ticket: https://jira.int.messagesystems.com/browse/FE-292

---

Support ticket UI can be triggered through query params or through redux actions

```js
// Support component opens form and hydrates on mount
app.sparkpost.com?supportTicket=true&supportMessage=message&supportSubject=subject
```

```js
// Toggles the support panel UI
toggleSupportPanel()

// Toggles support ticket form (algolia search shown when false)
toggleTicketForm()     

// Fills support ticket form
hydrateTicketForm({ message, subject })
```
