### PR TITLE
FE-395:  Handle GET failures correctly in Subaccounts and Sending Domains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
 node_js:
   - "8"
-install: npm install -dd # change to npm ci when travis runs npm 5.7+ (currently 5.6)
-script: npm run test-ci && npm run build && npm run coveralls
+cache:
+  directories:
+    - build # shows bundle size diff per file/chunk
+    - "$HOME/.npm" # to avoid fetching modules from npm every time
 before_install: npm install -g greenkeeper-lockfile@1
+install: npm install --loglevel http # change to npm ci when travis runs npm 5.7+ (currently 5.6)
 before_script: greenkeeper-lockfile-update
+script: npm run test-ci && npm run build && npm run coveralls
 after_script: greenkeeper-lockfile-upload

--- a/src/actions/sendingDomains.js
+++ b/src/actions/sendingDomains.js
@@ -17,7 +17,8 @@ export function get(id) {
     meta: {
       method: 'GET',
       url: `/sending-domains/${id}`,
-      id
+      id,
+      showErrorAlert: false
     }
   });
 }
@@ -127,3 +128,5 @@ export function verifyPostmasterToken({ id, token, subaccount }) {
 export function verifyAbuseToken({ id, token, subaccount }) {
   return verifyToken({ id, subaccount, type: 'abuse_at', token });
 }
+
+export const clearSendingDomain = () => ({ type: 'CLEAR_SENDING_DOMAIN' });

--- a/src/actions/subaccounts.js
+++ b/src/actions/subaccounts.js
@@ -40,7 +40,9 @@ export function getSubaccount(id) {
     type: 'GET_SUBACCOUNT',
     meta: {
       method: 'GET',
-      url: `subaccounts/${id}`
+      url: `subaccounts/${id}`,
+      // sparkpostApiRequest suppress 404 and not 400 for invalid
+      showErrorAlert: false
     }
   });
 }

--- a/src/actions/subaccounts.js
+++ b/src/actions/subaccounts.js
@@ -55,3 +55,5 @@ export function editSubaccount(id, data) {
     }
   });
 }
+
+export const clearSubaccount = () => ({ type: 'CLEAR_SUBACCOUNT' });

--- a/src/actions/tests/__snapshots__/sendingDomains.test.js.snap
+++ b/src/actions/tests/__snapshots__/sendingDomains.test.js.snap
@@ -1,267 +1,335 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Action Creator: Sending Domains Create domain should be assigned a subaccount 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "domain": "domain.com",
-      "shared_with_subaccounts": false,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "domain": "domain.com",
+        "shared_with_subaccounts": false,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "url": "/sending-domains",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "url": "/sending-domains",
+    "type": "CREATE_SENDING_DOMAIN",
   },
-  "type": "CREATE_SENDING_DOMAIN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Create domain should be assigned to master 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "domain": "domain.com",
-      "shared_with_subaccounts": false,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "domain": "domain.com",
+        "shared_with_subaccounts": false,
+      },
+      "headers": Object {},
+      "method": "POST",
+      "url": "/sending-domains",
     },
-    "headers": Object {},
-    "method": "POST",
-    "url": "/sending-domains",
+    "type": "CREATE_SENDING_DOMAIN",
   },
-  "type": "CREATE_SENDING_DOMAIN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Create domain should be shared with all subaccount 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "domain": "domain.com",
-      "shared_with_subaccounts": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "domain": "domain.com",
+        "shared_with_subaccounts": true,
+      },
+      "headers": Object {},
+      "method": "POST",
+      "url": "/sending-domains",
     },
-    "headers": Object {},
-    "method": "POST",
-    "url": "/sending-domains",
+    "type": "CREATE_SENDING_DOMAIN",
   },
-  "type": "CREATE_SENDING_DOMAIN",
-}
+]
 `;
 
-exports[`Action Creator: Sending Domains Remove remove calls API 1`] = `
-Object {
-  "meta": Object {
-    "headers": Object {},
-    "method": "DELETE",
-    "url": "/sending-domains/example.com",
+exports[`Action Creator: Sending Domains Remove should remove calls API 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "headers": Object {},
+      "method": "DELETE",
+      "url": "/sending-domains/example.com",
+    },
+    "type": "DELETE_SENDING_DOMAIN",
   },
-  "type": "DELETE_SENDING_DOMAIN",
-}
+]
 `;
 
-exports[`Action Creator: Sending Domains Remove remove includes subaccount header with required 1`] = `
-Object {
-  "meta": Object {
-    "headers": Object {
-      "x-msys-subaccount": 101,
+exports[`Action Creator: Sending Domains Remove should remove includes subaccount header with required 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "DELETE",
+      "url": "/sending-domains/example.com",
     },
-    "method": "DELETE",
-    "url": "/sending-domains/example.com",
+    "type": "DELETE_SENDING_DOMAIN",
   },
-  "type": "DELETE_SENDING_DOMAIN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Update should request with correct post data 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "is_default_bounce_domain": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "is_default_bounce_domain": true,
+      },
+      "headers": Object {},
+      "method": "PUT",
+      "url": "/sending-domains/domain.com",
     },
-    "headers": Object {},
-    "method": "PUT",
-    "url": "/sending-domains/domain.com",
+    "type": "UPDATE_SENDING_DOMAIN",
   },
-  "type": "UPDATE_SENDING_DOMAIN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Update should update domain owned by subaccount 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "is_default_bounce_domain": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "is_default_bounce_domain": true,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "PUT",
+      "url": "/sending-domains/domain.com",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "PUT",
-    "url": "/sending-domains/domain.com",
+    "type": "UPDATE_SENDING_DOMAIN",
   },
-  "type": "UPDATE_SENDING_DOMAIN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify Token should dispatch verify abuse token action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "abuse_at_token": "12345",
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "abuse_at_token": "12345",
+      },
+      "domain": "sub.com",
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "type": "abuse_at",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "domain": "sub.com",
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "type": "abuse_at",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_TOKEN",
   },
-  "type": "VERIFY_TOKEN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify Token should dispatch verify mailbox token action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "verification_mailbox_token": "12345",
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "verification_mailbox_token": "12345",
+      },
+      "domain": "sub.com",
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "type": "verification_mailbox",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "domain": "sub.com",
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "type": "verification_mailbox",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_TOKEN",
   },
