### PR TITLE
disallow chrome to autofill cc hidden fields, reverts error tracking code

### DIFF
--- a/src/actions/billingCreate.js
+++ b/src/actions/billingCreate.js
@@ -1,10 +1,8 @@
-import _ from 'lodash';
 import { isAws } from 'src/helpers/conditions/account';
 import { formatCreateData, formatDataForCors } from 'src/helpers/billing';
 import { fetch as fetchAccount } from './account';
 import chainActions from 'src/actions/helpers/chainActions';
 import { cors, createZuoraAccount, syncSubscription, updateSubscription } from './billing';
-import errorTracker from 'src/helpers/errorTracker';
 
 export default function billingCreate (values) {
   return (dispatch, getState) => {
@@ -15,12 +13,6 @@ export default function billingCreate (values) {
     }
 
     const { corsData, billingData } = formatDataForCors(values);
-
-    errorTracker.addBreadcrumb({
-      message: 'billing data',
-      category: 'payload',
-      data: _.omit(billingData, ['creditCard.cardNumber', 'creditCard.cardHolderInfo', 'creditCard.securityCode'])
-    });
 
     // action creator wrappers for chaining as callbacks
     const corsCreateBilling = ({ meta }) => cors({ meta, context: 'create-account', data: corsData });

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -109,11 +109,6 @@ class ErrorTracker {
     if (!Raven.isSetup()) { return; }
     Raven.captureException(error, { logger, extra });
   }
-
-  addBreadcrumb (data) {
-    if (!Raven.isSetup()) { return; }
-    Raven.captureBreadcrumb(data);
-  }
 }
 
 // Export a constructed instance to avoid the need to call `new` everywhere

--- a/src/pages/billing/forms/fields/PaymentForm.js
+++ b/src/pages/billing/forms/fields/PaymentForm.js
@@ -114,7 +114,12 @@ export class PaymentForm extends Component {
           </Grid.Column>
         </Grid>
 
-        {/* Hidden redux-form connected fields */}
+        {
+        /*
+        Hidden redux-form connected fields.
+        autoComplete attr is to prevent chrome automatically filling credit card number.
+        */
+        }
         <div className={styles.hidden} >
           <Field name='card.type' component='input' tabIndex='-1' autoComplete="new-password" />
           <Field name='card.expMonth' component='input' tabIndex='-1' autoComplete="new-password"/>

--- a/src/pages/billing/forms/fields/PaymentForm.js
+++ b/src/pages/billing/forms/fields/PaymentForm.js
@@ -24,7 +24,7 @@ import styles from './Fields.module.scss';
  * card.securityCode
  */
 export class PaymentForm extends Component {
-  componentDidMount() {
+  componentDidMount () {
     const types = Payment.getCardArray();
     // Formats strings for our api (the ones we accept)
     Payment.setCardArray(formatCardTypes(types));
@@ -45,16 +45,16 @@ export class PaymentForm extends Component {
       change(formName, 'card.expMonth', values.month);
       change(formName, 'card.expYear', values.year);
     }
-  }
+  };
 
   // Sets type from cc number into a hidden field
   handleType = (e) => {
     const { change, formName } = this.props;
     const value = Payment.fns.cardType(e.target.value);
     change(formName, 'card.type', value);
-  }
+  };
 
-  validateType(number) {
+  validateType (number) {
     const cardType = Payment.fns.cardType(number);
     const allowedCards = _.map(config.cardTypes, 'apiFormat');
 
@@ -67,7 +67,7 @@ export class PaymentForm extends Component {
 
   dateFormat = (date) => minLength(9)(date) ? 'Must be MM / YYYY' : undefined;
 
-  render() {
+  render () {
     const { disabled } = this.props;
     return (
       <div>
@@ -116,9 +116,9 @@ export class PaymentForm extends Component {
 
         {/* Hidden redux-form connected fields */}
         <div className={styles.hidden} >
-          <Field name='card.type' component='input' tabIndex='-1' />
-          <Field name='card.expMonth' component='input' tabIndex='-1'/>
-          <Field name='card.expYear' component='input' tabIndex='-1'/>
+          <Field name='card.type' component='input' tabIndex='-1' autoComplete="new-password" />
+          <Field name='card.expMonth' component='input' tabIndex='-1' autoComplete="new-password"/>
+          <Field name='card.expYear' component='input' tabIndex='-1' autoComplete="new-password"/>
         </div>
       </div>
     );

--- a/src/pages/billing/forms/fields/tests/__snapshots__/PaymentForm.test.js.snap
+++ b/src/pages/billing/forms/fields/tests/__snapshots__/PaymentForm.test.js.snap
@@ -57,16 +57,19 @@ exports[`Payment Form:  should render 1`] = `
   </Grid>
   <div>
     <Field
+      autoComplete="new-password"
       component="input"
       name="card.type"
       tabIndex="-1"
     />
     <Field
+      autoComplete="new-password"
       component="input"
       name="card.expMonth"
       tabIndex="-1"
     />
     <Field
+      autoComplete="new-password"
       component="input"
       name="card.expYear"
       tabIndex="-1"


### PR DESCRIPTION
There are multiple ways to solve this but IMO this is simplest. So far it seems to be working fine but real test would be on tst/stg. 

other approaches
- rename fields
- set state locally 
- calculate these upon submit

all those require more work than this is. renaming field may be trivial but still can't be tested locally. 

https://cs.chromium.org/chromium/src/components/autofill/core/common/autofill_regex_constants.cc?l=135-194 is the regex chrome use for field matching. as i couldn't enable cc auto fill locally, it's tough to test. also seemed this approach isn't very uncommon. 

notes: 
- also reverting the code that we used to log zuora payload
- someone may not ask "why not just autocomplete='off'". most browsers/extensions ignores that now. there is a SO thread about it but i lost it. I can find again if you (reviewer) is interested. 