### PR TITLE
Add optimizely

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
 
     <title>SparkPost</title>
 
+    <script type="text/javascript" src="https://cdn.optimizely.com/js/4552732375.js"></script>
      <!-- Pushes app load failure to Sentry -->
     <script>
       function trackAppLoadError() {


### PR DESCRIPTION
Marketing will use the url (like /onboarding) to detect if signup success. i've pointed to possible false positives as we can visit that page at anytime. but seems there can be javascript condition from optimizely. so they'll check `document.referrer` to verify the referrer is `/join`.

we'll have to do a end to end test on staging as optimizely needs to reach our page to run test. @jettpendleton will help us verify on staging before we deploy to prod.