### PR TITLE
FE-93: Remove support@ email address from app and site

### DIFF
--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -28,7 +28,7 @@ export class SupportForm extends Component {
     return this.props.createTicket(ticket);
   };
 
-  renderSuccess () {
+  renderSuccess() {
     const { ticketId, onContinue } = this.props;
 
     return <div className={styles.SupportForm}>
@@ -41,12 +41,12 @@ export class SupportForm extends Component {
     </div>;
   }
 
-  reset (parentReset) {
+  reset(parentReset) {
     this.props.reset(formName);
     return parentReset();
   }
 
-  renderForm () {
+  renderForm() {
     const {
       handleSubmit,
       invalid,
@@ -68,7 +68,6 @@ export class SupportForm extends Component {
           <Field
             name='issueId'
             label='I need help with...'
-            placeholder='Select an option'
             helpText={needsOnlineSupport && (
               <Fragment>
                 Additional technical support is available on paid
@@ -78,7 +77,10 @@ export class SupportForm extends Component {
             errorInLabel
             disabled={submitting}
             component={SelectWrapper}
-            options={issues.map(({ id, label }) => ({ label, value: id }))}
+            options={[
+              { disabled: true, label: 'Select an option', value: '' },
+              ...issues.map(({ id, label }) => ({ label, value: id }))
+            ]}
             validate={required}
           />
           <Field
@@ -111,7 +113,7 @@ export class SupportForm extends Component {
     </div>;
   }
 
-  render () {
+  render() {
     if (this.props.submitSucceeded) {
       return this.renderSuccess();
     }

--- a/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
@@ -19,12 +19,16 @@ exports[`Support Form Component Form should render 1`] = `
         options={
           Array [
             Object {
+              "disabled": true,
+              "label": "Select an option",
+              "value": "",
+            },
+            Object {
               "label": "I need help!",
               "value": "technical_issues",
             },
           ]
         }
-        placeholder="Select an option"
         validate={[Function]}
       />
       <Field
@@ -86,12 +90,16 @@ exports[`Support Form Component Form should render issue dropdown with help text
   options={
     Array [
       Object {
+        "disabled": true,
+        "label": "Select an option",
+        "value": "",
+      },
+      Object {
         "label": "I need help!",
         "value": "technical_issues",
       },
     ]
   }
-  placeholder="Select an option"
   validate={[Function]}
 />
 `;
@@ -115,12 +123,16 @@ exports[`Support Form Component Form should render with selected issue message l
         options={
           Array [
             Object {
+              "disabled": true,
+              "label": "Select an option",
+              "value": "",
+            },
+            Object {
               "label": "I need help!",
               "value": "technical_issues",
             },
           ]
         }
-        placeholder="Select an option"
         validate={[Function]}
       />
       <Field

--- a/src/components/supportTicketLink/SupportTicketLink.js
+++ b/src/components/supportTicketLink/SupportTicketLink.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { UnstyledLink } from '@sparkpost/matchbox';
+import { openSupportTicketForm } from 'src/actions/support';
+
+export function SupportTicketLink({ children, openSupportTicketForm, ...ticketOptions }) {
+  return (
+    <UnstyledLink onClick={() => openSupportTicketForm(ticketOptions)}>
+      {children}
+    </UnstyledLink>
+  );
+}
+
+export default connect(undefined, { openSupportTicketForm })(SupportTicketLink);

--- a/src/components/supportTicketLink/tests/SupportTicketLink.test.js
+++ b/src/components/supportTicketLink/tests/SupportTicketLink.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SupportTicketLink } from '../SupportTicketLink';
+
+describe('SupportTicketLink', () => {
+  it('should render an unstyled link with a click handler', () => {
+    const wrapper = shallow(<SupportTicketLink>Click Me</SupportTicketLink>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('when clicked', () => {
+    const props = { openSupportTicketForm: jest.fn(), issueId: 'example_issue' };
+    const wrapper = shallow(<SupportTicketLink {...props}>Click Me</SupportTicketLink>);
+
+    it('should call openSupportTicketForm', () => {
+      wrapper.simulate('click');
+      expect(props.openSupportTicketForm).toHaveBeenCalledWith({ issueId: 'example_issue' });
+    });
+  });
+});

--- a/src/components/supportTicketLink/tests/__snapshots__/SupportTicketLink.test.js.snap
+++ b/src/components/supportTicketLink/tests/__snapshots__/SupportTicketLink.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SupportTicketLink should render an unstyled link with a click handler 1`] = `
+<UnstyledLink
+  onClick={[Function]}
+>
+  Click Me
+</UnstyledLink>
+`;

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -24,12 +24,6 @@ const config = {
     { paymentFormat: 'discover', apiFormat: 'Discover' }
   ],
   chartColors: ['#04AEF9', '#fa6423', '#FFD300', '#8CCA3A', '#b94696'],
-  contact: {
-    abuseEmail: 'compliance@sparkpost.com',
-    contactEmail: 'hello@sparkpost.com',
-    supportEmail: 'support@sparkpost.com',
-    billingEmail: 'billing@sparkpost.com'
-  },
   cookieConsent: {
     cookie: {
       name: 'cookieConsent',

--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -59,7 +59,7 @@ export const ManuallyBilledBanner = ({ account, ...rest }) => {
         </p>
       ) : (
         <p>
-          To make changes to your plan, billing information, or addons, {
+          To make changes to your plan, billing information, or addons, please {
             <SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>
           }.
         </p>

--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import config from 'src/config';
 import { format } from 'date-fns';
-import { Banner, UnstyledLink } from '@sparkpost/matchbox';
+import { Banner } from '@sparkpost/matchbox';
 import { Link } from 'react-router-dom';
 import { LINKS } from 'src/constants';
 import * as conversions from 'src/helpers/conversionTracking';
 import { ANALYTICS_PREMIUM_SUPPORT, ANALYTICS_ENTERPRISE_SUPPORT } from 'src/constants';
+import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 const dateFormat = (date) => format(date, 'MMM DD, YYYY');
 
@@ -38,12 +38,6 @@ export const ManuallyBilledBanner = ({ account, ...rest }) => {
     return null;
   }
 
-  const content = account.pending_subscription // Is this even possible??
-    ? <p>
-        You're scheduled to switch to the {account.pending_subscription.name} plan on {dateFormat(account.pending_subscription.effective_date)}. If you have any questions, please <UnstyledLink to={`mailto:${config.contact.supportEmail}`}>contact support</UnstyledLink>.
-    </p>
-    : <p>To make changes to your plan, billing information, or addons, <UnstyledLink to={`mailto:${config.contact.supportEmail}`}>contact support</UnstyledLink>.</p>;
-
   const convertAction = !account.pending_subscription
     ? { content: 'Enable Automatic Billing', to: '/account/billing/plan', Component: Link }
     : null;
@@ -56,8 +50,20 @@ export const ManuallyBilledBanner = ({ account, ...rest }) => {
     <Banner
       status='info'
       title={`Your current ${account.subscription.name} plan includes ${account.subscription.plan_volume.toLocaleString()} emails per month`}
-      action={convertAction}>
-      {content}
+      action={convertAction}
+    >
+      {account.pending_subscription ? (
+        <p>
+          You're scheduled to switch to the {account.pending_subscription.name} plan
+          on {dateFormat(account.pending_subscription.effective_date)}.
+        </p>
+      ) : (
+        <p>
+          To make changes to your plan, billing information, or addons, {
+            <SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>
+          }.
+        </p>
+      )}
       {convertMarkup}
     </Banner>
   );

--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -13,12 +13,21 @@ const dateFormat = (date) => format(date, 'MMM DD, YYYY');
  * Renders pending plan change information
  * @prop account Account state from redux store
  */
-export const PendingPlanBanner = ({ account }) => account.pending_subscription
-  ? <Banner status='info' title='Pending Plan Change' >
-    <p>You're scheduled to switch to the {account.pending_subscription.name} plan on {dateFormat(account.pending_subscription.effective_date)}, and can't update your plan until that switch happens.</p>
-    <p>If you have any questions, please <UnstyledLink to={`mailto:${config.contact.supportEmail}`}>contact support</UnstyledLink>.</p>
-  </Banner>
-  : null;
+export const PendingPlanBanner = ({ account }) => {
+  if (!account.pending_subscription) {
+    return null;
+  }
+
+  return (
+    <Banner status='info' title='Pending Plan Change' >
+      <p>
+        You're scheduled to switch to the {account.pending_subscription.name} plan
+        on {dateFormat(account.pending_subscription.effective_date)}, and can't update your plan
+        until that switch happens.
+      </p>
+    </Banner>
+  );
+};
 
 /**
  * Renders plan information for non-self-serve users

--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Panel, Button, UnstyledLink } from '@sparkpost/matchbox';
+import { Panel, Button } from '@sparkpost/matchbox';
 import config from 'src/config';
 import { getPlanPrice } from 'src/helpers/billing';
 import PlanPrice from 'src/components/billing/PlanPrice';
+import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 export class Confirmation extends React.Component {
   renderSelectedPlanMarkup() {
@@ -60,9 +61,14 @@ export class Confirmation extends React.Component {
           <div>
             <p>Note: your current plan includes a free dedicated IP address.</p>
             <p>If you downgrade to the selected plan, you will lose that discount and will be charged the standard
-              ${ config.sendingIps.pricePerIp } / month price for each dedicated IP on your next statement.</p>
-            <p>To remove dedicated IPs from your account, please <UnstyledLink
-              to={`mailto:${config.contact.supportEmail}`}>contact our support team</UnstyledLink>.</p>
+              ${config.sendingIps.pricePerIp} / month price for each dedicated IP on your next statement.</p>
+            <p>
+              To remove dedicated IPs from your account, {
+                <SupportTicketLink issueId="general_issue">
+                  submit a support ticket
+                </SupportTicketLink>
+              }.
+            </p>
           </div>
         );
       }
@@ -76,13 +82,13 @@ export class Confirmation extends React.Component {
     return (
       <Panel>
         <Panel.Section>
-          { this.renderCurrentPlanMarkup() }
+          {this.renderCurrentPlanMarkup()}
         </Panel.Section>
         <Panel.Section>
-          { this.renderSelectedPlanMarkup() }
-          { effectiveDateMarkup }
-          { ipMarkup }
-          { addonMarkup }
+          {this.renderSelectedPlanMarkup()}
+          {effectiveDateMarkup}
+          {ipMarkup}
+          {addonMarkup}
         </Panel.Section>
         <Panel.Section>
           <Button
@@ -91,7 +97,7 @@ export class Confirmation extends React.Component {
             primary={!isDowngrade}
             destructive={isDowngrade}
             disabled={disableSubmit}>
-            { buttonText }
+            {buttonText}
           </Button>
         </Panel.Section>
       </Panel>

--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -63,7 +63,7 @@ export class Confirmation extends React.Component {
             <p>If you downgrade to the selected plan, you will lose that discount and will be charged the standard
               ${config.sendingIps.pricePerIp} / month price for each dedicated IP on your next statement.</p>
             <p>
-              To remove dedicated IPs from your account, {
+              To remove dedicated IPs from your account, please {
                 <SupportTicketLink issueId="general_issue">
                   submit a support ticket
                 </SupportTicketLink>

--- a/src/pages/billing/components/SuspendedForBilling.js
+++ b/src/pages/billing/components/SuspendedForBilling.js
@@ -1,8 +1,7 @@
-
 import React, { Fragment } from 'react';
-import config from 'src/config';
-import { Banner, UnstyledLink } from '@sparkpost/matchbox';
+import { Banner } from '@sparkpost/matchbox';
 import UpdatePaymentForm from '../forms/UpdatePayment';
+import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 export default function SuspendedForBilling({ account }) {
   const { billing = {}} = account;
@@ -10,8 +9,18 @@ export default function SuspendedForBilling({ account }) {
   return (
     <Fragment>
       <Banner status='danger' title='Your account has been suspended due to a billing problem' >
-        <p>We sent an email notification to your current billing contact email address{email}. To reactivate your account and pay your outstanding balance due, please update your payment information below.</p>
-        <p>If you have any questions, please <UnstyledLink to={`mailto:${config.contact.billingEmail}`}>contact us</UnstyledLink>.</p>
+        <p>
+          We sent an email notification to your current billing contact email address {email}. To
+          reactivate your account and pay your outstanding balance due, please update your payment
+          information below.
+        </p>
+        <p>
+          If this is incorrect, please {
+            <SupportTicketLink issueId="account_suspension">
+              submit a support ticket
+            </SupportTicketLink>
+          } and let us know why.
+        </p>
       </Banner>
       <UpdatePaymentForm />
     </Fragment>

--- a/src/pages/billing/components/SuspendedForBilling.js
+++ b/src/pages/billing/components/SuspendedForBilling.js
@@ -16,7 +16,7 @@ export default function SuspendedForBilling({ account }) {
         </p>
         <p>
           If this is incorrect, please {
-            <SupportTicketLink issueId="account_suspension">
+            <SupportTicketLink issueId="general_billing">
               submit a support ticket
             </SupportTicketLink>
           } and let us know why.

--- a/src/pages/billing/components/tests/SuspendedForBilling.test.js
+++ b/src/pages/billing/components/tests/SuspendedForBilling.test.js
@@ -3,11 +3,6 @@ import { shallow } from 'enzyme';
 import SuspendedForBilling from '../SuspendedForBilling';
 
 jest.mock('../../forms/UpdatePayment', () => function UpdatePaymentForm() {});
-jest.mock('src/config', () => ({
-  contact: {
-    billingEmail: 'billing.email@example.com'
-  }
-}));
 
 describe('Component: SuspendedForBilling', () => {
 

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -44,12 +44,6 @@ exports[`Billing Banners:  ManuallyBilledBanner should render with pending subsc
     omg
      plan on 
     Oct 05, 2020
-    . If you have any questions, please 
-    <UnstyledLink
-      to="mailto:support@sparkpost.com"
-    >
-      contact support
-    </UnstyledLink>
     .
   </p>
 </Banner>
@@ -69,11 +63,11 @@ exports[`Billing Banners:  ManuallyBilledBanner should render with subscription 
 >
   <p>
     To make changes to your plan, billing information, or addons, 
-    <UnstyledLink
-      to="mailto:support@sparkpost.com"
+    <Connect(SupportTicketLink)
+      issueId="general_issue"
     >
-      contact support
-    </UnstyledLink>
+      submit a support ticket
+    </Connect(SupportTicketLink)>
     .
   </p>
   <p>

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -62,7 +62,7 @@ exports[`Billing Banners:  ManuallyBilledBanner should render with subscription 
   title="Your current whoa plan includes 123 emails per month"
 >
   <p>
-    To make changes to your plan, billing information, or addons, 
+    To make changes to your plan, billing information, or addons, please 
     <Connect(SupportTicketLink)
       issueId="general_issue"
     >

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -93,15 +93,6 @@ exports[`Billing Banners:  PendingPlanBanner should render with pending_subscrip
     Oct 05, 2020
     , and can't update your plan until that switch happens.
   </p>
-  <p>
-    If you have any questions, please 
-    <UnstyledLink
-      to="mailto:support@sparkpost.com"
-    >
-      contact support
-    </UnstyledLink>
-    .
-  </p>
 </Banner>
 `;
 

--- a/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
@@ -148,7 +148,7 @@ exports[`Confirmation:  should render correctly with a downgrade 1`] = `
          / month price for each dedicated IP on your next statement.
       </p>
       <p>
-        To remove dedicated IPs from your account, 
+        To remove dedicated IPs from your account, please 
         <Connect(SupportTicketLink)
           issueId="general_issue"
         >
@@ -283,7 +283,7 @@ exports[`Confirmation:  should render correctly with an upgrade 1`] = `
          / month price for each dedicated IP on your next statement.
       </p>
       <p>
-        To remove dedicated IPs from your account, 
+        To remove dedicated IPs from your account, please 
         <Connect(SupportTicketLink)
           issueId="general_issue"
         >

--- a/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
@@ -148,12 +148,12 @@ exports[`Confirmation:  should render correctly with a downgrade 1`] = `
          / month price for each dedicated IP on your next statement.
       </p>
       <p>
-        To remove dedicated IPs from your account, please 
-        <UnstyledLink
-          to="mailto:support@sparkpost.com"
+        To remove dedicated IPs from your account, 
+        <Connect(SupportTicketLink)
+          issueId="general_issue"
         >
-          contact our support team
-        </UnstyledLink>
+          submit a support ticket
+        </Connect(SupportTicketLink)>
         .
       </p>
     </div>
@@ -283,12 +283,12 @@ exports[`Confirmation:  should render correctly with an upgrade 1`] = `
          / month price for each dedicated IP on your next statement.
       </p>
       <p>
-        To remove dedicated IPs from your account, please 
-        <UnstyledLink
-          to="mailto:support@sparkpost.com"
+        To remove dedicated IPs from your account, 
+        <Connect(SupportTicketLink)
+          issueId="general_issue"
         >
-          contact our support team
-        </UnstyledLink>
+          submit a support ticket
+        </Connect(SupportTicketLink)>
         .
       </p>
     </div>

--- a/src/pages/billing/components/tests/__snapshots__/SuspendedForBilling.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/SuspendedForBilling.test.js.snap
@@ -7,18 +7,18 @@ exports[`Component: SuspendedForBilling should render correctly 1`] = `
     title="Your account has been suspended due to a billing problem"
   >
     <p>
-      We sent an email notification to your current billing contact email address
+      We sent an email notification to your current billing contact email address 
        (account.billing.email@example.com)
       . To reactivate your account and pay your outstanding balance due, please update your payment information below.
     </p>
     <p>
-      If you have any questions, please 
-      <UnstyledLink
-        to="mailto:billing.email@example.com"
+      If this is incorrect, please 
+      <Connect(SupportTicketLink)
+        issueId="account_suspension"
       >
-        contact us
-      </UnstyledLink>
-      .
+        submit a support ticket
+      </Connect(SupportTicketLink)>
+       and let us know why.
     </p>
   </Banner>
   <UpdatePaymentForm />

--- a/src/pages/billing/components/tests/__snapshots__/SuspendedForBilling.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/SuspendedForBilling.test.js.snap
@@ -14,7 +14,7 @@ exports[`Component: SuspendedForBilling should render correctly 1`] = `
     <p>
       If this is incorrect, please 
       <Connect(SupportTicketLink)
-        issueId="account_suspension"
+        issueId="general_billing"
       >
         submit a support ticket
       </Connect(SupportTicketLink)>


### PR DESCRIPTION
The following are the different scenarios that need to be tested.

1. Before downgrading an account that includes a free dedicated IP to a paid account that does not, the user is warned they will have to start paying for the dedicated IP and the user is asked to contact support if they want to remove it.  This mailto:support@sparkpost.com link was changed to a submit a support ticket link that opens the support panel.  To test, sign-in as brian.kemper+fe-93-150k@sparkpost.com, navigate to the plan picker page and change the dropdown to the 50k plan.  

<img width="1375" alt="screen shot 2018-05-18 at 10 26 49 am" src="https://user-images.githubusercontent.com/1335605/40240189-04b58d7a-5a86-11e8-8240-6ada910dea6e.png">

2. When a user is suspended for billing, the billing summary page warns the user and provides instructions to unsuspend their account.  There was a generic contact us if you have any questions and I changed it to this submit a support ticket message.  To test, sign-in as brian.kemper+fe-93-billing-suspended@sparkpost.com and navigate to billing summary page.

<img width="1375" alt="screen shot 2018-05-18 at 10 47 49 am" src="https://user-images.githubusercontent.com/1335605/40241410-f4019e9e-5a88-11e8-8c2e-70aee1a2c041.png">

3. When a user requests to change their plan, the pending banner is displayed on both the billing summary and plan picker pages.  There was a generic contact us message that has been removed.  To test, sign-in as brian.kemper+fe-93-pending@sparkpost.com and navigate to both the billing summary.  (Don't worry about the plan picker page change, there is no link for user to navigate to it)

<img width="1374" alt="screen shot 2018-05-18 at 1 26 19 pm" src="https://user-images.githubusercontent.com/1335605/40248811-1afaec9c-5a9f-11e8-9be5-367c7ad89af4.png">

<img width="1377" alt="screen shot 2018-05-18 at 1 26 11 pm" src="https://user-images.githubusercontent.com/1335605/40248813-1cfb0afe-5a9f-11e8-8aa4-b599daae54ed.png">

4.  When a user has a manually billed paid account, the manually billed banner is displayed on the billing summary page.  There was a generic contact us message that was replaced with the submit a ticket link.  To test, sign-in as brian.kemper+fe-93-manual@sparkpost.com and navigate to the billing summary page.

<img width="1381" alt="screen shot 2018-05-18 at 3 23 38 pm" src="https://user-images.githubusercontent.com/1335605/40253911-8d2135f0-5aaf-11e8-93c0-ae6a52c68199.png">



