### PR TITLE
Fix error: val.replace is not a function

### DIFF
--- a/src/helpers/analytics/tests/__snapshots__/utils.test.js.snap
+++ b/src/helpers/analytics/tests/__snapshots__/utils.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Analytics Utils determineFormValidationState serializes when syncErrors contains object in value 1`] = `
+Object {
+  "action": "Validation Error",
+  "label": "fooForm: billingInfo={\\"address\\":\\"Required\\",\\"zip\\":\\"Required\\"}",
+}
+`;
+
 exports[`Analytics Utils determineFormValidationState validation error with fields errors 1`] = `
 Object {
   "action": "Validation Error",

--- a/src/helpers/analytics/tests/utils.test.js
+++ b/src/helpers/analytics/tests/utils.test.js
@@ -46,6 +46,12 @@ describe('Analytics Utils', () => {
         payload: { syncErrors: { _error: 'must be value=2' }},
         meta: { form: 'fooForm' }
       }
+    },
+    'serializes when syncErrors contains object in value': {
+      action: {
+        payload: { syncErrors: { billingInfo: { address: 'Required', zip: 'Required' }}},
+        meta: { form: 'fooForm' }
+      }
     }
   };
 

--- a/src/helpers/analytics/utils.js
+++ b/src/helpers/analytics/utils.js
@@ -7,7 +7,7 @@ export function isWhitelistedForm(event) {
 }
 
 export function determineFormValidationState(action) {
-  const fieldErrors = _.map(action.payload.syncErrors, (val, key) => `${key}=${val.replace('=','%3D')}`); //in case any error message contains equal sign (=)
+  const fieldErrors = _.map(action.payload.syncErrors, (val, key) => `${key}=${_.isString(val) ? val.replace('=','%3D') : JSON.stringify(val)}`);
 
   return {
     action: `Validation ${fieldErrors.length ? 'Error' : 'Success'}`,


### PR DESCRIPTION
(json serialize when val is object)

created this PR as hotfix as it's broken on `master` (though it's not deployed to prod yet)