### PR TITLE
FE-442: Make Chrome translate users less unhappy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,13 @@
         "when": "never",
         "children": true
       }
+    ],
+    "no-restricted-syntax": [
+      "warn",
+      {
+        "message": "☀️ Plz avoid bare strings inside JSX ☀️",
+        "selector": "JSXElement[children.length > 1] > Literal[value=/\\w+/]"
+      }
     ]
   },
   "extends": [

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -19,16 +19,16 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, ...rest }) => {
     : null;
 
   return (
-    <span>
+    <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{plan.volume.toLocaleString()}</strong> <span>emails/month</span>
+        <strong>{plan.volume.toLocaleString()}</strong> emails/month
         {priceInfo.price > 0 && <span> at <strong>${priceInfo.price.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
-        {plan.isFree && <span>&nbsp;for Free</span>}
+        {plan.isFree && ' for Free'}
       </span>
       <span className={styles.SupportLabel}>
-        {showOverage && <span>{overage}</span>}
+        {showOverage && overage}
 
-        {showIp && <span>{ip}</span>}
+        {showIp && ip}
       </span>
     </span>
   );

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -21,14 +21,14 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, ...rest }) => {
   return (
     <span>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{ plan.volume.toLocaleString() }</strong> emails/month
+        <strong>{plan.volume.toLocaleString()}</strong> <span>emails/month</span>
         {priceInfo.price > 0 && <span> at <strong>${priceInfo.price.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
-        {plan.isFree && ' for Free'}
+        {plan.isFree && <span>&nbsp;for Free</span>}
       </span>
       <span className={styles.SupportLabel}>
-        {showOverage && overage }
+        {showOverage && <span>{overage}</span>}
 
-        { showIp && ip }
+        {showIp && <span>{ip}</span>}
       </span>
     </span>
   );

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -1,17 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PlanPrice allows class name overriding 1`] = `
-<span>
+<span
+  className="notranslate"
+>
   <span
     className="abcd-class"
   >
     <strong>
       50,000
     </strong>
-     
-    <span>
-      emails/month
-    </span>
+     emails/month
     <span>
        at 
       <strong>
@@ -29,17 +28,16 @@ exports[`PlanPrice allows class name overriding 1`] = `
 `;
 
 exports[`PlanPrice renders correctly 1`] = `
-<span>
+<span
+  className="notranslate"
+>
   <span
     className="MainLabel"
   >
     <strong>
       50,000
     </strong>
-     
-    <span>
-      emails/month
-    </span>
+     emails/month
     <span>
        at 
       <strong>
@@ -57,20 +55,17 @@ exports[`PlanPrice renders correctly 1`] = `
 `;
 
 exports[`PlanPrice renders correctly for free plan 1`] = `
-<span>
+<span
+  className="notranslate"
+>
   <span
     className="MainLabel"
   >
     <strong>
       50,000
     </strong>
-     
-    <span>
-      emails/month
-    </span>
-    <span>
-       for Free
-    </span>
+     emails/month
+     for Free
   </span>
   <span
     className="SupportLabel"
@@ -79,17 +74,16 @@ exports[`PlanPrice renders correctly for free plan 1`] = `
 `;
 
 exports[`PlanPrice renders correctly with hourly plans 1`] = `
-<span>
+<span
+  className="notranslate"
+>
   <span
     className="MainLabel"
   >
     <strong>
       50,000
     </strong>
-     
-    <span>
-      emails/month
-    </span>
+     emails/month
     <span>
        at 
       <strong>
@@ -107,17 +101,16 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
 `;
 
 exports[`PlanPrice renders free ip 1`] = `
-<span>
+<span
+  className="notranslate"
+>
   <span
     className="MainLabel"
   >
     <strong>
       50,000
     </strong>
-     
-    <span>
-      emails/month
-    </span>
+     emails/month
     <span>
        at 
       <strong>
@@ -131,25 +124,22 @@ exports[`PlanPrice renders free ip 1`] = `
   <span
     className="SupportLabel"
   >
-    <span>
-      First dedicated IP address is free
-    </span>
+    First dedicated IP address is free
   </span>
 </span>
 `;
 
 exports[`PlanPrice renders free ip and overage correct 1`] = `
-<span>
+<span
+  className="notranslate"
+>
   <span
     className="MainLabel"
   >
     <strong>
       50,000
     </strong>
-     
-    <span>
-      emails/month
-    </span>
+     emails/month
     <span>
        at 
       <strong>
@@ -163,12 +153,8 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
   <span
     className="SupportLabel"
   >
-    <span>
-      $0.75/ thousand extra emails. 
-    </span>
-    <span>
-      First dedicated IP address is free
-    </span>
+    $0.75/ thousand extra emails. 
+    First dedicated IP address is free
   </span>
 </span>
 `;
@@ -176,17 +162,16 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
 exports[`PlanPrice renders nothing when no plan 1`] = `""`;
 
 exports[`PlanPrice renders with overage 1`] = `
-<span>
+<span
+  className="notranslate"
+>
   <span
     className="MainLabel"
   >
     <strong>
       50,000
     </strong>
-     
-    <span>
-      emails/month
-    </span>
+     emails/month
     <span>
        at 
       <strong>
@@ -200,9 +185,7 @@ exports[`PlanPrice renders with overage 1`] = `
   <span
     className="SupportLabel"
   >
-    <span>
-      $0.75/ thousand extra emails. 
-    </span>
+    $0.75/ thousand extra emails. 
   </span>
 </span>
 `;

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -8,7 +8,10 @@ exports[`PlanPrice allows class name overriding 1`] = `
     <strong>
       50,000
     </strong>
-     emails/month
+     
+    <span>
+      emails/month
+    </span>
     <span>
        at 
       <strong>
@@ -33,7 +36,10 @@ exports[`PlanPrice renders correctly 1`] = `
     <strong>
       50,000
     </strong>
-     emails/month
+     
+    <span>
+      emails/month
+    </span>
     <span>
        at 
       <strong>
@@ -58,8 +64,13 @@ exports[`PlanPrice renders correctly for free plan 1`] = `
     <strong>
       50,000
     </strong>
-     emails/month
-     for Free
+     
+    <span>
+      emails/month
+    </span>
+    <span>
+       for Free
+    </span>
   </span>
   <span
     className="SupportLabel"
@@ -75,7 +86,10 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
     <strong>
       50,000
     </strong>
-     emails/month
+     
+    <span>
+      emails/month
+    </span>
     <span>
        at 
       <strong>
@@ -100,7 +114,10 @@ exports[`PlanPrice renders free ip 1`] = `
     <strong>
       50,000
     </strong>
-     emails/month
+     
+    <span>
+      emails/month
+    </span>
     <span>
        at 
       <strong>
@@ -114,7 +131,9 @@ exports[`PlanPrice renders free ip 1`] = `
   <span
     className="SupportLabel"
   >
-    First dedicated IP address is free
+    <span>
+      First dedicated IP address is free
+    </span>
   </span>
 </span>
 `;
@@ -127,7 +146,10 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
     <strong>
       50,000
     </strong>
-     emails/month
+     
+    <span>
+      emails/month
+    </span>
     <span>
        at 
       <strong>
@@ -141,8 +163,12 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
   <span
     className="SupportLabel"
   >
-    $0.75/ thousand extra emails. 
-    First dedicated IP address is free
+    <span>
+      $0.75/ thousand extra emails. 
+    </span>
+    <span>
+      First dedicated IP address is free
+    </span>
   </span>
 </span>
 `;
@@ -157,7 +183,10 @@ exports[`PlanPrice renders with overage 1`] = `
     <strong>
       50,000
     </strong>
-     emails/month
+     
+    <span>
+      emails/month
+    </span>
     <span>
        at 
       <strong>
@@ -171,7 +200,9 @@ exports[`PlanPrice renders with overage 1`] = `
   <span
     className="SupportLabel"
   >
-    $0.75/ thousand extra emails. 
+    <span>
+      $0.75/ thousand extra emails. 
+    </span>
   </span>
 </span>
 `;

--- a/src/components/reduxFormWrappers/FileFieldWrapper.js
+++ b/src/components/reduxFormWrappers/FileFieldWrapper.js
@@ -28,7 +28,7 @@ export default class FileFieldWrapper extends Component {
     this.dropzoneRef = ref;
   }
 
-  render () {
+  render() {
     const { disabled, fileType, helpText, input, label, meta, required } = this.props;
     const filename = _.get(input, 'value.name');
     const acceptedTypes = fileType ? `.${fileType}` : '';
@@ -57,7 +57,7 @@ export default class FileFieldWrapper extends Component {
           >
             {(filename && !meta.error)
               ? <span>{shrinkToFit(filename, 50)}</span>
-              : <span className={styles.Placeholder}><FileUpload /> Drag a file here, or click to browse</span>}
+              : <span className={styles.Placeholder}><FileUpload /><span>Drag a file here, or click to browse</span></span>}
           </Dropzone>
         </div>
         {helpText ? <div className={styles.Help}>{helpText}</div> : null}

--- a/src/components/reduxFormWrappers/tests/__snapshots__/FileFieldWrapper.test.js.snap
+++ b/src/components/reduxFormWrappers/tests/__snapshots__/FileFieldWrapper.test.js.snap
@@ -31,7 +31,9 @@ exports[`FileFieldWrapper renders disabled file input 1`] = `
         className="Placeholder"
       >
         <FileUpload />
-         Drag a file here, or click to browse
+        <span>
+          Drag a file here, or click to browse
+        </span>
       </span>
     </Dropzone>
   </div>
@@ -69,7 +71,9 @@ exports[`FileFieldWrapper renders file input 1`] = `
         className="Placeholder"
       >
         <FileUpload />
-         Drag a file here, or click to browse
+        <span>
+          Drag a file here, or click to browse
+        </span>
       </span>
     </Dropzone>
   </div>
@@ -111,7 +115,9 @@ exports[`FileFieldWrapper renders file input with error message 1`] = `
         className="Placeholder"
       >
         <FileUpload />
-         Drag a file here, or click to browse
+        <span>
+          Drag a file here, or click to browse
+        </span>
       </span>
     </Dropzone>
   </div>
@@ -149,7 +155,9 @@ exports[`FileFieldWrapper renders file input with help message 1`] = `
         className="Placeholder"
       >
         <FileUpload />
-         Drag a file here, or click to browse
+        <span>
+          Drag a file here, or click to browse
+        </span>
       </span>
     </Dropzone>
   </div>
@@ -192,7 +200,9 @@ exports[`FileFieldWrapper renders file input with no specified type 1`] = `
         className="Placeholder"
       >
         <FileUpload />
-         Drag a file here, or click to browse
+        <span>
+          Drag a file here, or click to browse
+        </span>
       </span>
     </Dropzone>
   </div>

--- a/src/components/tags/DomainStatusTag.js
+++ b/src/components/tags/DomainStatusTag.js
@@ -15,7 +15,7 @@ const DomainStatusTag = ({ status, className }) => {
       <Tooltip
         content='This domain must be verified before use.'
         dark>
-        <Tag className={className} color='yellow'><ErrorOutline size={size} /> Unverified</Tag>
+        <Tag className={className} color='yellow'><ErrorOutline size={size} /><span> Unverified</span></Tag>
       </Tooltip>
     );
   }
@@ -25,7 +25,7 @@ const DomainStatusTag = ({ status, className }) => {
       <Tooltip
         content='This domain is not available for use. For more information, please contact support.'
         dark>
-        <Tag className={className} color='red'><ErrorOutline size={size} /> Blocked</Tag>
+        <Tag className={className} color='red'><ErrorOutline size={size} /><span> Blocked</span></Tag>
       </Tooltip>
     );
   }
@@ -35,7 +35,7 @@ const DomainStatusTag = ({ status, className }) => {
       <Tooltip
         content='This domain is pending review, please check back again soon.'
         dark>
-        <Tag className={className}><Schedule size={size} /> Pending</Tag>
+        <Tag className={className}><Schedule size={size} /><span> Pending</span></Tag>
       </Tooltip>
     );
   }

--- a/src/components/tags/tests/__snapshots__/DomainStatusTag.test.js.snap
+++ b/src/components/tags/tests/__snapshots__/DomainStatusTag.test.js.snap
@@ -23,7 +23,9 @@ exports[`Component: DomainStatusTag should render for blocked status 1`] = `
     <ErrorOutline
       size={15}
     />
-     Blocked
+    <span>
+       Blocked
+    </span>
   </Tag>
 </Tooltip>
 `;
@@ -49,7 +51,9 @@ exports[`Component: DomainStatusTag should render for pending status 1`] = `
     <Schedule
       size={15}
     />
-     Pending
+    <span>
+       Pending
+    </span>
   </Tag>
 </Tooltip>
 `;
@@ -77,7 +81,9 @@ exports[`Component: DomainStatusTag should render for unverified status 1`] = `
     <ErrorOutline
       size={15}
     />
-     Unverified
+    <span>
+       Unverified
+    </span>
   </Tag>
 </Tooltip>
 `;

--- a/src/pages/sendingDomains/components/SetupSending.js
+++ b/src/pages/sendingDomains/components/SetupSending.js
@@ -100,7 +100,7 @@ export class SetupSending extends Component {
           color: 'orange'
         }]}
         sectioned
-        title={<Fragment>{titleIcon} DNS Settings</Fragment>}
+        title={<Fragment>{titleIcon} <span>DNS Settings</span></Fragment>}
       >
         <LabelledValue label='Type'><p>TXT</p></LabelledValue>
         <LabelledValue label='Hostname'><p>{dkimHostname}</p></LabelledValue>

--- a/src/pages/sendingDomains/components/tests/__snapshots__/SetupSending.test.js.snap
+++ b/src/pages/sendingDomains/components/tests/__snapshots__/SetupSending.test.js.snap
@@ -41,7 +41,10 @@ exports[`Component: SetupSending renders correctly for unverified DKIM and inval
       title={
         <React.Fragment>
           <ErrorIcon />
-           DNS Settings
+           
+          <span>
+            DNS Settings
+          </span>
         </React.Fragment>
       }
     >
@@ -111,7 +114,10 @@ exports[`Component: SetupSending renders correctly for unverified DKIM and inval
       title={
         <React.Fragment>
           <ErrorIcon />
-           DNS Settings
+           
+          <span>
+            DNS Settings
+          </span>
         </React.Fragment>
       }
     >
@@ -163,7 +169,10 @@ exports[`Component: SetupSending renders correctly when ownership and DKIM are v
       title={
         <React.Fragment>
           <VerifiedIcon />
-           DNS Settings
+           
+          <span>
+            DNS Settings
+          </span>
         </React.Fragment>
       }
     >
@@ -227,7 +236,10 @@ exports[`Component: SetupSending renders correctly when ownership is valid and D
       title={
         <React.Fragment>
           <ErrorIcon />
-           DNS Settings
+           
+          <span>
+            DNS Settings
+          </span>
         </React.Fragment>
       }
     >

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -98,7 +98,7 @@ export class ListPage extends Component {
         onDelete={this.handleDelete}
         onCancel={this.handleCancel}
         open={isOpen}
-        content={<p>User "{name}" will no longer be able to log in or access this SparkPost account and all API keys associated with this user will be immediately deleted.</p>}
+        content={<p><span>User "</span><span>{name}</span><span>" will no longer be able to log in or access this SparkPost account and all API keys associated with this user will be immediately deleted.</span></p>}
         title="Are you sure you want to delete this user?"
       />
     );
@@ -120,7 +120,7 @@ export class ListPage extends Component {
           }}
           defaultSortColumn='name'
         />
-        { this.renderDeleteModal() }
+        {this.renderDeleteModal()}
       </div>
     );
   }
@@ -142,7 +142,7 @@ export class ListPage extends Component {
           image: Users,
           content: <p>Manage your team's accounts and roles.</p>
         }}>
-        { error ? this.renderError() : this.renderPage() }
+        {error ? this.renderError() : this.renderPage()}
       </Page>
     );
   }

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -84,8 +84,13 @@ exports[`Page: Users List should render correctly by default 1`] = `
     <DeleteModal
       content={
         <p>
-          User "
-          " will no longer be able to log in or access this SparkPost account and all API keys associated with this user will be immediately deleted.
+          <span>
+            User "
+          </span>
+          <span />
+          <span>
+            " will no longer be able to log in or access this SparkPost account and all API keys associated with this user will be immediately deleted.
+          </span>
         </p>
       }
       onCancel={[Function]}


### PR DESCRIPTION
This PR starts to address the [interaction between React and Chrome's page translation feature](https://github.com/facebook/react/issues/11538).

In essence, Chrome replaces text nodes in the DOM with translated equivalents. React expects exclusive access to the DOM so it throws when it next tries to do updates around translated content.

For instance, in the following:

 ```jsx
<h1>{ showIcon && 'This is bare text' }</h1>
```

If we toggle `showIcon` after Chrome translates the text, React tries to remove a now-nonexistent node.

### Issue Detection and Linting
I added an eslint rule to warn about the most common instance of the issue. It detects a bare string inside JSX with at least 1 sibling. For example:

```jsx
const MyThing = () => <div>This is bare text with this sibling: <Sibling /></div>;
```

This doesn't catch variables or expressions that evaluate to bare strings unfortunately.

### Minimal Fixes

The absolute simplest thing is to wrap bare text in `<span>` to insulate React from DOM edits underneath. It's ugly in complex cases though and there are some edges where it doesn't work.

### Outstanding Issues
 - The simple fix is ugly and, if applied as an autofix, would cruft up a lot of code unnecessarily
 - Complex cases are not auto-detected (think `<p>{ thisMightBeAString }</p` or `<p>{ funcWhichCouldReturnWhateverOrNothing() }</p>`)
 - Current lint rule warns unnecessarily on cases where the content won't change such as config and props: `<p>{ fixedValueProp && 'Some text' }</p>`
 - The PlanPicker renders incorrectly after translation due to some unknown translation-related DOM edit.
 - ChangePlan's component tree is so nested and spread over source files, it's difficult to comprehend.
