### PR TITLE
FE-306: Fix hiding on hover on ff

### DIFF
--- a/src/components/pieChart/async/Chart.scss
+++ b/src/components/pieChart/async/Chart.scss
@@ -6,7 +6,8 @@
 
 .Chart--hover {
   .recharts-sector {
-    opacity: 0.4;
+    opacity: 1;
+    -webkit-opacity: 0.4;
   }
 }
 

--- a/src/components/pieChart/async/Chart.scss
+++ b/src/components/pieChart/async/Chart.scss
@@ -1,8 +1,7 @@
 // Global scoped to target recharts classnames
 .recharts-sector {
-  opacity: 1;
-  -moz-fill-opacity: 1;
-  transition: opacity 0.3s;
+  fill-opacity: 1;
+  transition: fill-opacity 0.3s;
 }
 
 .Chart--hover {

--- a/src/components/pieChart/async/Chart.scss
+++ b/src/components/pieChart/async/Chart.scss
@@ -1,18 +1,18 @@
 // Global scoped to target recharts classnames
 .recharts-sector {
   opacity: 1;
+  -moz-fill-opacity: 1;
   transition: opacity 0.3s;
 }
 
 .Chart--hover {
   .recharts-sector {
-    opacity: 1;
-    -webkit-opacity: 0.4;
+    fill-opacity: 0.4;
   }
 }
 
 .recharts-sector.Chart--forceOpacity {
-  opacity: 1 !important;
+  fill-opacity: 1 !important;
 }
 
 .recharts-sector.Chart--hasChildren {


### PR DESCRIPTION
(Temporary; less annoying) Fixes hiding of pie chart on hover with one caveat (in ff); see photos below:

Before:
<img width="355" alt="screen shot 2018-04-23 at 4 48 21 pm" src="https://user-images.githubusercontent.com/14877079/39152379-35521dd2-4716-11e8-8ae1-d5e99cec9295.png">

After:
<img width="334" alt="screen shot 2018-04-23 at 4 50 04 pm" src="https://user-images.githubusercontent.com/14877079/39152449-676a1608-4716-11e8-9afd-71ac49afd49c.png">
(does not set opacity for other slices)

Other things tried:
- Upgrading `recharts` to latest version `1.0.0-beta.10`. Reverted as didn't solve it
- Tried `-moz-opacity: 0.4`. Didn't work. Nor does `-moz-opacity: 1`.  


