### PR TITLE
FE-508: Reinstate website auth cookie

### DIFF
--- a/public/static/tenant-config/production.js
+++ b/public/static/tenant-config/production.js
@@ -1,6 +1,15 @@
 window.SP = window.SP || {};
 window.SP.productionConfig = {
   apiBase: 'http://api.sparkpost.test/api/v1',
+  authentication: {
+    site: {
+      cookie: {
+        options: {
+          domain: '.sparkpost.test'
+        }
+      }
+    }
+  },
   cookieConsent: {
     cookie: {
       options: {

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,5 +1,6 @@
 import { sparkpostLogin } from '../helpers/http';
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
+import * as websiteAuth from 'src/actions/websiteAuth';
 import { getTfaStatusBeforeLoggedIn } from 'src/actions/tfa';
 import { showAlert } from 'src/actions/globalAlert';
 import { removeHerokuToolbar } from 'src/helpers/heroku';
@@ -21,6 +22,7 @@ export function login({ authData = {}, saveCookie = false }) {
   }
 
   return (dispatch) => {
+    dispatch(websiteAuth.login(saveCookie)); // Complete the website cookie set up process
     dispatch({
       type: 'LOGIN_SUCCESS',
       payload: authData
@@ -52,6 +54,9 @@ export function authenticate(username, password, rememberMe = false) {
     return sparkpostLogin(username, password, rememberMe)
       .then(({ data = {}} = {}) => {
         const authData = { ...data, username };
+
+        // Start website auth token cookie setup process
+        dispatch(websiteAuth.authenticate(username, password, rememberMe));
 
         return Promise.all([ authData, getTfaStatusBeforeLoggedIn({ username, token: authData.access_token })]);
       })
@@ -129,8 +134,11 @@ export function ssoCheck(username) {
 }
 
 export function refresh(token, refreshToken) {
-  const newCookie = authCookie.merge({ access_token: token, refresh_token: refreshToken });
-  return login({ authData: newCookie });
+  return (dispatch) => {
+    const newCookie = authCookie.merge({ access_token: token, refresh_token: refreshToken });
+    dispatch(websiteAuth.refresh());
+    return login({ authData: newCookie });
+  };
 }
 
 export function logout() {
@@ -140,6 +148,8 @@ export function logout() {
     if (!auth.loggedIn) {
       return;
     }
+
+    dispatch(websiteAuth.logout());
 
     removeHerokuToolbar();
     authCookie.remove();

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -137,7 +137,7 @@ export function refresh(token, refreshToken) {
   return (dispatch) => {
     const newCookie = authCookie.merge({ access_token: token, refresh_token: refreshToken });
     dispatch(websiteAuth.refresh());
-    return login({ authData: newCookie });
+    return dispatch(login({ authData: newCookie }));
   };
 }
 

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -120,5 +120,8 @@ Array [
   Array [
     undefined,
   ],
+  Array [
+    [Function],
+  ],
 ]
 `;

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -26,6 +26,9 @@ Array [
     },
   ],
   Array [
+    undefined,
+  ],
+  Array [
     [Function],
   ],
 ]
@@ -37,6 +40,9 @@ Array [
     Object {
       "type": "LOGIN_PENDING",
     },
+  ],
+  Array [
+    undefined,
   ],
   Array [
     Object {
@@ -96,12 +102,23 @@ Array [
 ]
 `;
 
-exports[`Action Creator: Auth should dispatch a logout when user is logged in 1`] = `
+exports[`Action Creator: Auth logout should dispatch a logout when user is logged in 1`] = `
 Array [
+  Array [
+    undefined,
+  ],
   Array [
     Object {
       "type": "LOGOUT",
     },
+  ],
+]
+`;
+
+exports[`Action Creator: Auth refresh should dispatch follow-on actions 1`] = `
+Array [
+  Array [
+    undefined,
   ],
 ]
 `;

--- a/src/actions/tests/auth.test.js
+++ b/src/actions/tests/auth.test.js
@@ -1,10 +1,12 @@
 import * as authActions from '../auth';
 import authCookie from 'src/helpers/authCookie';
+import * as websiteAuth from 'src/actions/websiteAuth';
 import { initializeAccessControl } from 'src/actions/accessControl';
 import { sparkpostLogin } from 'src/helpers/http';
 import { getTfaStatusBeforeLoggedIn } from 'src/actions/tfa';
 
 jest.mock('src/helpers/authCookie');
+jest.mock('src/actions/websiteAuth');
 jest.mock('src/actions/accessControl');
 jest.mock('src/helpers/http');
 jest.mock('src/actions/tfa');
@@ -40,7 +42,7 @@ describe('Action Creator: Auth', () => {
   });
 
   describe('login tests', () => {
-    it('should not save cookie on default login call', async() => {
+    it('should not save cookie on default login call', async () => {
       const thunk = authActions.login({ authData });
       await thunk(dispatchMock);
       expect(authCookie.save).toHaveBeenCalledTimes(0);
@@ -49,27 +51,34 @@ describe('Action Creator: Auth', () => {
         type: 'LOGIN_SUCCESS',
         payload: authData
       });
-      expect(dispatchMock).toHaveBeenCalledTimes(2);
+      expect(dispatchMock).toHaveBeenCalledTimes(3);
     });
 
-    it('should create cookie when flag is passed', async() => {
+    it('should create cookie when flag is passed', async () => {
       const thunk = authActions.login({ authData, saveCookie: true });
       await thunk(dispatchMock);
       expect(authCookie.save).toHaveBeenCalledTimes(1);
-      expect(dispatchMock).toHaveBeenCalledTimes(2);
+      expect(dispatchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('should dispatch website auth login', async () => {
+      const thunk = authActions.login({ authData, saveCookie: true });
+      await thunk(dispatchMock);
+      expect(websiteAuth.login).toHaveBeenCalledTimes(1);
+      expect(websiteAuth.login).toHaveBeenCalledWith(true);
     });
   });
 
   describe('authenticate tests', () => {
 
-    it('should return if you are already logged in', async() => {
+    it('should return if you are already logged in', async () => {
       stateMock.auth.loggedIn = true ;
       const thunk = authActions.authenticate('foo', 'pw');
       await thunk(dispatchMock, getStateMock);
       expect(dispatchMock).toHaveBeenCalledTimes(0);
     });
 
-    it('should update TFA to enabled if user is TFA', async() => {
+    it('should update TFA to enabled if user is TFA', async () => {
       getTfaStatusBeforeLoggedIn.mockImplementation(() => Promise.resolve({
         data: {
           results: {
@@ -83,7 +92,7 @@ describe('Action Creator: Auth', () => {
       expect(dispatchMock.mock.calls).toMatchSnapshot();
     });
 
-    it('should login if user is not TFA', async() => {
+    it('should login if user is not TFA', async () => {
       getTfaStatusBeforeLoggedIn.mockImplementation(() => Promise.resolve({
         data: {
           results: {
@@ -97,7 +106,7 @@ describe('Action Creator: Auth', () => {
       expect(dispatchMock.mock.calls).toMatchSnapshot();
     });
 
-    it('should dispatch a failed login if login fails', async() => {
+    it('should dispatch a failed login if login fails', async () => {
       sparkpostLogin.mockImplementation(() => Promise.reject({
         response: {
           data: {
@@ -114,13 +123,13 @@ describe('Action Creator: Auth', () => {
   });
 
   describe('confirm password tests', () => {
-    it('should dispatch a confirm password success when login succeeds', async() => {
+    it('should dispatch a confirm password success when login succeeds', async () => {
       const thunk = authActions.confirmPassword('bar', 'pw');
       await thunk(dispatchMock, getStateMock);
       expect(dispatchMock.mock.calls).toMatchSnapshot();
     });
 
-    it('should dispatch a confirm password fail when login fails', async() => {
+    it('should dispatch a confirm password fail when login fails', async () => {
       sparkpostLogin.mockImplementation(() => Promise.reject({
         response: {
           data: {
@@ -136,20 +145,41 @@ describe('Action Creator: Auth', () => {
     });
   });
 
-  it('should dispatch a logout when user is logged in', async() => {
-    stateMock.auth.loggedIn = true;
-    const thunk = authActions.logout();
-    await thunk(dispatchMock, getStateMock);
-    expect(authCookie.remove).toHaveBeenCalledTimes(1);
-    expect(dispatchMock.mock.calls).toMatchSnapshot();
+  describe('refresh', () => {
+    const newToken = 'new access token';
+    const newRefreshToken = 'new refresh token';
+
+    it('should merge new tokens into the cookie', async () => {
+      const thunk = authActions.refresh(newToken, newRefreshToken);
+      await thunk(dispatchMock, getStateMock);
+      expect(authCookie.merge).toHaveBeenCalledWith({
+        access_token: newToken,
+        refresh_token: newRefreshToken
+      });
+    });
+
+    it('should dispatch follow-on actions', async () => {
+      const thunk = authActions.refresh(newToken, newRefreshToken);
+      await thunk(dispatchMock, getStateMock);
+      expect(dispatchMock.mock.calls).toMatchSnapshot();
+    });
   });
 
-  it('should NOT dispatch a logout when user is already logged out', async() => {
-    stateMock.auth.loggedIn = false;
-    const thunk = authActions.logout();
-    await thunk(dispatchMock, getStateMock);
-    expect(authCookie.remove).not.toHaveBeenCalled();
-    expect(dispatchMock).not.toHaveBeenCalled();
-  });
+  describe('logout', () => {
+    it('should dispatch a logout when user is logged in', async () => {
+      stateMock.auth.loggedIn = true;
+      const thunk = authActions.logout();
+      await thunk(dispatchMock, getStateMock);
+      expect(authCookie.remove).toHaveBeenCalledTimes(1);
+      expect(dispatchMock.mock.calls).toMatchSnapshot();
+    });
 
+    it('should NOT dispatch a logout when user is already logged out', async () => {
+      stateMock.auth.loggedIn = false;
+      const thunk = authActions.logout();
+      await thunk(dispatchMock, getStateMock);
+      expect(authCookie.remove).not.toHaveBeenCalled();
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/actions/tests/websiteAuth.test.js
+++ b/src/actions/tests/websiteAuth.test.js
@@ -1,0 +1,92 @@
+import { authenticate, refresh, login, logout } from '../websiteAuth';
+import { sparkpostLogin, useRefreshToken } from 'src/helpers/http';
+import siteCookie from 'src/helpers/websiteAuthCookie';
+
+jest.mock('src/helpers/http');
+jest.mock('src/helpers/websiteAuthCookie');
+
+describe('Action Creator: Website Auth', () => {
+  let dispatchMock;
+  let getStateMock;
+  let stateMock;
+
+  const apiResponse = { data: 'yay' };
+  const apiError = {
+    response: {
+      data: {
+        error_description: 'boom'
+      }
+    }
+  };
+
+  beforeEach(() => {
+    dispatchMock = jest.fn((a) => Promise.resolve(a));
+
+    stateMock = { websiteAuth: { refreshToken: 'refreshToken' }};
+
+    getStateMock = jest.fn(() => stateMock);
+  });
+
+  describe('authenticate', () => {
+    it('should dispatch success', async () => {
+      sparkpostLogin.mockResolvedValue(apiResponse);
+      const thunk = authenticate('user', 'pass', true);
+      await thunk(dispatchMock);
+      expect(dispatchMock).toHaveBeenCalledWith({
+        type: 'WEBSITE_AUTH_SUCCESS',
+        payload: 'yay'
+      });
+    });
+
+    it('should dispatch failure', async () => {
+      sparkpostLogin.mockRejectedValue(apiError);
+      const thunk = authenticate('user', 'pass', true);
+      await thunk(dispatchMock);
+      expect(dispatchMock).toHaveBeenCalledWith({
+        type: 'WEBSITE_AUTH_FAIL',
+        payload: { errorDescription: 'boom' }
+      });
+    });
+  });
+
+  describe('login', () => {
+    it('should not save cookie by default', () => {
+      login(false)(dispatchMock, getStateMock);
+      expect(siteCookie.save).toHaveBeenCalledTimes(0);
+    });
+
+    it('should save cookie if able', () => {
+      login(true)(dispatchMock, getStateMock);
+      expect(siteCookie.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('refresh', () => {
+    it('should dispatch success', async () => {
+      useRefreshToken.mockResolvedValue(apiResponse);
+      const thunk = refresh();
+      await thunk(dispatchMock, getStateMock);
+      expect(dispatchMock).toHaveBeenCalledWith({
+        type: 'WEBSITE_AUTH_SUCCESS',
+        payload: 'yay'
+      });
+    });
+
+    it('should dispatch failure', async () => {
+      useRefreshToken.mockRejectedValue(apiError);
+      const thunk = refresh();
+      await thunk(dispatchMock, getStateMock);
+      expect(dispatchMock).toHaveBeenCalledWith({
+        type: 'WEBSITE_AUTH_FAIL',
+        payload: { errorDescription: 'boom' }
+      });
+    });
+  });
+
+  describe('logout', () => {
+    it('should remove cookie', () => {
+      logout();
+      expect(siteCookie.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/actions/websiteAuth.js
+++ b/src/actions/websiteAuth.js
@@ -1,0 +1,62 @@
+import { sparkpostLogin, useRefreshToken } from '../helpers/http';
+import siteCookie from '../helpers/websiteAuthCookie';
+import config from 'src/config';
+const { authentication } = config;
+const { site: siteCfg } = authentication;
+
+function successAction({ data = {}}) {
+  return {
+    type: 'WEBSITE_AUTH_SUCCESS',
+    payload: data
+  };
+}
+
+function errorAction(err) {
+  const { response = {}} = err;
+  const { data = {}} = response;
+  const { error_description: errorDescription } = data;
+  return {
+    type: 'WEBSITE_AUTH_FAIL',
+    payload: {
+      errorDescription
+    }
+  };
+}
+
+function handleAuthResponse(apiCall, dispatch) {
+  return apiCall.then((result) => { dispatch(successAction(result)); })
+    .catch((err) => { dispatch(errorAction(err)); });
+}
+
+export function authenticate(username, password, rememberMe = false) {
+  return (dispatch) => handleAuthResponse(
+    sparkpostLogin(username, password, rememberMe, siteCfg.authHeader),
+    dispatch);
+}
+
+export function login(saveCookie) {
+  return (dispatch, getState) => {
+    if (saveCookie) {
+      siteCookie.save(getState().websiteAuth);
+    }
+    dispatch({
+      type: 'WEBSITE_AUTH_COMPLETE'
+    });
+  };
+}
+
+export function refresh() {
+  return (dispatch, getState) => {
+    const { websiteAuth: { refreshToken }} = getState();
+    return handleAuthResponse(
+      useRefreshToken(refreshToken, siteCfg.authHeader),
+      dispatch);
+  };
+}
+
+export function logout() {
+  siteCookie.remove();
+  return {
+    type: 'WEBSITE_AUTH_LOGOUT'
+  };
+}

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -7,15 +7,24 @@ const config = {
   },
   apiRequestBodyMaxSizeBytes: 500 * 1000, // ~ 500 KB
   authentication: {
-    cookie: {
-      name: 'auth',
-      options: {
-        path: '/'
-      }
+    app: {
+      cookie: {
+        name: 'auth',
+        options: {
+          path: '/'
+        }
+      },
+      authHeader: 'Basic bXN5c1dlYlVJOmZhODZkNzJlLTYyODctNDUxMy1hZTdmLWVjOGM4ZmEwZDc2Ng=='
     },
-    headers: {
-      Authorization: 'Basic bXN5c1dlYlVJOmZhODZkNzJlLTYyODctNDUxMy1hZTdmLWVjOGM4ZmEwZDc2Ng==',
-      'Content-Type': 'application/x-www-form-urlencoded'
+    site: {
+      cookie: {
+        name: 'website_auth',
+        options: {
+          domain: '.sparkpost.test',
+          path: '/'
+        }
+      },
+      authHeader: 'Basic bXN5c1VJTGltaXRlZDphZjE0OTdkYS02NjI5LTQ3NTEtODljZS01ZDBmODE4N2MyMDQ='
     }
   },
   cardTypes: [
@@ -81,13 +90,6 @@ const config = {
   },
   tenant: 'local',
   website: {
-    cookie: {
-      name: 'website_auth',
-      options: {
-        domain: '.sparkpost.com',
-        path: '/'
-      }
-    },
     domain: 'sparkpost.com'
   },
   zuora: {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -81,6 +81,13 @@ const config = {
   },
   tenant: 'local',
   website: {
+    cookie: {
+      name: 'website_auth',
+      options: {
+        domain: '.sparkpost.com',
+        path: '/'
+      }
+    },
     domain: 'sparkpost.com'
   },
   zuora: {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -20,7 +20,7 @@ const config = {
       cookie: {
         name: 'website_auth',
         options: {
-          domain: '.sparkpost.test',
+          domain: '.sparkpost.com',
           path: '/'
         }
       },

--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -13,10 +13,20 @@ const testConfig = {
     }
   },
   authentication: {
-    cookie: {
-      name: 'test',
-      options: {
-        path: '/'
+    app: {
+      cookie: {
+        name: 'test',
+        options: {
+          path: '/'
+        }
+      }
+    },
+    site: {
+      cookie: {
+        name: 'website_test',
+        options: {
+          path: '/'
+        }
       }
     }
   },

--- a/src/helpers/authCookie.js
+++ b/src/helpers/authCookie.js
@@ -1,10 +1,12 @@
 import cookie from 'js-cookie';
 import config from 'src/config';
 
-const { name, options } = config.authentication.cookie;
+const authCookie = config.authentication.cookie;
+const websiteCookie = config.website.cookie;
 
 function save(data) {
-  cookie.set(name, data, options);
+  cookie.set(authCookie.name, data, authCookie.options);
+  cookie.set(websiteCookie.name, data, websiteCookie.options);
 }
 
 function merge(data) {
@@ -14,11 +16,12 @@ function merge(data) {
 }
 
 function get() {
-  return cookie.getJSON(name);
+  return cookie.getJSON(authCookie.name);
 }
 
 function remove() {
-  return cookie.remove(name, options);
+  cookie.remove(websiteCookie.name, websiteCookie.options);
+  return cookie.remove(authCookie.name, authCookie.options);
 }
 
 export default { save, merge, get, remove };

--- a/src/helpers/authCookie.js
+++ b/src/helpers/authCookie.js
@@ -1,12 +1,10 @@
 import cookie from 'js-cookie';
 import config from 'src/config';
 
-const authCookie = config.authentication.cookie;
-const websiteCookie = config.website.cookie;
+const authCookie = config.authentication.app.cookie;
 
 function save(data) {
   cookie.set(authCookie.name, data, authCookie.options);
-  cookie.set(websiteCookie.name, data, websiteCookie.options);
 }
 
 function merge(data) {
@@ -20,7 +18,6 @@ function get() {
 }
 
 function remove() {
-  cookie.remove(websiteCookie.name, websiteCookie.options);
   return cookie.remove(authCookie.name, authCookie.options);
 }
 

--- a/src/helpers/http.js
+++ b/src/helpers/http.js
@@ -4,18 +4,23 @@ import { sparkpost as sparkpostRequest } from 'src/helpers/axiosInstances';
 
 const { authentication } = config;
 
+const buildHeaders = (authHeader) => ({
+  Authorization: authHeader,
+  'Content-Type': 'application/x-www-form-urlencoded'
+});
+
 // TODO handle timeout error better
 
-function useRefreshToken(refreshToken) {
+function useRefreshToken(refreshToken, authHeader = authentication.app.authHeader) {
   return sparkpostRequest({
     method: 'POST',
     url: '/authenticate',
     data: `grant_type=refresh_token&refresh_token=${refreshToken}`,
-    headers: authentication.headers
+    headers: buildHeaders(authHeader)
   });
 }
 
-function sparkpostLogin(username, password, rememberMe) {
+function sparkpostLogin(username, password, rememberMe, authHeader = authentication.app.authHeader) {
   username = encodeURIComponent(username);
   password = encodeURIComponent(password);
   const data = `grant_type=password&username=${username}&password=${password}&rememberMe=${rememberMe}`;
@@ -24,7 +29,7 @@ function sparkpostLogin(username, password, rememberMe) {
     method: 'POST',
     url: '/authenticate',
     data,
-    headers: authentication.headers
+    headers: buildHeaders(authHeader)
   });
 }
 

--- a/src/helpers/tests/authCookie.test.js
+++ b/src/helpers/tests/authCookie.test.js
@@ -5,22 +5,25 @@ import config from 'src/config';
 jest.mock('js-cookie');
 
 describe('Helper: auth cookie', () => {
-  it('should save a cookie using config values', () => {
+  const { name: authCookieName, options: authCookieOptions } = config.authentication.cookie;
+  const { name: websiteCookieName, options: websiteCookieOptions } = config.website.cookie;
+
+  it('should save both auth and website cookies using config values', () => {
     const data = {};
-    const { name, options } = config.authentication.cookie;
     authCookie.save(data);
-    expect(cookieMock.set).toHaveBeenCalledWith(name, data, options);
+    expect(cookieMock.set).toHaveBeenCalledWith(authCookieName, data, authCookieOptions);
+    expect(cookieMock.set).toHaveBeenCalledWith(websiteCookieName, data, websiteCookieOptions);
   });
 
   it('should get a cookie', () => {
-    const cookieData = {};
-    cookieMock.getJSON.mockReturnValue(cookieData);
-    expect(authCookie.get()).toBe(cookieData);
+    const data = {};
+    cookieMock.getJSON.mockReturnValue(data);
+    expect(authCookie.get()).toBe(data);
   });
 
-  it('should remove a cookie', () => {
-    const { name, options } = config.authentication.cookie;
+  it('should remove both auth and website cookies', () => {
     authCookie.remove();
-    expect(cookieMock.remove).toHaveBeenCalledWith(name, options);
+    expect(cookieMock.remove).toHaveBeenCalledWith(authCookieName, authCookieOptions);
+    expect(cookieMock.remove).toHaveBeenCalledWith(websiteCookieName, websiteCookieOptions);
   });
 });

--- a/src/helpers/tests/authCookie.test.js
+++ b/src/helpers/tests/authCookie.test.js
@@ -5,14 +5,12 @@ import config from 'src/config';
 jest.mock('js-cookie');
 
 describe('Helper: auth cookie', () => {
-  const { name: authCookieName, options: authCookieOptions } = config.authentication.cookie;
-  const { name: websiteCookieName, options: websiteCookieOptions } = config.website.cookie;
+  const { name: authCookieName, options: authCookieOptions } = config.authentication.app.cookie;
 
-  it('should save both auth and website cookies using config values', () => {
+  it('should save auth cookie using config values', () => {
     const data = {};
     authCookie.save(data);
     expect(cookieMock.set).toHaveBeenCalledWith(authCookieName, data, authCookieOptions);
-    expect(cookieMock.set).toHaveBeenCalledWith(websiteCookieName, data, websiteCookieOptions);
   });
 
   it('should get a cookie', () => {
@@ -24,6 +22,5 @@ describe('Helper: auth cookie', () => {
   it('should remove both auth and website cookies', () => {
     authCookie.remove();
     expect(cookieMock.remove).toHaveBeenCalledWith(authCookieName, authCookieOptions);
-    expect(cookieMock.remove).toHaveBeenCalledWith(websiteCookieName, websiteCookieOptions);
   });
 });

--- a/src/helpers/tests/websiteAuthCookie.test.js
+++ b/src/helpers/tests/websiteAuthCookie.test.js
@@ -1,0 +1,19 @@
+import cookieMock from 'js-cookie';
+import websiteAuthCookie from '../websiteAuthCookie';
+import config from 'src/config';
+
+jest.mock('js-cookie');
+
+describe('Helper: website auth cookie', () => {
+  const { name: authCookieName, options: authCookieOptions } = config.authentication.site.cookie;
+
+  it('should save cookie', () => {
+    websiteAuthCookie.save('fredo');
+    expect(cookieMock.set).toHaveBeenCalledWith(authCookieName, 'fredo', authCookieOptions);
+  });
+
+  it('should remove cookie', () => {
+    websiteAuthCookie.remove();
+    expect(cookieMock.remove).toHaveBeenCalledWith(authCookieName, authCookieOptions);
+  });
+});

--- a/src/helpers/tests/websiteAuthCookie.test.js
+++ b/src/helpers/tests/websiteAuthCookie.test.js
@@ -8,8 +8,11 @@ describe('Helper: website auth cookie', () => {
   const { name: authCookieName, options: authCookieOptions } = config.authentication.site.cookie;
 
   it('should save cookie', () => {
-    websiteAuthCookie.save('fredo');
-    expect(cookieMock.set).toHaveBeenCalledWith(authCookieName, 'fredo', authCookieOptions);
+    websiteAuthCookie.save({ name: 'fredo' });
+    expect(cookieMock.set).toHaveBeenCalledWith(authCookieName, {
+      name: 'fredo',
+      tenant: config.tenant
+    }, authCookieOptions);
   });
 
   it('should remove cookie', () => {

--- a/src/helpers/websiteAuthCookie.js
+++ b/src/helpers/websiteAuthCookie.js
@@ -2,9 +2,10 @@ import cookie from 'js-cookie';
 import config from 'src/config';
 
 const websiteAuthCookie = config.authentication.site.cookie;
+const tenant = config.tenant;
 
 function save(data) {
-  cookie.set(websiteAuthCookie.name, data, websiteAuthCookie.options);
+  cookie.set(websiteAuthCookie.name, { ...data, tenant }, websiteAuthCookie.options);
 }
 
 function remove() {

--- a/src/helpers/websiteAuthCookie.js
+++ b/src/helpers/websiteAuthCookie.js
@@ -1,0 +1,14 @@
+import cookie from 'js-cookie';
+import config from 'src/config';
+
+const websiteAuthCookie = config.authentication.site.cookie;
+
+function save(data) {
+  cookie.set(websiteAuthCookie.name, data, websiteAuthCookie.options);
+}
+
+function remove() {
+  cookie.remove(websiteAuthCookie.name, websiteAuthCookie.options);
+}
+
+export default { save, remove };

--- a/src/pages/join/tests/JoinPage.test.js
+++ b/src/pages/join/tests/JoinPage.test.js
@@ -18,7 +18,10 @@ jest.mock('js-cookie');
 jest.mock('src/config', () => ({
   zuora: {}, //axiosInstance throws without this
   brightback: {}, //axiosInstance throws without this
-  authentication: { cookie: {}}, //authCookie throws without this
+  authentication: { //authCookie throws without this
+    app: { cookie: {}},
+    site: { cookie: {}}
+  },
   heroku: {
     cookieName: 'my-cookie'
   },

--- a/src/pages/sendingDomains/components/tests/EditBounce.test.js
+++ b/src/pages/sendingDomains/components/tests/EditBounce.test.js
@@ -9,7 +9,14 @@ import config from 'src/config';
 jest.mock('src/config', () => ({
   zuora: {}, //axiosInstance throws without this
   brightback: {}, //axiosInstance throws without this
-  authentication: { cookie: {}}, //authCookie throws without this,
+  authentication: { //authCookie throws without this,
+    app: {
+      cookie: {}
+    },
+    site: {
+      cookie: {}
+    }
+  },
   heroku: {
     cookieName: 'my-cookie'
   },

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -37,6 +37,7 @@ import tfa from './tfa';
 import tfaBackupCodes from './tfaBackupCodes';
 import trackingDomains from './trackingDomains';
 import webhooks from './webhooks';
+import websiteAuth from './websiteAuth';
 
 const appReducer = combineReducers({
   acceptedReport,
@@ -75,7 +76,8 @@ const appReducer = combineReducers({
   tfaBackupCodes,
   trackingDomains,
   users,
-  webhooks
+  webhooks,
+  websiteAuth
 });
 
 /**

--- a/src/reducers/websiteAuth.js
+++ b/src/reducers/websiteAuth.js
@@ -1,0 +1,13 @@
+const initialState = {};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case 'WEBSITE_AUTH_SUCCESS':
+      return {
+        ...action.payload, // access_token, refresh_token, token_type
+        ...state
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/websiteAuth.js
+++ b/src/reducers/websiteAuth.js
@@ -7,6 +7,10 @@ export default (state = initialState, action) => {
         ...action.payload, // access_token, refresh_token, token_type
         ...state
       };
+
+    case 'WEBSITE_AUTH_FAIL':
+      return { ...initialState };
+
     default:
       return state;
   }


### PR DESCRIPTION
**Testing Locally**
1. Log in
1. Confirm both "auth" and "website_auth" cookies were created with "Application" tab of dev tools
    - Note: verify format and token values for each cookie
1. Log out
1. Confirm both "auth" and "website_auth" cookies were deleted with "Application" tab of dev tools

TBD:
 - [x] Wait for FE-464 config bust up?
 - [x] Verify TFA
 - [ ] Verify SSO
 - [x] Deal with [website cookie expiry](https://github.com/SparkPost/webui/blob/11e2bcc7f5a8c44c218b48ceecc2cee27ac34b3d/src/assets/config/config.js#L23)
 - [x] Publish the fact that this will work across _all_ tenants unlike the previous implementation
