### PR TITLE
FE-309 simplifies attribution on sign up

### DIFF
--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`JoinPage getAttributionData merges attribution data from query params onto stored cookie data 1`] = `
+Object {
+  "sfdcid": "123",
+  "utm_medium": "script",
+  "utm_source": "script",
+}
+`;
+
+exports[`JoinPage getAttributionData returns correct attribution data from stored cookie 1`] = `
+Object {
+  "sfdcid": "123",
+  "utm_source": "script",
+}
+`;
+
+exports[`JoinPage registerSubmit calls register with correct data 1`] = `
+Array [
+  Array [
+    Object {
+      "email": "foo@bar.com",
+      "first_name": "foo",
+      "last_name": "bar",
+      "password": "foobar",
+      "salesforce_data": Object {
+        "email_opt_out": true,
+        "src": "Test Source",
+        "utm_source": "test file",
+      },
+      "sfdcid": "abcd",
+      "tou_accepted": true,
+    },
+  ],
+]
+`;
+
 exports[`JoinPage render renders aws logo when signup from aws 1`] = `
 <div>
   <Script


### PR DESCRIPTION
Now we read from the query string and merge those values on top of anything we find in the `attribution` cookie, and send the resulting merge along with the account create call. I verified this works in tst end-to-end from local UI to sandbox Salesforce (it wasn't easy either, so let me know if you are planning to try an end-to-end test of this).

This mainly fixes this bug:
* If the attribution cookie was mistakenly set to `{}` (or set to anything at all), we would ignore the query param data -- now we merge the query param data on top of the cookie data

We no longer store the cookie in this flow. As best as I can tell, the original tickets (FAD-4947 and FAD-4948) don't mention that requirement and nobody is aware of a reason for doing that.