### PR TITLE
FE-502 Fix billing country and state validation

### DIFF
--- a/src/pages/billing/forms/fields/BillingAddressForm.js
+++ b/src/pages/billing/forms/fields/BillingAddressForm.js
@@ -7,6 +7,7 @@ import { Grid } from '@sparkpost/matchbox';
 import { TextFieldWrapper, SelectWrapper } from 'src/components';
 import { required } from 'src/helpers/validation';
 import { getZipLabel } from 'src/helpers/billing';
+import { getFirstStateForCountry } from 'src/selectors/accountBillingForms';
 
 import styles from './Fields.module.scss';
 import _ from 'lodash';
@@ -24,15 +25,6 @@ export class BillingAddressForm extends Component {
     showName: true
   }
 
-  handleCountryChange = (e) => {
-    const value = e.target.value;
-
-    // Removes state value from store
-    if (value !== 'US' && value !== 'CA') {
-      this.props.change(this.props.formName, 'billingAddress.state', null);
-    }
-  }
-
   componentDidMount() {
     const { firstName, lastName } = this.props;
 
@@ -40,6 +32,21 @@ export class BillingAddressForm extends Component {
     // Their values are still in the redux-form store although the fields are hidden
     if (firstName && lastName) {
       this.setState({ showName: false });
+    }
+  }
+
+  componentDidUpdate({ countryValue: prevCountry }) {
+    const { countryValue, change, formName, firstState } = this.props;
+
+    // Handles billingAddress.state field mutation when country changes
+    if (prevCountry !== countryValue) {
+      if (countryValue === 'US' || countryValue === 'CA') {
+        // Sets first state value
+        change(formName, 'billingAddress.state', firstState);
+      } else {
+        // Removes state value from store
+        change(formName, 'billingAddress.state', null);
+      }
     }
   }
 
@@ -86,7 +93,7 @@ export class BillingAddressForm extends Component {
     return (
       <div>
         <p><small>Billing Address</small></p>
-        { nameFields }
+        {nameFields}
         <Field
           label='Country'
           name='billingAddress.country'
@@ -95,10 +102,9 @@ export class BillingAddressForm extends Component {
           options={countries}
           validate={required}
           disabled={disabled}
-          onChange={this.handleCountryChange}
         />
         <Grid>
-          { stateOrProvince }
+          {stateOrProvince}
           <Grid.Column xs={6}>
             <Field
               label={getZipLabel(countryValue)}
@@ -126,10 +132,13 @@ BillingAddressForm.propTypes = {
 // Get country value from state
 const mapStateToProps = (state, { formName }) => {
   const selector = formValueSelector(formName);
+  const countryValue = selector(state, 'billingAddress.country');
+
   return {
-    countryValue: selector(state, 'billingAddress.country'),
+    countryValue,
     firstName: selector(state, 'billingAddress.firstName'),
-    lastName: selector(state, 'billingAddress.lastName')
+    lastName: selector(state, 'billingAddress.lastName'),
+    firstState: getFirstStateForCountry(state, countryValue)
   };
 };
 export default connect(mapStateToProps, { change })(BillingAddressForm);

--- a/src/pages/billing/forms/fields/BillingAddressForm.js
+++ b/src/pages/billing/forms/fields/BillingAddressForm.js
@@ -129,8 +129,8 @@ BillingAddressForm.propTypes = {
   formName: PropTypes.string.isRequired
 };
 
-// Get country value from state
 const mapStateToProps = (state, { formName }) => {
+  // Get country value from state
   const selector = formValueSelector(formName);
   const countryValue = selector(state, 'billingAddress.country');
 

--- a/src/pages/billing/forms/fields/tests/BillingAddressForm.test.js
+++ b/src/pages/billing/forms/fields/tests/BillingAddressForm.test.js
@@ -9,13 +9,16 @@ describe('Billing Address Form:', () => {
     formName: 'form-name',
     countryValue: 'GG',
     countries: [
-      { value: 'US', label: 'USOFA', states: [{ name: 'mrylnd', value: 'MD' }]}
+      { value: 'US', label: 'USOFA', states: [{ name: 'mrylnd', value: 'MD' }]},
+      { value: 'CA', label: 'CANADA', states: [{ name: 'alberta', value: 'AB' }]}
     ],
-    change: jest.fn()
+    change: jest.fn(),
+    firstState: 'FirstState'
   };
 
   beforeEach(() => {
     wrapper = shallow(<BillingAddressForm {...props} />);
+    jest.clearAllMocks();
   });
 
   it('should render', () => {
@@ -39,12 +42,25 @@ describe('Billing Address Form:', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should handle state value', () => {
-    const changeSpy = jest.spyOn(wrapper.instance().props, 'change');
-    wrapper.instance().handleCountryChange({ target: { value: 'US' }});
-    expect(changeSpy).not.toHaveBeenCalled();
-    changeSpy.mockReset();
-    wrapper.instance().handleCountryChange({ target: { value: 'GG' }});
-    expect(changeSpy).toHaveBeenCalledWith(props.formName, 'billingAddress.state', null);
+  describe('on component did update', () => {
+    it('should select first state if US is selected', () => {
+      wrapper.setProps({ countryValue: 'US' });
+      expect(props.change).toHaveBeenCalledWith(props.formName, 'billingAddress.state', props.firstState);
+    });
+
+    it('should select first state if CA is selected', () => {
+      wrapper.setProps({ countryValue: 'CA' });
+      expect(props.change).toHaveBeenCalledWith(props.formName, 'billingAddress.state', props.firstState);
+    });
+
+    it('should deselect state if not US or Canada', () => {
+      wrapper.setProps({ countryValue: 'AF' });
+      expect(props.change).toHaveBeenCalledWith(props.formName, 'billingAddress.state', null);
+    });
+
+    it('should not do anything if country has not changed', () => {
+      wrapper.setProps({ firstState: 'MD' });
+      expect(props.change).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/pages/billing/forms/fields/tests/BillingAddressForm.test.js
+++ b/src/pages/billing/forms/fields/tests/BillingAddressForm.test.js
@@ -18,7 +18,6 @@ describe('Billing Address Form:', () => {
 
   beforeEach(() => {
     wrapper = shallow(<BillingAddressForm {...props} />);
-    jest.clearAllMocks();
   });
 
   it('should render', () => {

--- a/src/pages/billing/forms/fields/tests/BillingContactForm.test.js
+++ b/src/pages/billing/forms/fields/tests/BillingContactForm.test.js
@@ -9,9 +9,11 @@ describe('Billing Address Form:', () => {
     formName: 'form-name',
     countryValue: 'GG',
     countries: [
-      { value: 'US', label: 'USOFA', states: [{ name: 'mrylnd', value: 'MD' }]}
+      { value: 'US', label: 'USOFA', states: [{ name: 'mrylnd', value: 'MD' }]},
+      { value: 'CA', label: 'CANADA', states: [{ name: 'alberta', value: 'AB' }]}
     ],
-    change: jest.fn()
+    change: jest.fn(),
+    firstState: 'FirstState'
   };
 
   beforeEach(() => {
@@ -27,12 +29,25 @@ describe('Billing Address Form:', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should handle state value', () => {
-    const changeSpy = jest.spyOn(wrapper.instance().props, 'change');
-    wrapper.instance().handleCountryChange({ target: { value: 'US' }});
-    expect(changeSpy).not.toHaveBeenCalled();
-    changeSpy.mockReset();
-    wrapper.instance().handleCountryChange({ target: { value: 'GG' }});
-    expect(changeSpy).toHaveBeenCalledWith(props.formName, 'billingContact.state', null);
+  describe('on component did update', () => {
+    it('should select first state if US is selected', () => {
+      wrapper.setProps({ countryValue: 'US' });
+      expect(props.change).toHaveBeenCalledWith(props.formName, 'billingContact.state', props.firstState);
+    });
+
+    it('should select first state if CA is selected', () => {
+      wrapper.setProps({ countryValue: 'CA' });
+      expect(props.change).toHaveBeenCalledWith(props.formName, 'billingContact.state', props.firstState);
+    });
+
+    it('should deselect state if not US or Canada', () => {
+      wrapper.setProps({ countryValue: 'AF' });
+      expect(props.change).toHaveBeenCalledWith(props.formName, 'billingContact.state', null);
+    });
+
+    it('should not do anything if country has not changed', () => {
+      wrapper.setProps({ firstState: 'MD' });
+      expect(props.change).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/pages/billing/forms/fields/tests/__snapshots__/BillingAddressForm.test.js.snap
+++ b/src/pages/billing/forms/fields/tests/__snapshots__/BillingAddressForm.test.js.snap
@@ -35,7 +35,6 @@ exports[`Billing Address Form: should render 1`] = `
     component={[Function]}
     label="Country"
     name="billingAddress.country"
-    onChange={[Function]}
     options={
       Array [
         Object {
@@ -47,6 +46,16 @@ exports[`Billing Address Form: should render 1`] = `
             },
           ],
           "value": "US",
+        },
+        Object {
+          "label": "CANADA",
+          "states": Array [
+            Object {
+              "name": "alberta",
+              "value": "AB",
+            },
+          ],
+          "value": "CA",
         },
       ]
     }
@@ -103,7 +112,6 @@ exports[`Billing Address Form: should show states 1`] = `
     component={[Function]}
     label="Country"
     name="billingAddress.country"
-    onChange={[Function]}
     options={
       Array [
         Object {
@@ -115,6 +123,16 @@ exports[`Billing Address Form: should show states 1`] = `
             },
           ],
           "value": "US",
+        },
+        Object {
+          "label": "CANADA",
+          "states": Array [
+            Object {
+              "name": "alberta",
+              "value": "AB",
+            },
+          ],
+          "value": "CA",
         },
       ]
     }

--- a/src/pages/billing/forms/fields/tests/__snapshots__/BillingContactForm.test.js.snap
+++ b/src/pages/billing/forms/fields/tests/__snapshots__/BillingContactForm.test.js.snap
@@ -41,7 +41,6 @@ exports[`Billing Address Form: should render 1`] = `
     component={[Function]}
     label="Country"
     name="billingContact.country"
-    onChange={[Function]}
     options={
       Array [
         Object {
@@ -53,6 +52,16 @@ exports[`Billing Address Form: should render 1`] = `
             },
           ],
           "value": "US",
+        },
+        Object {
+          "label": "CANADA",
+          "states": Array [
+            Object {
+              "name": "alberta",
+              "value": "AB",
+            },
+          ],
+          "value": "CA",
         },
       ]
     }
@@ -115,7 +124,6 @@ exports[`Billing Address Form: should show states 1`] = `
     component={[Function]}
     label="Country"
     name="billingContact.country"
-    onChange={[Function]}
     options={
       Array [
         Object {
@@ -127,6 +135,16 @@ exports[`Billing Address Form: should show states 1`] = `
             },
           ],
           "value": "US",
+        },
+        Object {
+          "label": "CANADA",
+          "states": Array [
+            Object {
+              "name": "alberta",
+              "value": "AB",
+            },
+          ],
+          "value": "CA",
         },
       ]
     }

--- a/src/selectors/accountBillingForms.js
+++ b/src/selectors/accountBillingForms.js
@@ -1,5 +1,15 @@
 import _ from 'lodash';
+import { createSelector } from 'reselect';
 import { currentPlanSelector, selectAvailablePlans, selectVisiblePlans } from './accountBillingInfo';
+
+export const getCountries = (state) => _.get(state, 'billing.countries');
+export const getFirstCountry = (state) => _.get(state, 'billing.countries[0].value');
+export const getCountry = (state, country) => country;
+
+export const getFirstStateForCountry = createSelector(
+  [getCountries, getCountry],
+  (countries, country) => _.get(_.find(countries, ({ value }) => value === country), 'states[0].value')
+);
 
 /**
  * Selects initial values for all the forms on account/billing/plan
@@ -8,13 +18,17 @@ export function changePlanInitialValues(state, { planCode } = {}) {
   const overridePlan = _.find(selectAvailablePlans(state), { code: planCode }); // typically from query string
   const currentPlan = currentPlanSelector(state);
   const firstVisiblePlan = _.first(selectVisiblePlans(state));
+  const firstCountry = getFirstCountry(state);
+  const firstState = getFirstStateForCountry(state, firstCountry);
 
   return {
     email: state.currentUser.email, // This sets the email value even though the field does not exist
     planpicker: overridePlan || currentPlan || firstVisiblePlan,
     billingAddress: {
       firstName: state.currentUser.first_name,
-      lastName: state.currentUser.last_name
+      lastName: state.currentUser.last_name,
+      country: firstCountry,
+      state: firstState
     }
   };
 }
@@ -23,10 +37,15 @@ export function changePlanInitialValues(state, { planCode } = {}) {
  * Selects initial values for all the update payment form on the summary page
  */
 export function updatePaymentInitialValues(state) {
+  const firstCountry = getFirstCountry(state);
+  const firstState = getFirstStateForCountry(state, firstCountry);
+
   return {
     billingAddress: {
       firstName: state.currentUser.first_name,
-      lastName: state.currentUser.last_name
+      lastName: state.currentUser.last_name,
+      country: firstCountry,
+      state: firstState
     }
   };
 }

--- a/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
+++ b/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
@@ -3,8 +3,10 @@
 exports[`Selector: Account billing form changePlanInitialValues when NOT self serve should find and return secret plan 1`] = `
 Object {
   "billingAddress": Object {
+    "country": "US",
     "firstName": "ann",
     "lastName": "perkins",
+    "state": "AL",
   },
   "email": "ann@perkins.com",
   "planpicker": Object {
@@ -19,8 +21,10 @@ Object {
 exports[`Selector: Account billing form changePlanInitialValues when NOT self serve should return change plan values: with a billing id 1`] = `
 Object {
   "billingAddress": Object {
+    "country": "US",
     "firstName": "ann",
     "lastName": "perkins",
+    "state": "AL",
   },
   "email": "ann@perkins.com",
   "planpicker": Object {
@@ -33,8 +37,10 @@ Object {
 exports[`Selector: Account billing form changePlanInitialValues when NOT self serve should return change plan values: without billing id 1`] = `
 Object {
   "billingAddress": Object {
+    "country": "US",
     "firstName": "ann",
     "lastName": "perkins",
+    "state": "AL",
   },
   "email": "ann@perkins.com",
   "planpicker": Object {
@@ -59,8 +65,10 @@ Object {
 exports[`Selector: Account billing form updatePaymentInitialValues should return update payment values 1`] = `
 Object {
   "billingAddress": Object {
+    "country": "US",
     "firstName": "ann",
     "lastName": "perkins",
+    "state": "AL",
   },
 }
 `;

--- a/src/selectors/tests/accountBillingForms.test.js
+++ b/src/selectors/tests/accountBillingForms.test.js
@@ -10,6 +10,13 @@ const baseUser = {
   zip_code: '54321'
 };
 
+const billingStore = {
+  countries: [
+    { value: 'US', states: [{ value: 'AL' }]},
+    { value: 'AF' }
+  ]
+};
+
 describe('Selector: Account billing form', () => {
   let user;
   let store;
@@ -24,7 +31,10 @@ describe('Selector: Account billing form', () => {
       { billingId: 'ias', code: 'im a secret', isFree: false, status: 'secret' }
     ]);
     user = Object.assign({}, baseUser);
-    store = { currentUser: user };
+    store = {
+      currentUser: user,
+      billing: billingStore
+    };
   });
 
   describe('changePlanInitialValues when NOT self serve', () => {
@@ -49,14 +59,14 @@ describe('Selector: Account billing form', () => {
 
   describe('updatePaymentInitialValues', () => {
     it('should return update payment values', () => {
-      const store = { currentUser: Object.assign({}, baseUser) };
+      const store = { currentUser: Object.assign({}, baseUser), billing: billingStore };
       expect(updatePaymentInitialValues(store)).toMatchSnapshot();
     });
   });
 
   describe('updateConteactInitialValues', () => {
     it('should return update contact values', () => {
-      const store = { account: { billing: Object.assign({}, baseUser) }};
+      const store = { account: { billing: Object.assign({}, baseUser) }, billing: billingStore };
       expect(updateContactInitialValues(store)).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
To reproduce:

- Open either the change plan page, onboarding plan page, or update payment modal.
- Make sure the billing address field is visible - select a new paid plan, and do not use saved credit card.
- Country initial value error:
  - Do no touch fields.
  - Attempt to submit to force validation
  - Country will show "Required"
  - State field is not displayed
- State initial value error:
  - Select a country without states (not US or CA)
  - Immediately select a country with states (US or CA)
  - States field should be visible 
  - Attempt to submit to force validation
  - State will show "Required"