### PR TITLE
FE-313: Webhooks subaccount is getting set to 0 on create

### DIFF
--- a/src/helpers/subaccounts.js
+++ b/src/helpers/subaccounts.js
@@ -1,3 +1,3 @@
-export function setSubaccountQuery(id) {
-  return typeof id !== 'undefined' ? `?subaccount=${id}` : '';
-}
+import _ from 'lodash';
+
+export const setSubaccountQuery = (id) => _.isNil(id) ? '' : `?subaccount=${id}`;

--- a/src/helpers/tests/subaccounts.test.js
+++ b/src/helpers/tests/subaccounts.test.js
@@ -1,14 +1,19 @@
 import * as subaccounts from '../subaccounts';
 
-describe('Subaccount Helpers', () => {
-  describe('setSubaccountQuery', () => {
-    it('should create a subaccount qp', () => {
-      expect(subaccounts.setSubaccountQuery(101)).toEqual('?subaccount=101');
-      expect(subaccounts.setSubaccountQuery('102')).toEqual('?subaccount=102');
-    });
+describe('setSubaccountQuery', () => {
+  it('should return an empty string for undefined', () => {
+    expect(subaccounts.setSubaccountQuery()).toEqual('');
+  });
 
-    it('should not create a subaccount qp if id is missing', () => {
-      expect(subaccounts.setSubaccountQuery()).toEqual('');
-    });
+  it('should return an empty string for null', () => {
+    expect(subaccounts.setSubaccountQuery()).toEqual('');
+  });
+
+  it('should return a query string for an integer', () => {
+    expect(subaccounts.setSubaccountQuery(101)).toEqual('?subaccount=101');
+  });
+
+  it('should return a query string for an string', () => {
+    expect(subaccounts.setSubaccountQuery('101')).toEqual('?subaccount=101');
   });
 });

--- a/src/helpers/tests/subaccounts.test.js
+++ b/src/helpers/tests/subaccounts.test.js
@@ -6,7 +6,7 @@ describe('setSubaccountQuery', () => {
   });
 
   it('should return an empty string for null', () => {
-    expect(subaccounts.setSubaccountQuery()).toEqual('');
+    expect(subaccounts.setSubaccountQuery(null)).toEqual('');
   });
 
   it('should return a query string for an integer', () => {

--- a/src/pages/webhooks/components/SubaccountSection.js
+++ b/src/pages/webhooks/components/SubaccountSection.js
@@ -7,8 +7,8 @@ import { RadioGroup, SubaccountTypeaheadWrapper, TextFieldWrapper } from 'src/co
 import { required } from 'src/helpers/validation';
 
 const createOptions = [
-  { label: 'Master account only', value: 'master' },
   { label: 'Master and all subaccounts', value: 'all' },
+  { label: 'Master account only', value: 'master' },
   { label: 'Single Subaccount', value: 'subaccount' }
 ];
 
@@ -22,7 +22,7 @@ const createOptions = [
  * - subaccount TextField | typeahead (disabled)
  */
 export class SubaccountSection extends Component {
-  componentDidUpdate(prevProps) {
+  componentDidUpdate (prevProps) {
     const { assignTo, formName, change } = this.props;
 
     // Clear subaccount value if switching away from subaccount
@@ -31,7 +31,7 @@ export class SubaccountSection extends Component {
     }
   }
 
-  renderCreate() {
+  renderCreate () {
     const { assignTo } = this.props;
 
     const typeahead = assignTo === 'subaccount'
@@ -50,7 +50,7 @@ export class SubaccountSection extends Component {
     );
   }
 
-  renderEdit() {
+  renderEdit () {
     const { subaccount } = this.props;
     let component = SubaccountTypeaheadWrapper;
 
@@ -69,14 +69,14 @@ export class SubaccountSection extends Component {
     );
   }
 
-  render() {
+  render () {
     return this.props.newWebhook ? this.renderCreate() : this.renderEdit();
   }
 }
 
 SubaccountSection.propTypes = {
   newWebhook: PropTypes.bool,
-  assignTo: PropTypes.oneOf(['master', 'all', 'subaccount', null]),
+  assignTo: PropTypes.oneOf(['master', 'all', 'subaccount']),
   change: PropTypes.func
 };
 

--- a/src/pages/webhooks/components/WebhookForm.js
+++ b/src/pages/webhooks/components/WebhookForm.js
@@ -34,16 +34,16 @@ export const WebhookForm = ({
         <NameField />
         <TargetField />
       </Panel.Section>
-      { hasSubaccounts && <Panel.Section><SubaccountSection newWebhook={newWebhook} formName={formName} /></Panel.Section> }
+      {hasSubaccounts && <Panel.Section><SubaccountSection newWebhook={newWebhook} formName={formName} /></Panel.Section>}
       <Panel.Section>
         <EventsRadioGroup />
-        { showEvents && eventBoxes }
+        {showEvents && eventBoxes}
       </Panel.Section>
       <Panel.Section>
         <AuthDropDown />
-        { auth && <AuthFields /> }
+        {auth && <AuthFields />}
       </Panel.Section>
-      { !newWebhook && <Panel.Section><ActiveField /></Panel.Section>}
+      {!newWebhook && <Panel.Section><ActiveField /></Panel.Section>}
       <Panel.Section>
         <Button submit primary disabled={disabled}>{submitText}</Button>
       </Panel.Section>
@@ -62,7 +62,7 @@ const mapStateToProps = (state, props) => {
     auth,
     hasSubaccounts: hasSubaccounts(state),
     initialValues: {
-      assignTo: 'master',
+      assignTo: 'all',
       eventsRadio: props.allChecked || props.newWebhook ? 'all' : 'select',
       subaccount: !props.newWebhook ? selectInitialSubaccountValue(state, props) : null,
       ...webhookValues,

--- a/src/pages/webhooks/components/tests/__snapshots__/SubaccountSection.test.js.snap
+++ b/src/pages/webhooks/components/tests/__snapshots__/SubaccountSection.test.js.snap
@@ -8,12 +8,12 @@ exports[`Webhooks SubaccountSection on create should render radio group 1`] = `
     options={
       Array [
         Object {
-          "label": "Master account only",
-          "value": "master",
-        },
-        Object {
           "label": "Master and all subaccounts",
           "value": "all",
+        },
+        Object {
+          "label": "Master account only",
+          "value": "master",
         },
         Object {
           "label": "Single Subaccount",


### PR DESCRIPTION
_Refer to [FE-313](https://jira.int.messagesystems.com/browse/FE-313)_

The originally reported issue is more an annoyance than a bug.  A webhook can listen for events for a all accounts, only the master account, or a designated subaccount.  The default was set to only the master account.  Which is annoying if you create a webhook, do a bunch integration work with it, then decide to create subaccounts.

While triaging/testing, I found a bug.  Here are the steps to reproduce.
1. With an account that has subaccounts.
1. Navigate to create webhook page <http://app.sparkpost.test/webhooks/create>
1. Fill-out all the required fields, select "Master and all subaccounts" option
1. Click "Create Webhook"

**Expected result:** After creation, you should be redirected to the edit page.
**Actual result:** When loading the edit page, the ajax request to fetch the webhook responds with 401 and immediately logs you out.

<img width="1385" alt="screen shot 2018-04-26 at 5 08 29 pm" src="https://user-images.githubusercontent.com/1335605/39333723-ea33236c-4979-11e8-8ea7-312b8a329c55.png">

**Triage results:** I found that the subaccount is defaulted to null in the action creator, then stored by the reducer in our store, passed back to `WebhooksCreate`, `componentDidUpdate` notices the change, builds the url, and redirects the user to the edit page.  The problem is the url is built with `setSubaccountQuery` which appends a subaccount query string if the argument is not undefined and we are passing it null, so the user is directed to http://app.sparkpost.test/webhooks/details/1867aae0-39ae-11e8-9d73-1505f66744e8?subaccount=null.  The null query string value is then used to fetch the subaccount which causes the 401 error.
