### PR TITLE
FE-509: Format numbers >= 1 billion with 'B' suffix

### DIFF
--- a/src/helpers/tests/units.test.js
+++ b/src/helpers/tests/units.test.js
@@ -22,7 +22,7 @@ describe('Formatting helpers', () => {
       expect(formatting.formatNumber(999)).toEqual((999).toLocaleString());
       expect(formatting.formatNumber(1000)).toMatch(/K$/);
       expect(formatting.formatNumber(1000 * 1000)).toMatch(/M$/);
-      expect(formatting.formatNumber(1000 * 1000 * 1000)).toMatch(/G$/);
+      expect(formatting.formatNumber(1000 * 1000 * 1000)).toMatch(/B$/);
     });
   });
 

--- a/src/helpers/tests/units.test.js
+++ b/src/helpers/tests/units.test.js
@@ -22,6 +22,7 @@ describe('Formatting helpers', () => {
       expect(formatting.formatNumber(999)).toEqual((999).toLocaleString());
       expect(formatting.formatNumber(1000)).toMatch(/K$/);
       expect(formatting.formatNumber(1000 * 1000)).toMatch(/M$/);
+      expect(formatting.formatNumber(1000 * 1000 * 1000)).toMatch(/G$/);
     });
   });
 

--- a/src/helpers/units.js
+++ b/src/helpers/units.js
@@ -79,7 +79,7 @@ export const formatNumber = (value) => {
   let suffix = '';
 
   const formatters = {
-    'G': BILLION,
+    'B': BILLION,
     'M': MILLION,
     'K': 1000
   };

--- a/src/helpers/units.js
+++ b/src/helpers/units.js
@@ -7,7 +7,7 @@ const QUARDRILLION = Math.pow(10, 15);
 
 export const isNumber = (value) => isNaN(parseFloat(value)) === false || isFinite(value) === true;
 
-export function roundToPlaces (number, places) {
+export function roundToPlaces(number, places) {
   const multiplier = Math.pow(10, places);
   return Math.round(number * multiplier) / multiplier;
 }
@@ -79,6 +79,7 @@ export const formatNumber = (value) => {
   let suffix = '';
 
   const formatters = {
+    'G': BILLION,
     'M': MILLION,
     'K': 1000
   };


### PR DESCRIPTION
### Testing
To repro log into a high volume account  and look at the summary report over a 6 month window.

Alternatively, hack a report to include a value in the billions.

