### PR TITLE
FE-298 make browsers support official 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,9 +1989,27 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.9.1",
+        "browserslist": "2.11.3",
         "invariant": "2.2.2",
         "semver": "5.4.1"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "2.11.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000844",
+            "electron-to-chromium": "1.3.47"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.47",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
+          "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ=",
+          "dev": true
+        }
       }
     },
     "babel-preset-flow": {
@@ -2575,13 +2593,21 @@
       }
     },
     "browserslist": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
-      "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000778",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-lite": "1.0.30000844",
+        "electron-to-chromium": "1.3.47"
+      },
+      "dependencies": {
+        "electron-to-chromium": {
+          "version": "1.3.47",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
+          "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ=",
+          "dev": true
+        }
       }
     },
     "bser": {
@@ -2752,9 +2778,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000778.tgz",
-      "integrity": "sha1-8efLixOx9nREAikddfC81MMWA2k=",
+      "version": "1.0.30000844",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000844.tgz",
+      "integrity": "sha512-UpKQE7y6dLHhlv75UyBCRiun34Q+bmxyX3zS+ve9M07YG52tRafOvop9N9d5jC+sikKuG7UMweJKJNts4FVehA==",
       "dev": true
     },
     "capture-stack-trace": {

--- a/package.json
+++ b/package.json
@@ -161,14 +161,10 @@
   "browserslist": {
     "production": [
       "> 1%",
+      "last 2 versions",
       "not ie <= 11",
-      "Firefox ESR",
-      "last 2 opera versions",
-      "last 2 edge versions",
-      "last 2 safari versions",
-      "last 2 chrome versions",
-      "last 2 firefox versions",
-      "last 2 FirefoxAndroid versions"
+      "not ie_mob <=11",
+      "Firefox ESR"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -160,10 +160,15 @@
   },
   "browserslist": {
     "production": [
-      "last 4 versions",
-      "not < 1%",
+      "> 1%",
+      "not ie <= 11",
       "Firefox ESR",
-      "not ie <= 11"
+      "last 2 opera versions",
+      "last 2 edge versions",
+      "last 2 safari versions",
+      "last 2 chrome versions",
+      "last 2 firefox versions",
+      "last 2 FirefoxAndroid versions"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "babel-preset-stage-2": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "brace": "^0.11.0",
+    "browserslist": "^3.2.8",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",
     "chalk": "^2.3.1",
     "coveralls": "^3.0.0",
@@ -159,10 +160,11 @@
   },
   "browserslist": {
     "production": [
-      ">1%",
       "last 4 versions",
+      "not < 1%",
       "Firefox ESR",
-      "not ie < 11"
+      "not ie < 11",
+      "not ie 11"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -163,8 +163,7 @@
       "last 4 versions",
       "not < 1%",
       "Firefox ESR",
-      "not ie < 11",
-      "not ie 11"
+      "not ie <= 11"
     ]
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,7 @@
           <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
         </svg>
         <h3>Oh no, SparkPost is having trouble loading.</h3>
-        <p>Please <a id='reloadLink'>try again</a> soon.</p>
+        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=last+4+versions%2C+not+%3C+1%25%2C+Firefox+ESR%2C+not+ie+11">supported browser</a>.</p>
         <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
       </div>
       <script type="text/javascript">

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,40 @@
 
      <!-- Pushes app load failure to Sentry -->
     <script>
+      /**
+       * Returns browser's name and version
+       * @credit https://jsfiddle.net/311aLtkz/
+       * @returns {*}
+       */
+      function getAgent(){
+        var isIE = /*@cc_on!@*/false || !!document.documentMode;
+
+        switch(true){
+          // Opera 8.0+
+          case (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0:
+            return 'Opera';
+
+          // Firefox 1.0+
+          case typeof InstallTrigger !== 'undefined':
+          return 'Firefox';
+
+          case !!window.chrome && !!window.chrome.webstore:
+            return 'Chrome';
+
+          case /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || safari.pushNotification):
+            return 'Safari';
+
+          case isIE:
+            return 'IE';
+
+          case !isIE && !!window.StyleMedia:
+            return 'Edge';
+
+          default:
+            return ':shrug:';
+        }
+      }
+
       function trackAppLoadError() {
         var key = window.SP.productionConfig.sentry.publicKey;
         var id = window.SP.productionConfig.sentry.projectId;
@@ -35,14 +69,24 @@
         Raven.captureMessage('Unable to load application');
       }
 
+      function reportError(){
+        var agentsToIgnoreError = /IE/i;
+
+        if(agentsToIgnoreError.test(getAgent())){
+          return;
+        }
+
+        var sentry = document.createElement('script');
+        sentry.src = 'https://cdn.ravenjs.com/3.24.0/raven.min.js';
+        sentry.onload = trackAppLoadError;
+        document.body.appendChild(sentry);
+      }
+
       function handleAppLoad() {
         document.getElementById('loading').className += 'ready'; // Kills loading screen
         if (!window.SPARKPOST_LOADED) {
           document.getElementById('error').className += 'show';
-          var sentry = document.createElement('script');
-          sentry.src = 'https://cdn.ravenjs.com/3.24.0/raven.min.js';
-          sentry.onload = trackAppLoadError;
-          document.body.appendChild(sentry);
+          reportError();
         }
       }
 
@@ -84,7 +128,8 @@
           <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
         </svg>
         <h3>Oh no, SparkPost is having trouble loading.</h3>
-        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=%3E+1%25%2C+not+ie+%3C%3D+11%2C+Firefox+ESR%2C+last+2+opera+versions%2C+last+2+edge+versions%2C+last+2+safari+versions%2C+last+2+chrome+versions%2C+last+2+opera+versions%2C+last+2+firefox+versions%2C+last+2+FirefoxAndroid+versions">supported browser</a>.</p>
+        <p>Please make sure you're using <a target="_blank" href="http://browserl.ist/?q=%3E+1%25%2C+not+ie+%3C%3D+11%2C+Firefox+ESR%2C+last+2+opera+versions%2C+last+2+edge+versions%2C+last+2+safari+versions%2C+last+2+chrome+versions%2C+last+2+opera+versions%2C+last+2+firefox+versions%2C+last+2+FirefoxAndroid+versions">a supported browser</a> and <a id='reloadLink'>try again</a>.
+        </p>
         <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
       </div>
       <script type="text/javascript">

--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,7 @@
           <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
         </svg>
         <h3>Oh no, SparkPost is having trouble loading.</h3>
-        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=last+4+versions%2C+not+%3C+1%25%2C+Firefox+ESR%2C+not+ie+11">supported browser</a>.</p>
+        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=last+4+versions%2C+not+%3C+1%25%2C+Firefox+ESR%2C+not+ie+%3C+11%2C+not+ie+11">supported browser</a>.</p>
         <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
       </div>
       <script type="text/javascript">

--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,7 @@
           <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
         </svg>
         <h3>Oh no, SparkPost is having trouble loading.</h3>
-        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=last+4+versions%2C+not+%3C+1%25%2C+Firefox+ESR%2C+not+ie+%3C+11%2C+not+ie+11">supported browser</a>.</p>
+        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=last+4+versions%2C+not+%3C+1%25%2C+Firefox+ESR%2C+not+ie+%3C%3D+11">supported browser</a>.</p>
         <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
       </div>
       <script type="text/javascript">

--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,7 @@
           <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
         </svg>
         <h3>Oh no, SparkPost is having trouble loading.</h3>
-        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=last+4+versions%2C+not+%3C+1%25%2C+Firefox+ESR%2C+not+ie+%3C%3D+11">supported browser</a>.</p>
+        <p>Please <a id='reloadLink'>try again</a> soon. Try using a <a target="_blank" href="http://browserl.ist/?q=%3E+1%25%2C+not+ie+%3C%3D+11%2C+Firefox+ESR%2C+last+2+opera+versions%2C+last+2+edge+versions%2C+last+2+safari+versions%2C+last+2+chrome+versions%2C+last+2+opera+versions%2C+last+2+firefox+versions%2C+last+2+FirefoxAndroid+versions">supported browser</a>.</p>
         <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
       </div>
       <script type="text/javascript">

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
      <!-- Pushes app load failure to Sentry -->
     <script>
       /**
-       * Returns browser's name and version
+       * Returns browser's name
        * @credit https://jsfiddle.net/311aLtkz/
        * @returns {*}
        */
@@ -43,7 +43,7 @@
 
           // Firefox 1.0+
           case typeof InstallTrigger !== 'undefined':
-          return 'Firefox';
+            return 'Firefox';
 
           case !!window.chrome && !!window.chrome.webstore:
             return 'Chrome';
@@ -54,7 +54,7 @@
           case isIE:
             return 'IE';
 
-          case !isIE && !!window.StyleMedia:
+          case !!window.StyleMedia:
             return 'Edge';
 
           default:
@@ -127,8 +127,9 @@
         <svg class='logo__icon' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.5 260">
           <path class='logo__flame' d="M106.5 101.3c-13.4 10.1-16 28-16.4 40.1C68.8 116.8 129.3 44.6 60.6 0 103.1 55.1 0 109.3 0 190.4c0 31.8 19.9 59.9 63.5 69.6 42.8-9.1 64-37.8 64-69.6 0-47.4-29.5-63.3-21-89.1zM63.6 234c-23.3 0-42.2-18.9-42.2-42.2 0-23.3 18.9-42.2 42.2-42.2 23.3 0 42.2 18.9 42.2 42.2.1 23.3-18.8 42.2-42.2 42.2z"/>
         </svg>
-        <h3>Oh no, SparkPost is having trouble loading.</h3>
-        <p>Please make sure you're using <a target="_blank" href="http://browserl.ist/?q=%3E+1%25%2C+not+ie+%3C%3D+11%2C+Firefox+ESR%2C+last+2+opera+versions%2C+last+2+edge+versions%2C+last+2+safari+versions%2C+last+2+chrome+versions%2C+last+2+opera+versions%2C+last+2+firefox+versions%2C+last+2+FirefoxAndroid+versions">a supported browser</a> and <a id='reloadLink'>try again</a>.
+        <p>
+          We're very sorry for the inconvenience.  Please <a id='reloadLink'>try again</a> soon.
+          <br /><small>(Note: If you're visiting from a legacy or uncommon browser, you may want to consider upgrading to latest version or trying another browser.)</small>
         </p>
         <p>If problems continue, check our <a href='https://status.sparkpost.com'>status page</a> for updates, or reach out on <a href='http://slack.sparkpost.com/'>Slack</a>.</p>
       </div>


### PR DESCRIPTION
- link http://browserl.ist/  in app not loading page. let me know objections
- Added browserslist dep as, otherwise, `npx browserslist` doesn't follow the rule in `package.json`
- explicitly disallowed all IE

we've about 83% coverage now

Notes: 
- Adding `not dead` isn't working during build (version issue, i guess). but > 1% and last 2 versions combination would probably give us something similar. 

- Browserlist repo suggested not to disallow unknown browsers but in our case our query disallowed browsers like baido, opera mobile, qq browsers. 
- There are some notes in ticket. 