### PR TITLE
FE-35: Error not surfaced to user when SSO sign-in fails

### DIFF
--- a/src/helpers/string.js
+++ b/src/helpers/string.js
@@ -70,3 +70,11 @@ export function stripTags(html) {
     .replace(spacesRegex, space) // avoid multiple spaces between words
     .trim();
 }
+
+export function decodeBase64(str) {
+  try {
+    return atob(str);
+  } catch (e) {
+    return undefined; // ignore parsing error
+  }
+}

--- a/src/helpers/tests/string.test.js
+++ b/src/helpers/tests/string.test.js
@@ -1,6 +1,6 @@
 import {
   snakeToFriendly, snakeToCamel, slugify, shrinkToFit, stringToArray, stringifyTypeaheadfilter,
-  stripTags
+  stripTags, decodeBase64
 } from '../string';
 
 describe('snakeToFrindly', () => {
@@ -75,5 +75,16 @@ describe('stripTags', () => {
 
   it('should replace newline strings with a space', () => {
     expect(stripTags('This is\\r\\na test.')).toEqual('This is a test.');
+  });
+});
+
+describe('decodeBase64', () => {
+  it('should ignores errors and returns undefined', () => {
+    expect(decodeBase64()).toBeUndefined();
+  });
+
+  it('should decode and return string', () => {
+    const encoded = btoa('Testing!');
+    expect(decodeBase64(encoded)).toEqual('Testing!');
   });
 });

--- a/src/pages/auth/AuthPage.js
+++ b/src/pages/auth/AuthPage.js
@@ -55,7 +55,7 @@ export class AuthPage extends Component {
   }
 
   ssoSignIn(username) {
-    return this.props.ssoCheck(username).catch((err) => err);
+    return this.props.ssoCheck(username);
   }
 
   regularSignIn(username, password, rememberMe) {

--- a/src/pages/auth/AuthPage.js
+++ b/src/pages/auth/AuthPage.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import qs from 'query-string';
 import { authenticate, ssoCheck, login } from 'src/actions/auth';
 import { verifyAndLogin } from 'src/actions/tfa';
 import { CenteredLogo } from 'src/components';
@@ -12,6 +13,7 @@ import config from 'src/config';
 import { DEFAULT_REDIRECT_ROUTE } from 'src/constants';
 import LoginForm from './components/LoginForm';
 import TfaForm from './components/TfaForm';
+import { decodeBase64 } from 'src/helpers/string';
 
 export class AuthPage extends Component {
   constructor(props) {
@@ -60,12 +62,6 @@ export class AuthPage extends Component {
     return this.props.authenticate(username, password, rememberMe);
   }
 
-  renderLoginError(errorDescription) {
-    return (
-      <Error error={errorDescription} />
-    );
-  }
-
   loginSubmit = (values) => {
     const { username, password, rememberMe } = values;
     this.state.ssoEnabled ? this.ssoSignIn(username) : this.regularSignIn(username, password, rememberMe);
@@ -84,9 +80,10 @@ export class AuthPage extends Component {
   }
 
   render() {
-    const { errorDescription } = this.props.auth;
+    const { auth, location, tfa } = this.props;
     const hasSignup = (config.featureFlags || {}).has_signup;
-    const { tfa } = this.props;
+    const search = qs.parse(location.search);
+    const loginError = decodeBase64(search.error) || auth.errorDescription; // SSO or submit error
 
     const footerMarkup = !tfa.enabled
       ? <Panel.Footer
@@ -98,7 +95,7 @@ export class AuthPage extends Component {
       <div>
         <CenteredLogo />
         <Panel sectioned accent title="Log In">
-          { errorDescription && this.renderLoginError(errorDescription)}
+          {loginError && <Error error={loginError} />}
 
           { tfa.enabled && <TfaForm onSubmit={this.tfaSubmit} /> }
           { !tfa.enabled && <LoginForm onSubmit={this.loginSubmit} ssoEnabled={this.state.ssoEnabled}/> }

--- a/src/pages/auth/tests/AuthPage.test.js
+++ b/src/pages/auth/tests/AuthPage.test.js
@@ -11,6 +11,9 @@ const props = {
     loggedIn: false,
     loginPending: false
   },
+  location: {
+    search: ''
+  },
   tfa: {
     enabled: false,
     username: 'bertha',
@@ -127,4 +130,9 @@ it('should redirect to sso if there is a sso user', () => {
 it('should set sso enabled if there ssoUser is null', () => {
   wrapper.setProps({ auth: { ssoUser: null }});
   expect(wrapper.state().ssoEnabled).toBeFalsy();
+});
+
+it('should display sso error message', () => {
+  wrapper.setProps({ location: { search: `?error=${btoa('Oh no!')}` }});
+  expect(wrapper).toMatchSnapshot();
 });

--- a/src/pages/auth/tests/AuthPage.test.js
+++ b/src/pages/auth/tests/AuthPage.test.js
@@ -46,6 +46,11 @@ it('renders correctly when there is a login error', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it('redirects to default route after mounted when logged in ', () => {
+  wrapper = shallow(<AuthPage {...props} auth={{ loggedIn: true }} />);
+  expect(props.history.push).toHaveBeenCalledWith(DEFAULT_REDIRECT_ROUTE);
+});
+
 it('redirects to default route when logged in', () => {
   wrapper.setProps({ auth: { loggedIn: true }});
   expect(props.history.push).toHaveBeenCalledWith(DEFAULT_REDIRECT_ROUTE);

--- a/src/pages/auth/tests/__snapshots__/AuthPage.test.js.snap
+++ b/src/pages/auth/tests/__snapshots__/AuthPage.test.js.snap
@@ -61,6 +61,38 @@ exports[`renders correctly when there is a login error 1`] = `
 </div>
 `;
 
+exports[`should display sso error message 1`] = `
+<div>
+  <CenteredLogo />
+  <Panel
+    accent={true}
+    sectioned={true}
+    title="Log In"
+  >
+    <Error
+      error="Oh no!"
+    />
+    <Connect(ReduxForm)
+      onSubmit={[Function]}
+      ssoEnabled={false}
+    />
+  </Panel>
+  <Panel.Footer
+    left={false}
+    right={
+      <small>
+        <UnstyledLink
+          Component={[Function]}
+          to="/forgot-password"
+        >
+          Forgot your password?
+        </UnstyledLink>
+      </small>
+    }
+  />
+</div>
+`;
+
 exports[`should display tfa form when TFA is enabled 1`] = `
 <div>
   <CenteredLogo />


### PR DESCRIPTION
_Refer to [FE-35](https://jira.int.messagesystems.com/browse/FE-35)_

**How to test locally**
- Load auth page with error param set to any base64 encoded string (e.g. http://app.sparkpost.test/auth?error=VW5hYmxlIHRvIGNyZWF0ZSB0b2tlbiBmb3IgU0FNTCB1c2VyLg%3D%3D)

**How to test in UAT**
1. Navigate to https://app-speuat.tst.sparkpost.com _[should load SparkPost authentication form and only ask for email or username]_
1. Enter "appteam+sso" _[should redirect to OneLogin authentication form]_
1. Enter "appteam" credentials from LastPass _[should redirect back to SparkPost authentication page with an error message]_