### PR TITLE
FE-342 Support ticket UI should account for number of available issue types

### DIFF
--- a/src/components/auth/ConditionSwitch.js
+++ b/src/components/auth/ConditionSwitch.js
@@ -4,12 +4,15 @@ import selectAccessConditionState from 'src/selectors/accessConditionState';
 
 export const defaultCase = () => true;
 
+export const Case = ({ children }) => children;
+Case.displayName = 'Case';
+
 /**
  * Returns the first child whose condition prop returns true
  *
  * Patterned after the React Router <Switch> element
  */
-export const ConditionSwitch = function({ children, ready, accessConditionState }) {
+export const ConditionSwitch = function ({ children, ready, accessConditionState }) {
   if (!ready) {
     return null;
   }

--- a/src/components/auth/tests/ConditionSwitch.test.js
+++ b/src/components/auth/tests/ConditionSwitch.test.js
@@ -1,32 +1,26 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ConditionSwitch, defaultCase } from '../ConditionSwitch';
+import { ConditionSwitch, defaultCase, Case } from '../ConditionSwitch';
 
 describe('Component: ConditionSwitch', () => {
-
-  // some dummy test components
-  function A() {}
-  function B() {}
-  function C() {}
-  function D() {}
 
   it('should render only the first item whose condition function returns truthy for', () => {
     const wrapper = shallow(
       <ConditionSwitch accessConditionState={{}} ready={true}>
-        <A condition={() => false} />
-        <B condition={() => true} />
-        <C condition={() => true} />
+        <Case condition={() => false}>A</Case>
+        <Case condition={() => true}>B</Case>
+        <Case condition={() => true}>C</Case>
       </ConditionSwitch>
     );
-    expect(wrapper.text()).toEqual('<B />');
+    expect(wrapper.html()).toEqual('B');
   });
 
   it('should render nothing when not ready', () => {
     const wrapper = shallow(
       <ConditionSwitch accessConditionState={{}} ready={false}>
-        <A condition={() => false} />
-        <B condition={() => true} />
-        <C condition={() => true} />
+        <Case condition={() => false}>A</Case>
+        <Case condition={() => true}>B</Case>
+        <Case condition={() => true}>C</Case>
       </ConditionSwitch>
     );
     expect(wrapper.text()).toEqual('');
@@ -35,25 +29,37 @@ describe('Component: ConditionSwitch', () => {
   it('should render the default case if everything before it returned false', () => {
     const wrapper = shallow(
       <ConditionSwitch accessConditionState={{}} ready={true}>
-        <A condition={() => false} />
-        <B condition={() => false} />
-        <C condition={() => false} />
-        <D condition={defaultCase} />
+        <Case condition={() => false}>A</Case>
+        <Case condition={() => false}>B</Case>
+        <Case condition={() => false}>C</Case>
+        <Case condition={defaultCase}>D</Case>
       </ConditionSwitch>
     );
-    expect(wrapper.text()).toEqual('<D />');
+    expect(wrapper.html()).toEqual('D');
   });
 
   it('should ignore components with no condition', () => {
     const wrapper = shallow(
       <ConditionSwitch accessConditionState={{}} ready={true}>
-        <A />
-        <B condition={() => false} />
-        <C condition={() => true} />
-        <D condition={defaultCase} />
+        <Case>A</Case>
+        <Case condition={() => false}>B</Case>
+        <Case condition={() => true}>C</Case>
+        <Case condition={defaultCase}>D</Case>
       </ConditionSwitch>
     );
-    expect(wrapper.text()).toEqual('<C />');
+    expect(wrapper.html()).toEqual('C');
+  });
+
+  it('should work with custom components', () => {
+    function Custom() {}
+
+    const wrapper = shallow(
+      <ConditionSwitch accessConditionState={{}} ready={true}>
+        <Case condition={() => false}>A</Case>
+        <Custom condition={() => true}/>
+      </ConditionSwitch>
+    );
+    expect(wrapper.text()).toEqual('<Custom />');
   });
 
 });

--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -4,17 +4,18 @@ import { withRouter } from 'react-router';
 import qs from 'query-string';
 import { Portal, Popover } from '@sparkpost/matchbox';
 import { Cancel, Help } from '@sparkpost/matchbox-icons';
+import { AccessControl } from 'src/components/auth';
 import * as supportActions from 'src/actions/support';
 import SupportForm from './components/SupportForm';
 import SearchPanel from './components/SearchPanel';
 import styles from './Support.module.scss';
 
 export class Support extends Component {
-  componentDidMount () {
+  componentDidMount() {
     this.maybeOpenTicket();
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     const { location } = this.props;
 
     if (location.search && location.search !== prevProps.location.search) {
@@ -46,7 +47,7 @@ export class Support extends Component {
     this.props.toggleTicketForm();
   }
 
-  render () {
+  render() {
     const { loggedIn, showPanel, showTicketForm } = this.props;
 
     if (!loggedIn) {
@@ -64,18 +65,21 @@ export class Support extends Component {
     return (
       <Portal containerId='support-portal'>
         <div className={styles.Support}>
-          <Popover
-            top
-            left
-            fixed
-            className={styles.Popover}
-            open={showPanel}
-            trigger={triggerMarkup}
-          >
-            {showPanel && (showTicketForm
-              ? <SupportForm onCancel={this.toggleForm} onContinue={this.toggleForm} />
-              : <SearchPanel toggleForm={this.toggleForm} />)}
-          </Popover>
+          {/* Wait for access control state to be ready before rendering the popover */}
+          <AccessControl condition={() => true}>
+            <Popover
+              top
+              left
+              fixed
+              className={styles.Popover}
+              open={showPanel}
+              trigger={triggerMarkup}
+            >
+              {showPanel && (showTicketForm
+                ? <SupportForm onCancel={this.toggleForm} onContinue={this.toggleForm} />
+                : <SearchPanel toggleForm={this.toggleForm} />)}
+            </Popover>
+          </AccessControl>
         </div>
       </Portal>
     );

--- a/src/components/support/components/NoIssues.js
+++ b/src/components/support/components/NoIssues.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Button } from '@sparkpost/matchbox';
+import styles from './NoIssues.module.scss';
+
+const NoIssues = ({ onCancel }) => (
+  <div className={styles.NoIssues}>
+    <div className={styles.Message}>
+      <h6>Sorry, you are not authorized to submit a support ticket.</h6>
+      <Button flat color='orange' onClick={onCancel}>Go Back</Button>
+    </div>
+  </div>
+);
+
+export default NoIssues;

--- a/src/components/support/components/NoIssues.js
+++ b/src/components/support/components/NoIssues.js
@@ -6,7 +6,7 @@ const NoIssues = ({ onCancel }) => (
   <div className={styles.NoIssues}>
     <div className={styles.Message}>
       <h6>Sorry, you are not authorized to submit a support ticket.</h6>
-      <Button flat color='orange' onClick={onCancel}>Go Back</Button>
+      <Button flat color='orange' onClick={onCancel}>Search support articles</Button>
     </div>
   </div>
 );

--- a/src/components/support/components/NoIssues.module.scss
+++ b/src/components/support/components/NoIssues.module.scss
@@ -1,0 +1,13 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.NoIssues {
+  height: rem(600);
+}
+
+.Message {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/components/support/components/SearchPanel.js
+++ b/src/components/support/components/SearchPanel.js
@@ -1,29 +1,41 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
 import { Panel } from '@sparkpost/matchbox';
 import AlgoliaResults from './AlgoliaResults';
 import styles from './SearchPanel.module.scss';
 import { InstantSearch, Hits } from 'react-instantsearch/dom';
 import SupportCta from './SupportCta';
 import AlgoliaSearch from './AlgoliaSearch.js';
+import { selectSupportIssues } from 'src/selectors/support';
 import config from 'src/config';
 const searchCfg = config.support.algolia;
 
-const SearchPanel = ({ toggleForm }) => (
-  <InstantSearch
-    appId={searchCfg.appID}
-    apiKey={searchCfg.apiKey}
-    indexName={searchCfg.index}
-  >
-    <Panel.Section>
-      <AlgoliaSearch />
-    </Panel.Section>
-    <Panel.Section className={styles.Results}>
-      <Hits hitComponent={AlgoliaResults} />
-    </Panel.Section>
-    <Panel.Section>
-      <SupportCta toggleForm={toggleForm} />
-    </Panel.Section>
-  </InstantSearch>
-);
+const SearchPanel = ({ toggleForm, issues }) => {
+  const canSubmitSupportTicket = issues.length > 0;
+  return (
+    <InstantSearch
+      appId={searchCfg.appID}
+      apiKey={searchCfg.apiKey}
+      indexName={searchCfg.index}
+    >
+      <Panel.Section>
+        <AlgoliaSearch />
+      </Panel.Section>
+      <Panel.Section className={classnames(styles.Results, canSubmitSupportTicket && styles.shorten)}>
+        <Hits hitComponent={AlgoliaResults} />
+      </Panel.Section>
+      {canSubmitSupportTicket && (
+        <Panel.Section>
+          <SupportCta toggleForm={toggleForm} />
+        </Panel.Section>
+      )}
+    </InstantSearch>
+  );
+};
 
-export default SearchPanel;
+const mapStateToProps = (state) => ({
+  issues: selectSupportIssues(state)
+});
+
+export default connect(mapStateToProps, {})(SearchPanel);

--- a/src/components/support/components/SearchPanel.js
+++ b/src/components/support/components/SearchPanel.js
@@ -11,7 +11,7 @@ import { selectSupportIssues } from 'src/selectors/support';
 import config from 'src/config';
 const searchCfg = config.support.algolia;
 
-const SearchPanel = ({ toggleForm, issues }) => {
+export const SearchPanel = ({ toggleForm, issues }) => {
   const canSubmitSupportTicket = issues.length > 0;
   return (
     <InstantSearch

--- a/src/components/support/components/SearchPanel.module.scss
+++ b/src/components/support/components/SearchPanel.module.scss
@@ -1,8 +1,12 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 .Results {
-  height: rem(425);
+  height: rem(525);
   overflow-y: scroll;
+
+  &.shorten {
+    height: rem(425);
+  }
 }
 
 .Results ul {

--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -12,6 +12,7 @@ import { hasOnlineSupport } from 'src/helpers/conditions/account';
 import { getBase64Contents } from 'src/helpers/file';
 import { required, maxFileSize } from 'src/helpers/validation';
 import { selectSupportIssue, selectSupportIssues } from 'src/selectors/support';
+import NoIssues from './NoIssues';
 
 import styles from './SupportForm.module.scss';
 
@@ -28,7 +29,7 @@ export class SupportForm extends Component {
     return this.props.createTicket(ticket);
   };
 
-  renderSuccess () {
+  renderSuccess() {
     const { ticketId, onContinue } = this.props;
 
     return <div className={styles.SupportForm}>
@@ -41,12 +42,12 @@ export class SupportForm extends Component {
     </div>;
   }
 
-  reset (parentReset) {
+  reset(parentReset) {
     this.props.reset(formName);
     return parentReset();
   }
 
-  renderForm () {
+  renderForm() {
     const {
       handleSubmit,
       invalid,
@@ -58,6 +59,7 @@ export class SupportForm extends Component {
       submitting,
       toggleSupportPanel
     } = this.props;
+
 
     return <div className={styles.SupportForm}>
       <Panel.Section>
@@ -111,10 +113,15 @@ export class SupportForm extends Component {
     </div>;
   }
 
-  render () {
+  render() {
     if (this.props.submitSucceeded) {
       return this.renderSuccess();
     }
+
+    if (this.props.issues.length < 1) {
+      return <NoIssues onCancel={() => this.reset(this.props.onCancel)} />;
+    }
+
     return this.renderForm();
   }
 }

--- a/src/components/support/components/tests/NoIssues.test.js
+++ b/src/components/support/components/tests/NoIssues.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import NoIssues from '../NoIssues';
+
+describe('NoIssues View Component', () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      onCancel: jest.fn()
+    };
+    wrapper = shallow(<NoIssues {...props} />);
+  });
+
+  it('should render', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should cancel', () => {
+    wrapper.find('Button').simulate('click');
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/support/components/tests/SearchPanel.test.js
+++ b/src/components/support/components/tests/SearchPanel.test.js
@@ -1,19 +1,25 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import SearchPanel from '../SearchPanel';
+import { SearchPanel } from '../SearchPanel';
 
 describe('Search Panel Component', () => {
   let wrapper;
 
   beforeEach(() => {
     const props = {
-      toggleForm: jest.fn()
+      toggleForm: jest.fn(),
+      issues: [1,2]
     };
     wrapper = shallow(<SearchPanel {...props} />);
   });
 
   it('should render', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not render cta without support issues', () => {
+    wrapper.setProps({ issues: []});
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/support/components/tests/SupportForm.test.js
+++ b/src/components/support/components/tests/SupportForm.test.js
@@ -63,6 +63,11 @@ describe('Support Form Component', () => {
       wrapper.setProps({ needsOnlineSupport: true });
       expect(wrapper.find('Field[name="issueId"]')).toMatchSnapshot();
     });
+
+    it('should render no issue view when no issues are available', () => {
+      wrapper.setProps({ issues: []});
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
   describe('Control', () => {
@@ -96,6 +101,14 @@ describe('Support Form Component', () => {
       const btns = wrapper.find('Button');
       expect(btns).toHaveLength(2);
       btns.at(1).simulate('click');
+      expect(spy).toHaveBeenCalled();
+      expect(props.onCancel).toHaveBeenCalled();
+    });
+
+    it('should cancel on no issue view', () => {
+      wrapper.setProps({ issues: []});
+      const spy = jest.spyOn(wrapper.instance(), 'reset');
+      wrapper.find('NoIssues').simulate('cancel');
       expect(spy).toHaveBeenCalled();
       expect(props.onCancel).toHaveBeenCalled();
     });

--- a/src/components/support/components/tests/__snapshots__/NoIssues.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/NoIssues.test.js.snap
@@ -16,7 +16,7 @@ exports[`NoIssues View Component should render 1`] = `
       onClick={[MockFunction]}
       size="default"
     >
-      Go Back
+      Search support articles
     </Button>
   </div>
 </div>

--- a/src/components/support/components/tests/__snapshots__/NoIssues.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/NoIssues.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoIssues View Component should render 1`] = `
+<div
+  className="NoIssues"
+>
+  <div
+    className="Message"
+  >
+    <h6>
+      Sorry, you are not authorized to submit a support ticket.
+    </h6>
+    <Button
+      color="orange"
+      flat={true}
+      onClick={[MockFunction]}
+      size="default"
+    >
+      Go Back
+    </Button>
+  </div>
+</div>
+`;

--- a/src/components/support/components/tests/__snapshots__/SearchPanel.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/SearchPanel.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Search Panel Component should render 1`] = `
+exports[`Search Panel Component should not render cta without support issues 1`] = `
 <CreateInstantSearch
   apiKey="key"
   appId="id"
@@ -20,6 +20,34 @@ exports[`Search Panel Component should render 1`] = `
   </Panel.Section>
   <Panel.Section
     className="Results"
+  >
+    <AlgoliaHits(Hits)
+      hitComponent={[Function]}
+    />
+  </Panel.Section>
+</CreateInstantSearch>
+`;
+
+exports[`Search Panel Component should render 1`] = `
+<CreateInstantSearch
+  apiKey="key"
+  appId="id"
+  indexName="index"
+  refresh={false}
+  root={
+    Object {
+      "Root": "div",
+      "props": Object {
+        "className": "ais-InstantSearch__root",
+      },
+    }
+  }
+>
+  <Panel.Section>
+    <AlgoliaSearchBox(UnknownComponent) />
+  </Panel.Section>
+  <Panel.Section
+    className="Results shorten"
   >
     <AlgoliaHits(Hits)
       hitComponent={[Function]}

--- a/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
@@ -96,6 +96,12 @@ exports[`Support Form Component Form should render issue dropdown with help text
 />
 `;
 
+exports[`Support Form Component Form should render no issue view when no issues are available 1`] = `
+<NoIssues
+  onCancel={[Function]}
+/>
+`;
+
 exports[`Support Form Component Form should render with selected issue message label 1`] = `
 <div
   className="SupportForm"

--- a/src/components/support/tests/__snapshots__/Support.test.js.snap
+++ b/src/components/support/tests/__snapshots__/Support.test.js.snap
@@ -7,26 +7,30 @@ exports[`Support Component render tests should render just the icon by default 1
   <div
     className="Support"
   >
-    <Popover
-      bottom={true}
-      className="Popover"
-      fixed={true}
-      left={true}
-      open={false}
-      right={true}
-      top={true}
-      trigger={
-        <a
-          className="Button"
-          onClick={[Function]}
-        >
-          <Help
-            className="Icon"
-            size={33}
-          />
-        </a>
-      }
-    />
+    <Connect(AccessControl)
+      condition={[Function]}
+    >
+      <Popover
+        bottom={true}
+        className="Popover"
+        fixed={true}
+        left={true}
+        open={false}
+        right={true}
+        top={true}
+        trigger={
+          <a
+            className="Button"
+            onClick={[Function]}
+          >
+            <Help
+              className="Icon"
+              size={33}
+            />
+          </a>
+        }
+      />
+    </Connect(AccessControl)>
   </div>
 </Portal>
 `;
@@ -38,31 +42,35 @@ exports[`Support Component render tests should show form and close icon when pan
   <div
     className="Support"
   >
-    <Popover
-      bottom={true}
-      className="Popover"
-      fixed={true}
-      left={true}
-      open={true}
-      right={true}
-      top={true}
-      trigger={
-        <a
-          className="Button"
-          onClick={[Function]}
-        >
-          <Cancel
-            className="Icon"
-            size={33}
-          />
-        </a>
-      }
+    <Connect(AccessControl)
+      condition={[Function]}
     >
-      <Connect(ReduxForm)
-        onCancel={[Function]}
-        onContinue={[Function]}
-      />
-    </Popover>
+      <Popover
+        bottom={true}
+        className="Popover"
+        fixed={true}
+        left={true}
+        open={true}
+        right={true}
+        top={true}
+        trigger={
+          <a
+            className="Button"
+            onClick={[Function]}
+          >
+            <Cancel
+              className="Icon"
+              size={33}
+            />
+          </a>
+        }
+      >
+        <Connect(ReduxForm)
+          onCancel={[Function]}
+          onContinue={[Function]}
+        />
+      </Popover>
+    </Connect(AccessControl)>
   </div>
 </Portal>
 `;
@@ -74,30 +82,34 @@ exports[`Support Component render tests should show search panel and close icon 
   <div
     className="Support"
   >
-    <Popover
-      bottom={true}
-      className="Popover"
-      fixed={true}
-      left={true}
-      open={true}
-      right={true}
-      top={true}
-      trigger={
-        <a
-          className="Button"
-          onClick={[Function]}
-        >
-          <Cancel
-            className="Icon"
-            size={33}
-          />
-        </a>
-      }
+    <Connect(AccessControl)
+      condition={[Function]}
     >
-      <SearchPanel
-        toggleForm={[Function]}
-      />
-    </Popover>
+      <Popover
+        bottom={true}
+        className="Popover"
+        fixed={true}
+        left={true}
+        open={true}
+        right={true}
+        top={true}
+        trigger={
+          <a
+            className="Button"
+            onClick={[Function]}
+          >
+            <Cancel
+              className="Icon"
+              size={33}
+            />
+          </a>
+        }
+      >
+        <Connect(Component)
+          toggleForm={[Function]}
+        />
+      </Popover>
+    </Connect(AccessControl)>
   </div>
 </Portal>
 `;

--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -8,7 +8,8 @@ import { PageLink } from 'src/components';
 import ConditionSwitch, { Case } from 'src/components/auth/ConditionSwitch';
 import { AccessControl } from 'src/components/auth';
 import { isAdmin, isEmailVerified } from 'src/helpers/conditions/user';
-import { hasOnlineSupport, hasStatus } from 'src/helpers/conditions/account';
+import { hasOnlineSupport, hasStatus, isSelfServeBilling } from 'src/helpers/conditions/account';
+import { all } from 'src/helpers/conditions/compose';
 import { not } from 'src/helpers/conditions';
 import { LINKS } from 'src/constants';
 
@@ -57,9 +58,16 @@ export class SendMoreCTA extends Component {
           Need to send more?
           {' '}
           <ConditionSwitch>
-            <Case condition={not(isEmailVerified)} children={this.renderVerifyEmailCTA()}/>
-            <Case condition={not(hasOnlineSupport)} children={this.renderUpgradeCTA()}/>
-            <Case condition={hasStatus('active')} children={this.renderSupportTicketCTA()}/>
+
+            {/* email isn't verified */}
+            <Case condition={not(isEmailVerified)} children={this.renderVerifyEmailCTA()} />
+
+            {/* is self serve billing and doesn't have online support */}
+            <Case condition={all(isSelfServeBilling, not(hasOnlineSupport))} children={this.renderUpgradeCTA()} />
+
+            {/* has online support and is active account status */}
+            <Case condition={all(hasOnlineSupport, hasStatus('active'))} children={this.renderSupportTicketCTA()} />
+
           </ConditionSwitch>
           {' '}
           <UnstyledLink to={LINKS.DAILY_MONTHLY_QUOTA_LIMIT_DOC} external>Learn more about these limits.</UnstyledLink>

--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -7,7 +7,7 @@ import { openSupportTicketForm } from 'src/actions/support';
 import { PageLink } from 'src/components';
 import ConditionSwitch, { Case } from 'src/components/auth/ConditionSwitch';
 import { AccessControl } from 'src/components/auth';
-import { isAdmin, isVerified } from 'src/helpers/conditions/user';
+import { isAdmin, isEmailVerified } from 'src/helpers/conditions/user';
 import { hasOnlineSupport, hasStatus } from 'src/helpers/conditions/account';
 import { not } from 'src/helpers/conditions';
 import { LINKS } from 'src/constants';
@@ -57,7 +57,7 @@ export class SendMoreCTA extends Component {
           Need to send more?
           {' '}
           <ConditionSwitch>
-            <Case condition={not(isVerified)} children={this.renderVerifyEmailCTA()}/>
+            <Case condition={not(isEmailVerified)} children={this.renderVerifyEmailCTA()}/>
             <Case condition={not(hasOnlineSupport)} children={this.renderUpgradeCTA()}/>
             <Case condition={hasStatus('active')} children={this.renderSupportTicketCTA()}/>
           </ConditionSwitch>

--- a/src/components/usageReport/tests/SendMoreCTA.test.js
+++ b/src/components/usageReport/tests/SendMoreCTA.test.js
@@ -10,11 +10,6 @@ describe('SendMoreCTA Component', () => {
   beforeEach(() => {
 
     props = {
-      currentUser: {
-        email_verified: true
-      },
-      allowSendingLimitRequest: false,
-      currentLimit: 1000,
       verifyEmail: jest.fn(() => Promise.resolve()),
       showAlert: jest.fn(() => Promise.resolve()),
       openSupportTicketForm: jest.fn()
@@ -24,34 +19,18 @@ describe('SendMoreCTA Component', () => {
     instance = wrapper.instance();
   });
 
-  it('renders when email address not verified', () => {
-    wrapper.setProps({ currentUser: { email_verified: false }});
+  it('renders correctly', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders correctly for aws free plan (cta to upgrade)', () => {
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('renders correctly for customers who can request limit bump', () => {
-    wrapper.setProps({ allowSendingLimitRequest: true });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('renders support form correctly', () => {
-    wrapper.setProps({ allowSendingLimitRequest: true });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('togles support ticket form correctly', () => {
-    wrapper.setProps({ allowSendingLimitRequest: true });
-    wrapper.find('UnstyledLink').at(0).simulate('click');
+  it('toggles support ticket form correctly', () => {
+    wrapper.find('UnstyledLink').at(1).simulate('click');
     expect(props.openSupportTicketForm).toHaveBeenCalledWith({ issueId: 'daily_limits' });
   });
 
   describe('resendVerification', () => {
     it('renders verifying state', () => {
-      wrapper.setProps({ verifyingEmail: true, currentUser: { email_verified: false }});
+      wrapper.setProps({ verifyingEmail: true });
       expect(wrapper.find('span').text()).toEqual('Resending a verification email... ');
     });
 

--- a/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
@@ -1,83 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SendMoreCTA Component renders correctly for aws free plan (cta to upgrade) 1`] = `
-<p>
-  Need to send more?
-   
-  <PageLink
-    to="/account/billing"
-  >
-    Upgrade your account.
-  </PageLink>
-   
-  <UnstyledLink
-    external={true}
-    to="https://support.sparkpost.com/customer/portal/articles/2030894"
-  >
-    Learn more about these limits.
-  </UnstyledLink>
-</p>
-`;
-
-exports[`SendMoreCTA Component renders correctly for customers who can request limit bump 1`] = `
-<p>
-  Need to send more?
-   
-  <React.Fragment>
+exports[`SendMoreCTA Component renders correctly 1`] = `
+<Connect(AccessControl)
+  condition={[Function]}
+>
+  <p>
+    Need to send more?
+     
+    <Connect(Component)>
+      <Case
+        condition={[Function]}
+      >
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          Verify your email.
+        </UnstyledLink>
+      </Case>
+      <Case
+        condition={[Function]}
+      >
+        <PageLink
+          to="/account/billing"
+        >
+          Upgrade your account.
+        </PageLink>
+      </Case>
+      <Case
+        condition={[Function]}
+      >
+        <React.Fragment>
+          <UnstyledLink
+            onClick={[Function]}
+          >
+            Submit a request
+          </UnstyledLink>
+           to increase your daily sending limit.
+        </React.Fragment>
+      </Case>
+    </Connect(Component)>
+     
     <UnstyledLink
-      onClick={[Function]}
+      external={true}
+      to="https://support.sparkpost.com/customer/portal/articles/2030894"
     >
-      Submit a request
+      Learn more about these limits.
     </UnstyledLink>
-     to increase your daily sending limit.
-  </React.Fragment>
-   
-  <UnstyledLink
-    external={true}
-    to="https://support.sparkpost.com/customer/portal/articles/2030894"
-  >
-    Learn more about these limits.
-  </UnstyledLink>
-</p>
-`;
-
-exports[`SendMoreCTA Component renders support form correctly 1`] = `
-<p>
-  Need to send more?
-   
-  <React.Fragment>
-    <UnstyledLink
-      onClick={[Function]}
-    >
-      Submit a request
-    </UnstyledLink>
-     to increase your daily sending limit.
-  </React.Fragment>
-   
-  <UnstyledLink
-    external={true}
-    to="https://support.sparkpost.com/customer/portal/articles/2030894"
-  >
-    Learn more about these limits.
-  </UnstyledLink>
-</p>
-`;
-
-exports[`SendMoreCTA Component renders when email address not verified 1`] = `
-<p>
-  Need to send more?
-   
-  <UnstyledLink
-    onClick={[Function]}
-  >
-    Verify your email.
-  </UnstyledLink>
-   
-  <UnstyledLink
-    external={true}
-    to="https://support.sparkpost.com/customer/portal/articles/2030894"
-  >
-    Learn more about these limits.
-  </UnstyledLink>
-</p>
+  </p>
+</Connect(AccessControl)>
 `;

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -1,4 +1,6 @@
-import { hasOnlineSupport } from 'src/helpers/conditions/account';
+import { hasOnlineSupport, hasStatus, hasStatusReasonCategory, isSuspendedForBilling } from 'src/helpers/conditions/account';
+import { all, not, any } from 'src/helpers/conditions';
+import { isAdmin } from 'src/helpers/conditions/user';
 
 // types of support issues
 // @note These values must be configured in Desk before being used and they are case-sensitive
@@ -7,6 +9,11 @@ const COMPLIANCE = 'Compliance';
 const ERRORS = 'Errors';
 const LIMITS = 'DailyLimits';
 const SUPPORT = 'Support';
+
+const isActiveOrSuspendedForBilling = any(
+  isSuspendedForBilling,
+  not(hasStatus('suspended'))
+);
 
 /**
  * @example
@@ -32,40 +39,42 @@ const supportIssues = [
     label: 'Technical errors',
     messageLabel: 'Tell us more about your issue',
     type: ERRORS,
-    condition: hasOnlineSupport
+    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
   },
   {
     id: 'general_billing',
     label: 'Billing problems',
     messageLabel: 'Tell us more about your billing issue',
     type: BILLING,
-    condition: hasOnlineSupport
-  },
-  {
-    id: 'account_cancellation',
-    label: 'Account cancellation',
-    messageLabel: 'Tell us why you are leaving',
-    type: COMPLIANCE
+    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
   },
   {
     id: 'account_suspension',
     label: 'Account suspension',
     messageLabel: 'Why do you think your account should be unsuspended?',
-    type: COMPLIANCE
+    type: COMPLIANCE,
+    condition: all(hasStatus('suspended'), not(hasStatusReasonCategory('100.01')))
   },
   {
     id: 'daily_limits',
     label: 'Daily sending limit increase',
     messageLabel: 'What limit do you need and why?',
     type: LIMITS,
-    condition: hasOnlineSupport
+    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
   },
   {
     id: 'general_issue',
     label: 'Another issue',
     messageLabel: 'Tell us more about your issue',
     type: SUPPORT,
-    condition: hasOnlineSupport
+    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
+  },
+  {
+    id: 'account_cancellation',
+    label: 'Account cancellation',
+    messageLabel: 'Tell us why you are leaving',
+    type: COMPLIANCE,
+    condition: isAdmin
   }
 ];
 

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -10,11 +10,6 @@ const ERRORS = 'Errors';
 const LIMITS = 'DailyLimits';
 const SUPPORT = 'Support';
 
-const isActiveOrSuspendedForBilling = any(
-  isSuspendedForBilling,
-  not(hasStatus('suspended'))
-);
-
 /**
  * @example
  *   {
@@ -39,14 +34,14 @@ const supportIssues = [
     label: 'Technical errors',
     messageLabel: 'Tell us more about your issue',
     type: ERRORS,
-    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
+    condition: all(hasOnlineSupport, hasStatus('active'))
   },
   {
     id: 'general_billing',
     label: 'Billing problems',
     messageLabel: 'Tell us more about your billing issue',
     type: BILLING,
-    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
+    condition: all(isAdmin, any(isSuspendedForBilling, hasStatus('active')))
   },
   {
     id: 'account_suspension',
@@ -60,14 +55,14 @@ const supportIssues = [
     label: 'Daily sending limit increase',
     messageLabel: 'What limit do you need and why?',
     type: LIMITS,
-    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
+    condition: all(hasOnlineSupport, hasStatus('active'))
   },
   {
     id: 'general_issue',
     label: 'Another issue',
     messageLabel: 'Tell us more about your issue',
     type: SUPPORT,
-    condition: all(hasOnlineSupport, isActiveOrSuspendedForBilling)
+    condition: all(hasOnlineSupport, hasStatus('active'))
   },
   {
     id: 'account_cancellation',

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -55,7 +55,7 @@ const supportIssues = [
     label: 'Daily sending limit increase',
     messageLabel: 'What limit do you need and why?',
     type: LIMITS,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    condition: all(hasOnlineSupport, isAdmin, hasStatus('active'))
   },
   {
     id: 'general_issue',

--- a/src/helpers/conditions/tests/user.test.js
+++ b/src/helpers/conditions/tests/user.test.js
@@ -26,8 +26,8 @@ describe('User Condition Tests', () => {
     expect(isAdmin({ currentUser })).toEqual(true);
   });
 
-  it('should return true if user is a superadmin', () => {
-    const currentUser = { access_level: 'superadmin' };
+  it('should return true if user is a superuser', () => {
+    const currentUser = { access_level: 'superuser' };
     expect(isAdmin({ currentUser })).toEqual(true);
   });
 

--- a/src/helpers/conditions/tests/user.test.js
+++ b/src/helpers/conditions/tests/user.test.js
@@ -1,4 +1,4 @@
-import { isAdmin, isHeroku, isAzure, isSso } from '../user';
+import { isAdmin, isHeroku, isAzure, isSso, hasRole } from '../user';
 
 describe('User Condition Tests', () => {
   it('should return true if user is heroku', () => {
@@ -26,6 +26,11 @@ describe('User Condition Tests', () => {
     expect(isAdmin({ currentUser })).toEqual(true);
   });
 
+  it('should return true if user is a superadmin', () => {
+    const currentUser = { access_level: 'superadmin' };
+    expect(isAdmin({ currentUser })).toEqual(true);
+  });
+
   it('should return false if user is not an admin', () => {
     const currentUser = { access_level: 'reporting' };
     expect(isAdmin({ currentUser })).toEqual(false);
@@ -39,5 +44,15 @@ describe('User Condition Tests', () => {
   it('should return false if user is sso', () => {
     const currentUser = { is_sso: false };
     expect(isSso({ currentUser })).toEqual(false);
+  });
+
+  it('should return true if access level matches', () => {
+    const currentUser = { access_level: 'admin' };
+    expect(hasRole('admin')({ currentUser })).toEqual(true);
+  });
+
+  it('should return true if access level does not match', () => {
+    const currentUser = { access_level: 'reporting' };
+    expect(hasRole('admin')({ currentUser })).toEqual(false);
   });
 });

--- a/src/helpers/conditions/user.js
+++ b/src/helpers/conditions/user.js
@@ -1,7 +1,13 @@
+import { any } from 'src/helpers/conditions';
+
 export const isHeroku = ({ currentUser }) => currentUser.access_level === 'heroku';
 
 export const isAzure = ({ currentUser }) => currentUser.access_level === 'azure';
 
-export const isAdmin = ({ currentUser }) => currentUser.access_level === 'admin';
+export const hasRole = (role) => ({ currentUser }) => currentUser.access_level === role;
+
+export const isAdmin = any(hasRole('admin'), hasRole('superadmin'));
 
 export const isSso = ({ currentUser }) => currentUser.is_sso;
+
+export const isVerified = ({ currentUser }) => currentUser.email_verified;

--- a/src/helpers/conditions/user.js
+++ b/src/helpers/conditions/user.js
@@ -6,8 +6,8 @@ export const isAzure = ({ currentUser }) => currentUser.access_level === 'azure'
 
 export const hasRole = (role) => ({ currentUser }) => currentUser.access_level === role;
 
-export const isAdmin = any(hasRole('admin'), hasRole('superadmin'));
+export const isAdmin = any(hasRole('admin'), hasRole('superuser'));
 
 export const isSso = ({ currentUser }) => currentUser.is_sso;
 
-export const isVerified = ({ currentUser }) => currentUser.email_verified;
+export const isEmailVerified = ({ currentUser }) => currentUser.email_verified;

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -11,7 +11,7 @@ import SuppressionBanner from './components/SuppressionBanner';
 
 import { showAlert } from 'src/actions/globalAlert';
 import { verifyEmail } from 'src/actions/currentUser';
-import { fetch as fetchAccount, getPlans } from 'src/actions/account';
+import { fetch as fetchAccount } from 'src/actions/account';
 import { checkSuppression } from 'src/actions/suppressions';
 import { list as listSendingDomains } from 'src/actions/sendingDomains';
 import { listApiKeys } from 'src/actions/api-keys';
@@ -24,7 +24,6 @@ export class DashboardPage extends Component {
   componentDidMount() {
     this.props.checkSuppression();
     this.props.listSendingDomains();
-    this.props.getPlans();
     this.props.listApiKeys({ id: 0 });
   }
 
@@ -55,7 +54,7 @@ export class DashboardPage extends Component {
     return (
       <Page title='Dashboard'>
 
-        { this.renderVerifyEmailCta() }
+        {this.renderVerifyEmailCta()}
 
         <UsageReport />
         <SuppressionBanner accountAgeInWeeks={accountAgeInWeeks} hasSuppressions={hasSuppressions} />
@@ -84,4 +83,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default withRouter(connect(mapStateToProps, { fetchAccount, checkSuppression, listSendingDomains, listApiKeys, verifyEmail, showAlert, getPlans })(DashboardPage));
+export default withRouter(connect(mapStateToProps, { fetchAccount, checkSuppression, listSendingDomains, listApiKeys, verifyEmail, showAlert })(DashboardPage));

--- a/src/pages/dashboard/tests/DashboardPage.test.js
+++ b/src/pages/dashboard/tests/DashboardPage.test.js
@@ -11,7 +11,6 @@ describe('Page: Dashboard tests', () => {
     checkSuppression: jest.fn(() => []),
     listSendingDomains: jest.fn(() => []),
     listApiKeys: jest.fn(() => []),
-    getPlans: jest.fn(() => []),
     account: {
       subscription: {
         code: 'paid'
@@ -52,7 +51,7 @@ describe('Page: Dashboard tests', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should show success alert on successful email verification', async() => {
+  it('should show success alert on successful email verification', async () => {
     await instance.resendVerification();
     expect(instance.props.showAlert).toHaveBeenCalledWith({
       type: 'success',

--- a/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
+++ b/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
@@ -36,13 +36,6 @@ exports[`Page: Dashboard tests should correctly render page when user is not ver
         "email_verfied": false,
       }
     }
-    getPlans={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-      }
-    }
     hasSuppressions={true}
     listApiKeys={
       [MockFunction] {
@@ -99,13 +92,6 @@ exports[`Page: Dashboard tests should display upgrade CTA when account is free a
     currentUser={
       Object {
         "email_verified": true,
-      }
-    }
-    getPlans={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
       }
     }
     hasSuppressions={true}
@@ -166,13 +152,6 @@ exports[`Page: Dashboard tests should render import suppression list when 0 supp
         "email_verified": true,
       }
     }
-    getPlans={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-      }
-    }
     hasSuppressions={false}
     listApiKeys={
       [MockFunction] {
@@ -229,13 +208,6 @@ exports[`Page: Dashboard tests should render page correctly with defaults 1`] = 
     currentUser={
       Object {
         "email_verified": true,
-      }
-    }
-    getPlans={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
       }
     }
     hasSuppressions={true}

--- a/src/selectors/support.js
+++ b/src/selectors/support.js
@@ -1,23 +1,14 @@
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import { currentPlanSelector } from './accountBillingInfo';
 import accessConditionState from './accessConditionState';
-import { hasOnlineSupport, hasStatus } from 'src/helpers/conditions/account';
-import { all } from 'src/helpers/conditions';
 import supportIssues from 'src/config/supportIssues';
 
 const getAccountSupport = (state) => state.account.support;
 const getSupportIssueId = (state, id) => id;
-const canSubmitSupportTicketSelector = (state) => all(hasOnlineSupport, hasStatus('active'))(state);
 
 export const entitledToPhoneSupport = createSelector(
   [getAccountSupport],
   (support) => support && support.phone
-);
-
-export const allowSendingLimitRequestSelector = createSelector(
-  [currentPlanSelector, canSubmitSupportTicketSelector],
-  (currentPlan, canSubmitSupportTicket) => currentPlan.status !== 'deprecated' && !(currentPlan.isFree) && canSubmitSupportTicket
 );
 
 export const currentLimitSelector = (state) => {

--- a/src/selectors/support.js
+++ b/src/selectors/support.js
@@ -2,10 +2,13 @@ import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { currentPlanSelector } from './accountBillingInfo';
 import accessConditionState from './accessConditionState';
+import { hasOnlineSupport, hasStatus } from 'src/helpers/conditions/account';
+import { all } from 'src/helpers/conditions';
 import supportIssues from 'src/config/supportIssues';
 
 const getAccountSupport = (state) => state.account.support;
 const getSupportIssueId = (state, id) => id;
+const canSubmitSupportTicketSelector = (state) => all(hasOnlineSupport, hasStatus('active'))(state);
 
 export const entitledToPhoneSupport = createSelector(
   [getAccountSupport],
@@ -13,8 +16,8 @@ export const entitledToPhoneSupport = createSelector(
 );
 
 export const allowSendingLimitRequestSelector = createSelector(
-  [currentPlanSelector],
-  (currentPlan) => currentPlan.status !== 'deprecated' && !(currentPlan.isFree)
+  [currentPlanSelector, canSubmitSupportTicketSelector],
+  (currentPlan, canSubmitSupportTicket) => currentPlan.status !== 'deprecated' && !(currentPlan.isFree) && canSubmitSupportTicket
 );
 
 export const currentLimitSelector = (state) => {

--- a/src/selectors/tests/support.test.js
+++ b/src/selectors/tests/support.test.js
@@ -1,11 +1,4 @@
 import * as selectors from '../support';
-import * as billingInfo from '../accountBillingInfo';
-import * as accountConditions from 'src/helpers/conditions/account';
-import cases from 'jest-in-case';
-
-jest.mock('../accountBillingInfo', () => ({
-  currentPlanSelector: jest.fn()
-}));
 
 jest.mock('src/config/supportIssues', () => [
   { id: 'without_condition' },
@@ -14,11 +7,6 @@ jest.mock('src/config/supportIssues', () => [
 ]);
 
 jest.mock('src/selectors/accessConditionState', () => jest.fn((s) => s));
-
-jest.mock('src/helpers/conditions/account', () => ({
-  hasStatus: jest.fn(),
-  hasOnlineSupport: jest.fn()
-}));
 
 describe('Selectors: support', () => {
   describe('entitled to support', () => {
@@ -82,59 +70,6 @@ describe('Selectors: support', () => {
       expect(selectors.currentLimitSelector(state)).toEqual(0);
     });
   });
-
-  const testCases = {
-    'return false for deprecated plans': {
-      plan: { status: 'deprecated' },
-      onlineSupport: true,
-      active: () => true,
-      expected: false
-    },
-    'return false for free plans': {
-      plan: { isFree: true },
-      onlineSupport: true,
-      active: () => true,
-      expected: false
-    },
-    'return true for paid public plans': {
-      plan: { status: 'public', code: '2.5m-0817' },
-      onlineSupport: true,
-      active: () => true,
-      expected: true
-    },
-    'return true for paid private': {
-      plan: { status: 'public', code: '2.5m-0817' },
-      onlineSupport: true,
-      active: () => true,
-      expected: true
-    },
-    'return true for aws plans': {
-      plan: { status: 'public', code: 'aws_basic', type: 'aws' },
-      onlineSupport: true,
-      active: () => true,
-      expected: true
-    },
-    'return false if account is not active': {
-      plan: { status: 'public', code: '2.5m-0817' },
-      onlineSupport: true,
-      active: () => false,
-      expected: false
-    },
-    'return false if account does not have online support': {
-      plan: { status: 'public', code: '2.5m-0817' },
-      onlineSupport: false,
-      active: () => true,
-      expected: false
-    }
-  };
-
-  cases('allowSendingLimitRequestSelector', ({ plan, expected, onlineSupport, active }) => {
-    billingInfo.currentPlanSelector.mockReturnValue(plan);
-    accountConditions.hasOnlineSupport.mockReturnValue(onlineSupport);
-    accountConditions.hasStatus.mockReturnValue(active);
-    expect(selectors.allowSendingLimitRequestSelector({ plan })).toBe(expected);
-  }, testCases);
-
 
   describe('selectSupportIssues', () => {
     it('should return issues that satisified condition', () => {


### PR DESCRIPTION
[Jira ticket](https://jira.int.messagesystems.com/browse/FE-342)
[Issue matrix](https://docs.google.com/spreadsheets/d/1Z8M-gnewvkcemxKOINxlbP3m4jkq7o56ceQ6I32y8f8/edit?usp=sharing)

---

- Adds access conditions to support issue types
- Adds a "no issues" view to the support panel instead of reverting to the algolia search panel
  - Showing some sort of message is probably a better experience
Decided to leave the 1-issue case as is (did not replace the Select)

To verify (DM for passwords)
- Free admin-  jon.ambas+free@sparkpost.com
- Free reporting - jon.ambas+freereporting@sparkpost.com
- Paid admin - jon.ambas+paid@sparkpost.com
- Paid reporting - jon.ambas+paidreporting@sparkpost.com
- For suspended cases, use control endpoint
  - note: its not possible to test "suspended due to billing problem" case