### PR TITLE
FE-495 Fix AB Testing Defects

### DIFF
--- a/src/actions/abTesting.js
+++ b/src/actions/abTesting.js
@@ -59,7 +59,8 @@ export function cancelAbTest({ id, subaccountId }) {
     meta: {
       method: 'POST',
       url: `/ab-test/${id}/cancel`,
-      headers: setSubaccountHeader(subaccountId)
+      headers: setSubaccountHeader(subaccountId),
+      id, subaccountId
     }
   });
 }

--- a/src/actions/tests/__snapshots__/abTesting.test.js.snap
+++ b/src/actions/tests/__snapshots__/abTesting.test.js.snap
@@ -7,7 +7,9 @@ Array [
       "headers": Object {
         "x-msys-subaccount": 101,
       },
+      "id": "test_one",
       "method": "POST",
+      "subaccountId": 101,
       "url": "/ab-test/test_one/cancel",
     },
     "type": "CANCEL_AB_TEST",

--- a/src/components/typeahead/TemplateTypeahead.js
+++ b/src/components/typeahead/TemplateTypeahead.js
@@ -37,7 +37,7 @@ export class TemplateTypeahead extends Component {
 }
 
 function mapStateToProps(state, props) {
-  const templates = selectPublishedTemplatesBySubaccount(state, props);
+  const templates = selectPublishedTemplatesBySubaccount(state, props.subaccountId);
   return {
     results: templates,
     hasTemplates: templates.length > 0

--- a/src/components/typeahead/Typeahead.js
+++ b/src/components/typeahead/Typeahead.js
@@ -46,7 +46,7 @@ export class Typeahead extends Component {
     }));
 
     const listClasses = cx('List', {
-      open: isOpen && (!inputValue || matches.length),
+      open: isOpen && !selectedItem && (!inputValue || matches.length),
       hasHelp: !!helpText
     });
 

--- a/src/components/typeahead/Typeahead.js
+++ b/src/components/typeahead/Typeahead.js
@@ -31,7 +31,7 @@ export class Typeahead extends Component {
     clearSelection,
     isOpen
   }) => {
-    const { name, results, disabled, label, placeholder = (isOpen ? 'Type to search' : 'None'), error, helpText, itemToString, renderItem } = this.props;
+    const { name, results, disabled, label, placeholder = (isOpen ? 'Type to search' : 'None'), error, helpText, errorInLabel, itemToString, renderItem } = this.props;
 
     const matches = sortMatch(
       results,
@@ -59,7 +59,8 @@ export class Typeahead extends Component {
       name,
       placeholder,
       helpText,
-      error: (!isOpen && error) ? error : null
+      error: (!isOpen && error) ? error : null,
+      errorInLabel
     });
 
     textFieldProps['data-lpignore'] = true;

--- a/src/helpers/templates.js
+++ b/src/helpers/templates.js
@@ -51,3 +51,17 @@ export const resolveTemplateStatus = ({ has_draft, has_published, published } = 
   // Unpublished draft template
   draft: !published && !has_published
 });
+
+
+/**
+ * Filters a list of templates available for use for the given subaccount
+ */
+export const filterTemplatesBySubaccount = ({ templates, subaccountId, hasSubaccounts }) => {
+  if (hasSubaccounts) {
+    return _.filter(templates, (template) => subaccountId
+      ? template.shared_with_subaccounts || template.subaccount_id === Number(subaccountId)
+      : !template.subaccount_id);
+  } else {
+    return templates;
+  }
+};

