### PR TITLE
FE-429 Remove ip pool empty state & small ui improvements

### DIFF
--- a/src/pages/ipPools/EditPage.js
+++ b/src/pages/ipPools/EditPage.js
@@ -1,17 +1,16 @@
-/* eslint max-lines: ["error", 200] */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { withRouter } from 'react-router-dom';
 
 import { Page } from '@sparkpost/matchbox';
-import { DeleteModal, ApiErrorBanner } from 'src/components';
-import PanelLoading from 'src/components/panelLoading/PanelLoading';
+import { Loading, DeleteModal, ApiErrorBanner } from 'src/components';
 import PoolForm from './components/PoolForm';
 
 import { showAlert } from 'src/actions/globalAlert';
 import { listPools, getPool, updatePool, deletePool } from 'src/actions/ipPools';
 import { updateSendingIp } from 'src/actions/sendingIps';
+import { shouldShowIpPurchaseCTA } from 'src/selectors/ipPools';
 
 import { decodeIp } from 'src/helpers/ipNames';
 import isDefaultPool from './helpers/defaultPool';
@@ -105,10 +104,10 @@ export class EditPage extends Component {
   }
 
   render() {
-    const { loading, pool } = this.props;
+    const { loading, pool, showPurchaseCTA } = this.props;
 
     if (loading) {
-      return <PanelLoading />;
+      return <Loading />;
     }
 
     return (
@@ -121,9 +120,10 @@ export class EditPage extends Component {
             onClick: this.toggleDelete,
             visible: !isDefaultPool(this.props.match.params.id)
           },
-          { content: 'Purchase IP',
+          { content: 'Purchase IPs',
             to: '/account/billing',
-            component: Link
+            component: Link,
+            visible: showPurchaseCTA
           }]
         }>
 
@@ -141,15 +141,16 @@ export class EditPage extends Component {
   }
 }
 
