### PR TITLE
FE-407 Deprecated plans cannot submit sending limit increase requests

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -65,6 +65,33 @@ _Note: Routes default to exact: true because [it makes more sense](https://githu
 
 Condition helpers are functions that return a condition function. Any time you need to use an access control condition, create a helper for that condition scenario. Whenever that returned function is called, it will be passed an object containing whatever [the `accessConditionState` selector](#access-condition-selector) returns, and it should return a boolean that reflects the access decision.
 
+#### Using condition helpers as selectors
+
+IMPORTANT NOTE: These functions are _primarily_ meant to be used with the Access Control components in this repo. They _cannot_ be used directly as selectors without first wrapping them with the `selectCondition` method exported from the accessConditionState selector.
+
+```js
+const isCool = ({ account }) => account.isCool
+
+// Best way, use access control components
+<AccessControl condition={isCool}>
+  {...}
+</AccessControl>
+
+// Good, if you want to use the boolean value outside of access control components
+import { selectCondition } from 'src/selectors/accessConditionState'
+
+const mapStateToProps = (state) => ({
+  isCool: selectCondition(isCool)(state) // will break someday
+})
+
+// Bad, do not do
+const mapStateToProps = (state) => ({
+  isCool: isCool(state) // will break someday
+})
+```
+
+#### Condition helpers should return functions
+
 To avoid repetitiveness and noise, don't make helpers that work like this:
 ```js
 // helpers/conditions/hasGrants.js

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -36,6 +36,28 @@ render() {
 
   _Note: The redirect will not happen before the `accessControlReady` flag is true in the global redux store. See the [Access Control Ready](#access-control-ready) section below for more information._
 
+## The `ConditionSwitch` and `Case` components
+
+Sometimes you want to evaluate a number of conditions but only act on the first condition that returns "true". This is how react router's "Switch" component works, and we've duplicated that here as well. For example:
+
+```jsx
+import { ConditionSwitch, Case } from 'src/components/auth'
+
+<ConditionSwitch>
+  <Case condition={onPlan('free-0817')}>
+    <h1>Show me to FREE customers</h1>
+  </Case>
+  <Case condition={not(isActive)}>
+    <h1>Show me to anyone who isn't FREE, and isn't active</h1>
+  </Case>
+  <Case condition={() => true}>
+    <h1>This last case will act as a "default" and be shown to everyone "else"</h1>
+  </Case>
+</ConditionSwitch>
+```
+
+The `ConditionSwitch` component will loop over its first level of "children" and grab the "condition" prop from each to evaluate it. The `Case` component just acts as an intermediary component to put the condition prop on. You could in theory do `<h1 condition={}>` and it would work, but could conflict with props for that real component, so `Case` helps to keep that separated.
+
 ## Route access
 
 The `<ProtectedRoute>` component now wraps its given component with the `<AccessControl>` component, passing through the `condition` from the route config (if it exists). It also sets `redirect` to "/dashboard" so that if the condition fails for any route, it will be redirected.

--- a/src/actions/accessControl.js
+++ b/src/actions/accessControl.js
@@ -1,16 +1,12 @@
-import { fetch as fetchAccount } from './account';
+import { fetch as fetchAccount, getPlans } from './account';
 import { get as getCurrentUser, getGrants } from './currentUser';
 
 // initialize some state used for access control
 export function initializeAccessControl() {
   return (dispatch) => Promise.all([
     dispatch(fetchAccount()),
-    dispatch(getCurrentUser())
-      .then(({ access_level }) => dispatch(getGrants({ role: access_level })))
+    dispatch(getPlans()),
+    dispatch(getCurrentUser()).then(({ access_level }) => dispatch(getGrants({ role: access_level })))
   ])
-    .then(() => dispatch({ type: 'ACCESS_CONTROL_READY' }))
-    .catch((err) => {
-    // TODO: log to SENTRY
-    // for now, just ignore this error
-    });
+    .then(() => dispatch({ type: 'ACCESS_CONTROL_READY' }));
 }

--- a/src/actions/tests/accessControl.test.js
+++ b/src/actions/tests/accessControl.test.js
@@ -1,0 +1,31 @@
+import { initializeAccessControl } from '../accessControl';
+import { fetch as fetchAccount, getPlans } from 'src/actions/account';
+import { get as getCurrentUser, getGrants } from 'src/actions/currentUser';
+
+jest.mock('src/actions/account');
+jest.mock('src/actions/currentUser');
+
+describe('Action: Initialize Access Control', () => {
+
+  beforeEach(() => {
+    fetchAccount.mockImplementation(() => Promise.resolve('test-account'));
+    getPlans.mockImplementation(() => Promise.resolve('test-plans'));
+    getCurrentUser.mockImplementation(() => Promise.resolve({ access_level: 'EQUISAPIEN' }));
+    getGrants.mockImplementation(() => Promise.resolve('test-grants'));
+  });
+
+  it('should initialize access control with a series of calls', async () => {
+    const dispatchMock = jest.fn((a) => a);
+    await initializeAccessControl()(dispatchMock);
+
+    expect(fetchAccount).toHaveBeenCalledTimes(1);
+    expect(getPlans).toHaveBeenCalledTimes(1);
+    expect(getCurrentUser).toHaveBeenCalledTimes(1);
+    expect(getGrants).toHaveBeenCalledWith({ role: 'EQUISAPIEN' });
+    expect(dispatchMock).toHaveBeenCalledTimes(5);
+    expect(dispatchMock).toHaveBeenLastCalledWith({
+      type: 'ACCESS_CONTROL_READY'
+    });
+  });
+
+});

--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -39,10 +39,6 @@ export class SendMoreCTA extends Component {
     return verifyingEmail ? <span>Resending a verification email... </span> : resendVerificationLink;
   }
 
-  renderUpgradeCTA() {
-    return <PageLink to="/account/billing">Upgrade your account.</PageLink>;
-  }
-
   renderSupportTicketCTA() {
     return (
       <Fragment>
@@ -63,10 +59,10 @@ export class SendMoreCTA extends Component {
             <Case condition={not(isEmailVerified)} children={this.renderVerifyEmailCTA()} />
 
             {/* on a deprecated plan */}
-            <Case condition={onPlanWithStatus('deprecated')} children={this.renderUpgradeCTA()} />
+            <Case condition={onPlanWithStatus('deprecated')} children={<PageLink to="/account/billing">Switch to a new plan.</PageLink>} />
 
             {/* is self serve billing and doesn't have online support */}
-            <Case condition={all(isSelfServeBilling, not(hasOnlineSupport))} children={this.renderUpgradeCTA()} />
+            <Case condition={all(isSelfServeBilling, not(hasOnlineSupport))} children={<PageLink to="/account/billing">Upgrade your account.</PageLink>} />
 
             {/* has online support and is active account status */}
             <Case condition={all(hasOnlineSupport, hasStatus('active'))} children={this.renderSupportTicketCTA()} />

--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -8,7 +8,7 @@ import { PageLink } from 'src/components';
 import ConditionSwitch, { Case } from 'src/components/auth/ConditionSwitch';
 import { AccessControl } from 'src/components/auth';
 import { isAdmin, isEmailVerified } from 'src/helpers/conditions/user';
-import { hasOnlineSupport, hasStatus, isSelfServeBilling } from 'src/helpers/conditions/account';
+import { hasOnlineSupport, hasStatus, isSelfServeBilling, onPlanWithStatus } from 'src/helpers/conditions/account';
 import { all } from 'src/helpers/conditions/compose';
 import { not } from 'src/helpers/conditions';
 import { LINKS } from 'src/constants';
@@ -61,6 +61,9 @@ export class SendMoreCTA extends Component {
 
             {/* email isn't verified */}
             <Case condition={not(isEmailVerified)} children={this.renderVerifyEmailCTA()} />
+
+            {/* on a deprecated plan */}
+            <Case condition={onPlanWithStatus('deprecated')} children={this.renderUpgradeCTA()} />
 
             {/* is self serve billing and doesn't have online support */}
             <Case condition={all(isSelfServeBilling, not(hasOnlineSupport))} children={this.renderUpgradeCTA()} />

--- a/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
@@ -29,6 +29,15 @@ exports[`SendMoreCTA Component renders correctly 1`] = `
       <Case
         condition={[Function]}
       >
+        <PageLink
+          to="/account/billing"
+        >
+          Upgrade your account.
+        </PageLink>
+      </Case>
+      <Case
+        condition={[Function]}
+      >
         <React.Fragment>
           <UnstyledLink
             onClick={[Function]}

--- a/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
@@ -23,7 +23,7 @@ exports[`SendMoreCTA Component renders correctly 1`] = `
         <PageLink
           to="/account/billing"
         >
-          Upgrade your account.
+          Switch to a new plan.
         </PageLink>
       </Case>
       <Case

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-
-import { hasOnlineSupport, hasStatus, hasStatusReasonCategory, isSuspendedForBilling } from 'src/helpers/conditions/account';
+import { hasOnlineSupport, hasStatus, hasStatusReasonCategory, isSuspendedForBilling, onPlanWithStatus } from 'src/helpers/conditions/account';
+import { isEmailVerified } from 'src/helpers/conditions/user';
 import { all, not, any } from 'src/helpers/conditions';
 import { isAdmin } from 'src/helpers/conditions/user';
 
@@ -99,7 +99,15 @@ const supportIssues = [
     id: 'daily_limits',
     label: 'Daily sending limit increase',
     messageLabel: 'What limit do you need and why?',
-    type: LIMITS
+    type: LIMITS,
+    condition: all(hasOnlineSupport, isAdmin, isEmailVerified, hasStatus('active'), not(onPlanWithStatus('deprecated')))
+  },
+  {
+    id: 'general_issue',
+    label: 'Another issue',
+    messageLabel: 'Tell us more about your issue',
+    type: SUPPORT,
+    condition: all(hasOnlineSupport, hasStatus('active'))
   },
   {
     id: 'account_cancellation',

--- a/src/helpers/conditions/README.md
+++ b/src/helpers/conditions/README.md
@@ -1,5 +1,5 @@
 # Access Condition Helpers
 
-IMPORTANT NOTE: These functions are _only_ meant to be used with the Access Control components in this repo. They _cannot_ be used directly as selectors without first providing them with the "accessConditionState" which is provided by src/selectors/accessConditionState (there are a few account-related selectors in that file that make some of the account condition helpers available as selectors, as an example of how to do that).
+These are methods that receive a specially selected chunk of redux state and return a boolean value, to be used for logic and access control decisions throughout the app.
 
-For more on access control and how it works, see [the access control docs](/docs/access-control.md)
+For more on condition helpers, see [the access control docs](/docs/access-control.md#condition-helpers)

--- a/src/helpers/conditions/README.md
+++ b/src/helpers/conditions/README.md
@@ -1,0 +1,5 @@
+# Access Condition Helpers
+
+IMPORTANT NOTE: These functions are _only_ meant to be used with the Access Control components in this repo. They _cannot_ be used directly as selectors without first providing them with the "accessConditionState" which is provided by src/selectors/accessConditionState (there are a few account-related selectors in that file that make some of the account condition helpers available as selectors, as an example of how to do that).
+
+For more on access control and how it works, see [the access control docs](/docs/access-control.md)

--- a/src/helpers/conditions/__mocks__/account.js
+++ b/src/helpers/conditions/__mocks__/account.js
@@ -1,4 +1,5 @@
 export const onPlan = jest.fn(() => () => true);
+export const onPlanWithStatus = jest.fn(() => () => true);
 export const hasStatus = jest.fn(() => true);
 export const hasStatusReasonCategory = jest.fn(() => true);
 export const isAws = jest.fn(() => true);

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -1,7 +1,8 @@
 import { any, all } from './compose';
 import _ from 'lodash';
 
-export const onPlan = (plan) => ({ account }) => account.subscription.code === plan;
+export const onPlan = (planCode) => ({ accountPlan }) => accountPlan.code === planCode;
+export const onPlanWithStatus = (status) => ({ accountPlan }) => accountPlan.status === status;
 export const onServiceLevel = (level) => ({ account }) => account.service_level === level;
 export const isEnterprise = any(
   onPlan('ent1'),

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -1,5 +1,6 @@
 import {
   onPlan,
+  onPlanWithStatus,
   onServiceLevel,
   isEnterprise,
   isSuspendedForBilling,
@@ -9,32 +10,22 @@ import {
   hasOnlineSupport
 } from '../account';
 
-describe('Condition: onPlan', () => {
-
-  it('should return a function that returns true if on given plan', () => {
-    const condition = onPlan('p1');
-    expect(condition({ account: { subscription: { code: 'p1' }}})).toEqual(true);
-  });
-
-  it('should return a function that returns false if not on the given plan', () => {
-    const condition = onPlan('p1');
-    expect(condition({ account: { subscription: { code: 'p2' }}})).toEqual(false);
-  });
-
+test('Condition: onPlan', () => {
+  const condition = onPlan('p1');
+  expect(condition({ accountPlan: { code: 'p1' }})).toEqual(true);
+  expect(condition({ accountPlan: { code: 'p2' }})).toEqual(false);
 });
 
-describe('Condition: onServiceLevel', () => {
+test('Condition: onPlanWithStatus', () => {
+  const condition = onPlanWithStatus('deprecated');
+  expect(condition({ accountPlan: { status: 'deprecated' }})).toEqual(true);
+  expect(condition({ accountPlan: { status: 'bananas' }})).toEqual(false);
+});
 
-  it('should return a function that returns false if not on given level', () => {
-    const condition = onServiceLevel('other');
-    expect(condition({ account: { service_level: 'standard' }})).toEqual(false);
-  });
-
-  it('should return a function that returns true if on the given level', () => {
-    const condition = onServiceLevel('other');
-    expect(condition({ account: { service_level: 'other' }})).toEqual(true);
-  });
-
+test('Condition: onServiceLevel', () => {
+  const condition = onServiceLevel('other');
+  expect(condition({ account: { service_level: 'other' }})).toEqual(true);
+  expect(condition({ account: { service_level: 'standard' }})).toEqual(false);
 });
 
 describe('Condition: isEnterprise', () => {
@@ -43,6 +34,8 @@ describe('Condition: isEnterprise', () => {
   let state;
   beforeEach(() => {
     state = {
+      accountPlan: {},
+      plans: [],
       account: {
         subscription: {
           code: 'abc1'
@@ -54,7 +47,7 @@ describe('Condition: isEnterprise', () => {
   });
 
   it('should return a function that returns true if on ent1 plan', () => {
-    state.account.subscription.code = 'ent1';
+    state.accountPlan.code = 'ent1';
     expect(condition(state)).toEqual(true);
   });
 

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -18,7 +18,8 @@ import PaymentForm from './fields/PaymentForm';
 import BillingAddressForm from './fields/BillingAddressForm';
 import Confirmation from '../components/Confirmation';
 import CardSummary from '../components/CardSummary';
-import { isAws, isSelfServeBilling } from 'src/selectors/accessConditionState';
+import { isAws, isSelfServeBilling } from 'src/helpers/conditions/account';
+import { selectCondition } from 'src/selectors/accessConditionState';
 import { not } from 'src/helpers/conditions';
 import * as conversions from 'src/helpers/conversionTracking';
 import AccessControl from 'src/components/auth/AccessControl';
@@ -59,7 +60,7 @@ export class ChangePlanForm extends Component {
     // decides which action to be taken based on
     // if it's aws account, it already has billing and if you use a saved CC
     let action;
-    if (isAws({ account })) {
+    if (this.props.isAws) {
       action = updateSubscription({ code: newCode });
     } else if (account.billing) {
       action = this.state.useSavedCC ? updateSubscription({ code: newCode }) : billingUpdate(newValues);
@@ -159,10 +160,11 @@ const mapStateToProps = (state, props) => {
 
   return {
     loading: (!state.account.created && state.account.loading) || (plans.length === 0 && state.billing.plansLoading),
+    isAws: selectCondition(isAws)(state),
     account: state.account,
     billing: state.billing,
     canUpdateBillingInfo: canUpdateBillingInfoSelector(state),
-    isSelfServeBilling: isSelfServeBilling(state),
+    isSelfServeBilling: selectCondition(isSelfServeBilling)(state),
     plans,
     currentPlan: currentPlanSelector(state),
     selectedPlan: selector(state, 'planpicker') || {},

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -13,13 +13,12 @@ import {
   currentPlanSelector, canUpdateBillingInfoSelector, selectVisiblePlans
 } from 'src/selectors/accountBillingInfo';
 import { Panel, Grid } from '@sparkpost/matchbox';
-import { PlanPicker } from 'src/components';
-import { Loading } from 'src/components';
+import { Loading, PlanPicker } from 'src/components';
 import PaymentForm from './fields/PaymentForm';
 import BillingAddressForm from './fields/BillingAddressForm';
 import Confirmation from '../components/Confirmation';
 import CardSummary from '../components/CardSummary';
-import { isAws, isSelfServeBilling } from 'src/helpers/conditions/account';
+import { isAws, isSelfServeBilling } from 'src/selectors/accessConditionState';
 import { not } from 'src/helpers/conditions';
 import * as conversions from 'src/helpers/conversionTracking';
 import AccessControl from 'src/components/auth/AccessControl';

--- a/src/pages/billing/forms/tests/ChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/ChangePlanForm.test.js
@@ -48,7 +48,7 @@ describe('Form Container: Change Plan', () => {
       billingCreate: jest.fn(() => Promise.resolve()),
       billingUpdate: jest.fn(() => Promise.resolve()),
       updateSubscription: jest.fn(() => Promise.resolve()),
-      isAWSAccount: false
+      isAws: false
     };
     accountConditions.isAws = jest.fn(() => false);
     wrapper = shallow(<ChangePlanForm {...props} />);
@@ -133,7 +133,7 @@ describe('Form Container: Change Plan', () => {
     });
 
     it('should update subscription for aws account', async () => {
-      accountConditions.isAws.mockImplementation(() => true);
+      wrapper.setProps({ isAws: true });
       await instance.onSubmit({ planpicker: { code: 'free' }});
       expect(instance.props.updateSubscription).toHaveBeenCalledWith({ code: 'free' });
     });

--- a/src/pages/billing/forms/tests/ChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/ChangePlanForm.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { ChangePlanForm } from '../ChangePlanForm';
 import { shallow } from 'enzyme';
-import * as accountConditions from 'src/helpers/conditions/account';
+import * as accountConditions from 'src/selectors/accessConditionState';
 import * as conversions from 'src/helpers/conversionTracking';
 
-jest.mock('src/helpers/conditions/account');
+jest.mock('src/selectors/accessConditionState');
 jest.mock('src/helpers/conversionTracking');
 
 describe('Form Container: Change Plan', () => {

--- a/src/selectors/__mocks__/accessConditionState.js
+++ b/src/selectors/__mocks__/accessConditionState.js
@@ -1,4 +1,2 @@
 export default jest.fn(() => ({}));
-export const onPlan = jest.fn(() => () => true);
-export const isAws = jest.fn(() => true);
-export const isSelfServeBilling = jest.fn(() => true);
+export const selectCondition = jest.fn(() => () => true);

--- a/src/selectors/__mocks__/accessConditionState.js
+++ b/src/selectors/__mocks__/accessConditionState.js
@@ -1,0 +1,4 @@
+export default jest.fn(() => ({}));
+export const onPlan = jest.fn(() => () => true);
+export const isAws = jest.fn(() => true);
+export const isSelfServeBilling = jest.fn(() => true);

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -1,9 +1,10 @@
 import { createSelector } from 'reselect';
+import _ from 'lodash';
 import * as accountConditions from 'src/helpers/conditions/account';
 
 const getAccount = (state) => state.account;
 const getUser = (state) => state.currentUser;
-const getPlans = (state) => state.billing.plans || [];
+const getPlans = (state) => _.get(state, 'billing.plans', []);
 const getACReady = (state) => state.accessControlReady;
 
 export const getCurrentAccountPlan = createSelector(

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -1,11 +1,52 @@
 import { createSelector } from 'reselect';
+import * as accountConditions from 'src/helpers/conditions/account';
 
 const getAccount = (state) => state.account;
 const getUser = (state) => state.currentUser;
+const getPlans = (state) => state.billing.plans || [];
 const getACReady = (state) => state.accessControlReady;
 
-export default createSelector(
-  [getAccount, getUser, getACReady],
-  (account, currentUser, ready) => ({ account, currentUser, ready })
+export const getCurrentAccountPlan = createSelector(
+  [getAccount, getPlans],
+  (account, plans) => plans.find((plan) => plan.code === account.subscription.code) || {}
 );
 
+const selectAccessConditionState = createSelector(
+  [getAccount, getUser, getPlans, getCurrentAccountPlan, getACReady],
+  (account, currentUser, plans, accountPlan, ready) => ({
+    account,
+    currentUser,
+    plans,
+    accountPlan,
+    ready
+  })
+);
+
+export default selectAccessConditionState;
+
+/**
+ * The following are a list of selectors that make
+ * condition helpers available to be used as "regular"
+ * selectors by first grabbing the computed access condition
+ * state and passing it to the condition, as it expects.
+ *
+ * Without this, using conditions as selectors would fail
+ * because things like 'accountPlan' would not be available.
+ *
+ * There may be a better way to organize this. :)
+ */
+
+export const onPlan = (planCode) => createSelector(
+  [selectAccessConditionState],
+  (state) => accountConditions.onPlan(planCode)(state)
+);
+
+export const isAws = createSelector(
+  [selectAccessConditionState],
+  accountConditions.isAws
+);
+
+export const isSelfServeBilling = createSelector(
+  [selectAccessConditionState],
+  accountConditions.isSelfServeBilling
+);

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 import _ from 'lodash';
-import * as accountConditions from 'src/helpers/conditions/account';
 
 const getAccount = (state) => state.account;
 const getUser = (state) => state.currentUser;
@@ -37,17 +36,19 @@ export default selectAccessConditionState;
  * There may be a better way to organize this. :)
  */
 
-export const onPlan = (planCode) => createSelector(
-  [selectAccessConditionState],
-  (state) => accountConditions.onPlan(planCode)(state)
-);
+export const selectCondition = (condition) => createSelector([selectAccessConditionState], condition);
 
-export const isAws = createSelector(
-  [selectAccessConditionState],
-  accountConditions.isAws
-);
+// export const onPlan = (planCode) => createSelector(
+//   [selectAccessConditionState],
+//   (state) => accountConditions.onPlan(planCode)(state)
+// );
 
-export const isSelfServeBilling = createSelector(
-  [selectAccessConditionState],
-  accountConditions.isSelfServeBilling
-);
+// export const isAws = createSelector(
+//   [selectAccessConditionState],
+//   accountConditions.isAws
+// );
+
+// export const isSelfServeBilling = createSelector(
+//   [selectAccessConditionState],
+//   accountConditions.isSelfServeBilling
+// );

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -25,30 +25,12 @@ const selectAccessConditionState = createSelector(
 export default selectAccessConditionState;
 
 /**
- * The following are a list of selectors that make
- * condition helpers available to be used as "regular"
- * selectors by first grabbing the computed access condition
- * state and passing it to the condition, as it expects.
+ * Use this helper to "wrap" a condition helper and turn it into a "regular selector"
  *
- * Without this, using conditions as selectors would fail
- * because things like 'accountPlan' would not be available.
- *
- * There may be a better way to organize this. :)
+ * Condition helpers expect a very specific state, so using condition helpers directly
+ * in mapStateToProps or in other selectors doesn't work. But by using this wrapper,
+ * the condition helper will be given the correct state to accurately return its boolean value.
  */
 
 export const selectCondition = (condition) => createSelector([selectAccessConditionState], condition);
 
-// export const onPlan = (planCode) => createSelector(
-//   [selectAccessConditionState],
-//   (state) => accountConditions.onPlan(planCode)(state)
-// );
-
-// export const isAws = createSelector(
-//   [selectAccessConditionState],
-//   accountConditions.isAws
-// );
-
-// export const isSelfServeBilling = createSelector(
-//   [selectAccessConditionState],
-//   accountConditions.isSelfServeBilling
-// );

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -1,11 +1,16 @@
 import { createSelector } from 'reselect';
 import _ from 'lodash';
-import { isAws, isSelfServeBilling, onPlan } from './accessConditionState';
+import { isAws, isSelfServeBilling, onPlan } from 'src/helpers/conditions/account';
+import { selectCondition } from './accessConditionState';
 
 const suspendedSelector = (state) => state.account.isSuspendedForBilling;
 const pendingSubscriptionSelector = (state) => state.account.pending_subscription;
 const plansSelector = (state) => state.billing.plans || [];
 const accountBillingSelector = (state) => state.account.billing;
+const selectIsAws = selectCondition(isAws);
+const selectIsSelfServeBilling = selectCondition(isSelfServeBilling);
+const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
+const selectIsFree1 = selectCondition(onPlan('free1'));
 
 export const currentSubscriptionSelector = (state) => state.account.subscription;
 
@@ -35,16 +40,11 @@ export const currentPlanSelector = createSelector(
   (currentPlanCode, plans) => _.find(plans, { code: currentPlanCode }) || {}
 );
 
-export const isAWSAccountSelector = createSelector(
-  [currentSubscriptionSelector],
-  (currentSubscription) => currentSubscription.type === 'aws'
-);
-
 /**
  * Returns true if user has billing account and they are on a paid plan
  */
 export const canUpdateBillingInfoSelector = createSelector(
-  [currentPlanSelector, accountBillingSelector, onPlan('ccfree1')],
+  [currentPlanSelector, accountBillingSelector, selectIsCcFree1],
   (currentPlan, accountBilling, isOnLegacyCcFreePlan) => (
     accountBilling && (isOnLegacyCcFreePlan || !currentPlan.isFree)
   )
@@ -54,12 +54,12 @@ export const canUpdateBillingInfoSelector = createSelector(
  * Return true if plan can purchase IP and has billing info (except for aws as it'll be billed outside)
  */
 export const canPurchaseIps = createSelector(
-  [currentPlanSelector, accountBillingSelector, isAWSAccountSelector],
+  [currentPlanSelector, accountBillingSelector, selectIsAws],
   (currentPlan, accountBilling, isAWSAccount) => currentPlan.canPurchaseIps === true && !!(accountBilling || isAWSAccount)
 );
 
 export const selectAvailablePlans = createSelector(
-  [plansSelector, isAws, isSelfServeBilling],
+  [plansSelector, selectIsAws, selectIsSelfServeBilling],
   (plans, isAws, isSelfServeBilling) => {
     const availablePlans = plans
       .filter(({ status }) => status === 'public' || status === 'secret')
@@ -75,7 +75,7 @@ export const selectAvailablePlans = createSelector(
 );
 
 export const selectVisiblePlans = createSelector(
-  [selectAvailablePlans, onPlan('free1')],
+  [selectAvailablePlans, selectIsFree1],
   (plans, isOnLegacyFree1Plan) => plans.filter(({ isFree, status }) =>
     status === 'public' &&
         !(isOnLegacyFree1Plan && isFree) //hide new free plans if on legacy free1 plan
@@ -89,7 +89,7 @@ export const selectBillingInfo = createSelector(
     canPurchaseIps,
     currentPlanSelector,
     selectVisiblePlans,
-    isAWSAccountSelector
+    selectIsAws
   ],
   (canUpdateBillingInfo, canChangePlan, canPurchaseIps, currentPlan, plans, isAWSAccount) => ({
     canUpdateBillingInfo,

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import _ from 'lodash';
-import { isAws, isSelfServeBilling, onPlan } from 'src/helpers/conditions/account';
+import { isAws, isSelfServeBilling, onPlan } from './accessConditionState';
 
 const suspendedSelector = (state) => state.account.isSuspendedForBilling;
 const pendingSubscriptionSelector = (state) => state.account.pending_subscription;

--- a/src/selectors/tests/accessConditionState.test.js
+++ b/src/selectors/tests/accessConditionState.test.js
@@ -1,5 +1,4 @@
-import selectAccessCondtionState, { onPlan, isAws, isSelfServeBilling } from '../accessConditionState';
-import * as accountConditions from 'src/helpers/conditions/account';
+import selectAccessCondtionState, { selectCondition } from '../accessConditionState';
 
 jest.mock('src/helpers/conditions/account');
 
@@ -7,7 +6,6 @@ describe('Selector: Access Condition State', () => {
 
   let testState;
   let testAccessConditionState;
-  let onPlanMock;
 
   beforeEach(() => {
     testState = {
@@ -34,29 +32,16 @@ describe('Selector: Access Condition State', () => {
       plans: testState.billing.plans,
       ready: false
     };
-
-    onPlanMock = jest.fn();
-    accountConditions.onPlan = jest.fn(() => onPlanMock);
   });
 
   test('default selector should return the correct state', () => {
     expect(selectAccessCondtionState(testState)).toEqual(testAccessConditionState);
   });
 
-  test('onPlan condition selector should call condition with correct state', () => {
-    onPlan('test1')(testState);
-    expect(accountConditions.onPlan).toHaveBeenCalledWith('test1');
-    expect(onPlanMock).toHaveBeenCalledWith(testAccessConditionState);
-  });
-
-  test('isAws condition selector should call condition with correct state', () => {
-    isAws(testState);
-    expect(accountConditions.isAws).toHaveBeenCalledWith(testAccessConditionState);
-  });
-
-  test('isSelfServeBilling condition selector should call condition with correct state', () => {
-    isSelfServeBilling(testState);
-    expect(accountConditions.isSelfServeBilling).toHaveBeenCalledWith(testAccessConditionState);
+  test('selectCondition should provide correct state to passed in condition', () => {
+    const testCondition = jest.fn(() => true);
+    expect(selectCondition(testCondition)(testState)).toEqual(true);
+    expect(testCondition).toHaveBeenCalledWith(testAccessConditionState);
   });
 
 });

--- a/src/selectors/tests/accessConditionState.test.js
+++ b/src/selectors/tests/accessConditionState.test.js
@@ -1,18 +1,62 @@
-import selectAccessCondtionState from '../accessConditionState';
+import selectAccessCondtionState, { onPlan, isAws, isSelfServeBilling } from '../accessConditionState';
+import * as accountConditions from 'src/helpers/conditions/account';
+
+jest.mock('src/helpers/conditions/account');
 
 describe('Selector: Access Condition State', () => {
 
-  it('should return the correct state', () => {
-    const state = {
-      account: {},
+  let testState;
+  let testAccessConditionState;
+  let onPlanMock;
+
+  beforeEach(() => {
+    testState = {
+      account: {
+        subscription: {
+          code: 'plan2'
+        }
+      },
+      billing: {
+        plans: [
+          { code: 'plan1', name: 'Plan 1' },
+          { code: 'plan2', name: 'Plan 2' },
+          { code: 'plan3', name: 'Plan 3' }
+        ]
+      },
       currentUser: {},
       accessControlReady: false
     };
-    expect(selectAccessCondtionState(state)).toEqual({
-      account: state.account,
-      currentUser: state.currentUser,
+
+    testAccessConditionState = {
+      account: testState.account,
+      currentUser: testState.currentUser,
+      accountPlan: testState.billing.plans[1],
+      plans: testState.billing.plans,
       ready: false
-    });
+    };
+
+    onPlanMock = jest.fn();
+    accountConditions.onPlan = jest.fn(() => onPlanMock);
+  });
+
+  test('default selector should return the correct state', () => {
+    expect(selectAccessCondtionState(testState)).toEqual(testAccessConditionState);
+  });
+
+  test('onPlan condition selector should call condition with correct state', () => {
+    onPlan('test1')(testState);
+    expect(accountConditions.onPlan).toHaveBeenCalledWith('test1');
+    expect(onPlanMock).toHaveBeenCalledWith(testAccessConditionState);
+  });
+
+  test('isAws condition selector should call condition with correct state', () => {
+    isAws(testState);
+    expect(accountConditions.isAws).toHaveBeenCalledWith(testAccessConditionState);
+  });
+
+  test('isSelfServeBilling condition selector should call condition with correct state', () => {
+    isSelfServeBilling(testState);
+    expect(accountConditions.isSelfServeBilling).toHaveBeenCalledWith(testAccessConditionState);
   });
 
 });

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -216,6 +216,7 @@ describe('plan selector', () => {
 
     it('should not return new free plans if customer on free1 plan', () => {
       state.account.subscription.code = 'free1';
+      state.billing.plans.push({ code: 'free1' });
       expect(billingInfo.selectVisiblePlans(state)).toMatchSnapshot();
     });
   });

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -113,19 +113,6 @@ describe('selectBillingInfo', () => {
 
 });
 
-describe('isAWSAccountSelector', () => {
-  let state;
-  beforeEach(() => {
-    state = {
-      account: { subscription: { code: 'free', type: 'aws' }}
-    };
-  });
-
-  it('returns true when subscription type is aws', () => {
-    expect(billingInfo.isAWSAccountSelector(state)).toBe(true);
-  });
-});
-
 describe('canPurchaseIps', () => {
   let state;
   beforeEach(() => {


### PR DESCRIPTION
* updated access control to include plans
* moved around some selectors so that they still work
* added a README to explain a few things about condition helpers
* updated SendMoreCTA so that deprecated plans prompt for upgrade instead of allowing sending limits support request
* updated test

TODO:
* [x] block accounts on deprecated plans from submitting sending request support ticket in support panel