-  "type": "VERIFY_TOKEN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify Token should dispatch verify postmaster token action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "postmaster_at_token": "12345",
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "postmaster_at_token": "12345",
+      },
+      "domain": "sub.com",
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "type": "postmaster_at",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "domain": "sub.com",
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "type": "postmaster_at",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_TOKEN",
   },
-  "type": "VERIFY_TOKEN",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify should dispatch verify abuse action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "abuse_at_verify": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "abuse_at_verify": true,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_SENDING_DOMAIN_ABUSE_AT",
   },
-  "type": "VERIFY_SENDING_DOMAIN_ABUSE_AT",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify should dispatch verify cname action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "cname_verify": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "cname_verify": true,
+      },
+      "headers": Object {},
+      "method": "POST",
+      "url": "/sending-domains/domain.com/verify",
     },
-    "headers": Object {},
-    "method": "POST",
-    "url": "/sending-domains/domain.com/verify",
+    "type": "VERIFY_SENDING_DOMAIN_CNAME",
   },
-  "type": "VERIFY_SENDING_DOMAIN_CNAME",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify should dispatch verify dkim action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "dkim_verify": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "dkim_verify": true,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_SENDING_DOMAIN_DKIM",
   },
-  "type": "VERIFY_SENDING_DOMAIN_DKIM",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify should dispatch verify mailbox action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "verification_mailbox": "example",
-      "verification_mailbox_verify": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "verification_mailbox": "example",
+        "verification_mailbox_verify": true,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_SENDING_DOMAIN_VERIFICATION_MAILBOX",
   },
-  "type": "VERIFY_SENDING_DOMAIN_VERIFICATION_MAILBOX",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify should dispatch verify postmaster action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "postmaster_at_verify": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "postmaster_at_verify": true,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_SENDING_DOMAIN_POSTMASTER_AT",
   },
-  "type": "VERIFY_SENDING_DOMAIN_POSTMASTER_AT",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify should verify as abuse when using the mailbox action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "abuse_at_verify": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "abuse_at_verify": true,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_SENDING_DOMAIN_ABUSE_AT",
   },
-  "type": "VERIFY_SENDING_DOMAIN_ABUSE_AT",
-}
+]
 `;
 
 exports[`Action Creator: Sending Domains Verify should verify as postmaster when using the mailbox action 1`] = `
-Object {
-  "meta": Object {
-    "data": Object {
-      "postmaster_at_verify": true,
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "postmaster_at_verify": true,
+      },
+      "headers": Object {
+        "x-msys-subaccount": 101,
+      },
+      "method": "POST",
+      "url": "/sending-domains/sub.com/verify",
     },
-    "headers": Object {
-      "x-msys-subaccount": 101,
-    },
-    "method": "POST",
-    "url": "/sending-domains/sub.com/verify",
+    "type": "VERIFY_SENDING_DOMAIN_POSTMASTER_AT",
   },
