### PR TITLE
FE-400: Users cannot remove reply-to email from a template

### DIFF
--- a/src/actions/helpers/templates.js
+++ b/src/actions/helpers/templates.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 const MODE_ABBRS = {
   draft: 'd',
   published: 'p'
@@ -10,8 +12,13 @@ const MODE_ABBRS = {
  * @param  {string} mode - 'draft' | 'published'
  * @return {string} key
  */
-const getTestDataKey = ({ id, username, mode }) => ([ 'tpldata', username, id, MODE_ABBRS[mode] ].join('/'));
+export const getTestDataKey = ({ id, username, mode }) => ([ 'tpldata', username, id, MODE_ABBRS[mode] ].join('/'));
 
-export {
-  getTestDataKey
+// Shape the content attributes for API
+export const shapeContent = (content = {}) => {
+  if (_.isEmpty(content.reply_to)) {
+    return _.omit(content, 'reply_to');
+  }
+
+  return content;
 };

--- a/src/actions/helpers/tests/templates.test.js
+++ b/src/actions/helpers/tests/templates.test.js
@@ -1,4 +1,4 @@
-import { getTestDataKey } from '../templates';
+import { getTestDataKey, shapeContent } from '../templates';
 
 describe('Helper: Templates local storage key', () => {
   it('should get the correct draft key', () => {
@@ -11,5 +11,15 @@ describe('Helper: Templates local storage key', () => {
     const options = { id: 'two', username: 'user', mode: 'published' };
     const results = getTestDataKey(options);
     expect(results).toEqual('tpldata/user/two/p');
+  });
+});
+
+describe('.shapeContent', () => {
+  it('should return content object with reply_to key', () => {
+    expect(shapeContent({ reply_to: 'test@example.com' })).toHaveProperty('reply_to');
+  });
+
+  it('should return content object without reply_to key', () => {
+    expect(shapeContent({ reply_to: '' })).not.toHaveProperty('reply_to');
   });
 });

--- a/src/actions/templates.js
+++ b/src/actions/templates.js
@@ -3,7 +3,7 @@
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
 import localforage from 'localforage';
 import config from 'src/config';
-import { getTestDataKey } from './helpers/templates';
+import { getTestDataKey, shapeContent } from './helpers/templates';
 import setSubaccountHeader from './helpers/setSubaccountHeader';
 
 export function listTemplates() {
@@ -33,7 +33,7 @@ export function getDraft(id, subaccountId) {
 }
 
 export function getDraftAndPreview(id, subaccountId) {
-  return async(dispatch) => {
+  return async (dispatch) => {
     const { content } = await dispatch(getDraft(id, subaccountId));
     const { payload = {}} = await dispatch(getTestData({ id, mode: 'draft' }));
     const substitution_data = payload.substitution_data || {};
@@ -73,7 +73,7 @@ export function getPublished(id, subaccountId) {
 }
 
 export function getPublishedAndPreview(id, subaccountId) {
-  return async(dispatch) => {
+  return async (dispatch) => {
     const { content } = await dispatch(getPublished(id, subaccountId));
     const { payload = {}} = await dispatch(getTestData({ id, mode: 'published' }));
     const substitution_data = payload.substitution_data || {};
@@ -83,7 +83,7 @@ export function getPublishedAndPreview(id, subaccountId) {
 }
 
 export function create(data) {
-  const { id, testData, assignTo, subaccount, ...formData } = data;
+  const { id, testData, assignTo, subaccount, content, ...formData } = data;
 
   return (dispatch) => {
     dispatch(setTestData({ id, mode: 'draft', data: testData }));
@@ -97,6 +97,7 @@ export function create(data) {
         data: {
           ...formData,
           id,
+          content: shapeContent(content),
           shared_with_subaccounts: assignTo === 'shared'
         }
       }
@@ -105,7 +106,7 @@ export function create(data) {
 }
 
 export function update(data, subaccountId, params = {}) {
-  const { id, testData, ...formData } = data;
+  const { id, testData, content, ...formData } = data;
 
   return (dispatch) => {
     dispatch(setTestData({ id, mode: 'draft', data: testData }));
@@ -115,7 +116,10 @@ export function update(data, subaccountId, params = {}) {
       meta: {
         method: 'PUT',
         url: `/templates/${id}`,
-        data: formData,
+        data: {
+          ...formData,
+          content: shapeContent(content)
+        },
         params,
         headers: setSubaccountHeader(subaccountId)
       }
@@ -206,7 +210,7 @@ export function sendPreview({ id, mode, emails, from, subaccountId }) {
     address: { email }
   }));
 
-  return async(dispatch) => {
+  return async (dispatch) => {
     const { payload: testData = {}} = await dispatch(getTestData({ id, mode }));
 
     return dispatch(sparkpostApiRequest({

--- a/src/actions/tests/__snapshots__/templates.test.js.snap
+++ b/src/actions/tests/__snapshots__/templates.test.js.snap
@@ -82,6 +82,7 @@ Array [
   Object {
     "meta": Object {
       "data": Object {
+        "content": Object {},
         "form": "data",
         "id": "id",
         "shared_with_subaccounts": false,
@@ -227,6 +228,7 @@ Array [
   Object {
     "meta": Object {
       "data": Object {
+        "content": Object {},
         "form": "data",
       },
       "headers": Object {},


### PR DESCRIPTION
How to test?
1. Create a template with a reply to email.
2. Remove the reply to email
3. Click Save or Publish

