### PR TITLE
FE-355 updated card expiration validation

### DIFF
--- a/src/helpers/tests/validation.test.js
+++ b/src/helpers/tests/validation.test.js
@@ -114,3 +114,43 @@ describe('URL Validation', () => {
     expect(validations.url('http://  google.com')).toEqual('Must be a valid URL');
   });
 });
+
+describe('Credit card expiration validation', () => {
+  const validateExpiry = validations.cardExpiry(new Date('2018-06-15'));
+
+  it('should be valid for a date in a future year', () => {
+    expect(validateExpiry('05 / 19')).toBeUndefined();
+    expect(validateExpiry('05/19')).toBeUndefined();
+    expect(validateExpiry('05 / 2019')).toBeUndefined();
+  });
+
+  it('should be valid for a date in the same year, future month', () => {
+    expect(validateExpiry('07 / 18')).toBeUndefined();
+    expect(validateExpiry('07/18')).toBeUndefined();
+    expect(validateExpiry('07 / 2018')).toBeUndefined();
+  });
+
+  it('should be valid for a date in the same year, same month', () => {
+    expect(validateExpiry('06 / 18')).toBeUndefined();
+    expect(validateExpiry('06/18')).toBeUndefined();
+    expect(validateExpiry('06 / 2018')).toBeUndefined();
+  });
+
+  it('should be invalid for a date in the same year, previous month', () => {
+    expect(validateExpiry('05 / 18')).toEqual('Please choose a valid expiration date');
+    expect(validateExpiry('05/18')).toEqual('Please choose a valid expiration date');
+    expect(validateExpiry('05 / 2018')).toEqual('Please choose a valid expiration date');
+  });
+
+  it('should be invalid for a date in a previous year', () => {
+    expect(validateExpiry('12 / 17')).toEqual('Please choose a valid expiration date');
+    expect(validateExpiry('12/17')).toEqual('Please choose a valid expiration date');
+    expect(validateExpiry('12 / 2017')).toEqual('Please choose a valid expiration date');
+  });
+
+  it('should be invalid for a date with an invalid month', () => {
+    expect(validateExpiry('44 / 20')).toEqual('Please choose a valid expiration date');
+    expect(validateExpiry('44/20')).toEqual('Please choose a valid expiration date');
+    expect(validateExpiry('44 / 2020')).toEqual('Please choose a valid expiration date');
+  });
+});