-  "type": "VERIFY_SENDING_DOMAIN_POSTMASTER_AT",
-}
+]
+`;
+
+exports[`Action Creator: Sending Domains should clear current sending domain 1`] = `
+Array [
+  Object {
+    "type": "CLEAR_SENDING_DOMAIN",
+  },
+]
+`;
+
+exports[`Action Creator: Sending Domains should request a list 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "url": "/sending-domains",
+    },
+    "type": "LIST_SENDING_DOMAINS",
+  },
+]
+`;
+
+exports[`Action Creator: Sending Domains should request a sending domain 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "id": 123,
+      "method": "GET",
+      "showErrorAlert": false,
+      "url": "/sending-domains/123",
+    },
+    "type": "GET_SENDING_DOMAIN",
+  },
+]
 `;

--- a/src/actions/tests/__snapshots__/subaccounts.test.js.snap
+++ b/src/actions/tests/__snapshots__/subaccounts.test.js.snap
@@ -28,6 +28,7 @@ Array [
   Object {
     "meta": Object {
       "method": "GET",
+      "showErrorAlert": false,
       "url": "subaccounts/123",
     },
     "type": "GET_SUBACCOUNT",

--- a/src/actions/tests/__snapshots__/subaccounts.test.js.snap
+++ b/src/actions/tests/__snapshots__/subaccounts.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Action: Subaccounts clearSubaccount 1`] = `
+Array [
+  Object {
+    "type": "CLEAR_SUBACCOUNT",
+  },
+]
+`;
+
+exports[`Action: Subaccounts editSubaccount 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "name": "Test Example",
+      },
+      "method": "PUT",
+      "url": "subaccounts/123",
+    },
+    "type": "EDIT_SUBACCOUNT",
+  },
+]
+`;
+
+exports[`Action: Subaccounts getSubaccount 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "url": "subaccounts/123",
+    },
+    "type": "GET_SUBACCOUNT",
+  },
+]
+`;
+
+exports[`Action: Subaccounts list 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "showErrorAlert": false,
+      "url": "/subaccounts",
+    },
+    "type": "LIST_SUBACCOUNTS",
+  },
+]
+`;

--- a/src/actions/tests/sendingDomains.test.js
+++ b/src/actions/tests/sendingDomains.test.js
@@ -1,88 +1,67 @@
+import { snapshotActionCases } from 'src/__testHelpers__/snapshotActionHelpers';
 import * as sendingDomains from '../sendingDomains';
 
 jest.mock('../helpers/sparkpostApiRequest', () => jest.fn((a) => a));
 
-describe('Action Creator: Sending Domains', () => {
-  describe('Create', () => {
-    it('domain should be assigned to master', async() => {
-      expect(sendingDomains.create({ domain: 'domain.com' })).toMatchSnapshot();
-    });
-
-    it('domain should be assigned a subaccount', async() => {
-      expect(sendingDomains.create({ domain: 'domain.com', subaccount: { id: 101 }})).toMatchSnapshot();
-    });
-
-    it('domain should be shared with all subaccount', async() => {
-      expect(sendingDomains.create({ domain: 'domain.com', assignTo: 'shared' })).toMatchSnapshot();
-    });
-  });
-
-  describe('Verify', () => {
-    it('should dispatch verify cname action', () => {
-      expect(sendingDomains.verifyCname({ id: 'domain.com' })).toMatchSnapshot();
-    });
-
-    it('should dispatch verify dkim action', () => {
-      expect(sendingDomains.verifyDkim({ id: 'sub.com', subaccount: 101 })).toMatchSnapshot();
-    });
-
-    it('should dispatch verify abuse action', () => {
-      expect(sendingDomains.verifyAbuse({ id: 'sub.com', subaccount: 101 })).toMatchSnapshot();
-    });
-
-    it('should dispatch verify mailbox action', () => {
-      const args = { id: 'sub.com', mailbox: 'example', subaccount: 101 };
-      expect(sendingDomains.verifyMailbox(args)).toMatchSnapshot();
-    });
-
-    it('should verify as postmaster when using the mailbox action', () => {
-      expect(sendingDomains.verifyMailbox({ id: 'sub.com', mailbox: 'postmaster', subaccount: 101 })).toMatchSnapshot();
-    });
-
-    it('should verify as abuse when using the mailbox action', () => {
-      expect(sendingDomains.verifyMailbox({ id: 'sub.com', mailbox: 'abuse', subaccount: 101 })).toMatchSnapshot();
-    });
-
-    it('should dispatch verify postmaster action', () => {
-      expect(sendingDomains.verifyPostmaster({ id: 'sub.com', subaccount: 101 })).toMatchSnapshot();
-    });
-  });
-
-  describe('Verify Token', () => {
-    it('should dispatch verify abuse token action', () => {
-      expect(sendingDomains.verifyAbuseToken({ id: 'sub.com', subaccount: 101, token: '12345' })).toMatchSnapshot();
-    });
-
-    it('should dispatch verify mailbox token action', () => {
-      const args = { id: 'sub.com', mailbox: 'example@test.com', subaccount: 101, token: '12345' };
-      expect(sendingDomains.verifyMailboxToken(args)).toMatchSnapshot();
-    });
-
-    it('should dispatch verify postmaster token action', () => {
-      expect(sendingDomains.verifyPostmasterToken({ id: 'sub.com', subaccount: 101, token: '12345' })).toMatchSnapshot();
-    });
-  });
-
-  describe('Update', () => {
-    it('should request with correct post data', () => {
-      expect(sendingDomains.update({ id: 'domain.com', is_default_bounce_domain: true })).toMatchSnapshot();
-    });
-
-    it('should update domain owned by subaccount', () => {
-      expect(sendingDomains.update({ id: 'domain.com', subaccount: 101, is_default_bounce_domain: true })).toMatchSnapshot();
-    });
-  });
-
-  describe('Remove', () => {
-    const domain = 'example.com';
-    const subaccount = 101;
-
-    it('remove calls API', () => {
-      expect(sendingDomains.remove({ id: domain })).toMatchSnapshot();
-    });
-
-    it('remove includes subaccount header with required', async() => {
-      expect(sendingDomains.remove({ id: domain, subaccount })).toMatchSnapshot();
-    });
-  });
+snapshotActionCases('Action Creator: Sending Domains', {
+  'Create domain should be assigned to master': {
+    action: () => sendingDomains.create({ domain: 'domain.com' })
+  },
+  'Create domain should be assigned a subaccount': {
+    action: () => sendingDomains.create({ domain: 'domain.com', subaccount: { id: 101 }})
+  },
+  'Create domain should be shared with all subaccount': {
+    action: () => sendingDomains.create({ domain: 'domain.com', assignTo: 'shared' })
+  },
+  'Verify should dispatch verify cname action': {
+    action: () => sendingDomains.verifyCname({ id: 'domain.com' })
+  },
+  'Verify should dispatch verify dkim action': {
+    action: () => sendingDomains.verifyDkim({ id: 'sub.com', subaccount: 101 })
+  },
+  'Verify should dispatch verify abuse action': {
+    action: () => sendingDomains.verifyAbuse({ id: 'sub.com', subaccount: 101 })
+  },
+  'Verify should dispatch verify mailbox action': {
+    action: () => sendingDomains.verifyMailbox({ id: 'sub.com', mailbox: 'example', subaccount: 101 })
+  },
+  'Verify should verify as postmaster when using the mailbox action': {
+    action: () => sendingDomains.verifyMailbox({ id: 'sub.com', mailbox: 'postmaster', subaccount: 101 })
+  },
+  'Verify should verify as abuse when using the mailbox action': {
+    action: () => sendingDomains.verifyMailbox({ id: 'sub.com', mailbox: 'abuse', subaccount: 101 })
+  },
+  'Verify should dispatch verify postmaster action': {
+    action: () => sendingDomains.verifyPostmaster({ id: 'sub.com', subaccount: 101 })
+  },
+  'Verify Token should dispatch verify abuse token action': {
+    action: () => sendingDomains.verifyAbuseToken({ id: 'sub.com', subaccount: 101, token: '12345' })
+  },
+  'Verify Token should dispatch verify mailbox token action': {
+    action: () => sendingDomains.verifyMailboxToken({ id: 'sub.com', mailbox: 'example@test.com', subaccount: 101, token: '12345' })
+  },
+  'Verify Token should dispatch verify postmaster token action': {
+    action: () => sendingDomains.verifyPostmasterToken({ id: 'sub.com', subaccount: 101, token: '12345' })
+  },
+  'Update should request with correct post data': {
+    action: () => sendingDomains.update({ id: 'domain.com', is_default_bounce_domain: true })
+  },
+  'Update should update domain owned by subaccount': {
+    action: () => sendingDomains.update({ id: 'domain.com', subaccount: 101, is_default_bounce_domain: true })
+  },
+  'Remove should remove calls API': {
+    action: () => sendingDomains.remove({ id: 'example.com' })
+  },
+  'Remove should remove includes subaccount header with required': {
+    action: () => sendingDomains.remove({ id: 'example.com', subaccount: 101 })
+  },
+  'should request a list': {
+    action: sendingDomains.list
+  },
+  'should request a sending domain': {
+    action: () => sendingDomains.get(123)
+  },
+  'should clear current sending domain': {
+    action: sendingDomains.clearSendingDomain
+  }
 });

--- a/src/actions/tests/subaccounts.test.js
+++ b/src/actions/tests/subaccounts.test.js
@@ -1,0 +1,19 @@
+import { snapshotActionCases } from 'src/__testHelpers__/snapshotActionHelpers';
+import * as actions from '../subaccounts';
+
+jest.mock('../helpers/sparkpostApiRequest');
+
+snapshotActionCases('Action: Subaccounts', {
+  clearSubaccount: {
+    action: actions.clearSubaccount
+  },
+  editSubaccount: {
+    action: () => actions.editSubaccount(123, { name: 'Test Example' })
+  },
+  getSubaccount: {
+    action: () => actions.getSubaccount(123)
+  },
+  list: {
+    action: actions.list
+  }
+});

--- a/src/pages/sendingDomains/tests/EditPage.test.js
+++ b/src/pages/sendingDomains/tests/EditPage.test.js
@@ -14,8 +14,9 @@ describe('Sending Domains Edit Page', () => {
   beforeEach(() => {
     props = {
       domain,
-      getError: null,
-      getLoading: false,
+      clearSendingDomain: jest.fn(),
+      error: null,
+      loading: false,
       getDomain: jest.fn(),
       deleteDomain: jest.fn(() => Promise.resolve()),
       updateDomain: jest.fn(() => Promise.resolve()),
@@ -31,18 +32,18 @@ describe('Sending Domains Edit Page', () => {
     wrapper = shallow(<EditPage {...props}/>);
   });
 
-  it('renders correctly', () => {
+  it('should renders correctly', () => {
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.instance().props.getDomain).toHaveBeenCalledTimes(1);
+    expect(props.getDomain).toHaveBeenCalledTimes(1);
   });
 
-  it('renders loading correctly', () => {
-    wrapper.setProps({ domain: { id: 'foobar.com' }});
+  it('should renders loading correctly', () => {
+    wrapper.setProps({ loading: true });
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders error banner correctly', () => {
-    wrapper.setProps({ getError: { message: 'error' }});
+  it('should redirects to list page with error message', () => {
+    wrapper.setProps({ error: new Error('Oh no!') });
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -52,18 +53,23 @@ describe('Sending Domains Edit Page', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should delete a sending domain', async() => {
+  it('should delete a sending domain', async () => {
     await wrapper.instance().deleteDomain();
     expect(props.deleteDomain).toHaveBeenCalledWith({ id: domain.id, subaccount: domain.subaccount_id });
   });
 
-  it('should redirect after delete', async() => {
+  it('should redirect after delete', async () => {
     await wrapper.instance().deleteDomain();
     expect(props.history.push).toHaveBeenCalledWith('/account/sending-domains');
   });
 
-  it('should toggle subaccount sharing', async() => {
+  it('should toggle subaccount sharing', async () => {
     await wrapper.instance().shareDomainChange();
     expect(props.updateDomain).toHaveBeenCalledWith({ id: domain.id, shared_with_subaccounts: true, subaccount: domain.subaccount_id });
+  });
+
+  it('should clear sending domain on unmount', () => {
+    wrapper.unmount();
+    expect(props.clearSendingDomain).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/sendingDomains/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/sendingDomains/tests/__snapshots__/EditPage.test.js.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sending Domains Edit Page renders correctly 1`] = `
+exports[`Sending Domains Edit Page should redirects to list page with error message 1`] = `
+<Connect(RedirectAndAlert)
+  alert={
+    Object {
+      "message": "Oh no!",
+      "type": "error",
+    }
+  }
+  to="/account/sending-domains"
+/>
+`;
+
+exports[`Sending Domains Edit Page should renders correctly 1`] = `
 <Page
   breadcrumbAction={
     Object {
@@ -142,46 +154,7 @@ exports[`Sending Domains Edit Page renders correctly 1`] = `
 </Page>
 `;
 
-exports[`Sending Domains Edit Page renders error banner correctly 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "Sending Domains",
-      "to": "/account/sending-domains",
-    }
-  }
-  empty={Object {}}
-  secondaryActions={
-    Array [
-      Object {
-        "content": "Delete",
-        "onClick": [Function],
-      },
-    ]
-  }
-  title="Edit example.com"
->
-  <ApiErrorBanner
-    errorDetails="error"
-    message="Sorry, we seem to have had some trouble loading your Sending Domain."
-    reload={[Function]}
-  />
-  <DeleteModal
-    content={
-      <p>
-        Any future transmission that uses this domain will be rejected.
-      </p>
-    }
-    onCancel={[Function]}
-    onDelete={[Function]}
-    open={false}
-    title="Are you sure you want to delete this sending domain?"
-  />
-</Page>
-`;
-
-exports[`Sending Domains Edit Page renders loading correctly 1`] = `<Loading />`;
+exports[`Sending Domains Edit Page should renders loading correctly 1`] = `<Loading />`;
 
 exports[`Sending Domains Edit Page should show a delete modal 1`] = `
 <Page

--- a/src/pages/subaccounts/DetailsPage.js
+++ b/src/pages/subaccounts/DetailsPage.js
@@ -3,17 +3,18 @@ import { connect } from 'react-redux';
 import { Link, withRouter, Route, Switch } from 'react-router-dom';
 import { Page, Tabs } from '@sparkpost/matchbox';
 
-import { getSubaccount } from 'src/actions/subaccounts';
+import { clearSubaccount, getSubaccount } from 'src/actions/subaccounts';
 import { ApiKeySuccessBanner } from 'src/components';
 import { selectSubaccount } from 'src/selectors/subaccounts';
 import { listPools } from 'src/actions/ipPools';
 import { listApiKeys, hideNewApiKey } from 'src/actions/api-keys';
 import { list as listDomains } from 'src/actions/sendingDomains';
+import RedirectAndAlert from 'src/components/globalAlert/RedirectAndAlert';
+import { Loading } from 'src/components/loading/Loading';
 
 import ApiKeysTab from './components/ApiKeysTab';
 import EditTab from './components/EditTab';
 import SendingDomainsTab from './components/SendingDomainsTab';
-import PanelLoading from 'src/components/panelLoading/PanelLoading';
 
 const breadcrumbAction = {
   content: 'Subaccounts',
@@ -41,12 +42,6 @@ const buildTabs = (id) => [
 ];
 
 export class DetailsPage extends Component {
-
-  // only want to show the new key after a create
-  componentWillUnmount() {
-    this.props.hideNewApiKey();
-  }
-
   componentDidMount() {
     this.props.getSubaccount(this.props.id);
     this.props.listPools();
@@ -54,54 +49,59 @@ export class DetailsPage extends Component {
     this.props.listDomains();
   }
 
-  renderApiKeyBanner() {
-    return (
-      <ApiKeySuccessBanner
-        title="Don't Forget Your API Key"
-      />
-    );
+  // only want to show the new key after a create
+  componentWillUnmount() {
+    this.props.clearSubaccount();
+    this.props.hideNewApiKey();
   }
 
   render() {
-    const { loading, location, id } = this.props;
+    const { error, id, loading, location, newKey, subaccount } = this.props;
     const tabs = buildTabs(id);
     const selectedTab = tabs.findIndex(({ to }) => location.pathname === to);
 
-    if (loading) {
+    if (error) {
       return (
-        <Page title={'loading...'} breadcrumbAction={breadcrumbAction} >
-          <Tabs selected={selectedTab} tabs={tabs} />
-          <PanelLoading />
-        </Page>
+        <RedirectAndAlert
+          to="/account/subaccounts"
+          alert={{ type: 'warning', message: `Unable to find subaccount for ${id}` }}
+        />
       );
     }
 
-    const { match, subaccount, newKey } = this.props;
+    if (loading) {
+      return <Loading />;
+    }
 
     return (
       <Page title={`${subaccount.name} (${subaccount.id})`} breadcrumbAction={breadcrumbAction}>
-        { newKey && this.renderApiKeyBanner() }
+        {newKey && <ApiKeySuccessBanner title="Don't Forget Your API Key" />}
         <Tabs selected={selectedTab} tabs={tabs} />
         <Switch>
-          <Route exact path={match.url} render={() => <EditTab subaccount={subaccount} />} />
-          <Route path={`${match.url}/api-keys`} render={() => <ApiKeysTab id={subaccount.id}/>} />
-          <Route path={`${match.url}/sending-domains`} render={() => <SendingDomainsTab id={subaccount.id}/>} />
+          <Route exact path="/account/subaccounts/:id" render={() => <EditTab subaccount={subaccount} />} />
+          <Route exact path="/account/subaccounts/:id/api-keys" render={() => <ApiKeysTab id={subaccount.id} />} />
+          <Route exact path="/account/subaccounts/:id/sending-domains" render={() => <SendingDomainsTab id={subaccount.id} />} />
         </Switch>
       </Page>
     );
   }
 }
 
-const mapStateToProps = (state, props) => {
-  const { subaccounts, apiKeys } = state;
-  return {
-    id: props.match.params.id,
-    loading: subaccounts.getLoading,
-    subaccount: selectSubaccount(state),
-    newKey: apiKeys.newKey
-  };
+const mapStateToProps = (state, props) => ({
+  error: state.subaccounts.getError,
+  id: props.match.params.id,
+  loading: state.subaccounts.getLoading,
+  subaccount: selectSubaccount(state),
+  newKey: state.apiKeys.newKey
+});
+
+const mapDispatchToProps = {
+  clearSubaccount,
+  getSubaccount,
+  hideNewApiKey,
+  listApiKeys,
+  listDomains,
+  listPools
 };
 
-export default withRouter(
-  connect(mapStateToProps, { getSubaccount, listPools, listApiKeys, hideNewApiKey, listDomains })(DetailsPage)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DetailsPage));

--- a/src/pages/subaccounts/DetailsPage.js
+++ b/src/pages/subaccounts/DetailsPage.js
@@ -64,7 +64,7 @@ export class DetailsPage extends Component {
       return (
         <RedirectAndAlert
           to="/account/subaccounts"
-          alert={{ type: 'warning', message: `Unable to find subaccount for ${id}` }}
+          alert={{ type: 'error', message: error.message }}
         />
       );
     }

--- a/src/pages/subaccounts/tests/DetailsPage.test.js
+++ b/src/pages/subaccounts/tests/DetailsPage.test.js
@@ -1,95 +1,87 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import { shallow } from 'enzyme';
 
 import { DetailsPage } from '../DetailsPage';
 
-// actions
-const getSubaccount = jest.fn();
-const listPools = jest.fn();
-const listApiKeys = jest.fn();
-const listDomains = jest.fn();
-const hideNewApiKey = jest.fn();
+describe('DetailsPage', () => {
+  let props;
+  let wrapper;
 
-const paths = {
-  edit: '/account/subaccounts/123',
-  keys: '/account/subaccounts/123/api-keys',
-  domains: '/account/subaccounts/123/sending-domains'
-};
+  beforeEach(() => {
+    props = {
+      id: '123',
+      loading: false,
+      subaccount: {
+        id: '123',
+        name: 'Bob Evans, the restaurant.'
+      },
+      location: {
+        pathname: '/account/subaccounts/123'
+      },
+      clearSubaccount: jest.fn(),
+      getSubaccount: jest.fn(),
+      hideNewApiKey: jest.fn(),
+      listApiKeys: jest.fn(),
+      listDomains: jest.fn(),
+      listPools: jest.fn()
+    };
 
-const props = {
-  id: '123',
-  loading: false,
-  subaccount: {
-    id: '123',
-    name: 'Bob Evans, the restaurant.'
-  },
-  location: { pathname: '' },
-  match: { url: paths.edit },
-  getSubaccount,
-  listPools,
-  listApiKeys,
-  listDomains,
-  hideNewApiKey
-};
+    wrapper = shallow(<DetailsPage {...props} />);
+  });
 
-let wrapper;
+  it('should render edit tab', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
-beforeEach(() => {
-  wrapper = shallow(<DetailsPage {...props} />);
-});
+  it('should render loading page', () => {
+    wrapper.setProps({ loading: true });
+    expect(wrapper).toMatchSnapshot();
+  });
 
-test('componentDidMount', () => {
-  expect(getSubaccount).toHaveBeenCalledWith('123');
-  expect(listPools).toHaveBeenCalled();
-  expect(listApiKeys).toHaveBeenCalled();
-  expect(listDomains).toHaveBeenCalled();
-  expect(hideNewApiKey).not.toHaveBeenCalled();
-});
+  it('should redirect and alert on error', () => {
+    wrapper.setProps({ error: new Error('Oh no!') });
+    expect(wrapper).toMatchSnapshot();
+  });
 
-test('componentDidUnmount', () => {
-  wrapper.unmount();
-  expect(hideNewApiKey).toHaveBeenCalled();
-});
-
-describe('on create scenario', () => {
-  it('should show api key banner on new key', () => {
+  it('should show api key banner with new api key', () => {
     wrapper.setProps({ newKey: 'my-key' });
     expect(wrapper).toMatchSnapshot();
   });
 
-});
+  it('should render api keys tab', () => {
+    wrapper.setProps({
+      location: {
+        pathname: '/account/subaccounts/123/api-keys'
+      }
+    });
 
-describe('edit path', () => {
-  beforeEach(() => {
-    wrapper.setProps({ location: { pathname: paths.edit }});
-  });
-
-  test('base props', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  test('loading', () => {
-    wrapper.setProps({ loading: true });
-    expect(wrapper).toMatchSnapshot();
-  });
-});
+  it('should select sending domains tab', () => {
+    wrapper.setProps({
+      location: {
+        pathname: '/account/subaccounts/123/sending-domains'
+      }
+    });
 
-describe('keys path', () => {
-  beforeEach(() => {
-    wrapper.setProps({ location: { pathname: paths.keys }});
-  });
-
-  test('base props', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  test('loading', () => {
-    wrapper.setProps({ loading: true });
-    expect(wrapper).toMatchSnapshot();
+  it('should request data on mount', () => {
+    expect(props.getSubaccount).toHaveBeenCalledWith('123');
+    expect(props.listApiKeys).toHaveBeenCalledTimes(1);
+    expect(props.listDomains).toHaveBeenCalledTimes(1);
+    expect(props.listPools).toHaveBeenCalledTimes(1);
   });
-});
 
-it('should select sending domains tab', () => {
-  wrapper.setProps({ location: { pathname: paths.domains }});
-  expect(wrapper).toMatchSnapshot();
+  it('should clear new api key on unmount', () => {
+    wrapper.unmount();
+    expect(props.hideNewApiKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear subaccount on unmount', () => {
+    wrapper.unmount();
+    expect(props.clearSubaccount).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/pages/subaccounts/tests/__snapshots__/DetailsPage.test.js.snap
+++ b/src/pages/subaccounts/tests/__snapshots__/DetailsPage.test.js.snap
@@ -1,102 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`edit path base props 1`] = `
-<Page
-  breadcrumbAction={
+exports[`DetailsPage should redirect and alert on error 1`] = `
+<Connect(RedirectAndAlert)
+  alert={
     Object {
-      "Component": [Function],
-      "content": "Subaccounts",
-      "to": "/account/subaccounts",
+      "message": "Unable to find subaccount for 123",
+      "type": "warning",
     }
   }
-  empty={Object {}}
-  title="Bob Evans, the restaurant. (123)"
->
-  <Tabs
-    color="orange"
-    connectBelow={true}
-    selected={0}
-    tabs={
-      Array [
-        Object {
-          "Component": [Function],
-          "content": "Details",
-          "to": "/account/subaccounts/123",
-        },
-        Object {
-          "Component": [Function],
-          "content": "API Keys",
-          "to": "/account/subaccounts/123/api-keys",
-        },
-        Object {
-          "Component": [Function],
-          "content": "Sending Domains",
-          "to": "/account/subaccounts/123/sending-domains",
-        },
-      ]
-    }
-  />
-  <Switch>
-    <Route
-      exact={true}
-      path="/account/subaccounts/123"
-      render={[Function]}
-    />
-    <Route
-      path="/account/subaccounts/123/api-keys"
-      render={[Function]}
-    />
-    <Route
-      path="/account/subaccounts/123/sending-domains"
-      render={[Function]}
-    />
-  </Switch>
-</Page>
+  to="/account/subaccounts"
+/>
 `;
 
-exports[`edit path loading 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "Subaccounts",
-      "to": "/account/subaccounts",
-    }
-  }
-  empty={Object {}}
-  title="loading..."
->
-  <Tabs
-    color="orange"
-    connectBelow={true}
-    selected={0}
-    tabs={
-      Array [
-        Object {
-          "Component": [Function],
-          "content": "Details",
-          "to": "/account/subaccounts/123",
-        },
-        Object {
-          "Component": [Function],
-          "content": "API Keys",
-          "to": "/account/subaccounts/123/api-keys",
-        },
-        Object {
-          "Component": [Function],
-          "content": "Sending Domains",
-          "to": "/account/subaccounts/123/sending-domains",
-        },
-      ]
-    }
-  />
-  <PanelLoading
-    minHeight="400px"
-  />
-</Page>
-`;
-
-exports[`keys path base props 1`] = `
+exports[`DetailsPage should render api keys tab 1`] = `
 <Page
   breadcrumbAction={
     Object {
@@ -135,64 +51,24 @@ exports[`keys path base props 1`] = `
   <Switch>
     <Route
       exact={true}
-      path="/account/subaccounts/123"
+      path="/account/subaccounts/:id"
       render={[Function]}
     />
     <Route
-      path="/account/subaccounts/123/api-keys"
+      exact={true}
+      path="/account/subaccounts/:id/api-keys"
       render={[Function]}
     />
     <Route
-      path="/account/subaccounts/123/sending-domains"
+      exact={true}
+      path="/account/subaccounts/:id/sending-domains"
       render={[Function]}
     />
   </Switch>
 </Page>
 `;
 
-exports[`keys path loading 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "Subaccounts",
-      "to": "/account/subaccounts",
-    }
-  }
-  empty={Object {}}
-  title="loading..."
->
-  <Tabs
-    color="orange"
-    connectBelow={true}
-    selected={1}
-    tabs={
-      Array [
-        Object {
-          "Component": [Function],
-          "content": "Details",
-          "to": "/account/subaccounts/123",
-        },
-        Object {
-          "Component": [Function],
-          "content": "API Keys",
-          "to": "/account/subaccounts/123/api-keys",
-        },
-        Object {
-          "Component": [Function],
-          "content": "Sending Domains",
-          "to": "/account/subaccounts/123/sending-domains",
-        },
-      ]
-    }
-  />
-  <PanelLoading
-    minHeight="400px"
-  />
-</Page>
-`;
-
-exports[`on create scenario should show api key banner on new key 1`] = `
+exports[`DetailsPage should render edit tab 1`] = `
 <Page
   breadcrumbAction={
     Object {
@@ -204,13 +80,10 @@ exports[`on create scenario should show api key banner on new key 1`] = `
   empty={Object {}}
   title="Bob Evans, the restaurant. (123)"
 >
-  <Connect(ApiKeySuccessBanner)
-    title="Don't Forget Your API Key"
-  />
   <Tabs
     color="orange"
     connectBelow={true}
-    selected={-1}
+    selected={0}
     tabs={
       Array [
         Object {
@@ -234,22 +107,26 @@ exports[`on create scenario should show api key banner on new key 1`] = `
   <Switch>
     <Route
       exact={true}
-      path="/account/subaccounts/123"
+      path="/account/subaccounts/:id"
       render={[Function]}
     />
     <Route
-      path="/account/subaccounts/123/api-keys"
+      exact={true}
+      path="/account/subaccounts/:id/api-keys"
       render={[Function]}
     />
     <Route
-      path="/account/subaccounts/123/sending-domains"
+      exact={true}
+      path="/account/subaccounts/:id/sending-domains"
       render={[Function]}
     />
   </Switch>
 </Page>
 `;
 
-exports[`should select sending domains tab 1`] = `
+exports[`DetailsPage should render loading page 1`] = `<Loading />`;
+
+exports[`DetailsPage should select sending domains tab 1`] = `
 <Page
   breadcrumbAction={
     Object {
@@ -288,15 +165,76 @@ exports[`should select sending domains tab 1`] = `
   <Switch>
     <Route
       exact={true}
-      path="/account/subaccounts/123"
+      path="/account/subaccounts/:id"
       render={[Function]}
     />
     <Route
-      path="/account/subaccounts/123/api-keys"
+      exact={true}
+      path="/account/subaccounts/:id/api-keys"
       render={[Function]}
     />
     <Route
-      path="/account/subaccounts/123/sending-domains"
+      exact={true}
+      path="/account/subaccounts/:id/sending-domains"
+      render={[Function]}
+    />
+  </Switch>
+</Page>
+`;
+
+exports[`DetailsPage should show api key banner with new api key 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "Component": [Function],
+      "content": "Subaccounts",
+      "to": "/account/subaccounts",
+    }
+  }
+  empty={Object {}}
+  title="Bob Evans, the restaurant. (123)"
+>
+  <Connect(ApiKeySuccessBanner)
+    title="Don't Forget Your API Key"
+  />
+  <Tabs
+    color="orange"
+    connectBelow={true}
+    selected={0}
+    tabs={
+      Array [
+        Object {
+          "Component": [Function],
+          "content": "Details",
+          "to": "/account/subaccounts/123",
+        },
+        Object {
+          "Component": [Function],
+          "content": "API Keys",
+          "to": "/account/subaccounts/123/api-keys",
+        },
+        Object {
+          "Component": [Function],
+          "content": "Sending Domains",
+          "to": "/account/subaccounts/123/sending-domains",
+        },
+      ]
+    }
+  />
+  <Switch>
+    <Route
+      exact={true}
+      path="/account/subaccounts/:id"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      path="/account/subaccounts/:id/api-keys"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      path="/account/subaccounts/:id/sending-domains"
       render={[Function]}
     />
   </Switch>

--- a/src/pages/subaccounts/tests/__snapshots__/DetailsPage.test.js.snap
+++ b/src/pages/subaccounts/tests/__snapshots__/DetailsPage.test.js.snap
@@ -4,8 +4,8 @@ exports[`DetailsPage should redirect and alert on error 1`] = `
 <Connect(RedirectAndAlert)
   alert={
     Object {
-      "message": "Unable to find subaccount for 123",
-      "type": "warning",
+      "message": "Oh no!",
+      "type": "error",
     }
   }
   to="/account/subaccounts"

--- a/src/reducers/sendingDomains.js
+++ b/src/reducers/sendingDomains.js
@@ -1,8 +1,13 @@
-const initialState = {
-  list: [],
+const initialDomainState = {
   domain: { dkim: {}, status: {}},
-  listError: null,
   getError: null,
+  getLoading: false
+};
+
+const initialState = {
+  ...initialDomainState,
+  list: [],
+  listError: null,
   verifyError: null,
   verifyTokenStatus: null,
   verifyTokenError: null
@@ -29,6 +34,9 @@ export default (state = initialState, { type, payload, meta }) => {
 
     case 'GET_SENDING_DOMAIN_FAIL':
       return { ...state, getError: payload, getLoading: false };
+
+    case 'CLEAR_SENDING_DOMAIN':
+      return { ...state, ...initialDomainState };
 
     case 'VERIFY_SENDING_DOMAIN_CNAME_PENDING':
       return { ...state, verifyCnameLoading: true, verifyCnameError: null };

--- a/src/reducers/subaccounts.js
+++ b/src/reducers/subaccounts.js
@@ -1,10 +1,14 @@
-const initialState = {
-  list: [],
-  subaccount: {},
-  listError: null,
+const initialSubaccountState = {
   getError: null,
-  listLoading: false,
-  getLoading: false
+  getLoading: false,
+  subaccount: {}
+};
+
+const initialState = {
+  ...initialSubaccountState,
+  list: [],
+  listError: null,
+  listLoading: false
 };
 
 export default (state = initialState, { type, payload }) => {
@@ -26,6 +30,9 @@ export default (state = initialState, { type, payload }) => {
 
     case 'GET_SUBACCOUNT_FAIL':
       return { ...state, getLoading: false, getError: payload };
+
+    case 'CLEAR_SUBACCOUNT':
+      return { ...state, ...initialSubaccountState };
 
     default:
       return state;

--- a/src/reducers/tests/__snapshots__/sendingDomains.test.js.snap
+++ b/src/reducers/tests/__snapshots__/sendingDomains.test.js.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sending Domain Update reducer update domain 1`] = `
+exports[`Sending Domain reducer clear sending domain 1`] = `
+Object {
+  "domain": Object {
+    "dkim": Object {},
+    "status": Object {},
+  },
+  "getError": null,
+  "getLoading": false,
+}
+`;
+
+exports[`Sending Domain reducer update domain 1`] = `
 Object {
   "domain": Object {
     "is_default_bounce_domain": true,
@@ -14,7 +25,7 @@ Object {
 }
 `;
 
-exports[`Sending Domain Update reducer update domain fail 1`] = `
+exports[`Sending Domain reducer update domain fail 1`] = `
 Object {
   "domain": Object {
     "is_default_bounce_domain": false,
@@ -35,7 +46,7 @@ Object {
 }
 `;
 
-exports[`Sending Domain Update reducer update pending 1`] = `
+exports[`Sending Domain reducer update pending 1`] = `
 Object {
   "domain": Object {
     "is_default_bounce_domain": false,

--- a/src/reducers/tests/__snapshots__/subaccounts.test.js.snap
+++ b/src/reducers/tests/__snapshots__/subaccounts.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reducer: Subaccount when get subaccount failed 1`] = `
+Object {
+  "getError": [Error: Oh no!],
+  "getLoading": false,
+  "list": Array [],
+  "listError": null,
+  "listLoading": false,
+  "subaccount": Object {},
+}
+`;
+
+exports[`Reducer: Subaccount when get subaccount is cleared 1`] = `
+Object {
+  "getError": null,
+  "getLoading": false,
+  "list": Array [],
+  "listError": null,
+  "listLoading": false,
+  "subaccount": Object {},
+}
+`;
+
+exports[`Reducer: Subaccount when get subaccount is pending 1`] = `
+Object {
+  "getError": null,
+  "getLoading": true,
+  "list": Array [],
+  "listError": null,
+  "listLoading": false,
+  "subaccount": Object {},
+}
+`;
+
+exports[`Reducer: Subaccount when get subaccount succeeds 1`] = `
+Object {
+  "getError": null,
+  "getLoading": false,
+  "list": Array [],
+  "listError": null,
+  "listLoading": false,
+  "subaccount": Object {
+    "id": "test-subaccount",
+    "name": "Test Subaccount",
+  },
+}
+`;
+
+exports[`Reducer: Subaccount when subaccount list failed to load 1`] = `
+Object {
+  "getError": null,
+  "getLoading": false,
+  "list": Array [],
+  "listError": [Error: Oh no!],
+  "listLoading": false,
+  "subaccount": Object {},
+}
+`;
+
+exports[`Reducer: Subaccount when subaccount list is pending 1`] = `
+Object {
+  "getError": null,
+  "getLoading": false,
+  "list": Array [],
+  "listError": null,
+  "listLoading": true,
+  "subaccount": Object {},
+}
+`;
+
+exports[`Reducer: Subaccount when subaccount list loaded 1`] = `
+Object {
+  "getError": null,
+  "getLoading": false,
+  "list": Array [
+    Object {
+      "id": "test-subaccount",
+      "name": "Test Subaccount",
+    },
+  ],
+  "listError": null,
+  "listLoading": false,
+  "subaccount": Object {},
+}
+`;

--- a/src/reducers/tests/sendingDomains.test.js
+++ b/src/reducers/tests/sendingDomains.test.js
@@ -1,18 +1,20 @@
 import cases from 'jest-in-case';
 import sendingDomainsReducer from '../sendingDomains';
 
-const state = {
-  domain: {
-    is_default_bounce_domain: false,
-    status: {
-      cname_status: null,
-      mx_status: null,
-      ownership_verified: 1
+cases('Sending Domain reducer', (action) => {
+  const state = {
+    domain: {
+      is_default_bounce_domain: false,
+      status: {
+        cname_status: null,
+        mx_status: null,
+        ownership_verified: 1
+      }
     }
-  }
-};
+  };
 
-const VERIFY_TEST_CASES = {
+  expect(sendingDomainsReducer(state, action)).toMatchSnapshot();
+}, {
   'verify cname pending': {
     type: 'VERIFY_SENDING_DOMAIN_CNAME_PENDING'
   },
@@ -67,14 +69,7 @@ const VERIFY_TEST_CASES = {
   'verify with postmaster fail': {
     payload: { errors: [ { message: 'Some error occurred' }]},
     type: 'VERIFY_SENDING_DOMAIN_POSTMASTER_AT_FAIL'
-  }
-};
-
-cases('Sending Domain reducer', (action) => {
-  expect(sendingDomainsReducer(state, action)).toMatchSnapshot();
-}, VERIFY_TEST_CASES);
-
-const UPDATE_TEST_CASES = {
+  },
   'update pending': {
     type: 'UPDATE_SENDING_DOMAIN_PENDING'
   },
@@ -90,9 +85,8 @@ const UPDATE_TEST_CASES = {
   'update domain fail': {
     payload: { errors: [ { message: 'Some error occurred' }]},
     type: 'UPDATE_SENDING_DOMAIN_FAIL'
+  },
+  'clear sending domain': {
+    type: 'CLEAR_SENDING_DOMAIN'
   }
-};
-
-cases('Sending Domain Update reducer', (action) => {
-  expect(sendingDomainsReducer(state, action)).toMatchSnapshot();
-}, UPDATE_TEST_CASES);
+});

--- a/src/reducers/tests/subaccounts.test.js
+++ b/src/reducers/tests/subaccounts.test.js
@@ -1,0 +1,37 @@
+import subaccountsReducer from '../subaccounts';
+import cases from 'jest-in-case';
+
+cases('Reducer: Subaccount', ({ name, ...action }) => {
+  expect(subaccountsReducer(undefined, action)).toMatchSnapshot();
+}, {
+  'when subaccount list failed to load': {
+    type: 'LIST_SUBACCOUNTS_FAIL',
+    payload: new Error('Oh no!')
+  },
+  'when subaccount list loaded': {
+    type: 'LIST_SUBACCOUNTS_SUCCESS',
+    payload: [
+      { id: 'test-subaccount', name: 'Test Subaccount' }
+    ]
+  },
+  'when subaccount list is pending': {
+    type: 'LIST_SUBACCOUNTS_PENDING'
+  },
+  'when get subaccount is cleared': {
+    type: 'CLEAR_SUBACCOUNT'
+  },
+  'when get subaccount failed': {
+    type: 'GET_SUBACCOUNT_FAIL',
+    payload: new Error('Oh no!')
+  },
+  'when get subaccount is pending': {
+    type: 'GET_SUBACCOUNT_PENDING'
+  },
+  'when get subaccount succeeds': {
+    type: 'GET_SUBACCOUNT_SUCCESS',
+    payload: {
+      id: 'test-subaccount',
+      name: 'Test Subaccount'
+    }
+  }
+});


### PR DESCRIPTION
**How to test?**

- For subaccount page, open a link to a subaccount that does not exist (e.g. http://app.sparkpost.test/account/subaccounts/0).  The expected result is to be redirected to the subaccount list page with a warning.
- For sending domain page, open a link to a sending domain that does not exist (e.g. http://app.sparkpost.test/account/sending-domains/edit/0).  The expected result is to be redirected to the sending domains list page with a warning.