--- a/src/helpers/tests/__snapshots__/templates.test.js.snap
+++ b/src/helpers/tests/__snapshots__/templates.test.js.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`template helpers filterTemplatesBySubaccount should return published templates for a specific subaccount 1`] = `
+Array [
+  Object {
+    "has_published": false,
+    "name": "unpublished",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedSubaccount",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+  },
+]
+`;
+
+exports[`template helpers filterTemplatesBySubaccount should return published templates for master account 1`] = `
+Array [
+  Object {
+    "has_published": true,
+    "name": "publishedMaster",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 0,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+  },
+]
+`;
+
+exports[`template helpers filterTemplatesBySubaccount should return published templates if no subaccounts exist 1`] = `
+Array [
+  Object {
+    "has_published": false,
+    "name": "unpublished",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedSubaccount",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedMaster",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 0,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+  },
+]
+`;
+
 exports[`template helpers normalizeTemplateFromAddress does not change obj formatted from 1`] = `
 Object {
   "content": Object {

--- a/src/helpers/tests/templates.test.js
+++ b/src/helpers/tests/templates.test.js
@@ -74,4 +74,48 @@ describe('template helpers', () => {
       })).toMatchSnapshot();
     });
   });
+
+  describe('filterTemplatesBySubaccount', () => {
+    let templates;
+    beforeEach(() => {
+      templates = [
+        {
+          name: 'unpublished',
+          has_published: false,
+          shared_with_subaccounts: false,
+          subaccount_id: 101
+        },
+        {
+          name: 'publishedSubaccount',
+          has_published: true,
+          shared_with_subaccounts: false,
+          subaccount_id: 101
+        },
+        {
+          name: 'publishedMaster',
+          has_published: true,
+          shared_with_subaccounts: false,
+          subaccount_id: 0
+        },
+        {
+          name: 'publishedShared',
+          has_published: true,
+          shared_with_subaccounts: true,
+          subaccount_id: 0
+        }
+      ];
+    });
+
+    it('should return published templates for master account', () => {
+      expect(templatesHelper.filterTemplatesBySubaccount({ templates, subaccountId: null, hasSubaccounts: true })).toMatchSnapshot();
+    });
+
+    it('should return published templates for a specific subaccount', () => {
+      expect(templatesHelper.filterTemplatesBySubaccount({ templates, subaccountId: 101, hasSubaccounts: true })).toMatchSnapshot();
+    });
+
+    it('should return published templates if no subaccounts exist', () => {
+      expect(templatesHelper.filterTemplatesBySubaccount({ templates, subaccountId: null , hasSubaccounts: false })).toMatchSnapshot();
+    });
+  });
 });

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -31,7 +31,7 @@ export function abTestDefaultTemplate(value, allValues, props) {
   if (allValues.subaccount) {
     return 'Template not available to selected subaccount';
   }
-  return 'Subaccount templates not available to master account';
+  return 'Template not available to master account';
 }
 
 export function hasNumber(value) {

--- a/src/pages/abTesting/CreatePage.js
+++ b/src/pages/abTesting/CreatePage.js
@@ -24,7 +24,7 @@ export class CreatePage extends Component {
   create = (values) => {
     const { createAbTestDraft, showAlert, history } = this.props;
     const { id, name, subaccount, default_variant = {}} = values;
-    const subaccountId = subaccount ? subaccount.id : 0;
+    const subaccountId = subaccount ? subaccount.id : null;
     const default_template = { template_id: default_variant.id };
     const abTest = { id, name, default_template };
 

--- a/src/pages/abTesting/components/AbTestCreateForm.js
+++ b/src/pages/abTesting/components/AbTestCreateForm.js
@@ -7,7 +7,7 @@ import { TextFieldWrapper } from 'src/components';
 import { TemplateTypeaheadWrapper, SubaccountTypeaheadWrapper } from 'src/components/reduxFormWrappers';
 import { slugify } from 'src/helpers/string';
 import { hasSubaccounts as hasSubaccountsSelector } from 'src/selectors/subaccounts';
-import { selectPublishedTemplatesBySubaccountFromTypeahead } from 'src/selectors/templates';
+import { selectPublishedTemplatesBySubaccount } from 'src/selectors/templates';
 import { required, maxLength, abTestId, abTestDefaultTemplate } from 'src/helpers/validation';
 
 const formName = 'abTestCreateForm';
@@ -94,13 +94,13 @@ export class AbTestCreateForm extends Component {
 
 function mapStateToProps(state, props) {
   const selector = formValueSelector(formName);
+  const subaccountId = selector(state, 'subaccount.id');
 
   return {
     initialValues: {},
     hasSubaccounts: hasSubaccountsSelector(state),
-    templates: selectPublishedTemplatesBySubaccountFromTypeahead(state, props, formName),
-    // Subaccount ID here is used to filter available templates in the typeahead
-    subaccountId: selector(state, 'subaccount.id')
+    templates: selectPublishedTemplatesBySubaccount(state, subaccountId),
+    subaccountId // Subaccount ID is used to filter available templates in the typeahead
   };
 }
 

--- a/src/pages/abTesting/components/AbTestCreateForm.js
+++ b/src/pages/abTesting/components/AbTestCreateForm.js
@@ -7,8 +7,8 @@ import { TextFieldWrapper } from 'src/components';
 import { TemplateTypeaheadWrapper, SubaccountTypeaheadWrapper } from 'src/components/reduxFormWrappers';
 import { slugify } from 'src/helpers/string';
 import { hasSubaccounts as hasSubaccountsSelector } from 'src/selectors/subaccounts';
+import { selectPublishedTemplatesBySubaccountFromTypeahead } from 'src/selectors/templates';
 import { required, maxLength, abTestId, abTestDefaultTemplate } from 'src/helpers/validation';
-import { selectPublishedTemplatesBySubaccount } from 'src/selectors/templates';
 
 const formName = 'abTestCreateForm';
 
@@ -80,6 +80,7 @@ export class AbTestCreateForm extends Component {
               ? <span>We will send this template by default when the test is not running. If you need to create a new template, <UnstyledLink component={Link} to='/templates'>head over to the templates page</UnstyledLink>.</span>
               : <span>No available templates.  <UnstyledLink component={Link} to='/templates'>Head over to the templates page to set some up</UnstyledLink>.</span>
             }
+            errorInLabel
             validate={[required, abTestDefaultTemplate]}
           />
         </Panel.Section>
@@ -97,9 +98,9 @@ function mapStateToProps(state, props) {
   return {
     initialValues: {},
     hasSubaccounts: hasSubaccountsSelector(state),
-    templates: selectPublishedTemplatesBySubaccount(state, props),
-    // Subaccount ID here is used to filter and validate available templates in the typeahead
-    subaccountId: selector(state, 'subaccount.id') || 0
+    templates: selectPublishedTemplatesBySubaccountFromTypeahead(state, props, formName),
+    // Subaccount ID here is used to filter available templates in the typeahead
+    subaccountId: selector(state, 'subaccount.id')
   };
 }
 

--- a/src/pages/abTesting/components/tests/__snapshots__/AbTestCreateForm.test.js.snap
+++ b/src/pages/abTesting/components/tests/__snapshots__/AbTestCreateForm.test.js.snap
@@ -43,6 +43,7 @@ exports[`A/B Test Create Form Component should render correctly 1`] = `
   <Panel.Section>
     <Field
       component={[Function]}
