### PR TITLE
FE-357

### DIFF
--- a/src/pages/subaccounts/components/ApiKeysTab.js
+++ b/src/pages/subaccounts/components/ApiKeysTab.js
@@ -36,11 +36,12 @@ export class ApiKeysTab extends Component {
   getRowData = ({ id, label, short_key }) => {
     const subaccountId = this.props.id;
 
+    //unlike api keys page, no need to check if user can edit as that logic checks if subaccount_id exists which is always true here
     return [
-      <Link to={`/account/api-keys/details/${id}${setSubaccountQuery(subaccountId)}`}>{label}</Link>,
+      <Link to={`/account/api-keys/edit/${id}${setSubaccountQuery(subaccountId)}`}>{label}</Link>,
       <code>{short_key}••••••••</code>
     ];
-  }
+  };
 
   renderEmpty() {
     return (
@@ -63,7 +64,7 @@ export class ApiKeysTab extends Component {
 
     return (
       <Panel>
-        { showEmpty
+        {showEmpty
           ? this.renderEmpty()
           : this.renderCollection(keys)
         }

--- a/src/pages/subaccounts/components/test/__snapshots__/ApiKeysTab.test.js.snap
+++ b/src/pages/subaccounts/components/test/__snapshots__/ApiKeysTab.test.js.snap
@@ -91,7 +91,7 @@ exports[`getRowData 1`] = `
 Array [
   <Link
     replace={false}
-    to="/account/api-keys/details/12313"
+    to="/account/api-keys/edit/12313"
   >
     test
   </Link>,


### PR DESCRIPTION
Fix route link to api key from subaccount details page

Error:
- Find a subaccount (that has api key)
- Open detail view, click `API Keys` tab
- Click an API Key -> Returns a 404 page

Fix: clicking an API Key in last step, would not show 404 rather take to api key edit page