### PR TITLE
FE-428 Replace support ticket form with message for heroku users

### DIFF
--- a/src/components/support/components/HerokuMessage.js
+++ b/src/components/support/components/HerokuMessage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Button } from '@sparkpost/matchbox';
+import { OpenInNew } from '@sparkpost/matchbox-icons';
+import styles from '../Support.module.scss';
+
+const HerokuMessage = () => (
+  <div className={styles.SupportContainer}>
+    <h6>Please submit a ticket through Heroku</h6>
+    <Button flat color='orange' external to='https://help.heroku.com'>Go to help.heroku.com <OpenInNew /></Button>
+  </div>
+);
+
+export default HerokuMessage;

--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -9,10 +9,12 @@ import { PageLink, SelectWrapper, TextFieldWrapper } from 'src/components';
 import FileFieldWrapper from 'src/components/reduxFormWrappers/FileFieldWrapper';
 import config from 'src/config';
 import { hasOnlineSupport } from 'src/helpers/conditions/account';
+import { isHeroku } from 'src/helpers/conditions/user';
 import { getBase64Contents } from 'src/helpers/file';
 import { required, maxFileSize } from 'src/helpers/validation';
 import { notAuthorizedToSubmitSupportTickets, selectSupportIssue, selectSupportIssues } from 'src/selectors/support';
 import NoIssues from './NoIssues';
+import HerokuMessage from './HerokuMessage';
 
 import styles from '../Support.module.scss';
 
@@ -110,7 +112,11 @@ export class SupportForm extends Component {
   }
 
   render() {
-    const { notAuthorizedToSubmitSupportTickets, openSupportPanel, submitSucceeded } = this.props;
+    const { notAuthorizedToSubmitSupportTickets, openSupportPanel, submitSucceeded, isHeroku } = this.props;
+
+    if (isHeroku) {
+      return <HerokuMessage />;
+    }
 
     if (notAuthorizedToSubmitSupportTickets) {
       return <NoIssues onCancel={openSupportPanel} />;
@@ -131,7 +137,8 @@ const mapStateToProps = (state) => ({
   needsOnlineSupport: !hasOnlineSupport(state),
   notAuthorizedToSubmitSupportTickets: notAuthorizedToSubmitSupportTickets(state),
   selectedIssue: selectSupportIssue(state, selector(state, 'issueId')),
-  ticketId: state.support.ticketId
+  ticketId: state.support.ticketId,
+  isHeroku: isHeroku(state)
 });
 
 const ReduxSupportForm = reduxForm({ form: formName })(SupportForm);

--- a/src/components/support/components/tests/HerokuMessage.test.js
+++ b/src/components/support/components/tests/HerokuMessage.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import HerokuMessage from '../HerokuMessage';
+
+describe('HerokuMessage View Component', () => {
+  it('should render', () => {
+    expect(shallow(<HerokuMessage />)).toMatchSnapshot();
+  });
+});

--- a/src/components/support/components/tests/SupportForm.test.js
+++ b/src/components/support/components/tests/SupportForm.test.js
@@ -12,7 +12,8 @@ describe('Support Form Component', () => {
     id: 'technical_issues',
     label: 'I need help!',
     messageLabel: 'Tell use more about your technical issue',
-    type: 'Support'
+    type: 'Support',
+    isHeroku: false
   };
 
   describe('Form', () => {
@@ -49,6 +50,11 @@ describe('Support Form Component', () => {
 
     it('should render unauthorized message', () => {
       wrapper.setProps({ notAuthorizedToSubmitSupportTickets: true });
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render heroku message', () => {
+      wrapper.setProps({ isHeroku: true });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/src/components/support/components/tests/__snapshots__/HerokuMessage.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/HerokuMessage.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HerokuMessage View Component should render 1`] = `
+<div
+  className="SupportContainer"
+>
+  <h6>
+    Please submit a ticket through Heroku
+  </h6>
+  <Button
+    color="orange"
+    external={true}
+    flat={true}
+    size="default"
+    to="https://help.heroku.com"
+  >
+    Go to help.heroku.com 
+    <OpenInNew />
+  </Button>
+</div>
+`;

--- a/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
+++ b/src/components/support/components/tests/__snapshots__/SupportForm.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Support Form Component Form should render heroku message 1`] = `<HerokuMessage />`;
+
 exports[`Support Form Component Form should render issue dropdown with help text 1`] = `
 <Field
   component={[Function]}


### PR DESCRIPTION
Two things:
- Not sure how to test a heroku user locally
- Is this the right url?

![screen shot 2018-07-03 at 5 15 02 pm](https://user-images.githubusercontent.com/3903325/42244879-af376b9c-7ee4-11e8-8904-0fd2a2417584.png)