--- a/src/helpers/tests/validation.test.js
+++ b/src/helpers/tests/validation.test.js
@@ -116,41 +116,59 @@ describe('URL Validation', () => {
 });
 
 describe('Credit card expiration validation', () => {
-  const validateExpiry = validations.cardExpiry(new Date('2018-06-15'));
+
+  let realDate;
+  const mockNow = new Date('2018-06-15T12:00:00-00:00');
+
+  beforeEach(() => {
+    realDate = Date;
+    /* eslint-disable-next-line no-global-assign */
+    Date = class extends Date {
+      constructor(...args) {
+        /* eslint-disable-next-line constructor-super */
+        return (args[0] === undefined) ? mockNow : super(...args);
+      }
+    };
+  });
+
+  afterEach(() => {
+    /* eslint-disable-next-line no-global-assign */
+    Date = realDate;
+  });
 
   it('should be valid for a date in a future year', () => {
-    expect(validateExpiry('05 / 19')).toBeUndefined();
-    expect(validateExpiry('05/19')).toBeUndefined();
-    expect(validateExpiry('05 / 2019')).toBeUndefined();
+    expect(validations.cardExpiry('05 / 19')).toBeUndefined();
+    expect(validations.cardExpiry('05/19')).toBeUndefined();
+    expect(validations.cardExpiry('05 / 2019')).toBeUndefined();
   });
 
   it('should be valid for a date in the same year, future month', () => {
-    expect(validateExpiry('07 / 18')).toBeUndefined();
-    expect(validateExpiry('07/18')).toBeUndefined();
-    expect(validateExpiry('07 / 2018')).toBeUndefined();
+    expect(validations.cardExpiry('07 / 18')).toBeUndefined();
+    expect(validations.cardExpiry('07/18')).toBeUndefined();
+    expect(validations.cardExpiry('07 / 2018')).toBeUndefined();
   });
 
   it('should be valid for a date in the same year, same month', () => {
-    expect(validateExpiry('06 / 18')).toBeUndefined();
-    expect(validateExpiry('06/18')).toBeUndefined();
-    expect(validateExpiry('06 / 2018')).toBeUndefined();
+    expect(validations.cardExpiry('06 / 18')).toBeUndefined();
+    expect(validations.cardExpiry('06/18')).toBeUndefined();
+    expect(validations.cardExpiry('06 / 2018')).toBeUndefined();
   });
 
   it('should be invalid for a date in the same year, previous month', () => {
-    expect(validateExpiry('05 / 18')).toEqual('Please choose a valid expiration date');
-    expect(validateExpiry('05/18')).toEqual('Please choose a valid expiration date');
-    expect(validateExpiry('05 / 2018')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('05 / 18')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('05/18')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('05 / 2018')).toEqual('Please choose a valid expiration date');
   });
 
   it('should be invalid for a date in a previous year', () => {
-    expect(validateExpiry('12 / 17')).toEqual('Please choose a valid expiration date');
-    expect(validateExpiry('12/17')).toEqual('Please choose a valid expiration date');
-    expect(validateExpiry('12 / 2017')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('12 / 17')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('12/17')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('12 / 2017')).toEqual('Please choose a valid expiration date');
   });
 
   it('should be invalid for a date with an invalid month', () => {
-    expect(validateExpiry('44 / 20')).toEqual('Please choose a valid expiration date');
-    expect(validateExpiry('44/20')).toEqual('Please choose a valid expiration date');
-    expect(validateExpiry('44 / 2020')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('44 / 20')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('44/20')).toEqual('Please choose a valid expiration date');
+    expect(validations.cardExpiry('44 / 2020')).toEqual('Please choose a valid expiration date');
   });
 });

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -74,3 +74,27 @@ export const maxFileSize = _.memoize(function maxFilesSize(maxSize) {
 export function url(value) {
   return isURL(value) ? undefined : 'Must be a valid URL';
 }
+
+export const cardExpiry = _.memoize((now = new Date()) => {
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
+  const message = 'Please choose a valid expiration date';
+
+  return (value) => {
+    let [month, year] = value.split(/ ?\/ ?/);
+    month = Number(month);
+    year = Number(year);
+
+    if (year < 100) {
+      year += 2000;
+    }
+
+    if (month < 1 || month > 12) {
+      return message;
+    }
+
+    if ((year < currentYear) || (year === currentYear && month < currentMonth)) {
+      return message;
+    }
+  };
+});

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { formatBytes } from 'src/helpers/units';
 import { emailRegex, emailLocalRegex, domainRegex } from './regex';
 import isURL from 'validator/lib/isURL';
+import Payment from 'payment';
 
 export function required(value) {
   return value ? undefined : 'Required';
@@ -75,26 +76,6 @@ export function url(value) {
   return isURL(value) ? undefined : 'Must be a valid URL';
 }
 
-export const cardExpiry = _.memoize((now = new Date()) => {
-  const currentYear = now.getFullYear();
-  const currentMonth = now.getMonth() + 1;
-  const message = 'Please choose a valid expiration date';
-
-  return (value) => {
-    let [month, year] = value.split(/ ?\/ ?/);
-    month = Number(month);
-    year = Number(year);
-
-    if (year < 100) {
-      year += 2000;
-    }
-
-    if (month < 1 || month > 12) {
-      return message;
-    }
-
-    if ((year < currentYear) || (year === currentYear && month < currentMonth)) {
-      return message;
-    }
-  };
-});
+export const cardExpiry = (value) => (
+  Payment.fns.validateCardExpiry(value) ? undefined : 'Please choose a valid expiration date'
+);

--- a/src/pages/billing/forms/fields/PaymentForm.js
+++ b/src/pages/billing/forms/fields/PaymentForm.js
@@ -5,9 +5,8 @@ import { Field, change } from 'redux-form';
 import { Grid } from '@sparkpost/matchbox';
 import _ from 'lodash';
 import config from 'src/config';
-
 import { TextFieldWrapper } from 'src/components';
-import { required, minLength } from 'src/helpers/validation';
+import { required, cardExpiry } from 'src/helpers/validation';
 import Payment from 'payment';
 import { formatCardTypes } from 'src/helpers/billing';
 
@@ -19,7 +18,8 @@ import { formatCardTypes } from 'src/helpers/billing';
  * card.securityCode
  */
 export class PaymentForm extends Component {
-  componentDidMount () {
+
+  componentDidMount() {
     const types = Payment.getCardArray();
     // Formats strings for our api (the ones we accept)
     Payment.setCardArray(formatCardTypes(types));
@@ -30,20 +30,21 @@ export class PaymentForm extends Component {
     Payment.formatCardCVC(ReactDOM.findDOMNode(this.cvc));
   }
 
-  validateType (number) {
+  // calculates "now" date once per mount of this component
+  validateCardExpiry = cardExpiry(new Date());
+
+  validateType(number) {
     const cardType = Payment.fns.cardType(number);
     const allowedCards = _.map(config.cardTypes, 'apiFormat');
 
-    if (_.includes(allowedCards, cardType)) {
+    if (allowedCards.includes(cardType)) {
       return undefined;
     }
 
     return `We only accept ${allowedCards.join(', ')}`;
   }
 
-  dateFormat = (date) => minLength(9)(date) ? 'Must be MM / YYYY' : undefined;
-
-  render () {
+  render() {
     const { disabled } = this.props;
     return (
       <div>
@@ -69,9 +70,9 @@ export class PaymentForm extends Component {
               label='Expiration Date'
               name='card.expCombined'
               ref={(input) => this.expiry = input}
-              placeholder='MM/YYYY'
+              placeholder='MM / YY'
               component={TextFieldWrapper}
-              validate={[required, this.dateFormat]}
+              validate={[required, this.validateCardExpiry]}
               disabled={disabled}
             />
           </Grid.Column>

--- a/src/pages/billing/forms/fields/PaymentForm.js
+++ b/src/pages/billing/forms/fields/PaymentForm.js
@@ -30,9 +30,6 @@ export class PaymentForm extends Component {
     Payment.formatCardCVC(ReactDOM.findDOMNode(this.cvc));
   }
 
-  // calculates "now" date once per mount of this component
-  validateCardExpiry = cardExpiry(new Date());
-
   validateType(number) {
     const cardType = Payment.fns.cardType(number);
     const allowedCards = _.map(config.cardTypes, 'apiFormat');
@@ -72,7 +69,7 @@ export class PaymentForm extends Component {
               ref={(input) => this.expiry = input}
               placeholder='MM / YY'
               component={TextFieldWrapper}
-              validate={[required, this.validateCardExpiry]}
+              validate={[required, cardExpiry]}
               disabled={disabled}
             />
           </Grid.Column>

--- a/src/pages/billing/forms/fields/tests/PaymentForm.test.js
+++ b/src/pages/billing/forms/fields/tests/PaymentForm.test.js
@@ -38,8 +38,11 @@ describe('Payment Form: ', () => {
   });
 
   it('should validate the expiration date', () => {
-    expect(wrapper.instance().dateFormat('22')).toEqual('Must be MM / YYYY');
-    expect(wrapper.instance().dateFormat('10 / 2020')).toEqual(undefined);
+    expect(wrapper.instance().validateCardExpiry('22')).toEqual('Please choose a valid expiration date');
+    expect(wrapper.instance().validateCardExpiry('10 / 2020')).toEqual(undefined);
+    expect(wrapper.instance().validateCardExpiry('10 / 20')).toEqual(undefined);
+    expect(wrapper.instance().validateCardExpiry('10/2020')).toEqual(undefined);
+    expect(wrapper.instance().validateCardExpiry('10/20')).toEqual(undefined);
   });
 
   it('validates card type', () => {

--- a/src/pages/billing/forms/fields/tests/PaymentForm.test.js
+++ b/src/pages/billing/forms/fields/tests/PaymentForm.test.js
@@ -37,14 +37,6 @@ describe('Payment Form: ', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should validate the expiration date', () => {
-    expect(wrapper.instance().validateCardExpiry('22')).toEqual('Please choose a valid expiration date');
-    expect(wrapper.instance().validateCardExpiry('10 / 2020')).toEqual(undefined);
-    expect(wrapper.instance().validateCardExpiry('10 / 20')).toEqual(undefined);
-    expect(wrapper.instance().validateCardExpiry('10/2020')).toEqual(undefined);
-    expect(wrapper.instance().validateCardExpiry('10/20')).toEqual(undefined);
-  });
-
   it('validates card type', () => {
     PaymentMock.fns.cardType = jest.fn().mockReturnValue('Visa');
     expect(wrapper.instance().validateType('')).toBeUndefined();

--- a/src/pages/billing/forms/fields/tests/__snapshots__/PaymentForm.test.js.snap
+++ b/src/pages/billing/forms/fields/tests/__snapshots__/PaymentForm.test.js.snap
@@ -32,7 +32,7 @@ exports[`Payment Form:  should render 1`] = `
         component={[Function]}
         label="Expiration Date"
         name="card.expCombined"
-        placeholder="MM/YYYY"
+        placeholder="MM / YY"
         validate={
           Array [
             [Function],


### PR DESCRIPTION
Before, the card had to be entered as `MM / YYYY`. There is a formatter watching the input that reformats as you type, so this is usually not a problem, but when Chrome auto-fill puts data in that field, the formatter doesn't run and it's left as `MM/YYYY` which broke the validation (because it lacked the spacing around the `/`). 

This ticket:
* Allows `MM / YYYY`, `MM/YYYY`, `MM / YY`, and `MM/YY` formats
* Implements a cardExpiry validator that validates the month is a valid month and that the month/year combo is either the current month/year, or in the future