+      errorInLabel={true}
       helpText={
         <span>
           We will send this template by default when the test is not running. If you need to create a new template, 
@@ -132,6 +133,7 @@ exports[`A/B Test Create Form Component should render when no available template
   <Panel.Section>
     <Field
       component={[Function]}
+      errorInLabel={true}
       helpText={
         <span>
           No available templates.  

--- a/src/pages/abTesting/tests/CreatePage.test.js
+++ b/src/pages/abTesting/tests/CreatePage.test.js
@@ -34,12 +34,12 @@ describe('A/B Test Create Page', () => {
   });
 
   it('should show an alert on successful A/B test creation', async () => {
-    await wrapper.instance().create({ id: 'woooooooow', subaccount: 1, default_variant: { id: 'ok' }});
+    await wrapper.instance().create({ id: 'woooooooow', subaccount: { id: 1 }, default_variant: { id: 'ok' }});
     expect(wrapper.instance().props.showAlert).toHaveBeenCalledWith({
       type: 'success',
       message: 'A/B test created'
     });
-    expect(wrapper.instance().props.history.push).toHaveBeenCalled();
+    expect(wrapper.instance().props.history.push).toHaveBeenCalledWith('/ab-testing/woooooooow/1?subaccount=1');
   });
 
   it('should show an alert on successful A/B test creation (no subaccounts)', async () => {
@@ -48,6 +48,6 @@ describe('A/B Test Create Page', () => {
       type: 'success',
       message: 'A/B test created'
     });
-    expect(wrapper.instance().props.history.push).toHaveBeenCalled();
+    expect(wrapper.instance().props.history.push).toHaveBeenCalledWith('/ab-testing/woooooooow/1');
   });
 });

--- a/src/reducers/abTesting.js
+++ b/src/reducers/abTesting.js
@@ -72,7 +72,11 @@ export default (state = initialState, { type, payload, meta }) => {
       return { ...state, cancelPending: true };
 
     case 'CANCEL_AB_TEST_SUCCESS':
-      return { ...state, cancelPending: false };
+      return {
+        ...state,
+        cancelPending: false,
+        list: state.list.map((t) => t.id === meta.id && t.subaccount_id === meta.subaccountId ? { ...t, status: payload.status } : t)
+      };
 
     case 'CANCEL_AB_TEST_FAIL':
       return { ...state, cancelPending: false };

--- a/src/reducers/abTesting.js
+++ b/src/reducers/abTesting.js
@@ -75,7 +75,7 @@ export default (state = initialState, { type, payload, meta }) => {
       return {
         ...state,
         cancelPending: false,
-        list: state.list.map((t) => t.id === meta.id && t.subaccount_id === meta.subaccountId ? { ...t, status: payload.status } : t)
+        list: state.list.map((t) => t.id === meta.id && t.subaccount_id === parseInt(meta.subaccountId, 10) ? { ...t, status: payload.status } : t)
       };
 
     case 'CANCEL_AB_TEST_FAIL':

--- a/src/reducers/tests/__snapshots__/abTesting.test.js.snap
+++ b/src/reducers/tests/__snapshots__/abTesting.test.js.snap
@@ -6,10 +6,12 @@ Object {
   "list": Array [
     Object {
       "id": "test-subaccount",
+      "status": "scheduled",
       "subaccount_id": 101,
     },
     Object {
       "id": "test-subaccount",
+      "status": "draft",
       "subaccount_id": 202,
     },
   ],
@@ -22,9 +24,33 @@ Object {
   "list": Array [
     Object {
       "id": "test-master",
+      "status": "running",
     },
     Object {
       "id": "test-subaccount",
+      "status": "draft",
+      "subaccount_id": 202,
+    },
+  ],
+}
+`;
+
+exports[`A/B Testing reducer updates canceled test correctly 1`] = `
+Object {
+  "cancelPending": false,
+  "list": Array [
+    Object {
+      "id": "test-master",
+      "status": "running",
+    },
+    Object {
+      "id": "test-subaccount",
+      "status": "cancelled",
+      "subaccount_id": 101,
+    },
+    Object {
+      "id": "test-subaccount",
+      "status": "draft",
       "subaccount_id": 202,
     },
   ],

--- a/src/reducers/tests/abTesting.test.js
+++ b/src/reducers/tests/abTesting.test.js
@@ -3,9 +3,9 @@ import abTestingReducer from '../abTesting';
 
 const state = {
   list: [
-    { 'id': 'test-master' },
-    { 'id': 'test-subaccount', subaccount_id: 101 },
-    { 'id': 'test-subaccount', subaccount_id: 202 }
+    { 'id': 'test-master', status: 'running' },
+    { 'id': 'test-subaccount', subaccount_id: 101, status: 'scheduled' },
+    { 'id': 'test-subaccount', subaccount_id: 202, status: 'draft' }
   ]
 };
 
@@ -17,6 +17,11 @@ const TEST_CASES = {
   'matches ab tests with subaccount correctly (excludes deleted one)': {
     type: 'DELETE_AB_TEST_SUCCESS',
     meta: { data: { id: 'test-subaccount', subaccountId: '101' }}
+  },
+  'updates canceled test correctly': {
+    type: 'CANCEL_AB_TEST_SUCCESS',
+    meta: { id: 'test-subaccount', subaccountId: '101' },
+    payload: { status: 'cancelled' }
   }
 };
 

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import config from 'src/config';
 import { createSelector } from 'reselect';
-import { formValueSelector } from 'redux-form';
 import { getDomains, isVerified } from 'src/selectors/sendingDomains';
 import { selectSubaccountIdFromProps, hasSubaccounts } from 'src/selectors/subaccounts';
 import { filterTemplatesBySubaccount } from 'src/helpers/templates';
@@ -43,24 +42,17 @@ export const selectDomainsBySubaccount = createSelector(
   })
 );
 
-// Selects published templates, filtered by subaccount prop
-// Used within typeahead
-export const selectPublishedTemplatesBySubaccount = createSelector(
-  [selectPublishedTemplates, selectSubaccountIdFromProps, hasSubaccounts],
-  (templates, subaccountId, subaccountsExist) => filterTemplatesBySubaccount({ templates, subaccountId, hasSubaccounts: subaccountsExist })
-);
+/**
+ * Selects subaccountId from the selector's second arguement, in place of props
+ */
+export const selectSubaccountId = (state, subaccountId) => subaccountId;
 
 /**
- * Selects subaccount id from a redux-form subaccount typeahead
+ * Selects published templates, filtered by provided subaccount
+ * @param state  redux state
+ * @param subaccountId
  */
-export const selectSubaccountIdFromFormTypeahead = (state, props, formName) => {
-  const selector = formValueSelector(formName);
-  return selector(state, 'subaccount.id');
-};
-
-// Selects published templates, filtered by subaccount typeahead value within redux-form
-// Used for form validation
-export const selectPublishedTemplatesBySubaccountFromTypeahead = createSelector(
-  [selectPublishedTemplates, selectSubaccountIdFromFormTypeahead, hasSubaccounts],
+export const selectPublishedTemplatesBySubaccount = createSelector(
+  [selectPublishedTemplates, selectSubaccountId, hasSubaccounts],
   (templates, subaccountId, subaccountsExist) => filterTemplatesBySubaccount({ templates, subaccountId, hasSubaccounts: subaccountsExist })
 );

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -200,63 +200,6 @@ Array [
 ]
 `;
 
-exports[`Templates selectors selectPublishedTemplatesBySubaccountFromTypeahead should return published templates for a specific subaccount 1`] = `
-Array [
-  Object {
-    "has_published": true,
-    "name": "publishedSubaccount",
-    "shared_with_subaccounts": false,
-    "subaccount_id": 101,
-  },
-  Object {
-    "has_published": true,
-    "name": "publishedShared",
-    "shared_with_subaccounts": true,
-    "subaccount_id": 0,
-  },
-]
-`;
-
-exports[`Templates selectors selectPublishedTemplatesBySubaccountFromTypeahead should return published templates for master account 1`] = `
-Array [
-  Object {
-    "has_published": true,
-    "name": "publishedMaster",
-    "shared_with_subaccounts": false,
-    "subaccount_id": 0,
-  },
-  Object {
-    "has_published": true,
-    "name": "publishedShared",
-    "shared_with_subaccounts": true,
-    "subaccount_id": 0,
-  },
-]
-`;
-
-exports[`Templates selectors selectPublishedTemplatesBySubaccountFromTypeahead should return published templates if no subaccounts exist 1`] = `
-Array [
-  Object {
-    "has_published": true,
-    "name": "publishedSubaccount",
-    "shared_with_subaccounts": false,
-    "subaccount_id": 101,
-  },
-  Object {
-    "has_published": true,
-    "name": "publishedMaster",
-    "shared_with_subaccounts": false,
-    "subaccount_id": 0,
-  },
-  Object {
-    "has_published": true,
-    "name": "publishedShared",
-    "shared_with_subaccounts": true,
-    "subaccount_id": 0,
-  },
-]
-`;
-
 exports[`Templates selectors selectTemplateTestData should return default data 1`] = `
 "{
   \\"substitution_data\\": {},

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -200,6 +200,63 @@ Array [
 ]
 `;
 
+exports[`Templates selectors selectPublishedTemplatesBySubaccountFromTypeahead should return published templates for a specific subaccount 1`] = `
+Array [
+  Object {
+    "has_published": true,
+    "name": "publishedSubaccount",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+  },
+]
+`;
+
+exports[`Templates selectors selectPublishedTemplatesBySubaccountFromTypeahead should return published templates for master account 1`] = `
+Array [
+  Object {
+    "has_published": true,
+    "name": "publishedMaster",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 0,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+  },
+]
+`;
+
+exports[`Templates selectors selectPublishedTemplatesBySubaccountFromTypeahead should return published templates if no subaccounts exist 1`] = `
+Array [
+  Object {
+    "has_published": true,
+    "name": "publishedSubaccount",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedMaster",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 0,
+  },
+  Object {
+    "has_published": true,
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+  },
+]
+`;
+
 exports[`Templates selectors selectTemplateTestData should return default data 1`] = `
 "{
   \\"substitution_data\\": {},

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -84,7 +84,8 @@ describe('Templates selectors', () => {
     },
     currentUser: {
       has_subaccounts: true
-    }
+    },
+    form: { testform: { values: {}}}
   };
 
   describe('Templates by id Selector', () => {
@@ -202,6 +203,29 @@ describe('Templates selectors', () => {
     it('should return published templates if no subaccounts exist', () => {
       store.currentUser.has_subaccounts = false;
       expect(selector.selectPublishedTemplatesBySubaccount(store, {})).toMatchSnapshot();
+    });
+  });
+
+  describe('selectPublishedTemplatesBySubaccountFromTypeahead', () => {
+
+    beforeEach(() => {
+      store.currentUser.has_subaccounts = true;
+      store.form.testform.values = { subaccount: null };
+    });
+
+    it('should return published templates for master account', () => {
+      expect(selector.selectPublishedTemplatesBySubaccountFromTypeahead(store, {}, 'testform')).toMatchSnapshot();
+    });
+
+    it('should return published templates for a specific subaccount', () => {
+      store.form.testform.values = { subaccount: { id: 101 }};
+      expect(selector.selectSubaccountIdFromFormTypeahead(store, {}, 'testform')).toBe(101);
+      expect(selector.selectPublishedTemplatesBySubaccountFromTypeahead(store, {}, 'testform')).toMatchSnapshot();
+    });
+
+    it('should return published templates if no subaccounts exist', () => {
+      store.currentUser.has_subaccounts = false;
+      expect(selector.selectPublishedTemplatesBySubaccountFromTypeahead(store, {}, 'testform')).toMatchSnapshot();
     });
   });
 });

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -193,39 +193,16 @@ describe('Templates selectors', () => {
 
   describe('selectPublishedTemplatesBySubaccount', () => {
     it('should return published templates for master account', () => {
-      expect(selector.selectPublishedTemplatesBySubaccount(store, {})).toMatchSnapshot();
+      expect(selector.selectPublishedTemplatesBySubaccount(store)).toMatchSnapshot();
     });
 
     it('should return published templates for a specific subaccount', () => {
-      expect(selector.selectPublishedTemplatesBySubaccount(store, { subaccountId: 101 })).toMatchSnapshot();
+      expect(selector.selectPublishedTemplatesBySubaccount(store, 101)).toMatchSnapshot();
     });
 
     it('should return published templates if no subaccounts exist', () => {
       store.currentUser.has_subaccounts = false;
-      expect(selector.selectPublishedTemplatesBySubaccount(store, {})).toMatchSnapshot();
-    });
-  });
-
-  describe('selectPublishedTemplatesBySubaccountFromTypeahead', () => {
-
-    beforeEach(() => {
-      store.currentUser.has_subaccounts = true;
-      store.form.testform.values = { subaccount: null };
-    });
-
-    it('should return published templates for master account', () => {
-      expect(selector.selectPublishedTemplatesBySubaccountFromTypeahead(store, {}, 'testform')).toMatchSnapshot();
-    });
-
-    it('should return published templates for a specific subaccount', () => {
-      store.form.testform.values = { subaccount: { id: 101 }};
-      expect(selector.selectSubaccountIdFromFormTypeahead(store, {}, 'testform')).toBe(101);
-      expect(selector.selectPublishedTemplatesBySubaccountFromTypeahead(store, {}, 'testform')).toMatchSnapshot();
-    });
-
-    it('should return published templates if no subaccounts exist', () => {
-      store.currentUser.has_subaccounts = false;
-      expect(selector.selectPublishedTemplatesBySubaccountFromTypeahead(store, {}, 'testform')).toMatchSnapshot();
+      expect(selector.selectPublishedTemplatesBySubaccount(store)).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
To verify

(1)
- Go to create page
- Select a template that is assigned to master and not shared with all
- Select a subaccount
- Attempt to submit, error should be visible

(2)
- Create a test assigned to master
- The following redirect should not include `?subaccount=0` and subaccount tag should not be visible

(3)
- Cancel a test from the list page
- Status tag should update to 'Cancelled'
- Test with an AB test assigned to a subaccount as well