### PR TITLE
FE-305: Give free accounts support doc access

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -13,6 +13,7 @@
     "<rootDir>/src/App.js",
     "<rootDir>/src/index.js",
     "<rootDir>/src/config",
+    "<rootDir>/src/components/index.js",
     "<rootDir>/src/helpers/registerServiceWorker",
     "<rootDir>/src/reducers",
     "tests/helpers/"

--- a/jest.config.json
+++ b/jest.config.json
@@ -11,12 +11,11 @@
   ],
   "coveragePathIgnorePatterns": [
     "<rootDir>/src/App.js",
-    "<rootDir>/src/index.js",
     "<rootDir>/src/config",
-    "<rootDir>/src/components/index.js",
     "<rootDir>/src/helpers/registerServiceWorker",
     "<rootDir>/src/reducers",
-    "tests/helpers/"
+    "tests/helpers/",
+    "index.js"
   ],
   "coverageThreshold": {
     "global": {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -24,6 +24,7 @@ export { default as SiftScience } from './siftScience/SiftScience';
 export { default as StatusTooltipHeader } from './domainStatus/StatusTooltipHeader';
 export { default as DomainStatusCell } from './domainStatus/DomainStatusCell';
 export { default as CookieConsent } from './cookieConsent/CookieConsent';
+export { default as PageLink } from './pageLink/PageLink';
 
 
 export * from './collection';

--- a/src/components/pageLink/PageLink.js
+++ b/src/components/pageLink/PageLink.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { UnstyledLink } from '@sparkpost/matchbox';
+
+// Link to a page in our application
+export default function PageLink ({ children, ...props }) {
+  return <UnstyledLink component={Link} {...props}>{children}</UnstyledLink>;
+}

--- a/src/components/pageLink/tests/PageLink.test.js
+++ b/src/components/pageLink/tests/PageLink.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PageLink from '../PageLink';
+
+describe('PageLink', () => {
+  it('should render a page link', () => {
+    const wrapper = shallow(<PageLink to="/profile">My Profile</PageLink>);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/pageLink/tests/__snapshots__/PageLink.test.js.snap
+++ b/src/components/pageLink/tests/__snapshots__/PageLink.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageLink should render a page link 1`] = `
+<UnstyledLink
+  component={[Function]}
+  to="/profile"
+>
+  My Profile
+</UnstyledLink>
+`;

--- a/src/components/smtpDetails/SmtpDetails.js
+++ b/src/components/smtpDetails/SmtpDetails.js
@@ -1,8 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { UnstyledLink } from '@sparkpost/matchbox';
-import { LabelledValue, CopyField } from 'src/components';
+import { LabelledValue, CopyField, PageLink } from 'src/components';
 
 import config from 'src/config';
 const smtpAuth = config.smtpAuth;
@@ -14,7 +12,7 @@ const smtpDesc = 'Use the information below to configure your SMTP client to rel
  * apiKey - enables a CopyField
  */
 class SmtpDetails extends Component {
-  render() {
+  render () {
     const { apiKey } = this.props;
 
     const smtpDescContent = apiKey
@@ -23,14 +21,14 @@ class SmtpDetails extends Component {
 
     const passwordContent = apiKey
       ? <CopyField value={apiKey} helpText='For security, this key will never be displayed in full again. Make sure you copy it somewhere safe!'/>
-      : <p>The password is an API key with <strong>Send via SMTP</strong> permissions.  <UnstyledLink to='/account/api-keys' Component={Link}>Manage API Keys</UnstyledLink></p>;
+      : <p>The password is an API key with <strong>Send via SMTP</strong> permissions.  <PageLink to="/account/api-keys">Manage API Keys</PageLink></p>;
 
     return (
       <Fragment>
         <p>{smtpDescContent}</p>
         <LabelledValue label='Host' value={smtpAuth.host}/>
         <LabelledValue label='Port' value={smtpAuth.port}/>
-        { config.smtpAuth.alternativePort && <LabelledValue label='Alternative Port' value={`${smtpAuth.alternativePort}`}/> }
+        {config.smtpAuth.alternativePort && <LabelledValue label='Alternative Port' value={`${smtpAuth.alternativePort}`}/>}
         <LabelledValue label='Authentication' value='AUTH LOGIN'/>
         <LabelledValue label='Encryption' value='STARTTLS'/>
         <LabelledValue label='Username' value={smtpAuth.username}/>

--- a/src/components/smtpDetails/tests/__snapshots__/SmtpDetails.test.js.snap
+++ b/src/components/smtpDetails/tests/__snapshots__/SmtpDetails.test.js.snap
@@ -79,12 +79,11 @@ exports[`Smtp component: Smtp Details should render page correctly with defaults
         Send via SMTP
       </strong>
        permissions.  
-      <UnstyledLink
-        Component={[Function]}
+      <PageLink
         to="/account/api-keys"
       >
         Manage API Keys
-      </UnstyledLink>
+      </PageLink>
     </p>
   </LabelledValue>
 </React.Fragment>

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -4,7 +4,6 @@ import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { Portal, Popover } from '@sparkpost/matchbox';
 import { Cancel, Help } from '@sparkpost/matchbox-icons';
-import { entitledToOnlineSupport } from 'src/selectors/support';
 import * as supportActions from 'src/actions/support';
 import SupportForm from './components/SupportForm';
 import SearchPanel from './components/SearchPanel';
@@ -49,9 +48,9 @@ export class Support extends Component {
   }
 
   render () {
-    const { loggedIn, entitledToOnlineSupport, showPanel, showTicketForm } = this.props;
+    const { loggedIn, showPanel, showTicketForm } = this.props;
 
-    if (!loggedIn || !entitledToOnlineSupport) {
+    if (!loggedIn) {
       return null;
     }
 
@@ -86,7 +85,6 @@ export class Support extends Component {
 
 const mapStateToProps = (state) => ({
   loggedIn: state.auth.loggedIn,
-  entitledToOnlineSupport: entitledToOnlineSupport(state),
   showPanel: state.support.showPanel,
   showTicketForm: state.support.showTicketForm
 });

--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -71,7 +71,7 @@ export class SupportForm extends Component {
             helpText={needsOnlineSupport && (
               <Fragment>
                 Additional technical support is available on paid
-                plans. <PageLink to="/account/billing/plan">Ugrade now</PageLink>.
+                plans. <PageLink to="/account/billing/plan">Upgrade now</PageLink>.
               </Fragment>
             )}
             errorInLabel

--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -1,13 +1,14 @@
 import _ from 'lodash';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { Field, formValueSelector, reduxForm } from 'redux-form';
 import { Button, Panel } from '@sparkpost/matchbox';
 
 import * as supportActions from 'src/actions/support';
-import { SelectWrapper, TextFieldWrapper } from 'src/components';
+import { PageLink, SelectWrapper, TextFieldWrapper } from 'src/components';
 import FileFieldWrapper from 'src/components/reduxFormWrappers/FileFieldWrapper';
 import config from 'src/config';
+import { hasOnlineSupport } from 'src/helpers/conditions/account';
 import { getBase64Contents } from 'src/helpers/file';
 import { required, maxFileSize } from 'src/helpers/validation';
 import { selectSupportIssue, selectSupportIssues } from 'src/selectors/support';
@@ -50,6 +51,7 @@ export class SupportForm extends Component {
       handleSubmit,
       invalid,
       issues,
+      needsOnlineSupport,
       onCancel,
       pristine,
       selectedIssue,
@@ -66,6 +68,12 @@ export class SupportForm extends Component {
             name='issueId'
             label='I need help with...'
             placeholder='Select an option'
+            helpText={needsOnlineSupport && (
+              <Fragment>
+                Additional technical support is available on paid
+                plans. <PageLink to="/account/billing/plan">Ugrade now</PageLink>.
+              </Fragment>
+            )}
             errorInLabel
             disabled={submitting}
             component={SelectWrapper}
@@ -114,6 +122,7 @@ export const formName = 'supportForm';
 const selector = formValueSelector(formName);
 const mapStateToProps = (state) => ({
   issues: selectSupportIssues(state),
+  needsOnlineSupport: !hasOnlineSupport(state),
   selectedIssue: selectSupportIssue(state, selector(state, 'issueId')),
   ticketId: state.support.ticketId
 });

--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -55,7 +55,8 @@ export class SupportForm extends Component {
       onCancel,
       pristine,
       selectedIssue,
-      submitting
+      submitting,
+      toggleSupportPanel
     } = this.props;
 
     return <div className={styles.SupportForm}>
@@ -71,7 +72,7 @@ export class SupportForm extends Component {
             helpText={needsOnlineSupport && (
               <Fragment>
                 Additional technical support is available on paid
-                plans. <PageLink to="/account/billing/plan">Upgrade now</PageLink>.
+                plans. <PageLink onClick={toggleSupportPanel} to="/account/billing/plan">Upgrade now</PageLink>.
               </Fragment>
             )}
             errorInLabel

--- a/src/components/support/components/tests/SupportForm.test.js
+++ b/src/components/support/components/tests/SupportForm.test.js
@@ -55,6 +55,11 @@ describe('Support Form Component', () => {
       wrapper.setProps({ selectedIssue: technicalIssue });
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render issue dropdown with help text', () => {
+      wrapper.setProps({ needsOnlineSupport: true });
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
   describe('Control', () => {

--- a/src/components/support/components/tests/SupportForm.test.js
+++ b/src/components/support/components/tests/SupportForm.test.js
@@ -58,7 +58,7 @@ describe('Support Form Component', () => {
 
     it('should render issue dropdown with help text', () => {
       wrapper.setProps({ needsOnlineSupport: true });
-      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.find('Field[name="issueId"]')).toMatchSnapshot();
     });
   });
 

--- a/src/components/support/components/tests/SupportForm.test.js
+++ b/src/components/support/components/tests/SupportForm.test.js
@@ -17,11 +17,14 @@ describe('Support Form Component', () => {
 
   describe('Form', () => {
     let props;
-    let handleSubmit;
 
     beforeEach(() => {
-      handleSubmit = jest.fn();
-      props = { handleSubmit, issues: [technicalIssue]};
+
+      props = {
+        handleSubmit: jest.fn(),
+        issues: [technicalIssue],
+        toggleSupportPanel: jest.fn()
+      };
       wrapper = shallow(<SupportForm {...props} />);
     });
 

--- a/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
@@ -63,76 +63,33 @@ exports[`Support Form Component Form should render 1`] = `
 `;
 
 exports[`Support Form Component Form should render issue dropdown with help text 1`] = `
-<div>
-  <Panel.Section>
-    <h6>
-      Submit A Support Ticket
-    </h6>
-  </Panel.Section>
-  <form>
-    <Panel.Section>
-      <Field
-        component={[Function]}
-        errorInLabel={true}
-        helpText={
-          <UNDEFINED>
-            Additional technical support is available on paid plans. 
-            <PageLink
-              to="/account/billing/plan"
-            >
-              Ugrade now
-            </PageLink>
-            .
-          </UNDEFINED>
-        }
-        label="I need help with..."
-        name="issueId"
-        options={
-          Array [
-            Object {
-              "label": "I need help!",
-              "value": "technical_issues",
-            },
-          ]
-        }
-        placeholder="Select an option"
-        validate={[Function]}
-      />
-      <Field
-        component={[Function]}
-        errorInLabel={true}
-        label="Tell us more about your issue"
-        multiline={true}
-        name="message"
-        resize="none"
-        rows={10}
-        validate={[Function]}
-      />
-      <Field
-        component={[Function]}
-        label="Attach a file"
-        name="attachment"
-        type="file"
-        validate={[Function]}
-      />
-    </Panel.Section>
-    <Panel.Section>
-      <Button
-        primary={true}
-        size="default"
-        submit={true}
+<Field
+  component={[Function]}
+  errorInLabel={true}
+  helpText={
+    <UNDEFINED>
+      Additional technical support is available on paid plans. 
+      <PageLink
+        to="/account/billing/plan"
       >
-        Submit Ticket
-      </Button>
-      <Button
-        onClick={[Function]}
-        size="default"
-      >
-        Cancel
-      </Button>
-    </Panel.Section>
-  </form>
-</div>
+        Upgrade now
+      </PageLink>
+      .
+    </UNDEFINED>
+  }
+  label="I need help with..."
+  name="issueId"
+  options={
+    Array [
+      Object {
+        "label": "I need help!",
+        "value": "technical_issues",
+      },
+    ]
+  }
+  placeholder="Select an option"
+  validate={[Function]}
+/>
 `;
 
 exports[`Support Form Component Form should render with selected issue message label 1`] = `

--- a/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
@@ -70,6 +70,7 @@ exports[`Support Form Component Form should render issue dropdown with help text
     <UNDEFINED>
       Additional technical support is available on paid plans. 
       <PageLink
+        onClick={[MockFunction]}
         to="/account/billing/plan"
       >
         Upgrade now

--- a/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
@@ -62,6 +62,79 @@ exports[`Support Form Component Form should render 1`] = `
 </div>
 `;
 
+exports[`Support Form Component Form should render issue dropdown with help text 1`] = `
+<div>
+  <Panel.Section>
+    <h6>
+      Submit A Support Ticket
+    </h6>
+  </Panel.Section>
+  <form>
+    <Panel.Section>
+      <Field
+        component={[Function]}
+        errorInLabel={true}
+        helpText={
+          <UNDEFINED>
+            Additional technical support is available on paid plans. 
+            <PageLink
+              to="/account/billing/plan"
+            >
+              Ugrade now
+            </PageLink>
+            .
+          </UNDEFINED>
+        }
+        label="I need help with..."
+        name="issueId"
+        options={
+          Array [
+            Object {
+              "label": "I need help!",
+              "value": "technical_issues",
+            },
+          ]
+        }
+        placeholder="Select an option"
+        validate={[Function]}
+      />
+      <Field
+        component={[Function]}
+        errorInLabel={true}
+        label="Tell us more about your issue"
+        multiline={true}
+        name="message"
+        resize="none"
+        rows={10}
+        validate={[Function]}
+      />
+      <Field
+        component={[Function]}
+        label="Attach a file"
+        name="attachment"
+        type="file"
+        validate={[Function]}
+      />
+    </Panel.Section>
+    <Panel.Section>
+      <Button
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Submit Ticket
+      </Button>
+      <Button
+        onClick={[Function]}
+        size="default"
+      >
+        Cancel
+      </Button>
+    </Panel.Section>
+  </form>
+</div>
+`;
+
 exports[`Support Form Component Form should render with selected issue message label 1`] = `
 <div>
   <Panel.Section>

--- a/src/components/support/tests/Support.test.js
+++ b/src/components/support/tests/Support.test.js
@@ -8,7 +8,6 @@ describe('Support Component', () => {
 
   beforeEach(() => {
     const props = {
-      entitledToOnlineSupport: true,
       loggedIn: true,
       location: {},
       openSupportPanel: jest.fn(),
@@ -23,18 +22,13 @@ describe('Support Component', () => {
   });
 
   describe('render tests', () => {
-    it('should not render the icon if the account is not entitled to support', () => {
-      wrapper.setProps({ entitledToOnlineSupport: false });
-      expect(wrapper.get(0)).toBeFalsy();
+    it('should render just the icon by default', () => {
+      expect(wrapper).toMatchSnapshot();
     });
 
     it('should not render icon if account is not logged in', () => {
       wrapper.setProps({ loggedIn: false });
       expect(wrapper.get(0)).toBeFalsy();
-    });
-
-    it('should render just the icon by default', () => {
-      expect(wrapper).toMatchSnapshot();
     });
 
     it('should show search panel and close icon when panel is opened', () => {

--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -1,10 +1,10 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { UnstyledLink } from '@sparkpost/matchbox';
-import { Link } from 'react-router-dom';
 import { verifyEmail } from 'src/actions/currentUser';
 import { showAlert } from 'src/actions/globalAlert';
 import { openSupportPanel, hydrateTicketForm } from 'src/actions/support';
+import { PageLink } from 'src/components';
 import { allowSendingLimitRequestSelector } from 'src/selectors/support';
 import { LINKS } from 'src/constants';
 
@@ -31,9 +31,7 @@ export class SendMoreCTA extends Component {
   }
 
   renderUpgradeCTA () {
-    return (<UnstyledLink Component={Link} to='/account/billing'>
-      Upgrade your account.
-    </UnstyledLink>);
+    return <PageLink to="/account/billing">Upgrade your account.</PageLink>;
   }
 
   toggleSupportForm = () => {
@@ -46,7 +44,7 @@ export class SendMoreCTA extends Component {
   renderSupportTicketCTA () {
     return (
       <Fragment>
-        <UnstyledLink Component={Link} onClick={this.toggleSupportForm}>Submit a request</UnstyledLink> to increase your daily sending limit.
+        <UnstyledLink onClick={this.toggleSupportForm}>Submit a request</UnstyledLink> to increase your daily sending limit.
       </Fragment>
     );
   }

--- a/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
@@ -4,12 +4,11 @@ exports[`SendMoreCTA Component renders correctly for aws free plan (cta to upgra
 <p>
   Need to send more?
    
-  <UnstyledLink
-    Component={[Function]}
+  <PageLink
     to="/account/billing"
   >
     Upgrade your account.
-  </UnstyledLink>
+  </PageLink>
    
   <UnstyledLink
     external={true}
@@ -26,7 +25,6 @@ exports[`SendMoreCTA Component renders correctly for customers who can request l
    
   <React.Fragment>
     <UnstyledLink
-      Component={[Function]}
       onClick={[Function]}
     >
       Submit a request
@@ -49,7 +47,6 @@ exports[`SendMoreCTA Component renders support form correctly 1`] = `
    
   <React.Fragment>
     <UnstyledLink
-      Component={[Function]}
       onClick={[Function]}
     >
       Submit a request

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -1,4 +1,5 @@
 // types of support issues
+// @note These values must be configured in Desk before being used and they are case-sensitive
 const BILLING = 'Billing';
 const COMPLIANCE = 'Compliance';
 const ERRORS = 'Errors';

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -1,3 +1,5 @@
+import { hasOnlineSupport } from 'src/helpers/conditions/account';
+
 // types of support issues
 // @note These values must be configured in Desk before being used and they are case-sensitive
 const BILLING = 'Billing';
@@ -21,7 +23,7 @@ const SUPPORT = 'Support';
  *     type: 'Example',
  *
  *     // optional, composed account helpers to determine which user can report this issue
- *     condition: isEnterprise()
+ *     condition: isEnterprise
  *   }
  */
 const supportIssues = [
@@ -29,13 +31,15 @@ const supportIssues = [
     id: 'technical_errors',
     label: 'Technical errors',
     messageLabel: 'Tell us more about your issue',
-    type: ERRORS
+    type: ERRORS,
+    condition: hasOnlineSupport
   },
   {
     id: 'general_billing',
     label: 'Billing problems',
     messageLabel: 'Tell us more about your billing issue',
-    type: BILLING
+    type: BILLING,
+    condition: hasOnlineSupport
   },
   {
     id: 'account_cancellation',
@@ -53,13 +57,15 @@ const supportIssues = [
     id: 'daily_limits',
     label: 'Daily sending limit increase',
     messageLabel: 'What limit do you need and why?',
-    type: LIMITS
+    type: LIMITS,
+    condition: hasOnlineSupport
   },
   {
     id: 'general_issue',
     label: 'Another issue',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT
+    type: SUPPORT,
+    condition: hasOnlineSupport
   }
 ];
 

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -16,3 +16,4 @@ export const isSuspendedForBilling = all(
 export const subscriptionSelfServeIsTrue = ({ account }) => _.get(account, 'subscription.self_serve', false);
 export const isAws = ({ account }) => _.get(account, 'subscription.type') === 'aws';
 export const isSelfServeBilling = any(subscriptionSelfServeIsTrue, isAws);
+export const hasOnlineSupport = ({ account }) => _.get(account, 'support.online', false);

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -5,7 +5,8 @@ import {
   isSuspendedForBilling,
   hasStatus,
   hasStatusReasonCategory,
-  isSelfServeBilling
+  isSelfServeBilling,
+  hasOnlineSupport
 } from '../account';
 
 describe('Condition: onPlan', () => {
@@ -127,4 +128,23 @@ describe('Condition: isSelfServeBilling', () => {
     expect(isSelfServeBilling({ account })).toEqual(true);
   });
 
+});
+
+describe('Condition: hasOnlineSupport', () => {
+  it('should return true for accounts with online support', () => {
+    const state = {
+      account: {
+        support: {
+          online: true
+        }
+      }
+    };
+
+    expect(hasOnlineSupport(state)).toEqual(true);
+  });
+
+  it('should return false for accounts without online support', () => {
+    const state = {};
+    expect(hasOnlineSupport(state)).toEqual(false);
+  });
 });

--- a/src/pages/auth/AuthPage.js
+++ b/src/pages/auth/AuthPage.js
@@ -1,12 +1,11 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import qs from 'query-string';
 import { authenticate, ssoCheck, login } from 'src/actions/auth';
 import { verifyAndLogin } from 'src/actions/tfa';
-import { CenteredLogo } from 'src/components';
-import { Panel, Error, UnstyledLink } from '@sparkpost/matchbox';
+import { CenteredLogo, PageLink } from 'src/components';
+import { Panel, Error } from '@sparkpost/matchbox';
 import { SubmissionError } from 'redux-form';
 
 import config from 'src/config';
@@ -16,21 +15,21 @@ import TfaForm from './components/TfaForm';
 import { decodeBase64 } from 'src/helpers/string';
 
 export class AuthPage extends Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
     this.state = {
       ssoEnabled: config.sso.enabled
     };
   }
 
-  componentDidMount() {
+  componentDidMount () {
     if (this.props.auth.loggedIn) {
       this.redirect();
       return;
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps (nextProps) {
     const { ssoUser, loggedIn, username } = nextProps.auth;
 
     if (loggedIn) {
@@ -49,7 +48,7 @@ export class AuthPage extends Component {
     }
   }
 
-  redirect(nextProps) {
+  redirect (nextProps) {
     // Passes location state through '/' or '/auth'
     // DefaultRedirect component handles protected routes
     const defaultRoute = { ...this.props.location, pathname: DEFAULT_REDIRECT_ROUTE };
@@ -57,11 +56,11 @@ export class AuthPage extends Component {
     this.props.history.push(route);
   }
 
-  ssoSignIn(username) {
+  ssoSignIn (username) {
     return this.props.ssoCheck(username);
   }
 
-  regularSignIn(username, password, rememberMe) {
+  regularSignIn (username, password, rememberMe) {
     return this.props.authenticate(username, password, rememberMe);
   }
 
@@ -82,7 +81,7 @@ export class AuthPage extends Component {
     });
   }
 
-  render() {
+  render () {
     const { auth, location, tfa } = this.props;
     const hasSignup = (config.featureFlags || {}).has_signup;
     const search = qs.parse(location.search);
@@ -90,8 +89,8 @@ export class AuthPage extends Component {
 
     const footerMarkup = !tfa.enabled
       ? <Panel.Footer
-        left={hasSignup && <small>Don't have an account? <UnstyledLink Component={Link} to='/join'>Sign up</UnstyledLink>.</small>}
-        right={<small><UnstyledLink Component={Link} to='/forgot-password'>Forgot your password?</UnstyledLink></small>} />
+        left={hasSignup && <small>Don't have an account? <PageLink to="/join">Sign up</PageLink>.</small>}
+        right={<small><PageLink to="/forgot-password">Forgot your password?</PageLink></small>} />
       : null;
 
     return (
@@ -100,8 +99,8 @@ export class AuthPage extends Component {
         <Panel sectioned accent title="Log In">
           {loginError && <Error error={loginError} />}
 
-          { tfa.enabled && <TfaForm onSubmit={this.tfaSubmit} /> }
-          { !tfa.enabled && <LoginForm onSubmit={this.loginSubmit} ssoEnabled={this.state.ssoEnabled}/> }
+          {tfa.enabled && <TfaForm onSubmit={this.tfaSubmit} />}
+          {!tfa.enabled && <LoginForm onSubmit={this.loginSubmit} ssoEnabled={this.state.ssoEnabled}/>}
         </Panel>
         {footerMarkup}
       </div>

--- a/src/pages/auth/tests/__snapshots__/AuthPage.test.js.snap
+++ b/src/pages/auth/tests/__snapshots__/AuthPage.test.js.snap
@@ -17,12 +17,11 @@ exports[`renders correctly 1`] = `
     left={false}
     right={
       <small>
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/forgot-password"
         >
           Forgot your password?
-        </UnstyledLink>
+        </PageLink>
       </small>
     }
   />
@@ -49,12 +48,11 @@ exports[`renders correctly when there is a login error 1`] = `
     left={false}
     right={
       <small>
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/forgot-password"
         >
           Forgot your password?
-        </UnstyledLink>
+        </PageLink>
       </small>
     }
   />
@@ -81,12 +79,11 @@ exports[`should display sso error message 1`] = `
     left={false}
     right={
       <small>
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/forgot-password"
         >
           Forgot your password?
-        </UnstyledLink>
+        </PageLink>
       </small>
     }
   />

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link, withRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
 import cookie from 'js-cookie';
 import _ from 'lodash';
 
-import { CenteredLogo } from 'src/components';
-import { Panel, Error, UnstyledLink } from '@sparkpost/matchbox';
+import { CenteredLogo, PageLink } from 'src/components';
+import { Panel, Error } from '@sparkpost/matchbox';
 import JoinForm from './components/JoinForm';
 import JoinError from './components/JoinError';
 import JoinLink from './components/JoinLink';
@@ -50,7 +50,7 @@ export class JoinPage extends Component {
       .then(() => this.props.history.push(AFTER_JOIN_REDIRECT_ROUTE, { plan }));
   };
 
-  render() {
+  render () {
     const { createError } = this.props.account;
     const { formData } = this.state;
     const title = inSPCEU() ? 'Sign Up For SparkPost EU' : 'Sign Up';
@@ -72,7 +72,7 @@ export class JoinPage extends Component {
           </Panel.Section>
         </Panel>
         <Panel.Footer
-          left={<small>Already have an account? <UnstyledLink Component={Link} to='/auth'>Log In</UnstyledLink>.</small>}
+          left={<small>Already have an account? <PageLink to="/auth">Log In</PageLink>.</small>}
           right={<JoinLink location={this.props.location} />}
         />
       </div>
@@ -80,7 +80,7 @@ export class JoinPage extends Component {
   }
 }
 
-function mapStateToProps(state, props) {
+function mapStateToProps (state, props) {
   return {
     account: state.account,
     params: qs.parse(props.location.search),

--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -61,12 +61,11 @@ exports[`JoinPage render renders aws logo when signup from aws 1`] = `
     left={
       <small>
         Already have an account? 
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Log In
-        </UnstyledLink>
+        </PageLink>
         .
       </small>
     }
@@ -109,12 +108,11 @@ exports[`JoinPage render renders correctly 1`] = `
     left={
       <small>
         Already have an account? 
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Log In
-        </UnstyledLink>
+        </PageLink>
         .
       </small>
     }
@@ -167,12 +165,11 @@ exports[`JoinPage render renders errors 1`] = `
     left={
       <small>
         Already have an account? 
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Log In
-        </UnstyledLink>
+        </PageLink>
         .
       </small>
     }

--- a/src/pages/onboarding/components/SkipLink.js
+++ b/src/pages/onboarding/components/SkipLink.js
@@ -1,14 +1,13 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { UnstyledLink } from '@sparkpost/matchbox';
 import { ArrowForward } from '@sparkpost/matchbox-icons';
+import { PageLink } from 'src/components';
 
 import styles from './SkipLink.module.scss';
 
 const SkipLink = ({ to, children }) => (
-  <UnstyledLink to={to} Component={Link} className={styles.SkipLink}>
+  <PageLink to={to} className={styles.SkipLink}>
     {children} <ArrowForward />
-  </UnstyledLink>
+  </PageLink>
 );
 
 export default SkipLink;

--- a/src/pages/onboarding/components/tests/__snapshots__/SkipLink.test.js.snap
+++ b/src/pages/onboarding/components/tests/__snapshots__/SkipLink.test.js.snap
@@ -1,12 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SkipLink should render correctly 1`] = `
-<UnstyledLink
-  Component={[Function]}
+<PageLink
   to="/a-path"
 >
   go to a path
    
   <ArrowForward />
-</UnstyledLink>
+</PageLink>
 `;

--- a/src/pages/passwordReset/ForgotPasswordPage.js
+++ b/src/pages/passwordReset/ForgotPasswordPage.js
@@ -1,12 +1,11 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { sendPasswordResetEmail } from 'src/actions/passwordReset';
 import { showAlert } from 'src/actions/globalAlert';
 import { required } from 'src/helpers/validation';
 import { reduxForm, Field } from 'redux-form';
-import { CenteredLogo, TextFieldWrapper } from 'src/components';
-import { Panel, Button, UnstyledLink } from '@sparkpost/matchbox';
+import { CenteredLogo, PageLink, TextFieldWrapper } from 'src/components';
+import { Panel, Button } from '@sparkpost/matchbox';
 
 const successAlert = {
   type: 'success',
@@ -19,7 +18,7 @@ const errorAlert = {
 };
 
 export class ForgotPasswordPage extends Component {
-  componentDidUpdate(prevProps) {
+  componentDidUpdate (prevProps) {
     const { emailSuccess, emailError, history, showAlert } = this.props;
 
     if (!prevProps.emailSuccess && emailSuccess) {
@@ -32,7 +31,7 @@ export class ForgotPasswordPage extends Component {
     }
   }
 
-  render() {
+  render () {
     const { handleSubmit, invalid, submitting, sendPasswordResetEmail } = this.props;
 
     const buttonText = submitting
@@ -55,7 +54,7 @@ export class ForgotPasswordPage extends Component {
           </form>
         </Panel>
         <Panel.Footer
-          left={<small>Remember your password? <UnstyledLink to='/auth' Component={Link}>Log in</UnstyledLink>.</small>}
+          left={<small>Remember your password? <PageLink to="/auth">Log in</PageLink>.</small>}
         />
       </Fragment>
     );

--- a/src/pages/passwordReset/ResetPasswordPage.js
+++ b/src/pages/passwordReset/ResetPasswordPage.js
@@ -1,12 +1,11 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { resetPassword } from 'src/actions/passwordReset';
 import { showAlert } from 'src/actions/globalAlert';
 import { required, minLength, endsWithWhitespace } from 'src/helpers/validation';
 import { reduxForm, Field } from 'redux-form';
-import { CenteredLogo, TextFieldWrapper } from 'src/components';
-import { Panel, Button, UnstyledLink } from '@sparkpost/matchbox';
+import { CenteredLogo, PageLink, TextFieldWrapper } from 'src/components';
+import { Panel, Button } from '@sparkpost/matchbox';
 import _ from 'lodash';
 
 export class ResetPasswordPage extends Component {
@@ -15,7 +14,7 @@ export class ResetPasswordPage extends Component {
     return resetPassword({ password, token });
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate (prevProps) {
     const { resetSuccess, resetError, history, showAlert } = this.props;
 
     if (!prevProps.resetSuccess && resetSuccess) {
@@ -42,7 +41,7 @@ export class ResetPasswordPage extends Component {
 
   comparePasswords = (value, { newPassword, confirmNewPassword }) => newPassword === confirmNewPassword ? undefined : 'Must be the same password'
 
-  render() {
+  render () {
     const { handleSubmit, invalid, submitting } = this.props;
 
     const buttonText = submitting
@@ -73,7 +72,7 @@ export class ResetPasswordPage extends Component {
           </form>
         </Panel>
         <Panel.Footer
-          left={<small>Remember your password? <UnstyledLink to='/auth' Component={Link}>Log in</UnstyledLink>.</small>}
+          left={<small>Remember your password? <PageLink to="/auth">Log in</PageLink>.</small>}
         />
       </Fragment>
     );

--- a/src/pages/passwordReset/tests/__snapshots__/ForgotPasswordPage.test.js.snap
+++ b/src/pages/passwordReset/tests/__snapshots__/ForgotPasswordPage.test.js.snap
@@ -34,12 +34,11 @@ exports[`Forgot Password Page should render with initial props 1`] = `
     left={
       <small>
         Remember your password? 
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Log in
-        </UnstyledLink>
+        </PageLink>
         .
       </small>
     }

--- a/src/pages/passwordReset/tests/__snapshots__/ResetPasswordPage.test.js.snap
+++ b/src/pages/passwordReset/tests/__snapshots__/ResetPasswordPage.test.js.snap
@@ -53,12 +53,11 @@ exports[`Forgot Password Page should render with initial props 1`] = `
     left={
       <small>
         Remember your password? 
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Log in
-        </UnstyledLink>
+        </PageLink>
         .
       </small>
     }

--- a/src/pages/register/RegisterPage.js
+++ b/src/pages/register/RegisterPage.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { withRouter, Redirect, Link } from 'react-router-dom';
+import { withRouter, Redirect } from 'react-router-dom';
 import qs from 'query-string';
 import ErrorTracker from 'src/helpers/errorTracker';
 
-import { CenteredLogo } from 'src/components';
-import { Panel, UnstyledLink } from '@sparkpost/matchbox';
+import { CenteredLogo, PageLink } from 'src/components';
+import { Panel } from '@sparkpost/matchbox';
 import PanelLoading from 'src/components/panelLoading/PanelLoading';
 import RegisterUserForm from './RegisterUserForm';
 
@@ -29,11 +29,11 @@ export class RegisterPage extends Component {
   }
 
 
-  componentDidMount() {
+  componentDidMount () {
     this.props.checkInviteToken(this.props.token);
   }
 
-  renderRegisterPanel() {
+  renderRegisterPanel () {
     const { invite, loading } = this.props;
 
     if (loading) {
@@ -56,7 +56,7 @@ export class RegisterPage extends Component {
     );
   }
 
-  render() {
+  render () {
     const { token } = this.props;
 
     if (token === undefined) {
@@ -68,15 +68,15 @@ export class RegisterPage extends Component {
         <CenteredLogo />
 
         <Panel accent title='Set Password'>
-          { this.renderRegisterPanel() }
+          {this.renderRegisterPanel()}
         </Panel>
-        <Panel.Footer left={<small><UnstyledLink Component={Link} to='/auth'>Already signed up?</UnstyledLink></small>} />
+        <Panel.Footer left={<small><PageLink to="/auth">Already signed up?</PageLink></small>} />
       </div>
     );
   }
 }
 
-function mapStateToProps({ auth, users }, props) {
+function mapStateToProps ({ auth, users }, props) {
   return {
     token: qs.parse(props.location.search).token,
     invite: users.invite,

--- a/src/pages/register/tests/__snapshots__/RegisterPage.test.js.snap
+++ b/src/pages/register/tests/__snapshots__/RegisterPage.test.js.snap
@@ -23,12 +23,11 @@ exports[`Page: RegisterPage happy path render 1`] = `
   <Panel.Footer
     left={
       <small>
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Already signed up?
-        </UnstyledLink>
+        </PageLink>
       </small>
     }
   />
@@ -49,12 +48,11 @@ exports[`Page: RegisterPage loading 1`] = `
   <Panel.Footer
     left={
       <small>
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Already signed up?
-        </UnstyledLink>
+        </PageLink>
       </small>
     }
   />
@@ -84,12 +82,11 @@ exports[`Page: RegisterPage token expired 1`] = `
   <Panel.Footer
     left={
       <small>
-        <UnstyledLink
-          Component={[Function]}
+        <PageLink
           to="/auth"
         >
           Already signed up?
-        </UnstyledLink>
+        </PageLink>
       </small>
     }
   />

--- a/src/pages/sendingDomains/ListPage.js
+++ b/src/pages/sendingDomains/ListPage.js
@@ -4,15 +4,18 @@ import { Link } from 'react-router-dom';
 import { list as listDomains } from 'src/actions/sendingDomains';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 import { hasUnverifiedDomains } from 'src/selectors/sendingDomains';
-import { Loading, TableCollection, SubaccountTag, DomainStatusCell, StatusTooltipHeader, ApiErrorBanner } from 'src/components';
-import { Page, UnstyledLink } from '@sparkpost/matchbox';
+import {
+  Loading, TableCollection, SubaccountTag, DomainStatusCell, StatusTooltipHeader, ApiErrorBanner,
+  PageLink
+} from 'src/components';
+import { Page } from '@sparkpost/matchbox';
 import { Setup } from 'src/components/images';
 import UnverifiedWarningBanner from './components/UnverifiedWarningBanner';
 import VerifyToken from './components/VerifyToken';
 import { LINKS } from 'src/constants';
 
 export class ListPage extends Component {
-  componentDidMount() {
+  componentDidMount () {
     this.props.listDomains();
   }
 
@@ -36,7 +39,7 @@ export class ListPage extends Component {
     const { domain, shared_with_subaccounts, subaccount_id } = row;
 
     const rowData = [
-      <UnstyledLink Component={Link} to={`/account/sending-domains/edit/${domain}`}>{domain}</UnstyledLink>,
+      <PageLink to={`/account/sending-domains/edit/${domain}`}>{domain}</PageLink>,
       <DomainStatusCell domain={row} />
     ];
 
@@ -51,7 +54,7 @@ export class ListPage extends Component {
     return rowData;
   }
 
-  renderCollection() {
+  renderCollection () {
     return (
       <TableCollection
         columns={this.getColumns()}
@@ -69,7 +72,7 @@ export class ListPage extends Component {
     );
   }
 
-  renderError() {
+  renderError () {
     return (
       <ApiErrorBanner
         errorDetails={this.props.listError.message}
@@ -79,7 +82,7 @@ export class ListPage extends Component {
     );
   }
 
-  render() {
+  render () {
     const { listError, listLoading, domains, hasUnverifiedDomains } = this.props;
 
     if (listLoading) {

--- a/src/pages/sendingDomains/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/sendingDomains/tests/__snapshots__/ListPage.test.js.snap
@@ -158,12 +158,11 @@ exports[`Sending Domains List Page renders loading correctly 1`] = `<Loading />`
 exports[`Sending Domains List Page renders rows correctly 1`] = `
 Array [
   Array [
-    <UnstyledLink
-      Component={[Function]}
+    <PageLink
       to="/account/sending-domains/edit/test.com"
     >
       test.com
-    </UnstyledLink>,
+    </PageLink>,
     <DomainStatusCell
       domain={
         Object {
@@ -189,12 +188,11 @@ Array [
     />,
   ],
   Array [
-    <UnstyledLink
-      Component={[Function]}
+    <PageLink
       to="/account/sending-domains/edit/test2.com"
     >
       test2.com
-    </UnstyledLink>,
+    </PageLink>,
     <DomainStatusCell
       domain={
         Object {
@@ -217,12 +215,11 @@ Array [
 exports[`Sending Domains List Page renders rows correctly with no subaccounts 1`] = `
 Array [
   Array [
-    <UnstyledLink
-      Component={[Function]}
+    <PageLink
       to="/account/sending-domains/edit/test.com"
     >
       test.com
-    </UnstyledLink>,
+    </PageLink>,
     <DomainStatusCell
       domain={
         Object {
@@ -241,12 +238,11 @@ Array [
     />,
   ],
   Array [
-    <UnstyledLink
-      Component={[Function]}
+    <PageLink
       to="/account/sending-domains/edit/test2.com"
     >
       test2.com
-    </UnstyledLink>,
+    </PageLink>,
     <DomainStatusCell
       domain={
         Object {

--- a/src/selectors/support.js
+++ b/src/selectors/support.js
@@ -7,11 +7,6 @@ import supportIssues from 'src/config/supportIssues';
 const getAccountSupport = (state) => state.account.support;
 const getSupportIssueId = (state, id) => id;
 
-export const entitledToOnlineSupport = createSelector(
-  [getAccountSupport],
-  (support) => support && support.online
-);
-
 export const entitledToPhoneSupport = createSelector(
   [getAccountSupport],
   (support) => support && support.phone

--- a/src/selectors/tests/support.test.js
+++ b/src/selectors/tests/support.test.js
@@ -20,33 +20,30 @@ describe('Selectors: support', () => {
       const state = {
         account: {}
       };
-      expect(selectors.entitledToOnlineSupport(state)).toBeFalsy();
       expect(selectors.entitledToPhoneSupport(state)).toBeFalsy();
     });
 
-    it('when account is not entitled to online support', () => {
+    it('when account is not entitled to phone support', () => {
       const state = {
         account: {
           support: {
-            online: false,
             phone: true
           }
         }
       };
-      expect(selectors.entitledToOnlineSupport(state)).toBeFalsy();
+
       expect(selectors.entitledToPhoneSupport(state)).toBeTruthy();
     });
 
-    it('when account entitled to online support', () => {
+    it('when account entitled to phone support', () => {
       const state = {
         account: {
           support: {
-            online: true,
             phone: false
           }
         }
       };
-      expect(selectors.entitledToOnlineSupport(state)).toBeTruthy();
+
       expect(selectors.entitledToPhoneSupport(state)).toBeFalsy();
     });
   });


### PR DESCRIPTION
_Refer to [FE-305](https://jira.int.messagesystems.com/browse/FE-305)_

**What to test?**
- Confirm the support panel is visible, support docs are searchable, and only a select list of issues are available for free accounts older than 30 days (e.g. brian.kemper+fad5684-free@sparkpost.com)

**Notes**
- Don't be alarmed if you see the full list of support options for newly created accounts.  Free accounts are granted online support for the first 30 days.