### PR TITLE
FE-406 - Pass query params in creation_params during signup

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -114,7 +114,7 @@ const config = {
     cookieDuration: 60 * 24 * 30,
     cookieDomain: '.sparkpost.com'
   },
-  salesforceDataParams: ['sfdcid', 'src', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']
+  salesforceDataParams: ['src', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']
 };
 
 export default config;

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -23,7 +23,7 @@ export class JoinPage extends Component {
     formData: {}
   };
 
-  formatQueryString = () => {
+  extractQueryParams = () => {
     const { params } = this.props;
     const existingCookie = cookie.getJSON(config.attribution.cookieName) || {};
 
@@ -41,7 +41,7 @@ export class JoinPage extends Component {
   registerSubmit = (values) => {
     this.setState({ formData: values });
     const { params: { plan }, register, authenticate } = this.props;
-    const { sfdcid, attributionData, creationParams } = this.formatQueryString();
+    const { sfdcid, attributionData, creationParams } = this.extractQueryParams();
 
     const accountFields = _.omit(values, 'email_opt_in');
     const signupData = {
@@ -63,14 +63,13 @@ export class JoinPage extends Component {
   render() {
     const { createError } = this.props.account;
     const { formData } = this.state;
-    const title = inSPCEU() ? 'Sign Up For SparkPost EU' : 'Sign Up';
 
     return (
       <div>
         {loadScript({ url: LINKS.RECAPTCHA_LIB_URL })}
         <CenteredLogo showAwsLogo={this.props.isAWSsignUp} />
 
-        <Panel accent title={title}>
+        <Panel accent title={this.props.title}>
           {
             createError &&
               <Panel.Section>
@@ -94,7 +93,8 @@ function mapStateToProps(state, props) {
   return {
     account: state.account,
     params: qs.parse(props.location.search),
-    isAWSsignUp: !!cookie.get(AWS_COOKIE_NAME)
+    isAWSsignUp: !!cookie.get(AWS_COOKIE_NAME),
+    title: inSPCEU() ? 'Sign Up For SparkPost EU' : 'Sign Up'
   };
 }
 

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -29,12 +29,10 @@ export class JoinPage extends Component {
 
     const allData = { ...existingCookie, ...params };
 
-    const excludeInCreationParams = config.salesforceDataParams.concat(['sfdcid']);
-
     return {
       sfdcid: allData.sfdcid,
       attributionData: _.pick(allData, config.salesforceDataParams),
-      creationParams: _.omit(allData, excludeInCreationParams)
+      creationParams: allData
     };
   }
 

--- a/src/pages/join/tests/JoinPage.test.js
+++ b/src/pages/join/tests/JoinPage.test.js
@@ -56,7 +56,8 @@ describe('JoinPage', () => {
       isAWSsignUp: false,
       location: {
         pathname: '/join'
-      }
+      },
+      title: 'Sign Up'
     };
     formValues = {
       first_name: 'foo',
@@ -79,6 +80,7 @@ describe('JoinPage', () => {
     it('renders correctly', () => {
       expect(wrapper).toMatchSnapshot();
     });
+
     it('renders errors', () => {
       instance.handleSignupFailure = jest.fn().mockReturnValue('Some error occurred');
       wrapper.setProps({ account: { createError: {}}}); //just to make it truthy
@@ -95,7 +97,7 @@ describe('JoinPage', () => {
     let attributionValues;
     beforeEach(() => {
       attributionValues = { sfdcid: 'abcd', attributionData: { src: 'Test Source', 'utm_source': 'test file' }, creationParams: { extra1: 'bar1', extra2: 'bar2' }};
-      instance.formatQueryString = jest.fn().mockReturnValue(attributionValues);
+      instance.extractQueryParams = jest.fn().mockReturnValue(attributionValues);
       instance.trackSignup = jest.fn();
     });
 
@@ -155,18 +157,24 @@ describe('JoinPage', () => {
   });
 
 
-  describe('formatQueryString', () => {
+  describe('extractQueryParams', () => {
     beforeEach(() => {
       cookie.getJSON.mockReturnValue({ sfdcid: '123', utm_source: 'script' });
     });
 
     it('returns correct data when value exists in cookie only', () => {
-      expect(instance.formatQueryString()).toMatchSnapshot();
+      expect(instance.extractQueryParams()).toMatchSnapshot();
+    });
+
+    it('returns correct data when cookie is absent', () => {
+      cookie.getJSON.mockReturnValue(undefined);
+      expect(instance.extractQueryParams()).toMatchSnapshot();
     });
 
     it('merges data from query params onto stored cookie data', () => {
       wrapper.setProps({ params: { foo: 'bar', sfdcid: '123', utm_medium: 'script' }});
-      expect(instance.formatQueryString()).toMatchSnapshot();
+      expect(instance.extractQueryParams()).toMatchSnapshot();
     });
+
   });
 });

--- a/src/pages/join/tests/JoinPage.test.js
+++ b/src/pages/join/tests/JoinPage.test.js
@@ -1,10 +1,12 @@
 import { shallow } from 'enzyme';
+import _ from 'lodash';
 import React from 'react';
 import cookie from 'js-cookie';
 import { JoinPage } from '../JoinPage';
 import { AFTER_JOIN_REDIRECT_ROUTE } from 'src/constants';
 import * as constants from 'src/constants';
 import * as analytics from 'src/helpers/analytics';
+import config from '../../../config';
 
 const username = 'foo_bar';
 let props;
@@ -94,10 +96,9 @@ describe('JoinPage', () => {
   });
 
   describe('registerSubmit', () => {
-    let attributionValues;
     beforeEach(() => {
-      attributionValues = { sfdcid: 'abcd', attributionData: { src: 'Test Source', 'utm_source': 'test file' }, creationParams: { extra1: 'bar1', extra2: 'bar2' }};
-      instance.extractQueryParams = jest.fn().mockReturnValue(attributionValues);
+      const allData = { sfdcid: 'abcd', src: 'Test Source', 'utm_source': 'test file', extra1: 'bar1', extra2: 'bar2' };
+      instance.extractQueryParams = jest.fn().mockReturnValue({ sfdcid: allData.sfdcid, attributionData: _.pick(allData, config.salesforceDataParams), creationParams: allData });
       instance.trackSignup = jest.fn();
     });
 

--- a/src/pages/join/tests/JoinPage.test.js
+++ b/src/pages/join/tests/JoinPage.test.js
@@ -30,7 +30,7 @@ jest.mock('src/config', () => ({
   links: {
     submitTicket: 'https://support.sparkpost.com/customer/portal/emails/new'
   },
-  salesforceDataParams: ['sfdcid', 'src', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'],
+  salesforceDataParams: ['src', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'],
   attribution: {
     cookieName: 'attribution',
     cookieDuration: 60 * 24 * 30,
@@ -94,8 +94,8 @@ describe('JoinPage', () => {
   describe('registerSubmit', () => {
     let attributionValues;
     beforeEach(() => {
-      attributionValues = { sfdcid: 'abcd', src: 'Test Source', 'utm_source': 'test file' };
-      instance.getAttributionData = jest.fn().mockReturnValue(attributionValues);
+      attributionValues = { sfdcid: 'abcd', attributionData: { src: 'Test Source', 'utm_source': 'test file' }, creationParams: { extra1: 'bar1', extra2: 'bar2' }};
+      instance.formatQueryString = jest.fn().mockReturnValue(attributionValues);
       instance.trackSignup = jest.fn();
     });
 
@@ -155,18 +155,18 @@ describe('JoinPage', () => {
   });
 
 
-  describe('getAttributionData', () => {
+  describe('formatQueryString', () => {
     beforeEach(() => {
       cookie.getJSON.mockReturnValue({ sfdcid: '123', utm_source: 'script' });
     });
 
-    it('returns correct attribution data from stored cookie', () => {
-      expect(instance.getAttributionData()).toMatchSnapshot();
+    it('returns correct data when value exists in cookie only', () => {
+      expect(instance.formatQueryString()).toMatchSnapshot();
     });
 
-    it('merges attribution data from query params onto stored cookie data', () => {
+    it('merges data from query params onto stored cookie data', () => {
       wrapper.setProps({ params: { foo: 'bar', sfdcid: '123', utm_medium: 'script' }});
-      expect(instance.getAttributionData()).toMatchSnapshot();
+      expect(instance.formatQueryString()).toMatchSnapshot();
     });
   });
 });

--- a/src/pages/join/tests/JoinPage.test.js
+++ b/src/pages/join/tests/JoinPage.test.js
@@ -172,7 +172,7 @@ describe('JoinPage', () => {
     });
 
     it('merges data from query params onto stored cookie data', () => {
-      wrapper.setProps({ params: { foo: 'bar', sfdcid: '123', utm_medium: 'script' }});
+      wrapper.setProps({ params: { sfdcid: 'overridden', utm_medium: 'new property' }});
       expect(instance.extractQueryParams()).toMatchSnapshot();
     });
 

--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JoinPage formatQueryString merges data from query params onto stored cookie data 1`] = `
+exports[`JoinPage extractQueryParams merges data from query params onto stored cookie data 1`] = `
 Object {
   "attributionData": Object {
     "utm_medium": "script",
@@ -13,7 +13,15 @@ Object {
 }
 `;
 
-exports[`JoinPage formatQueryString returns correct data when value exists in cookie only 1`] = `
+exports[`JoinPage extractQueryParams returns correct data when cookie is absent 1`] = `
+Object {
+  "attributionData": Object {},
+  "creationParams": Object {},
+  "sfdcid": undefined,
+}
+`;
+
+exports[`JoinPage extractQueryParams returns correct data when value exists in cookie only 1`] = `
 Object {
   "attributionData": Object {
     "utm_source": "script",

--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -1,17 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JoinPage getAttributionData merges attribution data from query params onto stored cookie data 1`] = `
+exports[`JoinPage formatQueryString merges data from query params onto stored cookie data 1`] = `
 Object {
+  "attributionData": Object {
+    "utm_medium": "script",
+    "utm_source": "script",
+  },
+  "creationParams": Object {
+    "foo": "bar",
+  },
   "sfdcid": "123",
-  "utm_medium": "script",
-  "utm_source": "script",
 }
 `;
 
-exports[`JoinPage getAttributionData returns correct attribution data from stored cookie 1`] = `
+exports[`JoinPage formatQueryString returns correct data when value exists in cookie only 1`] = `
 Object {
+  "attributionData": Object {
+    "utm_source": "script",
+  },
+  "creationParams": Object {},
   "sfdcid": "123",
-  "utm_source": "script",
 }
 `;
 
@@ -19,6 +27,10 @@ exports[`JoinPage registerSubmit calls register with correct data 1`] = `
 Array [
   Array [
     Object {
+      "creation_params": Object {
+        "extra1": "bar1",
+        "extra2": "bar2",
+      },
       "email": "foo@bar.com",
       "first_name": "foo",
       "last_name": "bar",

--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -43,6 +43,9 @@ Array [
       "creation_params": Object {
         "extra1": "bar1",
         "extra2": "bar2",
+        "sfdcid": "abcd",
+        "src": "Test Source",
+        "utm_source": "test file",
       },
       "email": "foo@bar.com",
       "first_name": "foo",

--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -3,13 +3,15 @@
 exports[`JoinPage extractQueryParams merges data from query params onto stored cookie data 1`] = `
 Object {
   "attributionData": Object {
-    "utm_medium": "script",
+    "utm_medium": "new property",
     "utm_source": "script",
   },
   "creationParams": Object {
-    "foo": "bar",
+    "sfdcid": "overridden",
+    "utm_medium": "new property",
+    "utm_source": "script",
   },
-  "sfdcid": "123",
+  "sfdcid": "overridden",
 }
 `;
 
@@ -26,7 +28,10 @@ Object {
   "attributionData": Object {
     "utm_source": "script",
   },
-  "creationParams": Object {},
+  "creationParams": Object {
+    "sfdcid": "123",
+    "utm_source": "script",
+  },
   "sfdcid": "123",
 }
 `;


### PR DESCRIPTION
**Notes:**
- ~From [this spec](https://github.com/SparkPost/sparkpost-admin-api-documentation/pull/249/files#diff-67ec3e3387465afb64e4f66518e488a6R48) it "appears to be" expecting EVERYTHING in creation_params. Reached out to @James-Burba to clarify and he'll confirm tomorrow.~ Currently, I'm only sending what's not already being sent.
 Update: Confirmed that params that aren't already passed otherwise, need to be passed here.

- Remove `sfdcid` from `salesforceDataParams` config, as that we're not actually sending in `salesforce_data`. 

- ~Accusers (master) API doesn't seem to complain about extra param, creation_params. However, I'll test with AC-129 branch tomorrow.~ Done

- Related accusers PR https://github.com/SparkPost/accusers-api/pull/415

**Testing:**
- Visit a signup URL with query params (example: http://app.sparkpost.test/join?src=almost-nowhere&utm_content=utmcontent&utm_term=test&utm_source=direct&utm_medium=web&utm_campaign=internal&sfdcid=dddddd&foo1=bar1&foo2=bar2)
- If you put an existing email address, account creation will fail but you could still inspect request headers. That way you can avoid many signups. 
