### PR TITLE
AC-287: Custom billing page for customers on annual plans

### DIFF
--- a/src/actions/billingCreate.js
+++ b/src/actions/billingCreate.js
@@ -1,10 +1,10 @@
-import { isAws } from 'src/helpers/conditions/account';
+import { isAws, isCustomBilling } from 'src/helpers/conditions/account';
 import { formatCreateData, formatDataForCors } from 'src/helpers/billing';
 import { fetch as fetchAccount } from './account';
 import chainActions from 'src/actions/helpers/chainActions';
 import { cors, createZuoraAccount, syncSubscription, updateSubscription } from './billing';
 
-export default function billingCreate (values) {
+export default function billingCreate(values) {
   return (dispatch, getState) => {
     // AWS plans don't get created through Zuora, instead update existing
     // subscription to the selected plan
@@ -18,11 +18,12 @@ export default function billingCreate (values) {
     const corsCreateBilling = ({ meta }) => cors({ meta, context: 'create-account', data: corsData });
     const fetchUsageAndBilling = ({ meta }) => fetchAccount({ include: 'usage,billing', meta });
     const constructZuoraAccount = ({ results: { signature, token, ...results }, meta }) => {
-      const { currentUser } = getState();
-      const data = formatCreateData({ ...results, ...billingData });
+      const state = getState();
+      const invoiceCollect = !isCustomBilling(state); // don't send initial invoice for custom plans
+      const data = formatCreateData({ ...results, ...billingData, invoiceCollect });
 
       // add user's email when creating account
-      data.billToContact.workEmail = currentUser.email;
+      data.billToContact.workEmail = state.currentUser.email;
       return createZuoraAccount({ data, token, signature, meta });
     };
     const actions = [corsCreateBilling, constructZuoraAccount, syncSubscription, fetchUsageAndBilling];

--- a/src/actions/tests/billingCreate.test.js
+++ b/src/actions/tests/billingCreate.test.js
@@ -1,7 +1,7 @@
 import billingCreate from '../billingCreate';
 import * as accountActions from 'src/actions/account';
 import * as billingActions from 'src/actions/billing';
-import { isAws } from 'src/helpers/conditions/account';
+import * as accountConditions from 'src/helpers/conditions/account';
 import * as billingHelpers from 'src/helpers/billing';
 
 jest.mock('src/actions/account');
@@ -14,7 +14,8 @@ describe('Action Creator: Billing Create', () => {
 
   beforeEach(() => {
     dispatch = jest.fn((a) => a);
-    isAws.mockImplementation(() => false);
+    accountConditions.isAws = jest.fn(() => false);
+    accountConditions.isCustomBilling = jest.fn(() => false);
   });
 
   it('update without a planpicker code', () => {
@@ -29,7 +30,8 @@ describe('Action Creator: Billing Create', () => {
       billToContact: {},
       creditCard: {
         cardNumber: '1111222233334444'
-      }
+      },
+      invoiceCollect: true
     };
     const getState = () => ({ currentUser });
     const thunk = billingCreate(values);
@@ -69,11 +71,11 @@ describe('Action Creator: Billing Create', () => {
     const values = { planpicker: { code: 'plan-code' }};
     const thunk = billingCreate(values);
 
-    isAws.mockImplementation(() => true);
+    accountConditions.isAws = jest.fn(() => true);
     billingActions.updateSubscription = jest.fn();
 
     thunk(dispatch, () => state);
-    expect(isAws).toHaveBeenCalledWith(state);
+    expect(accountConditions.isAws).toHaveBeenCalledWith(state);
     expect(billingActions.updateSubscription).toHaveBeenCalledWith({ code: 'plan-code' });
   });
 });

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -36,7 +36,13 @@ import { emailVerificationRedirect, emailRedirects } from './emailRoutes';
 import SecretBillingPlanOrBillingSummaryPage from './SecretBillingPlanOrBillingSummaryPage';
 
 import { hasGrants, all, not } from 'src/helpers/conditions';
-import { isEnterprise, isAws, isCustomBilling } from 'src/helpers/conditions/account';
+import {
+  isAws,
+  isCustomBilling,
+  isEnterprise,
+  isSubscriptionPending,
+  onSubscriptionWithType
+} from 'src/helpers/conditions/account';
 import { isHeroku, isAzure } from 'src/helpers/conditions/user';
 import { configFlag, configEquals } from 'src/helpers/conditions/config';
 
@@ -512,6 +518,19 @@ const routes = [
     layout: App,
     title: 'Billing',
     supportDocSearch: 'billing'
+  },
+  {
+    path: '/account/billing/enable-automatic',
+    component: billing.EnableAutomaticBillingPage,
+    condition: all(
+      hasGrants('account/manage'),
+      isCustomBilling,
+      onSubscriptionWithType('manual'),
+      not(isSubscriptionPending)
+    ),
+    layout: App,
+    title: 'Billing | Enable Automatic Billing',
+    supportDocSearch: 'upgrade account'
   },
   {
     path: '/account/billing/plan',

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -40,8 +40,7 @@ import {
   isAws,
   isCustomBilling,
   isEnterprise,
-  isSubscriptionPending,
-  onSubscriptionWithType
+  isSelfServeBilling
 } from 'src/helpers/conditions/account';
 import { isHeroku, isAzure } from 'src/helpers/conditions/user';
 import { configFlag, configEquals } from 'src/helpers/conditions/config';
@@ -524,9 +523,8 @@ const routes = [
     component: billing.EnableAutomaticBillingPage,
     condition: all(
       hasGrants('account/manage'),
-      isCustomBilling,
-      onSubscriptionWithType('manual'),
-      not(isSubscriptionPending)
+      not(isSelfServeBilling),
+      isCustomBilling
     ),
     layout: App,
     title: 'Billing | Enable Automatic Billing',

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -36,7 +36,7 @@ import { emailVerificationRedirect, emailRedirects } from './emailRoutes';
 import SecretBillingPlanOrBillingSummaryPage from './SecretBillingPlanOrBillingSummaryPage';
 
 import { hasGrants, all, not } from 'src/helpers/conditions';
-import { isEnterprise, isAws } from 'src/helpers/conditions/account';
+import { isEnterprise, isAws, isCustomBilling } from 'src/helpers/conditions/account';
 import { isHeroku, isAzure } from 'src/helpers/conditions/user';
 import { configFlag, configEquals } from 'src/helpers/conditions/config';
 
@@ -516,7 +516,13 @@ const routes = [
   {
     path: '/account/billing/plan',
     component: billing.ChangePlanPage,
-    condition: all(hasGrants('account/manage'), not(isEnterprise), not(isHeroku), not(isAzure)),
+    condition: all(
+      hasGrants('account/manage'),
+      not(isEnterprise),
+      not(isHeroku),
+      not(isAzure),
+      not(isCustomBilling)
+    ),
     layout: App,
     title: 'Billing | Change My Plan',
     supportDocSearch: 'upgrade account'

--- a/src/helpers/billing.js
+++ b/src/helpers/billing.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import config from 'src/config';
 import Payment from 'payment';
 
-export function formatDataForCors (values) {
+export function formatDataForCors(values) {
   const { email, planpicker, card, billingAddress } = values;
 
   // For CORS Endpoint + sift
@@ -52,7 +52,7 @@ export function formatDataForCors (values) {
   return { corsData, billingData };
 }
 
-export function formatUpdateData ({ accountKey, billingAddress, card }) {
+export function formatUpdateData({ accountKey, billingAddress, card }) {
   const { securityCode } = card;
   const { zip, country, state } = billingAddress;
   return {
@@ -75,7 +75,7 @@ export function formatUpdateData ({ accountKey, billingAddress, card }) {
   };
 }
 
-export function formatCreateData ({
+export function formatCreateData({
   accountNumber,
   crmId,
   name,
@@ -83,14 +83,15 @@ export function formatCreateData ({
   discountId = false,
   billingId,
   creditCard,
-  billToContact
+  billToContact,
+  invoiceCollect = true
 }) {
   const formatted = {
     accountNumber,
     autoPay: true,
     crmId,
     currency: 'USD',
-    invoiceCollect: true,
+    invoiceCollect,
     name,
     subscription: {
       contractEffectiveDate,
@@ -108,7 +109,7 @@ export function formatCreateData ({
   return formatted;
 }
 
-export function formatContactData ({ billingContact }) {
+export function formatContactData({ billingContact }) {
   return {
     email: billingContact.email,
     first_name: billingContact.firstName,
@@ -120,7 +121,7 @@ export function formatContactData ({ billingContact }) {
 }
 
 // Formats countries before storing in state
-export function formatCountries (countries) {
+export function formatCountries(countries) {
   const ordered = _.flatten([
     _.remove(countries, { code: 'US' }),
     _.remove(countries, { code: 'GB' }),
@@ -131,14 +132,14 @@ export function formatCountries (countries) {
   return ordered.map((country) => formatForSelect(country));
 }
 
-function formatForSelect ({ code, name, states }) {
+function formatForSelect({ code, name, states }) {
   if (states) {
     return { value: code, label: name, states: states.map((state) => formatForSelect(state)) };
   }
   return { value: code, label: name };
 }
 
-export function getZipLabel (country) {
+export function getZipLabel(country) {
   if (country === 'US') {
     return 'Zip Code';
   }
@@ -153,7 +154,7 @@ export function getZipLabel (country) {
 /**
  * Reshapes type strings from what the payment lib provides to a format our api accepts
  */
-export function formatCardTypes (cards) {
+export function formatCardTypes(cards) {
   return cards.map((card) => {
     const type = _.find(config.cardTypes, { paymentFormat: card.type });
     return { ...card, type: type ? type.apiFormat : card.type };
@@ -161,13 +162,13 @@ export function formatCardTypes (cards) {
 }
 
 
-export function getPlanPrice (plan) {
+export function getPlanPrice(plan) {
   const pricingInterval = _.has(plan, 'hourly') ? 'hourly' : 'monthly';
   const intervalShortName = pricingInterval === 'hourly' ? 'hr' : 'mo';
   return { intervalShort: intervalShortName, intervalLong: pricingInterval, price: plan[pricingInterval] };
 }
 
-export function prepareCardInfo ({ expCombined, ...cardInfo }) {
+export function prepareCardInfo({ expCombined, ...cardInfo }) {
   const expiryInfo = Payment.fns.cardExpiryVal(expCombined);
 
   return {

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -16,6 +16,7 @@ export const isSuspendedForBilling = all(
 );
 export const subscriptionSelfServeIsTrue = ({ account }) => _.get(account, 'subscription.self_serve', false);
 export const isAws = ({ account }) => _.get(account, 'subscription.type') === 'aws';
+export const isCustomBilling = ({ account }) => _.get(account, 'subscription.custom', false);
 export const isSelfServeBilling = any(subscriptionSelfServeIsTrue, isAws);
 export const hasOnlineSupport = ({ account }) => _.get(account, 'support.online', false);
 export const hasUiOption = (option) => ({ account }) => _.has(account.options, `ui.${option}`);

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 export const onPlan = (planCode) => ({ accountPlan }) => accountPlan.code === planCode;
 export const onPlanWithStatus = (status) => ({ accountPlan }) => accountPlan.status === status;
 export const onServiceLevel = (level) => ({ account }) => account.service_level === level;
-export const onSubscriptionWithType = (type) => ({ account: { subscription }}) => subscription.type === type;
 export const isEnterprise = any(
   onPlan('ent1'),
   onServiceLevel('enterprise')
@@ -18,11 +17,7 @@ export const isSuspendedForBilling = all(
 export const subscriptionSelfServeIsTrue = ({ account }) => _.get(account, 'subscription.self_serve', false);
 export const isAws = ({ account }) => _.get(account, 'subscription.type') === 'aws';
 export const isCustomBilling = ({ account }) => _.get(account, 'subscription.custom', false);
-export const isSelfServeBilling = any(
-  subscriptionSelfServeIsTrue,
-  all(isCustomBilling, onSubscriptionWithType('zuora')),
-  isAws
-);
+export const isSelfServeBilling = any(subscriptionSelfServeIsTrue, isAws);
 export const hasOnlineSupport = ({ account }) => _.get(account, 'support.online', false);
 export const hasUiOption = (option) => ({ account }) => _.has(account.options, `ui.${option}`);
 export const isSubscriptionPending = ({ account }) => Boolean(account.pending_subscription);

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 export const onPlan = (planCode) => ({ accountPlan }) => accountPlan.code === planCode;
 export const onPlanWithStatus = (status) => ({ accountPlan }) => accountPlan.status === status;
 export const onServiceLevel = (level) => ({ account }) => account.service_level === level;
+export const onSubscriptionWithType = (type) => ({ account: { subscription }}) => subscription.type === type;
 export const isEnterprise = any(
   onPlan('ent1'),
   onServiceLevel('enterprise')
@@ -17,6 +18,11 @@ export const isSuspendedForBilling = all(
 export const subscriptionSelfServeIsTrue = ({ account }) => _.get(account, 'subscription.self_serve', false);
 export const isAws = ({ account }) => _.get(account, 'subscription.type') === 'aws';
 export const isCustomBilling = ({ account }) => _.get(account, 'subscription.custom', false);
-export const isSelfServeBilling = any(subscriptionSelfServeIsTrue, isAws);
+export const isSelfServeBilling = any(
+  subscriptionSelfServeIsTrue,
+  all(isCustomBilling, onSubscriptionWithType('zuora')),
+  isAws
+);
 export const hasOnlineSupport = ({ account }) => _.get(account, 'support.online', false);
 export const hasUiOption = (option) => ({ account }) => _.has(account.options, `ui.${option}`);
+export const isSubscriptionPending = ({ account }) => Boolean(account.pending_subscription);

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -6,6 +6,7 @@ import {
   isSuspendedForBilling,
   hasStatus,
   hasStatusReasonCategory,
+  isCustomBilling,
   isSelfServeBilling,
   hasOnlineSupport,
   hasUiOption
@@ -164,5 +165,32 @@ describe('Condition: hasUiOption', () => {
       }
     };
     expect(hasUiOption('iceCream')(state)).toEqual(false);
+  });
+});
+
+
+describe('Condition: isCustomBilling', () => {
+  it('should return false', () => {
+    const state = {
+      account: {
+        subscription: {
+          custom: false
+        }
+      }
+    };
+
+    expect(isCustomBilling(state)).toEqual(false);
+  });
+
+  it('should return true', () => {
+    const state = {
+      account: {
+        subscription: {
+          custom: true
+        }
+      }
+    };
+
+    expect(isCustomBilling(state)).toEqual(true);
   });
 });

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -2,6 +2,7 @@ import {
   onPlan,
   onPlanWithStatus,
   onServiceLevel,
+  onSubscriptionWithType,
   isEnterprise,
   isSuspendedForBilling,
   hasStatus,
@@ -111,18 +112,49 @@ describe('Conditon: hasStatusReasonCategory', () => {
 });
 
 describe('Condition: isSelfServeBilling', () => {
-
-  it('should return whether the account is self serve billing', () => {
+  it('should return false with undefined subscription', () => {
     const account = {};
     expect(isSelfServeBilling({ account })).toEqual(false);
-    account.subscription = {};
+  });
+
+  it('should return false with empty subscription', () => {
+    const account = {
+      subscription: {}
+    };
+
     expect(isSelfServeBilling({ account })).toEqual(false);
-    account.subscription.self_serve = false;
+  });
+
+  it('should return false with manual subscription', () => {
+    const account = {
+      subscription: {
+        self_serve: false
+      }
+    };
+
     expect(isSelfServeBilling({ account })).toEqual(false);
-    account.subscription.self_serve = true;
+  });
+
+  it('should return true with custom self server subscription', () => {
+    const account = {
+      subscription: {
+        custom: true,
+        type: 'zuora'
+      }
+    };
+
     expect(isSelfServeBilling({ account })).toEqual(true);
   });
 
+  it('should return true with self serve subscription', () => {
+    const account = {
+      subscription: {
+        self_serve: true
+      }
+    };
+
+    expect(isSelfServeBilling({ account })).toEqual(true);
+  });
 });
 
 describe('Condition: hasOnlineSupport', () => {
@@ -192,5 +224,31 @@ describe('Condition: isCustomBilling', () => {
     };
 
     expect(isCustomBilling(state)).toEqual(true);
+  });
+});
+
+describe('Condition: onSubscriptionWithType', () => {
+  it('should return true', () => {
+    const state = {
+      account: {
+        subscription: {
+          type: 'manual'
+        }
+      }
+    };
+
+    expect(onSubscriptionWithType('manual')(state)).toEqual(true);
+  });
+
+  it('should return false', () => {
+    const state = {
+      account: {
+        subscription: {
+          type: 'manual'
+        }
+      }
+    };
+
+    expect(onSubscriptionWithType('zuora')(state)).toEqual(false);
   });
 });

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -2,7 +2,6 @@ import {
   onPlan,
   onPlanWithStatus,
   onServiceLevel,
-  onSubscriptionWithType,
   isEnterprise,
   isSuspendedForBilling,
   hasStatus,
@@ -135,17 +134,6 @@ describe('Condition: isSelfServeBilling', () => {
     expect(isSelfServeBilling({ account })).toEqual(false);
   });
 
-  it('should return true with custom self server subscription', () => {
-    const account = {
-      subscription: {
-        custom: true,
-        type: 'zuora'
-      }
-    };
-
-    expect(isSelfServeBilling({ account })).toEqual(true);
-  });
-
   it('should return true with self serve subscription', () => {
     const account = {
       subscription: {
@@ -224,31 +212,5 @@ describe('Condition: isCustomBilling', () => {
     };
 
     expect(isCustomBilling(state)).toEqual(true);
-  });
-});
-
-describe('Condition: onSubscriptionWithType', () => {
-  it('should return true', () => {
-    const state = {
-      account: {
-        subscription: {
-          type: 'manual'
-        }
-      }
-    };
-
-    expect(onSubscriptionWithType('manual')(state)).toEqual(true);
-  });
-
-  it('should return false', () => {
-    const state = {
-      account: {
-        subscription: {
-          type: 'manual'
-        }
-      }
-    };
-
-    expect(onSubscriptionWithType('zuora')(state)).toEqual(false);
   });
 });

--- a/src/helpers/tests/__snapshots__/billing.test.js.snap
+++ b/src/helpers/tests/__snapshots__/billing.test.js.snap
@@ -55,6 +55,28 @@ Array [
 ]
 `;
 
+exports[`Billing Helpers formatCreateData returns formatted data 1`] = `
+Object {
+  "accountNumber": 123,
+  "autoPay": true,
+  "billToContact": Symbol(bill-to-contact),
+  "creditCard": Symbol(credit-card),
+  "crmId": 123,
+  "currency": "USD",
+  "invoiceCollect": true,
+  "name": "Super Test",
+  "subscription": Object {
+    "contractEffectiveDate": "01/01/1970",
+    "subscribeToRatePlans": Array [
+      Object {
+        "productRatePlanId": "b1ll7",
+      },
+    ],
+    "termType": "EVERGREEN",
+  },
+}
+`;
+
 exports[`Billing Helpers formatDataForCors should return the correctly formatted values 1`] = `
 Object {
   "billingData": Object {

--- a/src/helpers/tests/billing.test.js
+++ b/src/helpers/tests/billing.test.js
@@ -1,6 +1,7 @@
 import {
   formatCountries,
   formatCardTypes,
+  formatCreateData,
   formatDataForCors,
   getPlanPrice,
   prepareCardInfo
@@ -95,8 +96,20 @@ describe('Billing Helpers', () => {
       expect(prepareCardInfo({ number: '411', expCombined: '02 / 2019' })).toMatchSnapshot();
     });
   });
+
+  describe('formatCreateData', () => {
+    it('returns formatted data', () => {
+      const data = {
+        accountNumber: 123,
+        billingId: 'b1ll7',
+        billToContact: Symbol('bill-to-contact'),
+        contractEffectiveDate: '01/01/1970',
+        creditCard: Symbol('credit-card'),
+        crmId: 123,
+        name: 'Super Test'
+      };
+
+      expect(formatCreateData(data)).toMatchSnapshot();
+    });
+  });
 });
-
-
-
-

--- a/src/pages/billing/EnableAutomaticBillingPage.js
+++ b/src/pages/billing/EnableAutomaticBillingPage.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Page } from '@sparkpost/matchbox';
+import PageLink from 'src/components/pageLink/PageLink';
+import EnableAutomaticBillingForm from './forms/EnableAutomaticBillingForm';
+
+const EnableAutomaticBillingPage = () => (
+  <Page
+    breadcrumbAction={{
+      Component: PageLink,
+      content: 'Back to billing',
+      to: '/account/billing'
+    }}
+  >
+    <EnableAutomaticBillingForm />
+  </Page>
+);
+
+export default EnableAutomaticBillingPage;

--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -8,21 +8,21 @@ import ConditionSwitch, { defaultCase } from 'src/components/auth/ConditionSwitc
 import { not } from 'src/helpers/conditions';
 import { isSuspendedForBilling, isSelfServeBilling } from 'src/helpers/conditions/account';
 import { Loading } from 'src/components';
-import { ManuallyBilledBanner } from './components/Banners';
 import BillingSummary from './components/BillingSummary';
+import ManuallyBilledBanner from './components/ManuallyBilledBanner';
 import SuspendedForBilling from './components/SuspendedForBilling';
 import { list as getInvoices } from 'src/actions/invoices';
 
 export class BillingSummaryPage extends Component {
 
-  componentDidMount () {
+  componentDidMount() {
     this.props.fetchAccount({ include: 'billing' });
     this.props.getPlans();
     this.props.getSendingIps();
     this.props.getInvoices();
   }
 
-  render () {
+  render() {
     const { loading, account, billingInfo, sendingIps, invoices } = this.props;
 
     if (loading) {

--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 import { LINKS } from 'src/constants';
 import * as conversions from 'src/helpers/conversionTracking';
 import { ANALYTICS_PREMIUM_SUPPORT, ANALYTICS_ENTERPRISE_SUPPORT } from 'src/constants';
-import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 const dateFormat = (date) => format(date, 'MMM DD, YYYY');
 
@@ -25,46 +24,6 @@ export const PendingPlanBanner = ({ account }) => {
         on {dateFormat(account.pending_subscription.effective_date)}, and can't update your plan
         until that switch happens.
       </p>
-    </Banner>
-  );
-};
-
-/**
- * Renders plan information for non-self-serve users
- * @prop account Account state from redux store
- */
-export const ManuallyBilledBanner = ({ account, ...rest }) => {
-  if (account.subscription.self_serve || !account.subscription.plan_volume) {
-    return null;
-  }
-
-  const convertAction = !account.pending_subscription
-    ? { content: 'Enable Automatic Billing', to: '/account/billing/plan', Component: Link }
-    : null;
-
-  const convertMarkup = !account.pending_subscription
-    ? <p>Enable automatic billing to self-manage your plan and add-ons.</p>
-    : null;
-
-  return (
-    <Banner
-      status='info'
-      title={`Your current ${account.subscription.name} plan includes ${account.subscription.plan_volume.toLocaleString()} emails per month`}
-      action={convertAction}
-    >
-      {account.pending_subscription ? (
-        <p>
-          You're scheduled to switch to the {account.pending_subscription.name} plan
-          on {dateFormat(account.pending_subscription.effective_date)}.
-        </p>
-      ) : (
-        <p>
-          To make changes to your plan, billing information, or addons, please {
-            <SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>
-          }.
-        </p>
-      )}
-      {convertMarkup}
     </Banner>
   );
 };

--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -71,7 +71,7 @@ export default class BillingSummary extends Component {
 
         <Panel accent title='Plan Overview'>
           <Panel.Section {...changePlanActions}>
-            <PlanSummary label='Your Plan' plan={currentPlan} />
+            <PlanSummary label='Your Plan' plan={account.subscription} />
           </Panel.Section>
           {canPurchaseIps && this.renderDedicatedIpSummarySection()}
         </Panel>

--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -71,7 +71,9 @@ export default class BillingSummary extends Component {
 
         <Panel accent title='Plan Overview'>
           <Panel.Section {...changePlanActions}>
-            <PlanSummary label='Your Plan' plan={account.subscription} />
+            <LabelledValue label="Your Plan">
+              <PlanSummary plan={account.subscription} />
+            </LabelledValue>
           </Panel.Section>
           {canPurchaseIps && this.renderDedicatedIpSummarySection()}
         </Panel>

--- a/src/pages/billing/components/ManuallyBilledBanner.js
+++ b/src/pages/billing/components/ManuallyBilledBanner.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { Banner } from '@sparkpost/matchbox';
+import PageLink from 'src/components/pageLink/PageLink';
+import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
+
+const dateFormat = (date) => format(date, 'MMM DD, YYYY');
+
+/**
+ * Renders plan information for non-self-serve users
+ * @prop account Account state from redux store
+ */
+const ManuallyBilledBanner = ({
+  account: {
+    pending_subscription: pendingSubscription,
+    subscription: {
+      custom,
+      name: subscriptionName,
+      period = 'month',
+      plan_volume: planVolume,
+      plan_volume_per_period: planVolumePerPeriod
+    }
+  }
+}) => {
+  const localePlanVolume = (planVolumePerPeriod || planVolume || 0).toLocaleString();
+  const title = `
+    Your current ${subscriptionName} plan includes ${localePlanVolume} emails per ${period}
+  `;
+
+  if (pendingSubscription) {
+    return (
+      <Banner status="info" title={title}>
+        <p>
+          You're scheduled to switch to the {pendingSubscription.name} plan on {
+            dateFormat(pendingSubscription.effective_date)
+          }.
+        </p>
+      </Banner>
+    );
+  }
+
+  // this is an edge case and should not happen often
+  if (custom && !planVolumePerPeriod) {
+    return (
+      <Banner
+        status="warning"
+        title="Your current plan is being transitioned to a custom plan"
+      >
+        <p>
+          If your account should not be transitioned, please {
+            <SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>
+          }.
+        </p>
+      </Banner>
+    );
+  }
+
+  return (
+    <Banner
+      status="info"
+      title={title}
+      action={{
+        Component: PageLink,
+        content: 'Enable Automatic Billing',
+        to: custom ? '/account/billing/enable-automatic' : '/account/billing/plan'
+      }}
+    >
+      <p>
+        To make changes to your plan or billing information, please {
+          <SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>
+        }.
+      </p>
+      {!custom && (
+        <p>
+          Enable automatic billing to self-manage your plan and add-ons.
+        </p>
+      )}
+    </Banner>
+  );
+};
+
+export default ManuallyBilledBanner;

--- a/src/pages/billing/components/ManuallyBilledBanner.js
+++ b/src/pages/billing/components/ManuallyBilledBanner.js
@@ -18,7 +18,7 @@ const ManuallyBilledBanner = ({
     }
   }
 }) => {
-  const localePlanVolume = (planVolumePerPeriod || planVolume || 0).toLocaleString();
+  const localePlanVolume = (planVolumePerPeriod || planVolume).toLocaleString();
   const title = `
     Your current ${subscriptionName} plan includes ${localePlanVolume} emails per ${period}
   `;

--- a/src/pages/billing/components/ManuallyBilledBanner.js
+++ b/src/pages/billing/components/ManuallyBilledBanner.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { format } from 'date-fns';
 import { Banner } from '@sparkpost/matchbox';
 import PageLink from 'src/components/pageLink/PageLink';
 import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
-
-const dateFormat = (date) => format(date, 'MMM DD, YYYY');
 
 /**
  * Renders plan information for non-self-serve users
@@ -12,7 +9,6 @@ const dateFormat = (date) => format(date, 'MMM DD, YYYY');
  */
 const ManuallyBilledBanner = ({
   account: {
-    pending_subscription: pendingSubscription,
     subscription: {
       custom,
       name: subscriptionName,
@@ -26,18 +22,6 @@ const ManuallyBilledBanner = ({
   const title = `
     Your current ${subscriptionName} plan includes ${localePlanVolume} emails per ${period}
   `;
-
-  if (pendingSubscription) {
-    return (
-      <Banner status="info" title={title}>
-        <p>
-          You're scheduled to switch to the {pendingSubscription.name} plan on {
-            dateFormat(pendingSubscription.effective_date)
-          }.
-        </p>
-      </Banner>
-    );
-  }
 
   // this is an edge case and should not happen often
   if (custom && !planVolumePerPeriod) {

--- a/src/pages/billing/components/ManuallyBilledBanner.js
+++ b/src/pages/billing/components/ManuallyBilledBanner.js
@@ -44,7 +44,7 @@ const ManuallyBilledBanner = ({
     return (
       <Banner
         status="warning"
-        title="Your current plan is being transitioned to a custom plan"
+        title={`Your current plan is being transitioned to a ${subscriptionName} plan`}
       >
         <p>
           If your account should not be transitioned, please {

--- a/src/pages/billing/components/PlanSummary.js
+++ b/src/pages/billing/components/PlanSummary.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LabelledValue } from 'src/components';
+import styles from './PlanSummary.module.scss';
 
 const PlanSummary = ({
   plan: {
@@ -16,12 +16,12 @@ const PlanSummary = ({
   const volume = (planVolumePerPeriod || planVolume).toLocaleString();
 
   return (
-    <LabelledValue label="Your Plan">
-      <h6>
+    <React.Fragment>
+      <h6 className={styles.Headline}>
         {volume} emails for {cost}
       </h6>
       {overage && <p>${overage.toFixed(2)} per thousand extra emails</p>}
-    </LabelledValue>
+    </React.Fragment>
   );
 };
 

--- a/src/pages/billing/components/PlanSummary.js
+++ b/src/pages/billing/components/PlanSummary.js
@@ -1,31 +1,26 @@
 import React from 'react';
 import { LabelledValue } from 'src/components';
 
-const PlanSummary = ({ plan }) => {
-  let monthly = '';
-
-  if (!plan) {
-    return <LabelledValue label='Your Plan' />;
+const PlanSummary = ({
+  plan: {
+    period,
+    plan_volume: planVolume,
+    plan_volume_per_period: planVolumePerPeriod,
+    overage,
+    recurring_charge: recurringCharge
   }
-
-  if (plan.monthly !== undefined) {
-    monthly = plan.monthly === 0
-      ? 'for Free'
-      : <span><strong>for ${plan.monthly.toLocaleString()}</strong> per month</span>;
-  }
-
-  const overage = plan.overage
-    ? <p>${plan.overage.toFixed(2)}/thousand extra emails</p>
-    : null;
-
-  const volume = plan.volume
-    ? <span><strong>{plan.volume.toLocaleString()}</strong> emails</span>
-    : null;
+}) => {
+  const cost = recurringCharge === 0
+    ? 'Free'
+    : `$${recurringCharge.toLocaleString()} per ${period || 'month'}`;
+  const volume = (planVolumePerPeriod || planVolume).toLocaleString();
 
   return (
-    <LabelledValue label='Your Plan'>
-      <h6>{ volume } { monthly }</h6>
-      { overage }
+    <LabelledValue label="Your Plan">
+      <h6>
+        {volume} emails for {cost}
+      </h6>
+      {overage && <p>${overage.toFixed(2)} per thousand extra emails</p>}
     </LabelledValue>
   );
 };

--- a/src/pages/billing/components/PlanSummary.module.scss
+++ b/src/pages/billing/components/PlanSummary.module.scss
@@ -1,0 +1,3 @@
+.Headline {
+  margin-bottom: 0;
+}

--- a/src/pages/billing/components/tests/Banners.test.js
+++ b/src/pages/billing/components/tests/Banners.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PendingPlanBanner, ManuallyBilledBanner, PremiumBanner, EnterpriseBanner } from '../Banners';
+import { PendingPlanBanner, PremiumBanner, EnterpriseBanner } from '../Banners';
 import * as conversions from 'src/helpers/conversionTracking';
 import * as constants from 'src/constants';
 import { shallow } from 'enzyme';
@@ -15,44 +15,6 @@ describe('Billing Banners: ', () => {
     };
     const wrapper = shallow(<PendingPlanBanner {...props} />);
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('ManuallyBilledBanner should render with subscription', () => {
-    const props = {
-      account: {
-        subscription: {
-          name: 'whoa',
-          plan_volume: 123
-        }
-      }
-    };
-    const wrapper = shallow(<ManuallyBilledBanner {...props} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('ManuallyBilledBanner should render with pending subscription', () => {
-    const props = {
-      account: {
-        subscription: {
-          name: 'whoa',
-          plan_volume: 123
-        },
-        pending_subscription: {
-          name: 'omg',
-          effective_date: '10/5/2020'
-        }
-      }
-    };
-    const wrapper = shallow(<ManuallyBilledBanner {...props} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('ManuallyBilledBanner should not render if self-serve', () => {
-    const props = {
-      account: { subscription: { self_serve: true }}
-    };
-    const wrapper = shallow(<ManuallyBilledBanner {...props} />);
-    expect(wrapper.find('t')).not.toExist();
   });
 
   describe('Premium banner', () => {

--- a/src/pages/billing/components/tests/BillingSummary.test.js
+++ b/src/pages/billing/components/tests/BillingSummary.test.js
@@ -15,7 +15,10 @@ describe('Component: Billing Summary', () => {
   beforeEach(() => {
     props = {
       account: {
-        billing: {}
+        billing: {},
+        subscription: {
+          plan_volume: 15000
+        }
       },
       currentPlan: {
         isFree: true

--- a/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
+++ b/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
@@ -18,21 +18,12 @@ describe('ManuallyBilledBanner', () => {
     expect(subject({ account })).toMatchSnapshot();
   });
 
-  it('renders banner with plan volume of zero when missing', () => {
-    const account = {
-      subscription: {
-        name: 'Test'
-      }
-    };
-
-    expect(subject({ account })).toMatchSnapshot();
-  });
-
   it('with transitioning custom subscription', () => {
     const account = {
       subscription: {
         custom: true,
         name: 'Custom',
+        plan_volume: 15000,
         plan_volume_per_period: undefined
       }
     };

--- a/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
+++ b/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
@@ -28,21 +28,6 @@ describe('ManuallyBilledBanner', () => {
     expect(subject({ account })).toMatchSnapshot();
   });
 
-  it('with pending subscription', () => {
-    const account = {
-      pending_subscription: {
-        name: 'Next Test',
-        effective_date: '10/5/2020'
-      },
-      subscription: {
-        name: 'Test',
-        plan_volume: 15000
-      }
-    };
-
-    expect(subject({ account })).toMatchSnapshot();
-  });
-
   it('with transitioning custom subscription', () => {
     const account = {
       subscription: {

--- a/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
+++ b/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
@@ -47,6 +47,7 @@ describe('ManuallyBilledBanner', () => {
     const account = {
       subscription: {
         custom: true,
+        name: 'Custom',
         plan_volume_per_period: undefined
       }
     };
@@ -58,6 +59,7 @@ describe('ManuallyBilledBanner', () => {
     const account = {
       subscription: {
         custom: true,
+        name: 'Custom',
         period: 'year',
         plan_volume: 10000,
         plan_volume_per_period: 120000

--- a/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
+++ b/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ManuallyBilledBanner from '../ManuallyBilledBanner';
+
+describe('ManuallyBilledBanner', () => {
+  const subject = ({ account = {}}) => (
+    shallow(<ManuallyBilledBanner account={account} />)
+  );
+
+  it('renders banner', () => {
+    const account = {
+      subscription: {
+        name: 'Test',
+        plan_volume: 15000
+      }
+    };
+
+    expect(subject({ account })).toMatchSnapshot();
+  });
+
+  it('renders banner with plan volume of zero when missing', () => {
+    const account = {
+      subscription: {
+        name: 'Test'
+      }
+    };
+
+    expect(subject({ account })).toMatchSnapshot();
+  });
+
+  it('with pending subscription', () => {
+    const account = {
+      pending_subscription: {
+        name: 'Next Test',
+        effective_date: '10/5/2020'
+      },
+      subscription: {
+        name: 'Test',
+        plan_volume: 15000
+      }
+    };
+
+    expect(subject({ account })).toMatchSnapshot();
+  });
+
+  it('with transitioning custom subscription', () => {
+    const account = {
+      subscription: {
+        custom: true,
+        plan_volume_per_period: undefined
+      }
+    };
+
+    expect(subject({ account })).toMatchSnapshot();
+  });
+
+  it('with custom subscription', () => {
+    const account = {
+      subscription: {
+        custom: true,
+        period: 'year',
+        plan_volume: 10000,
+        plan_volume_per_period: 120000
+      }
+    };
+
+    expect(subject({ account })).toMatchSnapshot();
+  });
+});

--- a/src/pages/billing/components/tests/PlanSummary.test.js
+++ b/src/pages/billing/components/tests/PlanSummary.test.js
@@ -2,53 +2,31 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import PlanSummary from '../PlanSummary';
 
-describe('Component: PlanSummary', () => {
+describe('PlanSummary', () => {
+  const subject = (plan = {}) => shallow(
+    <PlanSummary plan={{ plan_volume: 1000, recurring_charge: 100, ...plan }} />
+  );
 
-  let props;
-  let wrapper;
+  it('renders summary', () => {
+    expect(subject()).toMatchSnapshot();
+  });
 
-  beforeEach(() => {
-    props = {
-      plan: {
-        overage: 0.01,
-        monthly: 100000,
-        volume: 100000000
-      }
+  it('renders summary for free plan', () => {
+    expect(subject({ recurring_charge: 0 })).toMatchSnapshot();
+  });
+
+  it('renders summary with overages', () => {
+    expect(subject({ overage: 0.0123 })).toMatchSnapshot();
+  });
+
+  it('renders summary with custom plan', () => {
+    const plan = {
+      plan_volume: 1000,
+      plan_volume_per_period: 12000,
+      recurring_charge: 100,
+      period: 'year'
     };
-    wrapper = shallow(<PlanSummary {...props} />);
-  });
 
-  it('should render correctly', () => {
-    expect(wrapper).toMatchSnapshot();
+    expect(subject(plan)).toMatchSnapshot();
   });
-
-  it('should render with no monthly value', () => {
-    delete props.plan.monthly;
-    wrapper.setProps({ plan: props.plan });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should render with 0 monthly value', () => {
-    props.plan.monthly = 0;
-    wrapper.setProps({ plan: props.plan });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should render with no overage value', () => {
-    delete props.plan.overage;
-    wrapper.setProps({ plan: props.plan });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should render with no volume value', () => {
-    delete props.plan.volume;
-    wrapper.setProps({ plan: props.plan });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should render with no plan', () => {
-    wrapper.setProps({ plan: undefined });
-    expect(wrapper).toMatchSnapshot();
-  });
-
 });

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -33,49 +33,6 @@ exports[`Billing Banners:  Enterprise banner renders 1`] = `
 </Banner>
 `;
 
-exports[`Billing Banners:  ManuallyBilledBanner should render with pending subscription 1`] = `
-<Banner
-  action={null}
-  status="info"
-  title="Your current whoa plan includes 123 emails per month"
->
-  <p>
-    You're scheduled to switch to the 
-    omg
-     plan on 
-    Oct 05, 2020
-    .
-  </p>
-</Banner>
-`;
-
-exports[`Billing Banners:  ManuallyBilledBanner should render with subscription 1`] = `
-<Banner
-  action={
-    Object {
-      "Component": [Function],
-      "content": "Enable Automatic Billing",
-      "to": "/account/billing/plan",
-    }
-  }
-  status="info"
-  title="Your current whoa plan includes 123 emails per month"
->
-  <p>
-    To make changes to your plan, billing information, or addons, please 
-    <Connect(SupportTicketLink)
-      issueId="general_issue"
-    >
-      submit a support ticket
-    </Connect(SupportTicketLink)>
-    .
-  </p>
-  <p>
-    Enable automatic billing to self-manage your plan and add-ons.
-  </p>
-</Banner>
-`;
-
 exports[`Billing Banners:  PendingPlanBanner should render with pending_subscription 1`] = `
 <Banner
   status="info"

--- a/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
@@ -6,6 +6,9 @@ exports[`Component: Billing Summary should render correctly for a paid plan 1`] 
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -29,7 +32,7 @@ exports[`Component: Billing Summary should render correctly for a paid plan 1`] 
         label="Your Plan"
         plan={
           Object {
-            "isFree": false,
+            "plan_volume": 15000,
           }
         }
       />
@@ -99,6 +102,9 @@ exports[`Component: Billing Summary should render correctly for a standard free 
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -122,7 +128,7 @@ exports[`Component: Billing Summary should render correctly for a standard free 
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />
@@ -143,6 +149,9 @@ exports[`Component: Billing Summary should render correctly if you can't buy IPs
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -166,7 +175,7 @@ exports[`Component: Billing Summary should render correctly if you can't buy IPs
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />
@@ -227,6 +236,9 @@ exports[`Component: Billing Summary should render correctly if you can't change 
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -239,7 +251,7 @@ exports[`Component: Billing Summary should render correctly if you can't change 
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />
@@ -309,6 +321,9 @@ exports[`Component: Billing Summary should render correctly if you can't update 
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -332,7 +347,7 @@ exports[`Component: Billing Summary should render correctly if you can't update 
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />
@@ -362,6 +377,9 @@ exports[`Component: Billing Summary should render with IP modal open 1`] = `
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -385,7 +403,7 @@ exports[`Component: Billing Summary should render with IP modal open 1`] = `
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />
@@ -459,6 +477,9 @@ exports[`Component: Billing Summary should render with the billing contact modal
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -482,7 +503,7 @@ exports[`Component: Billing Summary should render with the billing contact modal
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />
@@ -556,6 +577,9 @@ exports[`Component: Billing Summary should render with the payment info modal op
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -579,7 +603,7 @@ exports[`Component: Billing Summary should render with the payment info modal op
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />
@@ -653,6 +677,9 @@ exports[`Component: Billing Summary should show the invoice history if there are
     account={
       Object {
         "billing": Object {},
+        "subscription": Object {
+          "plan_volume": 15000,
+        },
       }
     }
   />
@@ -676,7 +703,7 @@ exports[`Component: Billing Summary should show the invoice history if there are
         label="Your Plan"
         plan={
           Object {
-            "isFree": true,
+            "plan_volume": 15000,
           }
         }
       />

--- a/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
@@ -28,14 +28,17 @@ exports[`Component: Billing Summary should render correctly for a paid plan 1`] 
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
     <DedicatedIpSummarySection
       count={0}
@@ -124,14 +127,17 @@ exports[`Component: Billing Summary should render correctly for a standard free 
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
   </Panel>
   <Component />
@@ -171,14 +177,17 @@ exports[`Component: Billing Summary should render correctly if you can't buy IPs
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
   </Panel>
   <Panel
@@ -247,14 +256,17 @@ exports[`Component: Billing Summary should render correctly if you can't change 
     title="Plan Overview"
   >
     <Panel.Section>
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
     <DedicatedIpSummarySection
       count={0}
@@ -343,14 +355,17 @@ exports[`Component: Billing Summary should render correctly if you can't update 
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
     <DedicatedIpSummarySection
       count={0}
@@ -399,14 +414,17 @@ exports[`Component: Billing Summary should render with IP modal open 1`] = `
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
     <DedicatedIpSummarySection
       count={0}
@@ -499,14 +517,17 @@ exports[`Component: Billing Summary should render with the billing contact modal
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
     <DedicatedIpSummarySection
       count={0}
@@ -599,14 +620,17 @@ exports[`Component: Billing Summary should render with the payment info modal op
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
     <DedicatedIpSummarySection
       count={0}
@@ -699,14 +723,17 @@ exports[`Component: Billing Summary should show the invoice history if there are
         ]
       }
     >
-      <PlanSummary
+      <LabelledValue
         label="Your Plan"
-        plan={
-          Object {
-            "plan_volume": 15000,
+      >
+        <PlanSummary
+          plan={
+            Object {
+              "plan_volume": 15000,
+            }
           }
-        }
-      />
+        />
+      </LabelledValue>
     </Panel.Section>
     <DedicatedIpSummarySection
       count={0}

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
@@ -69,7 +69,7 @@ exports[`ManuallyBilledBanner with custom subscription 1`] = `
   }
   status="info"
   title="
-    Your current undefined plan includes 120,000 emails per year
+    Your current Custom plan includes 120,000 emails per year
   "
 >
   <p>
@@ -104,7 +104,7 @@ exports[`ManuallyBilledBanner with pending subscription 1`] = `
 exports[`ManuallyBilledBanner with transitioning custom subscription 1`] = `
 <Banner
   status="warning"
-  title="Your current plan is being transitioned to a custom plan"
+  title="Your current plan is being transitioned to a Custom plan"
 >
   <p>
     If your account should not be transitioned, please 

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
@@ -84,23 +84,6 @@ exports[`ManuallyBilledBanner with custom subscription 1`] = `
 </Banner>
 `;
 
-exports[`ManuallyBilledBanner with pending subscription 1`] = `
-<Banner
-  status="info"
-  title="
-    Your current Test plan includes 15,000 emails per month
-  "
->
-  <p>
-    You're scheduled to switch to the 
-    Next Test
-     plan on 
-    Oct 05, 2020
-    .
-  </p>
-</Banner>
-`;
-
 exports[`ManuallyBilledBanner with transitioning custom subscription 1`] = `
 <Banner
   status="warning"

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
@@ -29,35 +29,6 @@ exports[`ManuallyBilledBanner renders banner 1`] = `
 </Banner>
 `;
 
-exports[`ManuallyBilledBanner renders banner with plan volume of zero when missing 1`] = `
-<Banner
-  action={
-    Object {
-      "Component": [Function],
-      "content": "Enable Automatic Billing",
-      "to": "/account/billing/plan",
-    }
-  }
-  status="info"
-  title="
-    Your current Test plan includes 0 emails per month
-  "
->
-  <p>
-    To make changes to your plan or billing information, please 
-    <Connect(SupportTicketLink)
-      issueId="general_issue"
-    >
-      submit a support ticket
-    </Connect(SupportTicketLink)>
-    .
-  </p>
-  <p>
-    Enable automatic billing to self-manage your plan and add-ons.
-  </p>
-</Banner>
-`;
-
 exports[`ManuallyBilledBanner with custom subscription 1`] = `
 <Banner
   action={

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ManuallyBilledBanner renders banner 1`] = `
+<Banner
+  action={
+    Object {
+      "Component": [Function],
+      "content": "Enable Automatic Billing",
+      "to": "/account/billing/plan",
+    }
+  }
+  status="info"
+  title="
+    Your current Test plan includes 15,000 emails per month
+  "
+>
+  <p>
+    To make changes to your plan or billing information, please 
+    <Connect(SupportTicketLink)
+      issueId="general_issue"
+    >
+      submit a support ticket
+    </Connect(SupportTicketLink)>
+    .
+  </p>
+  <p>
+    Enable automatic billing to self-manage your plan and add-ons.
+  </p>
+</Banner>
+`;
+
+exports[`ManuallyBilledBanner renders banner with plan volume of zero when missing 1`] = `
+<Banner
+  action={
+    Object {
+      "Component": [Function],
+      "content": "Enable Automatic Billing",
+      "to": "/account/billing/plan",
+    }
+  }
+  status="info"
+  title="
+    Your current Test plan includes 0 emails per month
+  "
+>
+  <p>
+    To make changes to your plan or billing information, please 
+    <Connect(SupportTicketLink)
+      issueId="general_issue"
+    >
+      submit a support ticket
+    </Connect(SupportTicketLink)>
+    .
+  </p>
+  <p>
+    Enable automatic billing to self-manage your plan and add-ons.
+  </p>
+</Banner>
+`;
+
+exports[`ManuallyBilledBanner with custom subscription 1`] = `
+<Banner
+  action={
+    Object {
+      "Component": [Function],
+      "content": "Enable Automatic Billing",
+      "to": "/account/billing/enable-automatic",
+    }
+  }
+  status="info"
+  title="
+    Your current undefined plan includes 120,000 emails per year
+  "
+>
+  <p>
+    To make changes to your plan or billing information, please 
+    <Connect(SupportTicketLink)
+      issueId="general_issue"
+    >
+      submit a support ticket
+    </Connect(SupportTicketLink)>
+    .
+  </p>
+</Banner>
+`;
+
+exports[`ManuallyBilledBanner with pending subscription 1`] = `
+<Banner
+  status="info"
+  title="
+    Your current Test plan includes 15,000 emails per month
+  "
+>
+  <p>
+    You're scheduled to switch to the 
+    Next Test
+     plan on 
+    Oct 05, 2020
+    .
+  </p>
+</Banner>
+`;
+
+exports[`ManuallyBilledBanner with transitioning custom subscription 1`] = `
+<Banner
+  status="warning"
+  title="Your current plan is being transitioned to a custom plan"
+>
+  <p>
+    If your account should not be transitioned, please 
+    <Connect(SupportTicketLink)
+      issueId="general_issue"
+    >
+      submit a support ticket
+    </Connect(SupportTicketLink)>
+    .
+  </p>
+</Banner>
+`;

--- a/src/pages/billing/components/tests/__snapshots__/PlanSummary.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/PlanSummary.test.js.snap
@@ -1,46 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PlanSummary renders summary 1`] = `
-<LabelledValue
-  label="Your Plan"
->
-  <h6>
+<React.Fragment>
+  <h6
+    className="Headline"
+  >
     1,000
      emails for 
     $100 per month
   </h6>
-</LabelledValue>
+</React.Fragment>
 `;
 
 exports[`PlanSummary renders summary for free plan 1`] = `
-<LabelledValue
-  label="Your Plan"
->
-  <h6>
+<React.Fragment>
+  <h6
+    className="Headline"
+  >
     1,000
      emails for 
     Free
   </h6>
-</LabelledValue>
+</React.Fragment>
 `;
 
 exports[`PlanSummary renders summary with custom plan 1`] = `
-<LabelledValue
-  label="Your Plan"
->
-  <h6>
+<React.Fragment>
+  <h6
+    className="Headline"
+  >
     12,000
      emails for 
     $100 per year
   </h6>
-</LabelledValue>
+</React.Fragment>
 `;
 
 exports[`PlanSummary renders summary with overages 1`] = `
-<LabelledValue
-  label="Your Plan"
->
-  <h6>
+<React.Fragment>
+  <h6
+    className="Headline"
+  >
     1,000
      emails for 
     $100 per month
@@ -50,5 +50,5 @@ exports[`PlanSummary renders summary with overages 1`] = `
     0.01
      per thousand extra emails
   </p>
-</LabelledValue>
+</React.Fragment>
 `;

--- a/src/pages/billing/components/tests/__snapshots__/PlanSummary.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/PlanSummary.test.js.snap
@@ -1,123 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: PlanSummary should render correctly 1`] = `
+exports[`PlanSummary renders summary 1`] = `
 <LabelledValue
   label="Your Plan"
 >
   <h6>
-    <span>
-      <strong>
-        100,000,000
-      </strong>
-       emails
-    </span>
-     
-    <span>
-      <strong>
-        for $
-        100,000
-      </strong>
-       per month
-    </span>
-  </h6>
-  <p>
-    $
-    0.01
-    /thousand extra emails
-  </p>
-</LabelledValue>
-`;
-
-exports[`Component: PlanSummary should render with 0 monthly value 1`] = `
-<LabelledValue
-  label="Your Plan"
->
-  <h6>
-    <span>
-      <strong>
-        100,000,000
-      </strong>
-       emails
-    </span>
-     
-    for Free
-  </h6>
-  <p>
-    $
-    0.01
-    /thousand extra emails
-  </p>
-</LabelledValue>
-`;
-
-exports[`Component: PlanSummary should render with no monthly value 1`] = `
-<LabelledValue
-  label="Your Plan"
->
-  <h6>
-    <span>
-      <strong>
-        100,000,000
-      </strong>
-       emails
-    </span>
-     
-  </h6>
-  <p>
-    $
-    0.01
-    /thousand extra emails
-  </p>
-</LabelledValue>
-`;
-
-exports[`Component: PlanSummary should render with no overage value 1`] = `
-<LabelledValue
-  label="Your Plan"
->
-  <h6>
-    <span>
-      <strong>
-        100,000,000
-      </strong>
-       emails
-    </span>
-     
-    <span>
-      <strong>
-        for $
-        100,000
-      </strong>
-       per month
-    </span>
+    1,000
+     emails for 
+    $100 per month
   </h6>
 </LabelledValue>
 `;
 
-exports[`Component: PlanSummary should render with no plan 1`] = `
-<LabelledValue
-  label="Your Plan"
-/>
-`;
-
-exports[`Component: PlanSummary should render with no volume value 1`] = `
+exports[`PlanSummary renders summary for free plan 1`] = `
 <LabelledValue
   label="Your Plan"
 >
   <h6>
-     
-    <span>
-      <strong>
-        for $
-        100,000
-      </strong>
-       per month
-    </span>
+    1,000
+     emails for 
+    Free
+  </h6>
+</LabelledValue>
+`;
+
+exports[`PlanSummary renders summary with custom plan 1`] = `
+<LabelledValue
+  label="Your Plan"
+>
+  <h6>
+    12,000
+     emails for 
+    $100 per year
+  </h6>
+</LabelledValue>
+`;
+
+exports[`PlanSummary renders summary with overages 1`] = `
+<LabelledValue
+  label="Your Plan"
+>
+  <h6>
+    1,000
+     emails for 
+    $100 per month
   </h6>
   <p>
     $
     0.01
-    /thousand extra emails
+     per thousand extra emails
   </p>
 </LabelledValue>
 `;

--- a/src/pages/billing/forms/EnableAutomaticBillingForm.js
+++ b/src/pages/billing/forms/EnableAutomaticBillingForm.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { reduxForm } from 'redux-form';
+import { withRouter } from 'react-router-dom';
+import { Button, Grid, Panel } from '@sparkpost/matchbox';
+import { getBillingCountries } from 'src/actions/billing';
+import billingCreate from 'src/actions/billingCreate';
+import { showAlert } from 'src/actions/globalAlert';
+import { Loading } from 'src/components/loading/Loading';
+import { prepareCardInfo } from 'src/helpers/billing';
+import { currentPlanSelector } from 'src/selectors/accountBillingInfo';
+import { getFirstCountry, getFirstStateForCountry } from 'src/selectors/accountBillingForms';
+import BillingAddressForm from './fields/BillingAddressForm';
+import PaymentForm from './fields/PaymentForm';
+
+const FORMNAME = 'enableAutomaticBilling';
+
+export class EnableAutomaticBillingForm extends React.Component {
+  componentDidMount() {
+    this.props.getBillingCountries();
+  }
+
+  onSubmit = (values) => {
+    const { billingCreate, history, showAlert } = this.props;
+
+    return billingCreate({ ...values, card: prepareCardInfo(values.card) })
+      .then(() => {
+        history.push('/account/billing');
+        showAlert({ type: 'success', message: 'Automatic Billing Enabled' });
+      });
+  };
+
+  render() {
+    const { billingCountries, currentPlan, handleSubmit, loading, submitting } = this.props;
+
+    if (loading) {
+      return <Loading />;
+    }
+
+    return (
+      <form onSubmit={handleSubmit(this.onSubmit)}>
+        <Grid>
+          <Grid.Column>
+            <Panel title="Add a Credit Card">
+              <Panel.Section>
+                <PaymentForm formName={FORMNAME} disabled={submitting} />
+              </Panel.Section>
+              <Panel.Section>
+                <BillingAddressForm
+                  formName={FORMNAME}
+                  disabled={submitting}
+                  countries={billingCountries}
+                />
+              </Panel.Section>
+            </Panel>
+          </Grid.Column>
+          <Grid.Column xs={12} md={5}>
+            <Panel>
+              <Panel.Section>
+                <small>Your Plan</small>
+                <h4>
+                  {currentPlan.plan_volume_per_period.toLocaleString()} emails/{currentPlan.period}
+                </h4>
+              </Panel.Section>
+              <Panel.Section>
+                <Button disabled={submitting} fullWidth primary type="submit">
+                  Enable Automatic Billing
+                </Button>
+              </Panel.Section>
+            </Panel>
+          </Grid.Column>
+        </Grid>
+      </form>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  const country = getFirstCountry(state);
+  const { billingId } = currentPlanSelector(state);
+
+  return {
+    billingCountries: state.billing.countries,
+    currentPlan: state.account.subscription,
+    initialValues: {
+      email: state.currentUser.email,
+      billingAddress: {
+        firstName: state.currentUser.first_name, // for billingCreate
+        lastName: state.currentUser.last_name, // for billingCreate
+        state: getFirstStateForCountry(state, country),
+        country
+      },
+      planpicker: {
+        billingId // for billingCreate
+      }
+    },
+    loading: state.billing.plansLoading
+  };
+};
+
+const mapDispatchtoProps = {
+  billingCreate,
+  getBillingCountries,
+  showAlert
+};
+
+export default (
+  withRouter(
+    connect(mapStateToProps, mapDispatchtoProps)(
+      reduxForm({ form: FORMNAME, enableReinitialize: true })(EnableAutomaticBillingForm)
+    )
+  )
+);

--- a/src/pages/billing/forms/EnableAutomaticBillingForm.js
+++ b/src/pages/billing/forms/EnableAutomaticBillingForm.js
@@ -75,7 +75,7 @@ export class EnableAutomaticBillingForm extends React.Component {
 
 const mapStateToProps = (state) => {
   const country = getFirstCountry(state);
-  const { billingId } = currentPlanSelector(state);
+  const currentPlan = currentPlanSelector(state);
 
   return {
     billingCountries: state.billing.countries,
@@ -88,9 +88,7 @@ const mapStateToProps = (state) => {
         state: getFirstStateForCountry(state, country),
         country
       },
-      planpicker: {
-        billingId // for billingCreate
-      }
+      planpicker: currentPlan // for billingCreate
     },
     loading: state.billing.plansLoading
   };

--- a/src/pages/billing/forms/EnableAutomaticBillingForm.js
+++ b/src/pages/billing/forms/EnableAutomaticBillingForm.js
@@ -10,6 +10,7 @@ import { Loading } from 'src/components/loading/Loading';
 import { prepareCardInfo } from 'src/helpers/billing';
 import { currentPlanSelector } from 'src/selectors/accountBillingInfo';
 import { getFirstCountry, getFirstStateForCountry } from 'src/selectors/accountBillingForms';
+import PlanSummary from '../components/PlanSummary';
 import BillingAddressForm from './fields/BillingAddressForm';
 import PaymentForm from './fields/PaymentForm';
 
@@ -31,7 +32,7 @@ export class EnableAutomaticBillingForm extends React.Component {
   };
 
   render() {
-    const { billingCountries, currentPlan, handleSubmit, loading, submitting } = this.props;
+    const { billingCountries, currentSubscription, handleSubmit, loading, submitting } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -55,12 +56,9 @@ export class EnableAutomaticBillingForm extends React.Component {
             </Panel>
           </Grid.Column>
           <Grid.Column xs={12} md={5}>
-            <Panel>
+            <Panel title="Your Plan">
               <Panel.Section>
-                <small>Your Plan</small>
-                <h4>
-                  {currentPlan.plan_volume_per_period.toLocaleString()} emails/{currentPlan.period}
-                </h4>
+                <PlanSummary plan={currentSubscription} />
               </Panel.Section>
               <Panel.Section>
                 <Button disabled={submitting} fullWidth primary type="submit">
@@ -81,7 +79,7 @@ const mapStateToProps = (state) => {
 
   return {
     billingCountries: state.billing.countries,
-    currentPlan: state.account.subscription,
+    currentSubscription: state.account.subscription,
     initialValues: {
       email: state.currentUser.email,
       billingAddress: {

--- a/src/pages/billing/forms/tests/EnableAutomaticBillingForm.test.js
+++ b/src/pages/billing/forms/tests/EnableAutomaticBillingForm.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import * as billingHelpers from 'src/helpers/billing';
+import { EnableAutomaticBillingForm } from '../EnableAutomaticBillingForm';
+
+jest.mock('src/helpers/billing');
+
+describe('EnableAutomaticBillingForm', () => {
+  const subject = (props = {}) => shallow(
+    <EnableAutomaticBillingForm
+      billingCountries={[
+        { value: 'US', label: 'United States' }
+      ]}
+      currentPlan={{
+        plan_volume_per_period: 15000,
+        period: 'year'
+      }}
+      handleSubmit={(handler) => handler}
+      getBillingCountries={() => (undefined)}
+      {...props}
+    />
+  );
+
+  it('renders form', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('calls getBillingCountries on mount', () => {
+    const getBillingCountries = jest.fn();
+    subject({ getBillingCountries });
+    expect(getBillingCountries).toHaveBeenCalled();
+  });
+
+  it('renders loading panel', () => {
+    const wrapper = subject({ loading: true });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders form disabled', () => {
+    const wrapper = subject({ submitting: true });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('creates billing, redirects, and shows alert on submit', async () => {
+    const props = {
+      billingCreate: jest.fn(() => Promise.resolve()),
+      history: { push: jest.fn() },
+      showAlert: jest.fn()
+    };
+    const wrapper = subject(props);
+    const values = {
+      billingAddress: {
+        state: 'MD',
+        zip: 21046
+      },
+      card: Symbol('card-info')
+    };
+    const preparedCardInfo = Symbol('prepared-card-info');
+    billingHelpers.prepareCardInfo = jest.fn(() => preparedCardInfo);
+
+    await wrapper.instance().onSubmit(values);
+
+    expect(billingHelpers.prepareCardInfo).toHaveBeenCalledWith(values.card);
+    expect(props.billingCreate).toHaveBeenCalledWith({ ...values, card: preparedCardInfo });
+    expect(props.history.push).toHaveBeenCalledWith('/account/billing');
+    expect(props.showAlert).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+});

--- a/src/pages/billing/forms/tests/__snapshots__/EnableAutomaticBillingForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/EnableAutomaticBillingForm.test.js.snap
@@ -33,16 +33,11 @@ exports[`EnableAutomaticBillingForm renders form 1`] = `
       md={5}
       xs={12}
     >
-      <Panel>
+      <Panel
+        title="Your Plan"
+      >
         <Panel.Section>
-          <small>
-            Your Plan
-          </small>
-          <h4>
-            15,000
-             emails/
-            year
-          </h4>
+          <PlanSummary />
         </Panel.Section>
         <Panel.Section>
           <Button
@@ -95,16 +90,11 @@ exports[`EnableAutomaticBillingForm renders form disabled 1`] = `
       md={5}
       xs={12}
     >
-      <Panel>
+      <Panel
+        title="Your Plan"
+      >
         <Panel.Section>
-          <small>
-            Your Plan
-          </small>
-          <h4>
-            15,000
-             emails/
-            year
-          </h4>
+          <PlanSummary />
         </Panel.Section>
         <Panel.Section>
           <Button

--- a/src/pages/billing/forms/tests/__snapshots__/EnableAutomaticBillingForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/EnableAutomaticBillingForm.test.js.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EnableAutomaticBillingForm renders form 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <Grid>
+    <Grid.Column>
+      <Panel
+        title="Add a Credit Card"
+      >
+        <Panel.Section>
+          <Connect(PaymentForm)
+            formName="enableAutomaticBilling"
+          />
+        </Panel.Section>
+        <Panel.Section>
+          <Connect(BillingAddressForm)
+            countries={
+              Array [
+                Object {
+                  "label": "United States",
+                  "value": "US",
+                },
+              ]
+            }
+            formName="enableAutomaticBilling"
+          />
+        </Panel.Section>
+      </Panel>
+    </Grid.Column>
+    <Grid.Column
+      md={5}
+      xs={12}
+    >
+      <Panel>
+        <Panel.Section>
+          <small>
+            Your Plan
+          </small>
+          <h4>
+            15,000
+             emails/
+            year
+          </h4>
+        </Panel.Section>
+        <Panel.Section>
+          <Button
+            fullWidth={true}
+            primary={true}
+            size="default"
+            type="submit"
+          >
+            Enable Automatic Billing
+          </Button>
+        </Panel.Section>
+      </Panel>
+    </Grid.Column>
+  </Grid>
+</form>
+`;
+
+exports[`EnableAutomaticBillingForm renders form disabled 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <Grid>
+    <Grid.Column>
+      <Panel
+        title="Add a Credit Card"
+      >
+        <Panel.Section>
+          <Connect(PaymentForm)
+            disabled={true}
+            formName="enableAutomaticBilling"
+          />
+        </Panel.Section>
+        <Panel.Section>
+          <Connect(BillingAddressForm)
+            countries={
+              Array [
+                Object {
+                  "label": "United States",
+                  "value": "US",
+                },
+              ]
+            }
+            disabled={true}
+            formName="enableAutomaticBilling"
+          />
+        </Panel.Section>
+      </Panel>
+    </Grid.Column>
+    <Grid.Column
+      md={5}
+      xs={12}
+    >
+      <Panel>
+        <Panel.Section>
+          <small>
+            Your Plan
+          </small>
+          <h4>
+            15,000
+             emails/
+            year
+          </h4>
+        </Panel.Section>
+        <Panel.Section>
+          <Button
+            disabled={true}
+            fullWidth={true}
+            primary={true}
+            size="default"
+            type="submit"
+          >
+            Enable Automatic Billing
+          </Button>
+        </Panel.Section>
+      </Panel>
+    </Grid.Column>
+  </Grid>
+</form>
+`;
+
+exports[`EnableAutomaticBillingForm renders loading panel 1`] = `<Loading />`;

--- a/src/pages/billing/index.js
+++ b/src/pages/billing/index.js
@@ -1,7 +1,9 @@
 import SummaryPage from './SummaryPage';
 import ChangePlanPage from './ChangePlanPage';
+import EnableAutomaticBillingPage from './EnableAutomaticBillingPage';
 
 export default {
   SummaryPage,
-  ChangePlanPage
+  ChangePlanPage,
+  EnableAutomaticBillingPage
 };

--- a/src/pages/billing/tests/EnableAutomaticBillingPage.test.js
+++ b/src/pages/billing/tests/EnableAutomaticBillingPage.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import EnableAutomaticBillingPage from '../EnableAutomaticBillingPage';
+
+describe('EnableAutomaticBillingPage', () => {
+  it('renders page with form', () => {
+    const wrapper = shallow(<EnableAutomaticBillingPage />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/billing/tests/__snapshots__/EnableAutomaticBillingPage.test.js.snap
+++ b/src/pages/billing/tests/__snapshots__/EnableAutomaticBillingPage.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EnableAutomaticBillingPage renders page with form 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "Component": [Function],
+      "content": "Back to billing",
+      "to": "/account/billing",
+    }
+  }
+  empty={Object {}}
+>
+  <withRouter(Connect(ReduxForm)) />
+</Page>
+`;

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import _ from 'lodash';
-import { isAws, isSelfServeBilling, onPlan } from 'src/helpers/conditions/account';
+import { isAws, isCustomBilling, isSelfServeBilling, onPlan } from 'src/helpers/conditions/account';
 import { selectCondition } from './accessConditionState';
 
 const suspendedSelector = (state) => state.account.isSuspendedForBilling;
@@ -8,6 +8,7 @@ const pendingSubscriptionSelector = (state) => state.account.pending_subscriptio
 const plansSelector = (state) => state.billing.plans || [];
 const accountBillingSelector = (state) => state.account.billing;
 const selectIsAws = selectCondition(isAws);
+const selectIsCustomBilling = selectCondition(isCustomBilling);
 const selectIsSelfServeBilling = selectCondition(isSelfServeBilling);
 const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
 const selectIsFree1 = selectCondition(onPlan('free1'));
@@ -28,8 +29,8 @@ export const currentPlanCodeSelector = createSelector(
  * Returns true if user does not have pending plan change or is not suspended
  */
 export const canChangePlanSelector = createSelector(
-  [suspendedSelector, pendingSubscriptionSelector],
-  (suspended, pendingSubscription) => !suspended && !pendingSubscription
+  [suspendedSelector, pendingSubscriptionSelector, selectIsCustomBilling],
+  (suspended, pendingSubscription, customBilling) => !suspended && !pendingSubscription && !customBilling
 );
 
 /**

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -73,6 +73,18 @@ describe('Selector: can change plan', () => {
 
     expect(billingInfo.canChangePlanSelector(state)).toEqual(false);
   });
+
+  it('should return false with a custom plan', () => {
+    const state = {
+      account: {
+        subscription: {
+          custom: true
+        }
+      }
+    };
+
+    expect(billingInfo.canChangePlanSelector(state)).toEqual(false);
+  });
 });
 
 describe('currentPlanCodeSelector: can select plan code', () => {


### PR DESCRIPTION
_The following are a couple test scenarios._

**1. A custom account without plan overrides** 
The is a temporary state when the Accounts Team has manually set a free account on a custom plan.

_brian.kemper+custom-annual@sparkpost.com_

<img width="1387" alt="screen shot 2018-09-25 at 1 09 54 pm" src="https://user-images.githubusercontent.com/1335605/46030509-56f7bf00-c0c4-11e8-9bd5-26b531eb5105.png">

**2. A custom account with plan overrides** 
The custom plan is all setup and ready for a user to enable automatic billing.

_brian.kemper+custom-overrides@sparkpost.com_

<img width="1388" alt="screen shot 2018-09-25 at 1 19 54 pm" src="https://user-images.githubusercontent.com/1335605/46031035-c91cd380-c0c5-11e8-9f0d-a7fc4b99eeda.png">

<img width="1385" alt="screen shot 2018-09-26 at 10 18 24 am" src="https://user-images.githubusercontent.com/1335605/46086180-8dd9dd80-c175-11e8-8067-02cd834ba0a6.png">

**3. A custom account that enabled automatic billing**
The user has provided a credit card to enable automatic billing.

_brian.kemper+custom-no-invoice@sparkpost.com_

<img width="1385" alt="screen shot 2018-09-26 at 2 27 43 pm" src="https://user-images.githubusercontent.com/1335605/46100902-9263bd80-c198-11e8-8467-638777d5de4a.png">

**4. A custom account pending a downgrade**

<img width="1388" alt="screen shot 2018-09-26 at 11 29 28 am" src="https://user-images.githubusercontent.com/1335605/46090884-9e8f5100-c17f-11e8-875d-1f376818bb79.png">
