### PR TITLE
FE-409 fixes bug with onboarding location state

### DIFF
--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from 'react';
-import { reduxForm, formValueSelector } from 'redux-form';
+import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { Panel, Grid, Button } from '@sparkpost/matchbox';
 import { showAlert } from 'src/actions/globalAlert';
@@ -8,8 +8,7 @@ import Steps from './components/Steps';
 import { getPlans } from 'src/actions/account';
 import { getBillingCountries } from 'src/actions/billing';
 import billingCreate from 'src/actions/billingCreate';
-import { selectVisiblePlans } from 'src/selectors/accountBillingInfo';
-import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
+import { choosePlanMSTP } from 'src/selectors/onboarding';
 import PaymentForm from 'src/pages/billing/forms/fields/PaymentForm';
 import BillingAddressForm from 'src/pages/billing/forms/fields/BillingAddressForm';
 import { isAws } from 'src/helpers/conditions/account';
@@ -21,12 +20,12 @@ const FORM_NAME = 'selectInitialPlan';
 const NEXT_STEP = '/onboarding/sending-domain';
 
 export class OnboardingPlanPage extends Component {
-  componentDidMount () {
+  componentDidMount() {
     this.props.getPlans();
     this.props.getBillingCountries();
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     const { hasError, history } = this.props;
 
     // if we can't get plans or countries form is useless
@@ -88,7 +87,7 @@ export class OnboardingPlanPage extends Component {
     );
   }
 
-  render () {
+  render() {
     const { loading, plans, submitting } = this.props;
 
     if (loading) {
@@ -119,20 +118,9 @@ export class OnboardingPlanPage extends Component {
   }
 }
 
-const mapStateToProps = (state, props) => {
-  const selector = formValueSelector(FORM_NAME);
-  const { plan: planCode } = props.location.state;
-
-  return {
-    loading: Boolean(state.account.loading || state.billing.plansLoading || state.billing.countriesLoading),
-    billing: state.billing,
-    plans: selectVisiblePlans(state),
-    initialValues: changePlanInitialValues(state, { planCode }),
-    selectedPlan: selector(state, 'planpicker'),
-    hasError: state.billing.plansError || state.billing.countriesError
-  };
-};
-const mapDispatchToProps = { billingCreate, showAlert, getPlans, getBillingCountries };
 const formOptions = { form: FORM_NAME, enableReinitialize: true };
 
-export default connect(mapStateToProps, mapDispatchToProps)(reduxForm(formOptions)(OnboardingPlanPage));
+export default connect(
+  choosePlanMSTP(FORM_NAME),
+  { billingCreate, showAlert, getPlans, getBillingCountries }
+)(reduxForm(formOptions)(OnboardingPlanPage));

--- a/src/selectors/onboarding.js
+++ b/src/selectors/onboarding.js
@@ -1,0 +1,20 @@
+import { formValueSelector } from 'redux-form';
+import { createStructuredSelector } from 'reselect';
+import { selectVisiblePlans } from 'src/selectors/accountBillingInfo';
+import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
+
+const getChoosePlanInitialValues = (state, props) => {
+  const { plan: planCode } = (props.location.state || {});
+  return changePlanInitialValues(state, { planCode });
+};
+
+// For more on createStructedSelector, see:
+// https://github.com/reduxjs/reselect#createstructuredselectorinputselectors-selectorcreator--createselector
+export const choosePlanMSTP = (formName) => createStructuredSelector({
+  loading: (state) => Boolean(state.account.loading || state.billing.plansLoading || state.billing.countriesLoading),
+  billing: (state) => state.billing,
+  plans: (state) => selectVisiblePlans(state),
+  initialValues: getChoosePlanInitialValues,
+  selectedPlan: (state) => formValueSelector(formName)(state, 'planpicker'),
+  hasError: (state) => Boolean(state.billing.plansError || state.billing.countriesError)
+});

--- a/src/selectors/tests/__snapshots__/onboarding.test.js.snap
+++ b/src/selectors/tests/__snapshots__/onboarding.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`choosePlanMSTP should return mapped prop values 1`] = `
+Object {
+  "billing": Object {},
+  "hasError": false,
+  "initialValues": "change-plan-initial-values",
+  "loading": false,
+  "plans": Array [
+    "visible plans",
+  ],
+  "selectedPlan": "selected-plan-redux-form-value",
+}
+`;

--- a/src/selectors/tests/onboarding.test.js
+++ b/src/selectors/tests/onboarding.test.js
@@ -1,0 +1,59 @@
+import { choosePlanMSTP } from '../onboarding';
+import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
+
+jest.mock('redux-form', () => ({
+  formValueSelector: () => () => 'selected-plan-redux-form-value'
+}));
+
+jest.mock('src/selectors/accountBillingForms', () => ({
+  changePlanInitialValues: jest.fn(() => 'change-plan-initial-values')
+}));
+
+jest.mock('src/selectors/accountBillingInfo', () => ({
+  selectVisiblePlans: jest.fn(() => ['visible plans'])
+}));
+
+describe('choosePlanMSTP', () => {
+
+  let state;
+  let props;
+
+  beforeEach(() => {
+    state = {
+      account: {},
+      billing: {}
+    };
+    props = {
+      location: {}
+    };
+  });
+
+  it('should return mapped prop values', () => {
+    const result = choosePlanMSTP()(state, props);
+    expect(result).toMatchSnapshot();
+    expect(result.loading).toEqual(false);
+    expect(result.hasError).toEqual(false);
+    expect(changePlanInitialValues).toHaveBeenCalledWith(state, { planCode: undefined });
+  });
+
+  it('should return when there is an error', () => {
+    state.billing.plansError = true;
+    const result = choosePlanMSTP()(state, props);
+    expect(result.hasError).toEqual(true);
+  });
+
+  it('should return when loading is true', () => {
+    state.account.loading = true;
+    const result = choosePlanMSTP()(state, props);
+    expect(result.loading).toEqual(true);
+  });
+
+  it('should pass on a plan code from location state', () => {
+    props.location.state = {
+      plan: 'passed-plan'
+    };
+    choosePlanMSTP()(state, props);
+    expect(changePlanInitialValues).toHaveBeenCalledWith(state, { planCode: 'passed-plan' });
+  });
+
+});


### PR DESCRIPTION
Main bug was caused by react-router not initializing `location.state` to an empty object, so if there is no state set, you have to check if the object is there before referencing any variable on the state. 

This PR also moves that mapStateToProps into a selector to test this case and some other logic.