### PR TITLE
FE-97: Request to cancel account thru in-app support

### DIFF
--- a/src/actions/support.js
+++ b/src/actions/support.js
@@ -70,7 +70,7 @@ export function toggleTicketForm () {
 }
 
 // Opens support ticket form and fills values if provided
-export function openSupportTicket ({ issueId, message } = {}) {
+export function openSupportTicketForm ({ issueId, message } = {}) {
   const issue = _.find(supportIssues, { id: issueId });
 
   return (dispatch) => {

--- a/src/actions/support.js
+++ b/src/actions/support.js
@@ -69,11 +69,14 @@ export function toggleTicketForm () {
   };
 }
 
-// Fills support ticket form values
-export function hydrateTicketForm ({ issueId, message } = {}) {
+// Opens support ticket form and fills values if provided
+export function openSupportTicket ({ issueId, message } = {}) {
   const issue = _.find(supportIssues, { id: issueId });
 
   return (dispatch) => {
+    // the support panel must be open before you can hydrate it
+    dispatch(openSupportPanel({ view: 'ticket' }));
+
     if (issue) {
       dispatch(change(formName, 'issueId', issueId));
     }
@@ -81,9 +84,5 @@ export function hydrateTicketForm ({ issueId, message } = {}) {
     if (message) {
       dispatch(change(formName, 'message', message));
     }
-
-    return {
-      type: 'HYDRATE_TICKET_FORM'
-    };
   };
 }

--- a/src/actions/tests/__snapshots__/support.test.js.snap
+++ b/src/actions/tests/__snapshots__/support.test.js.snap
@@ -21,9 +21,18 @@ Object {
 }
 `;
 
-exports[`Action Creator: Support hydrateTicketForm should not hydrate without values 1`] = `
-Object {
-  "type": "HYDRATE_TICKET_FORM",
+exports[`Action Creator: Support openSupportTicket should open support panel 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "payload": Object {
+          "view": "ticket",
+        },
+        "type": "OPEN_SUPPORT_PANEL",
+      },
+    ],
+  ],
 }
 `;
 

--- a/src/actions/tests/__snapshots__/support.test.js.snap
+++ b/src/actions/tests/__snapshots__/support.test.js.snap
@@ -21,7 +21,7 @@ Object {
 }
 `;
 
-exports[`Action Creator: Support openSupportTicket should open support panel 1`] = `
+exports[`Action Creator: Support openSupportTicketForm should open support panel 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/src/actions/tests/support.test.js
+++ b/src/actions/tests/support.test.js
@@ -29,21 +29,21 @@ describe('Action Creator: Support', () => {
     });
   });
 
-  describe('openSupportTicket', () => {
+  describe('openSupportTicketForm', () => {
 
     it('should open support panel', () => {
-      support.openSupportTicket()(dispatchMock);
+      support.openSupportTicketForm()(dispatchMock);
       expect(dispatchMock).toMatchSnapshot();
     });
 
     it('should open support panel and set support ticket message', () => {
-      support.openSupportTicket({ message: 'test' })(dispatchMock);
+      support.openSupportTicketForm({ message: 'test' })(dispatchMock);
       expect(formActions.change).toHaveBeenCalledWith('supportForm', 'message', 'test');
       expect(formActions.change).toHaveBeenCalledTimes(1);
     });
 
     it('should open support panel ane set support ticket issue', () => {
-      support.openSupportTicket({ issueId: 'technical_errors' })(dispatchMock);
+      support.openSupportTicketForm({ issueId: 'technical_errors' })(dispatchMock);
       expect(formActions.change).toHaveBeenCalledWith('supportForm', 'issueId', 'technical_errors');
       expect(formActions.change).toHaveBeenCalledTimes(1);
     });

--- a/src/actions/tests/support.test.js
+++ b/src/actions/tests/support.test.js
@@ -29,20 +29,21 @@ describe('Action Creator: Support', () => {
     });
   });
 
-  describe('hydrateTicketForm', () => {
-    it('should not hydrate without values', () => {
-      expect(support.hydrateTicketForm({})(dispatchMock)).toMatchSnapshot();
-      expect(formActions.change).not.toHaveBeenCalled();
+  describe('openSupportTicket', () => {
+
+    it('should open support panel', () => {
+      support.openSupportTicket()(dispatchMock);
+      expect(dispatchMock).toMatchSnapshot();
     });
 
-    it('should hydrate message', () => {
-      support.hydrateTicketForm({ message: 'test' })(dispatchMock);
+    it('should open support panel and set support ticket message', () => {
+      support.openSupportTicket({ message: 'test' })(dispatchMock);
       expect(formActions.change).toHaveBeenCalledWith('supportForm', 'message', 'test');
       expect(formActions.change).toHaveBeenCalledTimes(1);
     });
 
-    it('should hydrate issueId', () => {
-      support.hydrateTicketForm({ issueId: 'technical_errors' })(dispatchMock);
+    it('should open support panel ane set support ticket issue', () => {
+      support.openSupportTicket({ issueId: 'technical_errors' })(dispatchMock);
       expect(formActions.change).toHaveBeenCalledWith('supportForm', 'issueId', 'technical_errors');
       expect(formActions.change).toHaveBeenCalledTimes(1);
     });

--- a/src/components/auth/SuspensionAlerts.js
+++ b/src/components/auth/SuspensionAlerts.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { showAlert } from 'src/actions/globalAlert';
-import { openSupportPanel, hydrateTicketForm } from 'src/actions/support';
+import { openSupportTicket } from 'src/actions/support';
 import { PageLink } from 'src/components';
 import { hasStatus, isSuspendedForBilling } from 'src/helpers/conditions/account';
 import { UnstyledLink } from '@sparkpost/matchbox';
@@ -12,10 +12,8 @@ import { UnstyledLink } from '@sparkpost/matchbox';
  * - Account suspended for billing
  */
 export class SuspensionAlerts extends Component {
-
   openTicket = () => {
-    this.props.openSupportPanel({ view: 'ticket' });
-    this.props.hydrateTicketForm({ issueId: 'account_suspension' });
+    this.props.openSupportTicket({ issueId: 'account_suspension' });
   }
 
   getMessage () {
@@ -56,5 +54,4 @@ const mapStateToProps = (state) => ({
   isSuspended: hasStatus('suspended')(state),
   isSuspendedForBilling: isSuspendedForBilling(state)
 });
-const mapDispatchToProps = { showAlert, openSupportPanel, hydrateTicketForm };
-export default connect(mapStateToProps, mapDispatchToProps)(SuspensionAlerts);
+export default connect(mapStateToProps, { showAlert, openSupportTicket })(SuspensionAlerts);

--- a/src/components/auth/SuspensionAlerts.js
+++ b/src/components/auth/SuspensionAlerts.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { showAlert } from 'src/actions/globalAlert';
-import { openSupportTicket } from 'src/actions/support';
+import { openSupportTicketForm } from 'src/actions/support';
 import { PageLink } from 'src/components';
 import { hasStatus, isSuspendedForBilling } from 'src/helpers/conditions/account';
 import { UnstyledLink } from '@sparkpost/matchbox';
@@ -13,7 +13,7 @@ import { UnstyledLink } from '@sparkpost/matchbox';
  */
 export class SuspensionAlerts extends Component {
   openTicket = () => {
-    this.props.openSupportTicket({ issueId: 'account_suspension' });
+    this.props.openSupportTicketForm({ issueId: 'account_suspension' });
   }
 
   getMessage () {
@@ -54,4 +54,4 @@ const mapStateToProps = (state) => ({
   isSuspended: hasStatus('suspended')(state),
   isSuspendedForBilling: isSuspendedForBilling(state)
 });
-export default connect(mapStateToProps, { showAlert, openSupportTicket })(SuspensionAlerts);
+export default connect(mapStateToProps, { showAlert, openSupportTicketForm })(SuspensionAlerts);

--- a/src/components/auth/tests/SuspensionAlerts.test.js
+++ b/src/components/auth/tests/SuspensionAlerts.test.js
@@ -8,10 +8,9 @@ describe('Component: SuspensionAlerts', () => {
 
   beforeEach(() => {
     props = {
-      hydrateTicketForm: jest.fn(),
       isSuspended: null,
       isSuspendedForBilling: false,
-      openSupportPanel: jest.fn(),
+      openSupportTicket: jest.fn(),
       showAlert: jest.fn()
     };
 
@@ -24,8 +23,7 @@ describe('Component: SuspensionAlerts', () => {
 
   it('should open ticket form', () => {
     wrapper.instance().openTicket();
-    expect(props.openSupportPanel).toHaveBeenCalledWith({ view: 'ticket' });
-    expect(props.hydrateTicketForm).toHaveBeenCalledWith({ issueId: 'account_suspension' });
+    expect(props.openSupportTicket).toHaveBeenCalledWith({ issueId: 'account_suspension' });
   });
 
   describe('componentDidUpdate', () => {

--- a/src/components/auth/tests/SuspensionAlerts.test.js
+++ b/src/components/auth/tests/SuspensionAlerts.test.js
@@ -10,7 +10,7 @@ describe('Component: SuspensionAlerts', () => {
     props = {
       isSuspended: null,
       isSuspendedForBilling: false,
-      openSupportTicket: jest.fn(),
+      openSupportTicketForm: jest.fn(),
       showAlert: jest.fn()
     };
 
@@ -23,7 +23,7 @@ describe('Component: SuspensionAlerts', () => {
 
   it('should open ticket form', () => {
     wrapper.instance().openTicket();
-    expect(props.openSupportTicket).toHaveBeenCalledWith({ issueId: 'account_suspension' });
+    expect(props.openSupportTicketForm).toHaveBeenCalledWith({ issueId: 'account_suspension' });
   });
 
   describe('componentDidUpdate', () => {

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -24,12 +24,11 @@ export class Support extends Component {
 
   // Opens and hydrates support ticket form from query params
   maybeOpenTicket = () => {
-    const { location, openSupportPanel, hydrateTicketForm } = this.props;
+    const { location, openSupportTicket } = this.props;
     const { supportTicket, supportMessage: message, supportIssue: issueId } = qs.parse(location.search);
 
     if (supportTicket) {
-      openSupportPanel({ view: 'ticket' });
-      hydrateTicketForm({ issueId, message });
+      openSupportTicket({ issueId, message });
     }
   }
 

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -24,11 +24,11 @@ export class Support extends Component {
 
   // Opens and hydrates support ticket form from query params
   maybeOpenTicket = () => {
-    const { location, openSupportTicket } = this.props;
+    const { location, openSupportTicketForm } = this.props;
     const { supportTicket, supportMessage: message, supportIssue: issueId } = qs.parse(location.search);
 
     if (supportTicket) {
-      openSupportTicket({ issueId, message });
+      openSupportTicketForm({ issueId, message });
     }
   }
 

--- a/src/components/support/tests/Support.test.js
+++ b/src/components/support/tests/Support.test.js
@@ -10,7 +10,7 @@ describe('Support Component', () => {
     const props = {
       loggedIn: true,
       location: {},
-      openSupportTicket: jest.fn(),
+      openSupportTicketForm: jest.fn(),
       toggleSupportPanel: jest.fn(),
       toggleTicketForm: jest.fn(),
       showPanel: false,
@@ -45,35 +45,35 @@ describe('Support Component', () => {
     it('should open panel and hydrate form if search value is present', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true&supportIssue=test_issue&supportMessage=testmessage' }});
 
-      expect(instance.props.openSupportTicket).toHaveBeenCalledWith(expect.objectContaining({
+      expect(instance.props.openSupportTicketForm).toHaveBeenCalledWith(expect.objectContaining({
         issueId: 'test_issue',
         message: 'testmessage'
       }));
     });
 
     it('should not open panel or hydrate form if search value is not present', () => {
-      expect(instance.props.openSupportTicket).not.toHaveBeenCalled();
+      expect(instance.props.openSupportTicketForm).not.toHaveBeenCalled();
     });
   });
 
   describe('on update', () => {
     it('should open panel and hydrate form if location changes and search value is present', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true&supportMessage=testmessage' }});
-      expect(instance.props.openSupportTicket).toHaveBeenCalledWith(expect.objectContaining({ message: 'testmessage' }));
+      expect(instance.props.openSupportTicketForm).toHaveBeenCalledWith(expect.objectContaining({ message: 'testmessage' }));
     });
 
     it('should not open panel or hydrate form if search does not change', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
       wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
 
-      expect(instance.props.openSupportTicket).toHaveBeenCalledTimes(1);
+      expect(instance.props.openSupportTicketForm).toHaveBeenCalledTimes(1);
     });
 
     it('should not open panel or hydrate form if search value is not present', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
       wrapper.setProps({ location: { search: undefined }});
 
-      expect(instance.props.openSupportTicket).toHaveBeenCalledTimes(1);
+      expect(instance.props.openSupportTicketForm).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/support/tests/Support.test.js
+++ b/src/components/support/tests/Support.test.js
@@ -10,10 +10,9 @@ describe('Support Component', () => {
     const props = {
       loggedIn: true,
       location: {},
-      openSupportPanel: jest.fn(),
+      openSupportTicket: jest.fn(),
       toggleSupportPanel: jest.fn(),
       toggleTicketForm: jest.fn(),
-      hydrateTicketForm: jest.fn(),
       showPanel: false,
       showTicketForm: false
     };
@@ -45,45 +44,36 @@ describe('Support Component', () => {
   describe('on mount', () => {
     it('should open panel and hydrate form if search value is present', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true&supportIssue=test_issue&supportMessage=testmessage' }});
-      jest.resetAllMocks(); // To clear the initial mount call
-      instance.componentDidMount();
-      expect(instance.props.openSupportPanel).toHaveBeenCalledWith({ view: 'ticket' });
-      expect(instance.props.hydrateTicketForm).toHaveBeenCalledWith(expect.objectContaining({
+
+      expect(instance.props.openSupportTicket).toHaveBeenCalledWith(expect.objectContaining({
         issueId: 'test_issue',
         message: 'testmessage'
       }));
     });
 
     it('should not open panel or hydrate form if search value is not present', () => {
-      expect(instance.props.openSupportPanel).not.toHaveBeenCalled();
-      expect(instance.props.hydrateTicketForm).not.toHaveBeenCalled();
+      expect(instance.props.openSupportTicket).not.toHaveBeenCalled();
     });
   });
 
   describe('on update', () => {
     it('should open panel and hydrate form if location changes and search value is present', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true&supportMessage=testmessage' }});
-      expect(instance.props.openSupportPanel).toHaveBeenCalledWith({ view: 'ticket' });
-      expect(instance.props.hydrateTicketForm).toHaveBeenCalledWith(expect.objectContaining({ message: 'testmessage' }));
+      expect(instance.props.openSupportTicket).toHaveBeenCalledWith(expect.objectContaining({ message: 'testmessage' }));
     });
 
     it('should not open panel or hydrate form if search does not change', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
-      jest.resetAllMocks();
-
       wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
 
-      expect(instance.props.openSupportPanel).not.toHaveBeenCalled();
-      expect(instance.props.hydrateTicketForm).not.toHaveBeenCalled();
+      expect(instance.props.openSupportTicket).toHaveBeenCalledTimes(1);
     });
 
     it('should not open panel or hydrate form if search value is not present', () => {
       wrapper.setProps({ location: { search: '?supportTicket=true,supportMessage=testmessage' }});
-      jest.resetAllMocks();
-
       wrapper.setProps({ location: { search: undefined }});
-      expect(instance.props.openSupportPanel).not.toHaveBeenCalled();
-      expect(instance.props.hydrateTicketForm).not.toHaveBeenCalled();
+
+      expect(instance.props.openSupportTicket).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { UnstyledLink } from '@sparkpost/matchbox';
 import { verifyEmail } from 'src/actions/currentUser';
 import { showAlert } from 'src/actions/globalAlert';
-import { openSupportTicket } from 'src/actions/support';
+import { openSupportTicketForm } from 'src/actions/support';
 import { PageLink } from 'src/components';
 import { allowSendingLimitRequestSelector } from 'src/selectors/support';
 import { LINKS } from 'src/constants';
@@ -35,7 +35,7 @@ export class SendMoreCTA extends Component {
   }
 
   toggleSupportForm = () => {
-    this.props.openSupportTicket({ issueId: 'daily_limits' });
+    this.props.openSupportTicketForm({ issueId: 'daily_limits' });
   }
 
   renderSupportTicketCTA () {
@@ -69,6 +69,6 @@ const mapStateToProps = (state) => ({
   allowSendingLimitRequest: allowSendingLimitRequestSelector(state)
 });
 const mapDispatchToProps = {
-  verifyEmail, showAlert, openSupportTicket
+  verifyEmail, showAlert, openSupportTicketForm
 };
 export default connect(mapStateToProps, mapDispatchToProps)(SendMoreCTA);

--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { UnstyledLink } from '@sparkpost/matchbox';
 import { verifyEmail } from 'src/actions/currentUser';
 import { showAlert } from 'src/actions/globalAlert';
-import { openSupportPanel, hydrateTicketForm } from 'src/actions/support';
+import { openSupportTicket } from 'src/actions/support';
 import { PageLink } from 'src/components';
 import { allowSendingLimitRequestSelector } from 'src/selectors/support';
 import { LINKS } from 'src/constants';
@@ -35,11 +35,8 @@ export class SendMoreCTA extends Component {
   }
 
   toggleSupportForm = () => {
-    const { openSupportPanel, hydrateTicketForm } = this.props;
-    openSupportPanel({ view: 'ticket' });
-    hydrateTicketForm({ issueId: 'daily_limits' });
+    this.props.openSupportTicket({ issueId: 'daily_limits' });
   }
-
 
   renderSupportTicketCTA () {
     return (
@@ -72,6 +69,6 @@ const mapStateToProps = (state) => ({
   allowSendingLimitRequest: allowSendingLimitRequestSelector(state)
 });
 const mapDispatchToProps = {
-  verifyEmail, showAlert, openSupportPanel, hydrateTicketForm
+  verifyEmail, showAlert, openSupportTicket
 };
 export default connect(mapStateToProps, mapDispatchToProps)(SendMoreCTA);

--- a/src/components/usageReport/tests/SendMoreCTA.test.js
+++ b/src/components/usageReport/tests/SendMoreCTA.test.js
@@ -17,7 +17,7 @@ describe('SendMoreCTA Component', () => {
       currentLimit: 1000,
       verifyEmail: jest.fn(() => Promise.resolve()),
       showAlert: jest.fn(() => Promise.resolve()),
-      openSupportTicket: jest.fn()
+      openSupportTicketForm: jest.fn()
     };
 
     wrapper = shallow(<SendMoreCTA {...props} />);
@@ -46,7 +46,7 @@ describe('SendMoreCTA Component', () => {
   it('togles support ticket form correctly', () => {
     wrapper.setProps({ allowSendingLimitRequest: true });
     wrapper.find('UnstyledLink').at(0).simulate('click');
-    expect(props.openSupportTicket).toHaveBeenCalledWith({ issueId: 'daily_limits' });
+    expect(props.openSupportTicketForm).toHaveBeenCalledWith({ issueId: 'daily_limits' });
   });
 
   describe('resendVerification', () => {

--- a/src/components/usageReport/tests/SendMoreCTA.test.js
+++ b/src/components/usageReport/tests/SendMoreCTA.test.js
@@ -17,8 +17,7 @@ describe('SendMoreCTA Component', () => {
       currentLimit: 1000,
       verifyEmail: jest.fn(() => Promise.resolve()),
       showAlert: jest.fn(() => Promise.resolve()),
-      openSupportPanel: jest.fn(),
-      hydrateTicketForm: jest.fn()
+      openSupportTicket: jest.fn()
     };
 
     wrapper = shallow(<SendMoreCTA {...props} />);
@@ -47,8 +46,7 @@ describe('SendMoreCTA Component', () => {
   it('togles support ticket form correctly', () => {
     wrapper.setProps({ allowSendingLimitRequest: true });
     wrapper.find('UnstyledLink').at(0).simulate('click');
-    expect(props.openSupportPanel).toHaveBeenCalledWith({ view: 'ticket' });
-    expect(props.hydrateTicketForm).toHaveBeenCalledWith({ issueId: 'daily_limits' });
+    expect(props.openSupportTicket).toHaveBeenCalledWith({ issueId: 'daily_limits' });
   });
 
   describe('resendVerification', () => {

--- a/src/helpers/conditions/tests/user.test.js
+++ b/src/helpers/conditions/tests/user.test.js
@@ -1,4 +1,4 @@
-import { isHeroku, isAzure } from '../user';
+import { isAdmin, isAzure, isHeroku } from '../user';
 
 describe('User Condition Tests', () => {
   it('should return true if user is heroku', () => {
@@ -19,5 +19,15 @@ describe('User Condition Tests', () => {
   it('should return false if user is not azure', () => {
     const currentUser = { access_level: 'blargh' };
     expect(isAzure({ currentUser })).toEqual(false);
+  });
+
+  it('should return true if user is an admin', () => {
+    const currentUser = { access_level: 'admin' };
+    expect(isAdmin({ currentUser })).toEqual(true);
+  });
+
+  it('should return false if user is not an admin', () => {
+    const currentUser = { access_level: 'reporting' };
+    expect(isAdmin({ currentUser })).toEqual(false);
   });
 });

--- a/src/helpers/conditions/user.js
+++ b/src/helpers/conditions/user.js
@@ -1,3 +1,4 @@
 export const isHeroku = ({ currentUser }) => currentUser.access_level === 'heroku';
 
 export const isAzure = ({ currentUser }) => currentUser.access_level === 'azure';
+export const isAdmin = ({ currentUser }) => currentUser.access_level === 'admin';

--- a/src/pages/profile/ProfilePage.js
+++ b/src/pages/profile/ProfilePage.js
@@ -7,7 +7,7 @@ import { updateUser } from 'src/actions/users';
 import { get as getCurrentUser } from 'src/actions/currentUser';
 import { confirmPassword } from 'src/actions/auth';
 import { showAlert } from 'src/actions/globalAlert';
-import { openSupportTicket } from 'src/actions/support';
+import { openSupportTicketForm } from 'src/actions/support';
 
 import NameForm from './components/NameForm';
 import PasswordForm from './components/PasswordForm';
@@ -20,7 +20,7 @@ import { isAdmin, isAzure, isHeroku } from 'src/helpers/conditions/user';
 
 export class ProfilePage extends Component {
   requestCancellation = () => {
-    this.props.openSupportTicket({ issueId: 'account_cancellation' });
+    this.props.openSupportTicketForm({ issueId: 'account_cancellation' });
   }
 
   updateProfile = (values) => {
@@ -90,7 +90,7 @@ const mapStateToProps = ({ account, currentUser }) => ({
 const mapDispatchToProps = {
   confirmPassword,
   getCurrentUser,
-  openSupportTicket,
+  openSupportTicketForm,
   showAlert,
   updateUser
 };

--- a/src/pages/profile/ProfilePage.js
+++ b/src/pages/profile/ProfilePage.js
@@ -16,7 +16,7 @@ import { AccessControl } from 'src/components/auth';
 import { LabelledValue } from 'src/components';
 import ErrorTracker from 'src/helpers/errorTracker';
 import { all, not } from 'src/helpers/conditions';
-import { isHeroku, isAzure } from 'src/helpers/conditions/user';
+import { isAdmin, isAzure, isHeroku } from 'src/helpers/conditions/user';
 
 export class ProfilePage extends Component {
   requestCancellation = () => {
@@ -71,10 +71,12 @@ export class ProfilePage extends Component {
           </Panel>
         </AccessControl>
 
-        <Panel sectioned title="Cancel Account">
-          <p>Cancelling your account is permanent and cannot be undone.</p>
-          <Button destructive onClick={this.requestCancellation}>Cancel Account</Button>
-        </Panel>
+        <AccessControl condition={isAdmin}>
+          <Panel sectioned title="Cancel Account">
+            <p>Cancelling your account is permanent and cannot be undone.</p>
+            <Button destructive onClick={this.requestCancellation}>Cancel Account</Button>
+          </Panel>
+        </AccessControl>
       </Page>
     );
   }

--- a/src/pages/profile/ProfilePage.js
+++ b/src/pages/profile/ProfilePage.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import { Page, Panel } from '@sparkpost/matchbox';
+import { Button, Page, Panel } from '@sparkpost/matchbox';
 
 import { updateUser } from 'src/actions/users';
 import { get as getCurrentUser } from 'src/actions/currentUser';
 import { confirmPassword } from 'src/actions/auth';
 import { showAlert } from 'src/actions/globalAlert';
+import { openSupportTicket } from 'src/actions/support';
 
 import NameForm from './components/NameForm';
 import PasswordForm from './components/PasswordForm';
@@ -18,6 +19,10 @@ import { all, not } from 'src/helpers/conditions';
 import { isHeroku, isAzure } from 'src/helpers/conditions/user';
 
 export class ProfilePage extends Component {
+  requestCancellation = () => {
+    this.props.openSupportTicket({ issueId: 'account_cancellation' });
+  }
+
   updateProfile = (values) => {
     const { username } = this.props.currentUser;
     const data = { first_name: values.firstName, last_name: values.lastName };
@@ -39,7 +44,7 @@ export class ProfilePage extends Component {
       .then(() => this.props.updateUser(username, { password: newPassword }));
   }
 
-  render() {
+  render () {
     const {
       username,
       email,
@@ -65,6 +70,11 @@ export class ProfilePage extends Component {
             <PasswordForm onSubmit={this.updatePassword} />
           </Panel>
         </AccessControl>
+
+        <Panel sectioned title="Cancel Account">
+          <p>Cancelling your account is permanent and cannot be undone.</p>
+          <Button destructive onClick={this.requestCancellation}>Cancel Account</Button>
+        </Panel>
       </Page>
     );
   }
@@ -75,4 +85,12 @@ const mapStateToProps = ({ account, currentUser }) => ({
   currentUser
 });
 
-export default connect(mapStateToProps, { updateUser, confirmPassword, showAlert, getCurrentUser })(ProfilePage);
+const mapDispatchToProps = {
+  confirmPassword,
+  getCurrentUser,
+  openSupportTicket,
+  showAlert,
+  updateUser
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProfilePage);

--- a/src/pages/profile/ProfilePage.js
+++ b/src/pages/profile/ProfilePage.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import { Button, Page, Panel } from '@sparkpost/matchbox';
+import { Page, Panel, UnstyledLink } from '@sparkpost/matchbox';
 
 import { updateUser } from 'src/actions/users';
 import { get as getCurrentUser } from 'src/actions/currentUser';
@@ -72,9 +72,15 @@ export class ProfilePage extends Component {
         </AccessControl>
 
         <AccessControl condition={isAdmin}>
-          <Panel sectioned title="Cancel Account">
-            <p>Cancelling your account is permanent and cannot be undone.</p>
-            <Button destructive onClick={this.requestCancellation}>Cancel Account</Button>
+          <Panel sectioned title="Request Account Cancellation">
+            <p>
+              To cancel your SparkPost account, {
+                <UnstyledLink onClick={this.requestCancellation}>
+                  submit a cancellation request
+                </UnstyledLink>
+              }. The request may take a few days to process.  All your data (e.g. domains, users, etc.)
+              will be permanently deleted. We're sorry to see you go!
+            </p>
           </Panel>
         </AccessControl>
       </Page>

--- a/src/pages/profile/tests/ProfilePage.test.js
+++ b/src/pages/profile/tests/ProfilePage.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
       username: 'Lord Stark',
       email: 'ned.stark@winterfell.biz',
       customer: 12345,
-      access_level: 'user'
+      access_level: 'admin'
     },
     updateUser: jest.fn(() => Promise.resolve()),
     getCurrentUser: jest.fn(() => Promise.resolve()),

--- a/src/pages/profile/tests/ProfilePage.test.js
+++ b/src/pages/profile/tests/ProfilePage.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
     updateUser: jest.fn(() => Promise.resolve()),
     getCurrentUser: jest.fn(() => Promise.resolve()),
     confirmPassword: jest.fn(() => Promise.resolve()),
-    openSupportTicket: jest.fn(),
+    openSupportTicketForm: jest.fn(),
     showAlert: jest.fn()
   };
 
@@ -77,7 +77,7 @@ describe('ProfilePage', () => {
   describe('requestCancellation', () => {
     it('should open support panel and preselect account cancellation', () => {
       instance.requestCancellation();
-      expect(props.openSupportTicket).toHaveBeenCalledWith({ issueId: 'account_cancellation' });
+      expect(props.openSupportTicketForm).toHaveBeenCalledWith({ issueId: 'account_cancellation' });
     });
   });
 });

--- a/src/pages/profile/tests/ProfilePage.test.js
+++ b/src/pages/profile/tests/ProfilePage.test.js
@@ -23,6 +23,7 @@ beforeEach(() => {
     updateUser: jest.fn(() => Promise.resolve()),
     getCurrentUser: jest.fn(() => Promise.resolve()),
     confirmPassword: jest.fn(() => Promise.resolve()),
+    openSupportTicket: jest.fn(),
     showAlert: jest.fn()
   };
 
@@ -45,14 +46,14 @@ describe('ProfilePage', () => {
   });
 
   describe('updateProfile', () => {
-    it('should update profile correctly', async() => {
+    it('should update profile correctly', async () => {
       await instance.updateProfile({ firstName: 'John', lastName: 'Doe' });
       expect(props.updateUser).toHaveBeenCalledWith('Lord Stark', { first_name: 'John', last_name: 'Doe' });
       expect(props.getCurrentUser).toHaveBeenCalledTimes(1);
       expect(props.showAlert).toHaveBeenCalledTimes(0);
     });
 
-    it('should ignore refetch error, but report error silently', async() => {
+    it('should ignore refetch error, but report error silently', async () => {
       const getCurrentUserError = new Error('wow');
       props.getCurrentUser.mockReturnValue(Promise.reject(getCurrentUserError));
       await instance.updateProfile({ firstName: 'Ryan', lastName: 'Seacrest' });
@@ -65,11 +66,18 @@ describe('ProfilePage', () => {
   });
 
   describe('updatePassword', () => {
-    it('updates password correctly', async() => {
+    it('updates password correctly', async () => {
       await instance.updatePassword({ currentPassword: '111', newPassword: '222' });
       expect(props.confirmPassword).toHaveBeenCalledWith('Lord Stark', '111');
       expect(props.updateUser).toHaveBeenCalledWith('Lord Stark', { password: '222' });
       expect(props.showAlert).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('requestCancellation', () => {
+    it('should open support panel and preselect account cancellation', () => {
+      instance.requestCancellation();
+      expect(props.openSupportTicket).toHaveBeenCalledWith({ issueId: 'account_cancellation' });
     });
   });
 });

--- a/src/pages/profile/tests/__snapshots__/ProfilePage.test.js.snap
+++ b/src/pages/profile/tests/__snapshots__/ProfilePage.test.js.snap
@@ -42,5 +42,20 @@ exports[`ProfilePage renders correctly 1`] = `
       />
     </Panel>
   </Connect(AccessControl)>
+  <Panel
+    sectioned={true}
+    title="Cancel Account"
+  >
+    <p>
+      Cancelling your account is permanent and cannot be undone.
+    </p>
+    <Button
+      destructive={true}
+      onClick={[Function]}
+      size="default"
+    >
+      Cancel Account
+    </Button>
+  </Panel>
 </Page>
 `;

--- a/src/pages/profile/tests/__snapshots__/ProfilePage.test.js.snap
+++ b/src/pages/profile/tests/__snapshots__/ProfilePage.test.js.snap
@@ -42,20 +42,24 @@ exports[`ProfilePage renders correctly 1`] = `
       />
     </Panel>
   </Connect(AccessControl)>
-  <Panel
-    sectioned={true}
-    title="Cancel Account"
+  <Connect(AccessControl)
+    condition={[Function]}
   >
-    <p>
-      Cancelling your account is permanent and cannot be undone.
-    </p>
-    <Button
-      destructive={true}
-      onClick={[Function]}
-      size="default"
+    <Panel
+      sectioned={true}
+      title="Cancel Account"
     >
-      Cancel Account
-    </Button>
-  </Panel>
+      <p>
+        Cancelling your account is permanent and cannot be undone.
+      </p>
+      <Button
+        destructive={true}
+        onClick={[Function]}
+        size="default"
+      >
+        Cancel Account
+      </Button>
+    </Panel>
+  </Connect(AccessControl)>
 </Page>
 `;

--- a/src/pages/profile/tests/__snapshots__/ProfilePage.test.js.snap
+++ b/src/pages/profile/tests/__snapshots__/ProfilePage.test.js.snap
@@ -47,18 +47,17 @@ exports[`ProfilePage renders correctly 1`] = `
   >
     <Panel
       sectioned={true}
-      title="Cancel Account"
+      title="Request Account Cancellation"
     >
       <p>
-        Cancelling your account is permanent and cannot be undone.
+        To cancel your SparkPost account, 
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          submit a cancellation request
+        </UnstyledLink>
+        . The request may take a few days to process.  All your data (e.g. domains, users, etc.) will be permanently deleted. We're sorry to see you go!
       </p>
-      <Button
-        destructive={true}
-        onClick={[Function]}
-        size="default"
-      >
-        Cancel Account
-      </Button>
     </Panel>
   </Connect(AccessControl)>
 </Page>


### PR DESCRIPTION
_Refer to [FE-97](https://jira.int.messagesystems.com/browse/FE-97)_

The majority of the AC for this ticket was completed in previous tickets.  The only thing completed was a little refactor to create `openSupportTicketForm` action creator and a "Request Account Cancellation" panel on the profile page which will only show for admin users (excludes reporting, heroku, azure, etc.).

<img width="1387" alt="screen shot 2018-05-15 at 10 48 15 am" src="https://user-images.githubusercontent.com/1335605/40064426-82afc25a-582d-11e8-80a3-ef9fed64c2fd.png">

