### PR TITLE
FE-371 fixed firefox invoice download issues

### DIFF
--- a/src/pages/billing/components/InvoiceHistory.js
+++ b/src/pages/billing/components/InvoiceHistory.js
@@ -46,18 +46,27 @@ export class InvoiceHistory extends Component {
   downloadInvoice = () => {
     const { invoice, showAlert, invoices, invoiceId } = this.props;
     const invoiceNumber = _.find(invoices, { id: invoiceId }).invoice_number;
-
     const url = URL.createObjectURL(invoice);
     const link = document.createElement('a');
+
     link.href = url;
     link.setAttribute('download', `sparkpost-invoice-${invoiceNumber}.pdf`);
+
+    // Firefox requires the link be added to the DOM before it can be .click()'d
+    document.body.appendChild(link);
     link.click();
+
+    // Need to make sure we wait for the next event loop to be sure the link click finishes
+    // before we remove the link from the DOM and revoke the object URL
+    setTimeout(() => {
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }, 0);
 
     showAlert({ type: 'success', message: `Downloaded invoice: ${invoiceNumber}` });
   };
 
   render() {
-
     const { invoices } = this.props;
 
     const maxWarning = invoices.length >= 20


### PR DESCRIPTION
Firefox requires a link to be added to the DOM before it can be programmatically "clicked", so here we are now doing `document.body.appendChild(link)` before `link.click()`, which makes the download work in Firefox.

The link doesn't show up because it has no children, so it's basically invisible. Still, I thought it would be a good idea to clean it up as well as clean up the blob URL we created earlier. I noticed doing this synchronously can lead to a race condition with the `.click()` firing properly based on Stack Overflow problems, so I wrapped it in a setTimeout(0) to force it to wait until the next cycle through the event loop. 

See:
* https://stackoverflow.com/questions/32225904/programmatical-click-on-a-tag-not-working-in-firefox
* https://stackoverflow.com/questions/30694453/blob-createobjecturl-download-not-working-in-firefox-but-works-when-debugging