### PR TITLE
FE-382 - add new support category, remove technical support category

### DIFF
--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -127,7 +127,7 @@ const supportIssues = [
 const augmentIssuesWithConditions = function () {
   return _.map(supportIssues, (supportIssue) => ({
     ...supportIssue,
-    condition: idConditionsMap[supportIssue.id] || defaultCondition
+    condition: supportIssue.condition || idConditionsMap[supportIssue.id] || defaultCondition
   }));
 };
 

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import { hasOnlineSupport, hasStatus, hasStatusReasonCategory, isSuspendedForBilling } from 'src/helpers/conditions/account';
 import { all, not, any } from 'src/helpers/conditions';
 import { isAdmin } from 'src/helpers/conditions/user';
@@ -9,6 +11,14 @@ const COMPLIANCE = 'Compliance';
 const ERRORS = 'Errors';
 const LIMITS = 'DailyLimits';
 const SUPPORT = 'Support';
+
+const defaultCondition = all(hasOnlineSupport, hasStatus('active'));
+const idConditionsMap = {
+  general_billing: all(isAdmin, any(isSuspendedForBilling, hasStatus('active'))),
+  account_suspension: all(hasStatus('suspended'), not(hasStatusReasonCategory('100.01'))),
+  account_cancellation: isAdmin
+};
+
 
 /**
  * @example
@@ -24,8 +34,6 @@ const SUPPORT = 'Support';
  *
  *     type: 'Example',
  *
- *     // optional, composed account helpers to determine which user can report this issue
- *     condition: isEnterprise
  *   }
  */
 const supportIssues = [
@@ -33,100 +41,94 @@ const supportIssues = [
     id: 'ui_errors',
     label: 'UI errors',
     messageLabel: 'Tell us more about your issue',
-    type: ERRORS,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: ERRORS
   },
   {
     id: 'sending_domain_block',
     label: 'Sending domain block',
     messageLabel: 'Tell us more about your issue',
-    type: COMPLIANCE,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: COMPLIANCE
   },
   {
     id: 'configuration_setup_support',
     label: 'Configuration support',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: SUPPORT
   },
   {
     id: 'dns',
     label: 'DNS help',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: SUPPORT
   },
   {
     id: 'placement_deliverability',
     label: 'Deliverability issues',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: SUPPORT
   },
   {
     id: 'reporting_and_event_issue',
     label: 'Reporting & event issues',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: SUPPORT
   },
   {
     id: 'blacklisting',
     label: 'IP blacklisting',
     messageLabel: 'Tell us more about your issue',
-    type: COMPLIANCE,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: COMPLIANCE
   },
   {
     id: 'product/support_feedback',
     label: 'Feedback',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: SUPPORT
   },
   {
     id: 'account_upgrade/downgrade_issue',
     label: 'Account upgrade/downgrade issues',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: SUPPORT
   },
   {
     id: 'general_billing',
     label: 'Billing problems',
     messageLabel: 'Tell us more about your billing issue',
-    type: BILLING,
-    condition: all(isAdmin, any(isSuspendedForBilling, hasStatus('active')))
+    type: BILLING
   },
   {
     id: 'account_suspension',
     label: 'Account suspension',
     messageLabel: 'Why do you think your account should be unsuspended?',
-    type: COMPLIANCE,
-    condition: all(hasStatus('suspended'), not(hasStatusReasonCategory('100.01')))
+    type: COMPLIANCE
   },
   {
     id: 'daily_limits',
     label: 'Daily sending limit increase',
     messageLabel: 'What limit do you need and why?',
-    type: LIMITS,
-    condition: all(hasOnlineSupport, isAdmin, hasStatus('active'))
+    type: LIMITS
   },
   {
     id: 'account_cancellation',
     label: 'Account cancellation',
     messageLabel: 'Tell us why you are leaving',
-    type: COMPLIANCE,
-    condition: isAdmin
+    type: COMPLIANCE
   },
   {
     id: 'general_issue',
     label: 'Another issue',
     messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
+    type: SUPPORT
   }
 ];
 
-export default supportIssues;
+
+const augmentIssuesWithConditions = function () {
+  return _.map(supportIssues, (supportIssue) => ({
+    ...supportIssue,
+    condition: idConditionsMap[supportIssue.id] || defaultCondition
+  }));
+};
+
+export default augmentIssuesWithConditions();

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -12,6 +12,7 @@ const ERRORS = 'Errors';
 const LIMITS = 'DailyLimits';
 const SUPPORT = 'Support';
 
+const defaultMessageLabel = 'Tell us more about your issue';
 const defaultCondition = all(hasOnlineSupport, hasStatus('active'));
 const idConditionsMap = {
   general_billing: all(isAdmin, any(isSuspendedForBilling, hasStatus('active'))),
@@ -29,7 +30,7 @@ const idConditionsMap = {
  *     // the label for the support form dropdown
  *     label: 'This is an example',
  *
- *     // the follow-up question for the support form
+ *     // the follow-up question for the support form (optional; to override default)
  *     messageLabel: 'Tell us more about your issue',
  *
  *     type: 'Example',
@@ -40,55 +41,46 @@ const supportIssues = [
   {
     id: 'ui_errors',
     label: 'UI errors',
-    messageLabel: 'Tell us more about your issue',
     type: ERRORS
   },
   {
     id: 'sending_domain_block',
     label: 'Sending domain block',
-    messageLabel: 'Tell us more about your issue',
     type: COMPLIANCE
   },
   {
     id: 'configuration_setup_support',
     label: 'Configuration support',
-    messageLabel: 'Tell us more about your issue',
     type: SUPPORT
   },
   {
     id: 'dns',
     label: 'DNS help',
-    messageLabel: 'Tell us more about your issue',
     type: SUPPORT
   },
   {
     id: 'placement_deliverability',
     label: 'Deliverability issues',
-    messageLabel: 'Tell us more about your issue',
     type: SUPPORT
   },
   {
     id: 'reporting_and_event_issue',
     label: 'Reporting & event issues',
-    messageLabel: 'Tell us more about your issue',
     type: SUPPORT
   },
   {
     id: 'blacklisting',
     label: 'IP blacklisting',
-    messageLabel: 'Tell us more about your issue',
     type: COMPLIANCE
   },
   {
     id: 'product/support_feedback',
     label: 'Feedback',
-    messageLabel: 'Tell us more about your issue',
     type: SUPPORT
   },
   {
     id: 'account_upgrade/downgrade_issue',
     label: 'Account upgrade/downgrade issues',
-    messageLabel: 'Tell us more about your issue',
     type: SUPPORT
   },
   {
@@ -118,17 +110,17 @@ const supportIssues = [
   {
     id: 'general_issue',
     label: 'Another issue',
-    messageLabel: 'Tell us more about your issue',
     type: SUPPORT
   }
 ];
 
 
-const augmentIssuesWithConditions = function () {
+const augmentIssuesList = function () {
   return _.map(supportIssues, (supportIssue) => ({
     ...supportIssue,
+    messageLabel: supportIssue.messageLabel || defaultMessageLabel,
     condition: supportIssue.condition || idConditionsMap[supportIssue.id] || defaultCondition
   }));
 };
 
-export default augmentIssuesWithConditions();
+export default augmentIssuesList();

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -30,10 +30,66 @@ const SUPPORT = 'Support';
  */
 const supportIssues = [
   {
-    id: 'technical_errors',
-    label: 'Technical errors',
+    id: 'ui_errors',
+    label: 'UI errors',
     messageLabel: 'Tell us more about your issue',
     type: ERRORS,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'sending_domain_block',
+    label: 'Sending domain block',
+    messageLabel: 'Tell us more about your issue',
+    type: COMPLIANCE,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'configuration_setup_support',
+    label: 'Configuration support',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'dns',
+    label: 'DNS help',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'placement_deliverability',
+    label: 'Deliverability issues',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'reporting_and_event_issue',
+    label: 'Reporting & event issues',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'blacklisting',
+    label: 'IP blacklisting',
+    messageLabel: 'Tell us more about your issue',
+    type: COMPLIANCE,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'product/support_feedback',
+    label: 'Feedback',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
+    condition: all(hasOnlineSupport, hasStatus('active'))
+  },
+  {
+    id: 'account_upgrade/downgrade_issue',
+    label: 'Account upgrade/downgrade issues',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
     condition: all(hasOnlineSupport, hasStatus('active'))
   },
   {
@@ -58,18 +114,18 @@ const supportIssues = [
     condition: all(hasOnlineSupport, isAdmin, hasStatus('active'))
   },
   {
-    id: 'general_issue',
-    label: 'Another issue',
-    messageLabel: 'Tell us more about your issue',
-    type: SUPPORT,
-    condition: all(hasOnlineSupport, hasStatus('active'))
-  },
-  {
     id: 'account_cancellation',
     label: 'Account cancellation',
     messageLabel: 'Tell us why you are leaving',
     type: COMPLIANCE,
     condition: isAdmin
+  },
+  {
+    id: 'general_issue',
+    label: 'Another issue',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
+    condition: all(hasOnlineSupport, hasStatus('active'))
   }
 ];
 

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -105,7 +105,7 @@ const supportIssues = [
     id: 'account_cancellation',
     label: 'Account cancellation',
     messageLabel: 'Tell us why you are leaving',
-    type: COMPLIANCE
+    type: BILLING
   },
   {
     id: 'general_issue',


### PR DESCRIPTION
Notes:
- We can't ship this until SC cutover
- As per ticket, we had to remove Technical Support. That will require updating, at least, https://www.sparkpost.com/docs/getting-started/how-to-get-help/. Support docs PR https://github.com/SparkPost/support-docs/pull/261
- I think it's worth renaming this part to something appropriate as that category is gone
  > Additional technical support is available on paid plans. Upgrade now.
 
  to like,
  > Additional support categories are available on paid plans. Upgrade now.