-const mapStateToProps = ({ ipPools }) => {
-  const { getLoading, getError, listLoading, listError, pool } = ipPools;
+const mapStateToProps = (state) => {
+  const { getLoading, getError, listLoading, listError, pool } = state.ipPools;
 
   return {
     loading: getLoading || listLoading,
     error: listError || getError,
     pool,
     listError,
-    getError
+    getError,
+    showPurchaseCTA: shouldShowIpPurchaseCTA(state)
   };
 };
 

--- a/src/pages/ipPools/ListPage.js
+++ b/src/pages/ipPools/ListPage.js
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 import { listPools } from 'src/actions/ipPools';
 import { getOrderedIpPools, shouldShowIpPurchaseCTA } from 'src/selectors/ipPools';
 import { Loading, TableCollection, ApiErrorBanner } from 'src/components';
-import { Setup } from 'src/components/images';
 import { Page } from '@sparkpost/matchbox';
 
 const columns = [
@@ -54,29 +53,21 @@ export class IpPoolsList extends Component {
   }
 
   render() {
-    const { loading, error, ipPools, showPurchaseCTA } = this.props;
+    const { loading, error, showPurchaseCTA } = this.props;
 
     if (loading) {
       return <Loading />;
     }
 
     const createAction = { content: 'Create IP Pool', Component: Link, to: '/account/ip-pools/create' };
-    const purchaseAction = { content: 'Purchase IPs', Component: Link, to: '/account/billing' };
-    const isEmptyState = ipPools.length === 1 && ipPools[0].ips.length === 0;
+    const purchaseActions = showPurchaseCTA ? [{ content: 'Purchase IPs', Component: Link, to: '/account/billing' }] : null;
 
     return (
       <Page
         primaryAction={createAction}
-        title='IP Pools'
-        empty={{
-          show: isEmptyState,
-          title: 'Boost your deliverability',
-          image: Setup,
-          content: <p>Purchase dedicated IPs to manage your IP Pools</p>,
-          secondaryAction: showPurchaseCTA ? createAction : null,
-          primaryAction: showPurchaseCTA ? purchaseAction : createAction
-        }}>
-        { error ? this.renderError() : (isEmptyState ? null : this.renderCollection()) }
+        secondaryActions={purchaseActions}
+        title='IP Pools' >
+        {error ? this.renderError() : this.renderCollection()}
       </Page>
     );
   }

--- a/src/pages/ipPools/components/PoolForm.js
+++ b/src/pages/ipPools/components/PoolForm.js
@@ -56,7 +56,7 @@ export class PoolForm extends Component {
       : null;
 
     return (
-      <React.Fragment>
+      <Fragment>
         <Panel.Section>
           <p>
             Add dedicated IPs to this pool by moving them from their current pool{purchaseCTA}.
@@ -68,7 +68,7 @@ export class PoolForm extends Component {
           getRowData={getRowDataFunc}
           pagination={false}
         />
-      </React.Fragment>
+      </Fragment>
     );
   }
 

--- a/src/pages/ipPools/components/PoolForm.js
+++ b/src/pages/ipPools/components/PoolForm.js
@@ -9,7 +9,7 @@ import AccessControl from 'src/components/auth/AccessControl';
 import { required } from 'src/helpers/validation';
 import { configFlag } from 'src/helpers/conditions/config';
 import { TextFieldWrapper, SendingDomainTypeaheadWrapper } from 'src/components';
-import { selectIpPoolFormInitialValues, selectIpsForCurrentPool } from 'src/selectors/ipPools';
+import { selectIpPoolFormInitialValues, selectIpsForCurrentPool, shouldShowIpPurchaseCTA } from 'src/selectors/ipPools';
 import isDefaultPool from '../helpers/defaultPool';
 
 
@@ -34,7 +34,7 @@ export class PoolForm extends Component {
   }
 
   renderCollection() {
-    const { isNew, ips, list, pool: currentPool } = this.props;
+    const { isNew, ips, list, pool: currentPool, showPurchaseCTA } = this.props;
     const poolOptions = list.map((pool) => ({
       value: pool.id,
       label: (pool.id === currentPool.id) ? '-- Change Pool --' : `${pool.name} (${pool.id})`
@@ -51,18 +51,16 @@ export class PoolForm extends Component {
       return null;
     }
 
-    // Empty pool
-    if (ips.length === 0) {
-      return <Panel.Section>
-        <p>Add a Dedicated IP to the pool by purchasing from the <UnstyledLink to="/account/billing" component={Link}>billing</UnstyledLink> page.</p>
-      </Panel.Section>;
-    }
-
+    const purchaseCTA = showPurchaseCTA
+      ? <React.Fragment>, or by purchasing new IPs from the <UnstyledLink to="/account/billing" component={Link}>billing page</UnstyledLink></React.Fragment>
+      : null;
 
     return (
       <React.Fragment>
         <Panel.Section>
-          <p>Add sending IPs to this pool by moving them from their current pool or by purchasing a new Dedicated IP.</p>
+          <p>
+            Add dedicated IPs to this pool by moving them from their current pool{purchaseCTA}.
+          </p>
         </Panel.Section>
         <TableCollection
           columns={columns}
@@ -78,30 +76,31 @@ export class PoolForm extends Component {
     const { isNew, pool, handleSubmit, submitting, pristine } = this.props;
     const submitText = isNew ? 'Create IP Pool' : 'Update IP Pool';
     const editingDefault = !isNew && isDefaultPool(pool.id);
-    const helpText = editingDefault ? 'Sorry, you can\'t edit the default pool\'s name. Then it wouldn\'t be the default!' : '';
+    const helpText = editingDefault ? 'You cannot change the default IP pool\'s name' : '';
 
     return (
       <Panel>
         <form onSubmit={handleSubmit}>
           <Panel.Section>
             <Field
-              name="name"
+              name='name'
               component={TextFieldWrapper}
               validate={required}
-              label="Pool Name"
+              label='Pool Name'
+              placeholder='My IP Pool'
               disabled={editingDefault || submitting}
               helpText={helpText}
             />
 
             {!editingDefault &&
-          <AccessControl condition={configFlag('featureFlags.allow_default_signing_domains_for_ip_pools')}>
-            <Field
-              name="signing_domain"
-              component={SendingDomainTypeaheadWrapper}
-              label="Default Signing Domain"
-              disabled={submitting}
-            />
-          </AccessControl>
+              <AccessControl condition={configFlag('featureFlags.allow_default_signing_domains_for_ip_pools')}>
+                <Field
+                  name="signing_domain"
+                  component={SendingDomainTypeaheadWrapper}
+                  label="Default Signing Domain"
+                  disabled={submitting}
+                />
+              </AccessControl>
             }
           </Panel.Section>
 
@@ -126,7 +125,8 @@ const mapStateToProps = (state, props) => {
     list,
     pool,
     ips: selectIpsForCurrentPool(state),
-    initialValues: selectIpPoolFormInitialValues(state, props)
+    initialValues: selectIpPoolFormInitialValues(state, props),
+    showPurchaseCTA: shouldShowIpPurchaseCTA(state)
   };
 };
 

--- a/src/pages/ipPools/components/PoolForm.js
+++ b/src/pages/ipPools/components/PoolForm.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { Field, reduxForm } from 'redux-form';
 import { Link } from 'react-router-dom';
@@ -52,7 +52,7 @@ export class PoolForm extends Component {
     }
 
     const purchaseCTA = showPurchaseCTA
-      ? <React.Fragment>, or by purchasing new IPs from the <UnstyledLink to="/account/billing" component={Link}>billing page</UnstyledLink></React.Fragment>
+      ? <Fragment>, or by <UnstyledLink to="/account/billing" component={Link}>purchasing new IPs</UnstyledLink></Fragment>
       : null;
 
     return (

--- a/src/pages/ipPools/components/tests/PoolForm.test.js
+++ b/src/pages/ipPools/components/tests/PoolForm.test.js
@@ -34,7 +34,8 @@ describe('PoolForm tests', () => {
       ],
       pool: { id: 'my-pool', name: 'My Pool' },
       handleSubmit: jest.fn(),
-      pristine: true
+      pristine: true,
+      showPurchaseCTA: true
     };
 
     wrapper = shallow(<PoolForm {...props} />);
@@ -70,8 +71,8 @@ describe('PoolForm tests', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should return a msg if there are no ips', () => {
-    wrapper.setProps({ ips: []});
+  it('should not show purchase cta if showPurchaseCTA is false', () => {
+    wrapper.setProps({ showPurchaseCTA: false });
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -91,4 +92,3 @@ describe('PoolForm tests', () => {
     expect(rows).toMatchSnapshot();
   });
 });
-

--- a/src/pages/ipPools/components/tests/__snapshots__/PoolForm.test.js.snap
+++ b/src/pages/ipPools/components/tests/__snapshots__/PoolForm.test.js.snap
@@ -31,12 +31,12 @@ exports[`PoolForm tests should not disable button if form is not pristine or not
         <p>
           Add dedicated IPs to this pool by moving them from their current pool
           <React.Fragment>
-            , or by purchasing new IPs from the 
+            , or by 
             <UnstyledLink
               component={[Function]}
               to="/account/billing"
             >
-              billing page
+              purchasing new IPs
             </UnstyledLink>
           </React.Fragment>
           .
@@ -103,12 +103,12 @@ exports[`PoolForm tests should not render signing_domain if editing default pool
         <p>
           Add dedicated IPs to this pool by moving them from their current pool
           <React.Fragment>
-            , or by purchasing new IPs from the 
+            , or by 
             <UnstyledLink
               component={[Function]}
               to="/account/billing"
             >
-              billing page
+              purchasing new IPs
             </UnstyledLink>
           </React.Fragment>
           .
@@ -185,12 +185,12 @@ exports[`PoolForm tests should not render signing_domain if feature flag is disa
         <p>
           Add dedicated IPs to this pool by moving them from their current pool
           <React.Fragment>
-            , or by purchasing new IPs from the 
+            , or by 
             <UnstyledLink
               component={[Function]}
               to="/account/billing"
             >
-              billing page
+              purchasing new IPs
             </UnstyledLink>
           </React.Fragment>
           .
@@ -420,12 +420,12 @@ exports[`PoolForm tests should render form 1`] = `
         <p>
           Add dedicated IPs to this pool by moving them from their current pool
           <React.Fragment>
-            , or by purchasing new IPs from the 
+            , or by 
             <UnstyledLink
               component={[Function]}
               to="/account/billing"
             >
-              billing page
+              purchasing new IPs
             </UnstyledLink>
           </React.Fragment>
           .
@@ -505,12 +505,12 @@ exports[`PoolForm tests should show help text when editing default pool 1`] = `
         <p>
           Add dedicated IPs to this pool by moving them from their current pool
           <React.Fragment>
-            , or by purchasing new IPs from the 
+            , or by 
             <UnstyledLink
               component={[Function]}
               to="/account/billing"
             >
-              billing page
+              purchasing new IPs
             </UnstyledLink>
           </React.Fragment>
           .
@@ -587,12 +587,12 @@ exports[`PoolForm tests should update button text to Saving and disable button w
         <p>
           Add dedicated IPs to this pool by moving them from their current pool
           <React.Fragment>
-            , or by purchasing new IPs from the 
+            , or by 
             <UnstyledLink
               component={[Function]}
               to="/account/billing"
             >
-              billing page
+              purchasing new IPs
             </UnstyledLink>
           </React.Fragment>
           .

--- a/src/pages/ipPools/components/tests/__snapshots__/PoolForm.test.js.snap
+++ b/src/pages/ipPools/components/tests/__snapshots__/PoolForm.test.js.snap
@@ -12,6 +12,7 @@ exports[`PoolForm tests should not disable button if form is not pristine or not
         helpText=""
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
       <Connect(AccessControl)
@@ -28,7 +29,17 @@ exports[`PoolForm tests should not disable button if form is not pristine or not
     <React.Fragment>
       <Panel.Section>
         <p>
-          Add sending IPs to this pool by moving them from their current pool or by purchasing a new Dedicated IP.
+          Add dedicated IPs to this pool by moving them from their current pool
+          <React.Fragment>
+            , or by purchasing new IPs from the 
+            <UnstyledLink
+              component={[Function]}
+              to="/account/billing"
+            >
+              billing page
+            </UnstyledLink>
+          </React.Fragment>
+          .
         </p>
       </Panel.Section>
       <TableCollection
@@ -80,16 +91,27 @@ exports[`PoolForm tests should not render signing_domain if editing default pool
       <Field
         component={[Function]}
         disabled={true}
-        helpText="Sorry, you can't edit the default pool's name. Then it wouldn't be the default!"
+        helpText="You cannot change the default IP pool's name"
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
     </Panel.Section>
     <React.Fragment>
       <Panel.Section>
         <p>
-          Add sending IPs to this pool by moving them from their current pool or by purchasing a new Dedicated IP.
+          Add dedicated IPs to this pool by moving them from their current pool
+          <React.Fragment>
+            , or by purchasing new IPs from the 
+            <UnstyledLink
+              component={[Function]}
+              to="/account/billing"
+            >
+              billing page
+            </UnstyledLink>
+          </React.Fragment>
+          .
         </p>
       </Panel.Section>
       <TableCollection
@@ -144,6 +166,7 @@ exports[`PoolForm tests should not render signing_domain if feature flag is disa
         helpText=""
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
       <Connect(AccessControl)
@@ -160,7 +183,17 @@ exports[`PoolForm tests should not render signing_domain if feature flag is disa
     <React.Fragment>
       <Panel.Section>
         <p>
-          Add sending IPs to this pool by moving them from their current pool or by purchasing a new Dedicated IP.
+          Add dedicated IPs to this pool by moving them from their current pool
+          <React.Fragment>
+            , or by purchasing new IPs from the 
+            <UnstyledLink
+              component={[Function]}
+              to="/account/billing"
+            >
+              billing page
+            </UnstyledLink>
+          </React.Fragment>
+          .
         </p>
       </Panel.Section>
       <TableCollection
@@ -215,6 +248,7 @@ exports[`PoolForm tests should not render table if no ips exist 1`] = `
         helpText=""
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
       <Connect(AccessControl)
@@ -254,6 +288,7 @@ exports[`PoolForm tests should not render table if pool is new 1`] = `
         helpText=""
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
       <Connect(AccessControl)
@@ -281,7 +316,7 @@ exports[`PoolForm tests should not render table if pool is new 1`] = `
 </Panel>
 `;
 
-exports[`PoolForm tests should render form 1`] = `
+exports[`PoolForm tests should not show purchase cta if showPurchaseCTA is false 1`] = `
 <Panel>
   <form
     onSubmit={[MockFunction]}
@@ -293,6 +328,7 @@ exports[`PoolForm tests should render form 1`] = `
         helpText=""
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
       <Connect(AccessControl)
@@ -309,7 +345,90 @@ exports[`PoolForm tests should render form 1`] = `
     <React.Fragment>
       <Panel.Section>
         <p>
-          Add sending IPs to this pool by moving them from their current pool or by purchasing a new Dedicated IP.
+          Add dedicated IPs to this pool by moving them from their current pool
+          .
+        </p>
+      </Panel.Section>
+      <TableCollection
+        columns={
+          Array [
+            "Sending IP",
+            "Hostname",
+            "IP Pool",
+          ]
+        }
+        defaultSortColumn={null}
+        defaultSortDirection="asc"
+        getRowData={[Function]}
+        pagination={false}
+        rows={
+          Array [
+            Object {
+              "external_ip": "external",
+              "hostname": "hostname",
+            },
+            Object {
+              "external_ip": "external-2",
+              "hostname": "hostname-2",
+            },
+          ]
+        }
+      />
+    </React.Fragment>
+    <Panel.Section>
+      <Button
+        disabled={true}
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Update IP Pool
+      </Button>
+    </Panel.Section>
+  </form>
+</Panel>
+`;
+
+exports[`PoolForm tests should render form 1`] = `
+<Panel>
+  <form
+    onSubmit={[MockFunction]}
+  >
+    <Panel.Section>
+      <Field
+        component={[Function]}
+        disabled={false}
+        helpText=""
+        label="Pool Name"
+        name="name"
+        placeholder="My IP Pool"
+        validate={[Function]}
+      />
+      <Connect(AccessControl)
+        condition={[Function]}
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          label="Default Signing Domain"
+          name="signing_domain"
+        />
+      </Connect(AccessControl)>
+    </Panel.Section>
+    <React.Fragment>
+      <Panel.Section>
+        <p>
+          Add dedicated IPs to this pool by moving them from their current pool
+          <React.Fragment>
+            , or by purchasing new IPs from the 
+            <UnstyledLink
+              component={[Function]}
+              to="/account/billing"
+            >
+              billing page
+            </UnstyledLink>
+          </React.Fragment>
+          .
         </p>
       </Panel.Section>
       <TableCollection
@@ -365,57 +484,6 @@ Array [
 ]
 `;
 
-exports[`PoolForm tests should return a msg if there are no ips 1`] = `
-<Panel>
-  <form
-    onSubmit={[MockFunction]}
-  >
-    <Panel.Section>
-      <Field
-        component={[Function]}
-        disabled={false}
-        helpText=""
-        label="Pool Name"
-        name="name"
-        validate={[Function]}
-      />
-      <Connect(AccessControl)
-        condition={[Function]}
-      >
-        <Field
-          component={[Function]}
-          disabled={false}
-          label="Default Signing Domain"
-          name="signing_domain"
-        />
-      </Connect(AccessControl)>
-    </Panel.Section>
-    <Panel.Section>
-      <p>
-        Add a Dedicated IP to the pool by purchasing from the 
-        <UnstyledLink
-          component={[Function]}
-          to="/account/billing"
-        >
-          billing
-        </UnstyledLink>
-         page.
-      </p>
-    </Panel.Section>
-    <Panel.Section>
-      <Button
-        disabled={true}
-        primary={true}
-        size="default"
-        submit={true}
-      >
-        Update IP Pool
-      </Button>
-    </Panel.Section>
-  </form>
-</Panel>
-`;
-
 exports[`PoolForm tests should show help text when editing default pool 1`] = `
 <Panel>
   <form
@@ -425,16 +493,27 @@ exports[`PoolForm tests should show help text when editing default pool 1`] = `
       <Field
         component={[Function]}
         disabled={true}
-        helpText="Sorry, you can't edit the default pool's name. Then it wouldn't be the default!"
+        helpText="You cannot change the default IP pool's name"
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
     </Panel.Section>
     <React.Fragment>
       <Panel.Section>
         <p>
-          Add sending IPs to this pool by moving them from their current pool or by purchasing a new Dedicated IP.
+          Add dedicated IPs to this pool by moving them from their current pool
+          <React.Fragment>
+            , or by purchasing new IPs from the 
+            <UnstyledLink
+              component={[Function]}
+              to="/account/billing"
+            >
+              billing page
+            </UnstyledLink>
+          </React.Fragment>
+          .
         </p>
       </Panel.Section>
       <TableCollection
@@ -489,6 +568,7 @@ exports[`PoolForm tests should update button text to Saving and disable button w
         helpText=""
         label="Pool Name"
         name="name"
+        placeholder="My IP Pool"
         validate={[Function]}
       />
       <Connect(AccessControl)
@@ -505,7 +585,17 @@ exports[`PoolForm tests should update button text to Saving and disable button w
     <React.Fragment>
       <Panel.Section>
         <p>
-          Add sending IPs to this pool by moving them from their current pool or by purchasing a new Dedicated IP.
+          Add dedicated IPs to this pool by moving them from their current pool
+          <React.Fragment>
+            , or by purchasing new IPs from the 
+            <UnstyledLink
+              component={[Function]}
+              to="/account/billing"
+            >
+              billing page
+            </UnstyledLink>
+          </React.Fragment>
+          .
         </p>
       </Panel.Section>
       <TableCollection

--- a/src/pages/ipPools/tests/EditPage.test.js
+++ b/src/pages/ipPools/tests/EditPage.test.js
@@ -30,7 +30,8 @@ describe('IP Pools Edit Page', () => {
       listPools: jest.fn(),
       listError: null,
       getError: null,
-      getPool: jest.fn()
+      getPool: jest.fn(),
+      showPurchaseCTA: true
     };
 
     wrapper = shallow(<EditPage {...props} />);
@@ -41,8 +42,13 @@ describe('IP Pools Edit Page', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should show loading panel when data is loading', () => {
+    it('should show loading when data is loading', () => {
       wrapper.setProps({ loading: true });
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should not show purchase action if showPurchaseCTA is false', () => {
+      wrapper.setProps({ showPurchaseCTA: false });
       expect(wrapper).toMatchSnapshot();
     });
 
@@ -73,7 +79,7 @@ describe('IP Pools Edit Page', () => {
       updatePoolSpy = jest.spyOn(wrapper.instance().props, 'updatePool');
     });
 
-    it('should show an alert on successful pool update', async() => {
+    it('should show an alert on successful pool update', async () => {
       await wrapper.instance().onUpdatePool({ name: 'my_pool', signing_domain: 'my-domain.sparkpost.com', '127_0_0_1': 'other_pool', '127_0_0_2': 'my-pool' });
       expect(wrapper.instance().props.showAlert).toHaveBeenCalledWith({
         type: 'success',
@@ -84,7 +90,7 @@ describe('IP Pools Edit Page', () => {
 
     });
 
-    it('should set signing_domain to empty string if it is null', async() => {
+    it('should set signing_domain to empty string if it is null', async () => {
       props.pool.signing_domain = null;
       await wrapper.instance().onUpdatePool({ name: 'my_pool', '127_0_0_1': 'other_pool', '127_0_0_2': 'my-pool' });
       expect(wrapper.instance().props.showAlert).toHaveBeenCalledWith({
@@ -95,7 +101,7 @@ describe('IP Pools Edit Page', () => {
       expect(wrapper.instance().props.history.push).toHaveBeenCalled();
     });
 
-    it('should not update pool if editing default pool', async() => {
+    it('should not update pool if editing default pool', async () => {
       wrapper.setProps({ match: { params: { id: 'default' }}});
       await wrapper.instance().onUpdatePool({ name: 'default', '127_0_0_1': 'other_pool', '127_0_0_2': 'default' });
       expect(wrapper.instance().props.showAlert).toHaveBeenCalledWith({
@@ -114,7 +120,7 @@ describe('IP Pools Edit Page', () => {
       expect(stateSpy).toHaveBeenCalledWith({ showDelete: true });
     });
 
-    it('should show alert on delete pool', async() => {
+    it('should show alert on delete pool', async () => {
       await wrapper.instance().onDeletePool();
       expect(wrapper.instance().props.showAlert).toHaveBeenCalledWith({
         type: 'success',

--- a/src/pages/ipPools/tests/ListPage.test.js
+++ b/src/pages/ipPools/tests/ListPage.test.js
@@ -45,18 +45,7 @@ describe('IP Pools List Page', () => {
     expect(rows).toMatchSnapshot();
   });
 
-  it('renders correctly when showPurchaseCTA is false', () => {
-    wrapper.setProps({ showPurchaseCTA: false });
-    expect(wrapper).toMatchSnapshot();
-
-  });
-
-  it('renders empty state correctly', () => {
-    wrapper.setProps({ ipPools: [{ name: 'Default', ips: []}]});
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('renders empty state correctly when showPurchaseCTA is false', () => {
+  it('does not render purchase action if showPurchaseCTA is false', () => {
     wrapper.setProps({ ipPools: [{ name: 'Default', ips: []}], showPurchaseCTA: false });
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/ipPools/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/EditPage.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IP Pools Edit Page render tests should render the edit page correctly 1`] = `
+exports[`IP Pools Edit Page render tests should not show purchase action if showPurchaseCTA is false 1`] = `
 <Page
   breadcrumbAction={
     Object {
@@ -19,8 +19,9 @@ exports[`IP Pools Edit Page render tests should render the edit page correctly 1
       },
       Object {
         "component": [Function],
-        "content": "Purchase IP",
+        "content": "Purchase IPs",
         "to": "/account/billing",
+        "visible": false,
       },
     ]
   }
@@ -44,11 +45,52 @@ exports[`IP Pools Edit Page render tests should render the edit page correctly 1
 </Page>
 `;
 
-exports[`IP Pools Edit Page render tests should show loading panel when data is loading 1`] = `
-<PanelLoading
-  minHeight="400px"
-/>
+exports[`IP Pools Edit Page render tests should render the edit page correctly 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "Component": [Function],
+      "content": "IP Pools",
+      "to": "/account/ip-pools",
+    }
+  }
+  empty={Object {}}
+  secondaryActions={
+    Array [
+      Object {
+        "content": "Delete",
+        "onClick": [Function],
+        "visible": true,
+      },
+      Object {
+        "component": [Function],
+        "content": "Purchase IPs",
+        "to": "/account/billing",
+        "visible": true,
+      },
+    ]
+  }
+  title="My Pool (my-pool)"
+>
+  <Connect(ReduxForm)
+    isNew={false}
+    onSubmit={[Function]}
+  />
+  <DeleteModal
+    content={
+      <p>
+        IPs in this pool will be re-assigned to your Default pool.
+      </p>
+    }
+    onCancel={[Function]}
+    onDelete={[Function]}
+    open={false}
+    title="Are you sure you want to delete this IP Pool?"
+  />
+</Page>
 `;
+
+exports[`IP Pools Edit Page render tests should show loading when data is loading 1`] = `<Loading />`;
 
 exports[`IP Pools Edit Page renderForm tests should show get error msg on error 1`] = `
 <Page
@@ -69,8 +111,9 @@ exports[`IP Pools Edit Page renderForm tests should show get error msg on error 
       },
       Object {
         "component": [Function],
-        "content": "Purchase IP",
+        "content": "Purchase IPs",
         "to": "/account/billing",
+        "visible": true,
       },
     ]
   }
@@ -113,8 +156,9 @@ exports[`IP Pools Edit Page renderForm tests should show list error msg on error
       },
       Object {
         "component": [Function],
-        "content": "Purchase IP",
+        "content": "Purchase IPs",
         "to": "/account/billing",
+        "visible": true,
       },
     ]
   }

--- a/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
@@ -1,23 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IP Pools List Page renders correctly when showPurchaseCTA is false 1`] = `
+exports[`IP Pools List Page does not render purchase action if showPurchaseCTA is false 1`] = `
 <Page
-  empty={
-    Object {
-      "content": <p>
-        Purchase dedicated IPs to manage your IP Pools
-      </p>,
-      "image": [Function],
-      "primaryAction": Object {
-        "Component": [Function],
-        "content": "Create IP Pool",
-        "to": "/account/ip-pools/create",
-      },
-      "secondaryAction": null,
-      "show": false,
-      "title": "Boost your deliverability",
-    }
-  }
+  empty={Object {}}
   primaryAction={
     Object {
       "Component": [Function],
@@ -25,6 +10,7 @@ exports[`IP Pools List Page renders correctly when showPurchaseCTA is false 1`] 
       "to": "/account/ip-pools/create",
     }
   }
+  secondaryActions={null}
   title="IP Pools"
 >
   <TableCollection
@@ -64,88 +50,13 @@ exports[`IP Pools List Page renders correctly when showPurchaseCTA is false 1`] 
     rows={
       Array [
         Object {
-          "id": 101,
-          "ips": Array [
-            Object {
-              "external_ip": 1111,
-            },
-            Object {
-              "external_ip": 2222,
-            },
-          ],
-          "name": "Test Pool 1",
-        },
-        Object {
-          "id": 102,
           "ips": Array [],
-          "name": "Test Pool 2",
+          "name": "Default",
         },
       ]
     }
   />
 </Page>
-`;
-
-exports[`IP Pools List Page renders empty state correctly 1`] = `
-<Page
-  empty={
-    Object {
-      "content": <p>
-        Purchase dedicated IPs to manage your IP Pools
-      </p>,
-      "image": [Function],
-      "primaryAction": Object {
-        "Component": [Function],
-        "content": "Purchase IPs",
-        "to": "/account/billing",
-      },
-      "secondaryAction": Object {
-        "Component": [Function],
-        "content": "Create IP Pool",
-        "to": "/account/ip-pools/create",
-      },
-      "show": true,
-      "title": "Boost your deliverability",
-    }
-  }
-  primaryAction={
-    Object {
-      "Component": [Function],
-      "content": "Create IP Pool",
-      "to": "/account/ip-pools/create",
-    }
-  }
-  title="IP Pools"
-/>
-`;
-
-exports[`IP Pools List Page renders empty state correctly when showPurchaseCTA is false 1`] = `
-<Page
-  empty={
-    Object {
-      "content": <p>
-        Purchase dedicated IPs to manage your IP Pools
-      </p>,
-      "image": [Function],
-      "primaryAction": Object {
-        "Component": [Function],
-        "content": "Create IP Pool",
-        "to": "/account/ip-pools/create",
-      },
-      "secondaryAction": null,
-      "show": true,
-      "title": "Boost your deliverability",
-    }
-  }
-  primaryAction={
-    Object {
-      "Component": [Function],
-      "content": "Create IP Pool",
-      "to": "/account/ip-pools/create",
-    }
-  }
-  title="IP Pools"
-/>
 `;
 
 exports[`IP Pools List Page should render loading component when loading data 1`] = `<Loading />`;
@@ -165,32 +76,22 @@ Array [
 
 exports[`IP Pools List Page should render the list page correctly 1`] = `
 <Page
-  empty={
-    Object {
-      "content": <p>
-        Purchase dedicated IPs to manage your IP Pools
-      </p>,
-      "image": [Function],
-      "primaryAction": Object {
-        "Component": [Function],
-        "content": "Purchase IPs",
-        "to": "/account/billing",
-      },
-      "secondaryAction": Object {
-        "Component": [Function],
-        "content": "Create IP Pool",
-        "to": "/account/ip-pools/create",
-      },
-      "show": false,
-      "title": "Boost your deliverability",
-    }
-  }
+  empty={Object {}}
   primaryAction={
     Object {
       "Component": [Function],
       "content": "Create IP Pool",
       "to": "/account/ip-pools/create",
     }
+  }
+  secondaryActions={
+    Array [
+      Object {
+        "Component": [Function],
+        "content": "Purchase IPs",
+        "to": "/account/billing",
+      },
+    ]
   }
   title="IP Pools"
 >
@@ -255,32 +156,22 @@ exports[`IP Pools List Page should render the list page correctly 1`] = `
 
 exports[`IP Pools List Page should show alert upon error 1`] = `
 <Page
-  empty={
-    Object {
-      "content": <p>
-        Purchase dedicated IPs to manage your IP Pools
-      </p>,
-      "image": [Function],
-      "primaryAction": Object {
-        "Component": [Function],
-        "content": "Purchase IPs",
-        "to": "/account/billing",
-      },
-      "secondaryAction": Object {
-        "Component": [Function],
-        "content": "Create IP Pool",
-        "to": "/account/ip-pools/create",
-      },
-      "show": false,
-      "title": "Boost your deliverability",
-    }
-  }
+  empty={Object {}}
   primaryAction={
     Object {
       "Component": [Function],
       "content": "Create IP Pool",
       "to": "/account/ip-pools/create",
     }
+  }
+  secondaryActions={
+    Array [
+      Object {
+        "Component": [Function],
+        "content": "Purchase IPs",
+        "to": "/account/billing",
+      },
+    ]
   }
   title="IP Pools"
 >


### PR DESCRIPTION
- Removed the empty state from the ip pools list page
- Added the `shouldShowIpPurchaseCTA` selector to the form and edit pages, wrapped around the purchase links/copy
- Some clean up