### PR TITLE
FE-307 Show total delays

### DIFF
--- a/src/pages/reports/delays/DelayPage.js
+++ b/src/pages/reports/delays/DelayPage.js
@@ -45,7 +45,7 @@ export class DelayPage extends Component {
       <MetricsSummary
         rateValue={safeRate(count_delayed_first, count_accepted)}
         rateTitle='Delayed Rate'
-        secondaryMessage={`${count_delayed.toLocaleString()} total delays.`}
+        secondaryMessage={`There were ${count_delayed.toLocaleString()} total delays in this time period. (Note: messages may be delayed multiple times)`}
       >
         <strong>{count_delayed_first.toLocaleString()}</strong> of <strong>{count_accepted.toLocaleString()}</strong> accepted messages were delayed on first attempt
       </MetricsSummary>

--- a/src/pages/reports/delays/DelayPage.js
+++ b/src/pages/reports/delays/DelayPage.js
@@ -31,7 +31,7 @@ export class DelayPage extends Component {
 
   renderTopLevelMetrics() {
     const { aggregatesLoading, aggregates } = this.props;
-    const { count_delayed_first, count_accepted } = aggregates;
+    const { count_delayed, count_delayed_first, count_accepted } = aggregates;
 
     if (aggregatesLoading) {
       return <PanelLoading minHeight='115px' />;
@@ -45,9 +45,9 @@ export class DelayPage extends Component {
       <MetricsSummary
         rateValue={safeRate(count_delayed_first, count_accepted)}
         rateTitle='Delayed Rate'
-        secondaryMessage={`${count_delayed_first.toLocaleString()} were delayed on first attempt.`}
+        secondaryMessage={`${count_delayed.toLocaleString()} total delays.`}
       >
-        <strong>{count_delayed_first.toLocaleString()}</strong> of your messages were delayed of <strong>{count_accepted.toLocaleString()}</strong> messages accepted
+        <strong>{count_delayed_first.toLocaleString()}</strong> of <strong>{count_accepted.toLocaleString()}</strong> accepted messages were delayed on first attempt
       </MetricsSummary>
     );
   }

--- a/src/pages/reports/delays/components/DelaysDataTable.js
+++ b/src/pages/reports/delays/components/DelaysDataTable.js
@@ -8,7 +8,7 @@ import { safeRate } from 'src/helpers/math';
 const columns = [
   { label: 'Reason', sortKey: 'reason', width: '45%' },
   { label: 'Domain', sortKey: 'domain' },
-  { label: 'Delayed', sortKey: 'count_delayed' },
+  { label: 'Total Delays', sortKey: 'count_delayed' },
   { label: 'Delayed First Attempt (%)', sortKey: 'count_delayed_first' }
 ];
 

--- a/src/pages/reports/delays/components/tests/__snapshots__/DelaysDataTable.test.js.snap
+++ b/src/pages/reports/delays/components/tests/__snapshots__/DelaysDataTable.test.js.snap
@@ -14,7 +14,7 @@ exports[`DelaysDataTable:  should render page 1`] = `
         "sortKey": "domain",
       },
       Object {
-        "label": "Delayed",
+        "label": "Total Delays",
         "sortKey": "count_delayed",
       },
       Object {

--- a/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
+++ b/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
@@ -9,16 +9,16 @@ exports[`DelayPage:  should render 1`] = `
   <Connect(MetricsSummary)
     rateTitle="Delayed Rate"
     rateValue={0.1}
-    secondaryMessage="10 were delayed on first attempt."
+    secondaryMessage="1,000 total delays."
   >
     <strong>
       10
     </strong>
-     of your messages were delayed of 
+     of 
     <strong>
       10,000
     </strong>
-     messages accepted
+     accepted messages were delayed on first attempt
   </Connect(MetricsSummary)>
   <Panel
     className="ReasonsTable"
@@ -52,16 +52,16 @@ exports[`DelayPage:  should show loading indicator when loading table 1`] = `
   <Connect(MetricsSummary)
     rateTitle="Delayed Rate"
     rateValue={0.1}
-    secondaryMessage="10 were delayed on first attempt."
+    secondaryMessage="1,000 total delays."
   >
     <strong>
       10
     </strong>
-     of your messages were delayed of 
+     of 
     <strong>
       10,000
     </strong>
-     messages accepted
+     accepted messages were delayed on first attempt
   </Connect(MetricsSummary)>
   <Panel
     className="ReasonsTable"

--- a/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
+++ b/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
@@ -9,7 +9,7 @@ exports[`DelayPage:  should render 1`] = `
   <Connect(MetricsSummary)
     rateTitle="Delayed Rate"
     rateValue={0.1}
-    secondaryMessage="1,000 total delays."
+    secondaryMessage="There were 1,000 total delays in this time period. (Note: messages may be delayed multiple times)"
   >
     <strong>
       10
@@ -52,7 +52,7 @@ exports[`DelayPage:  should show loading indicator when loading table 1`] = `
   <Connect(MetricsSummary)
     rateTitle="Delayed Rate"
     rateValue={0.1}
-    secondaryMessage="1,000 total delays."
+    secondaryMessage="There were 1,000 total delays in this time period. (Note: messages may be delayed multiple times)"
   >
     <strong>
       10


### PR DESCRIPTION
Revised the top level message a bit:
New
> **5,309** of **231,119** accepted messages were delayed on first attempt in the **last 24 hours**.

Old
>**5,503** of your messages were delayed of **233,189** messages accepted in the **last 24 hours**.