### PR TITLE
FE-540 Add webhook batches list & details pages

### DIFF
--- a/src/actions/tests/__snapshots__/webhooks.test.js.snap
+++ b/src/actions/tests/__snapshots__/webhooks.test.js.snap
@@ -64,7 +64,8 @@ Array [
     "meta": Object {
       "headers": Object {},
       "method": "GET",
-      "url": "/webhooks/123/batch-status",
+      "params": Object {},
+      "url": "/webhooks/123/batches",
     },
     "type": "GET_WEBHOOK_BATCHES",
   },

--- a/src/actions/webhooks.js
+++ b/src/actions/webhooks.js
@@ -105,14 +105,15 @@ export function getEventSamples(events) {
   });
 }
 
-export function getBatches({ id, subaccount = null }) {
+export function getBatches({ id, subaccount = null, params }) {
   const headers = setSubaccountHeader(subaccount);
   return sparkpostApiRequest({
     type: 'GET_WEBHOOK_BATCHES',
     meta: {
       method: 'GET',
-      url: `/webhooks/${id}/batch-status`,
-      headers
+      url: `/webhooks/${id}/batches`,
+      headers,
+      params
     }
   });
 }

--- a/src/actions/webhooks.js
+++ b/src/actions/webhooks.js
@@ -105,7 +105,7 @@ export function getEventSamples(events) {
   });
 }
 
-export function getBatches({ id, subaccount = null, params }) {
+export function getBatches({ id, subaccount = null, params = {}}) {
   const headers = setSubaccountHeader(subaccount);
   return sparkpostApiRequest({
     type: 'GET_WEBHOOK_BATCHES',

--- a/src/pages/webhooks/DetailsPage.js
+++ b/src/pages/webhooks/DetailsPage.js
@@ -13,6 +13,8 @@ import { Page, Tabs } from '@sparkpost/matchbox';
 import TestTab from './components/TestTab';
 import EditTab from './components/EditTab';
 import BatchTab from './components/BatchTab';
+import BatchDetailsTab from './components/BatchDetailsTab';
+
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 
 export class WebhooksDetails extends Component {
@@ -53,6 +55,8 @@ export class WebhooksDetails extends Component {
     const editPath = `/webhooks/details/${webhookId}`;
     const testPath = `/webhooks/details/${webhookId}/test`;
     const batchPath = `/webhooks/details/${webhookId}/batches`;
+    const batchDetailsPath = `/webhooks/details/${webhookId}/batches/:batchId`;
+
     const secondaryActions = [
       {
         content: 'Delete',
@@ -71,7 +75,7 @@ export class WebhooksDetails extends Component {
         to: `${testPath}${query}`
       },
       {
-        content: 'Batch Status',
+        content: 'Batches',
         Component: Link,
         to: `${batchPath}${query}`
       }
@@ -96,9 +100,11 @@ export class WebhooksDetails extends Component {
           selected={selectedTab}
           tabs={tabs}
         />
-        <Route exact path={editPath} render={() => <EditTab webhook={webhook}/> } />
+        <Route exact path={editPath} render={() => <EditTab webhook={webhook}/>} />
         <Route path={testPath} render={() => <TestTab webhook={webhook}/>} />
-        <Route path={batchPath} render={() => <BatchTab webhook={webhook}/>} />
+        <Route exact path={batchPath} render={() => <BatchTab webhook={webhook} query={query}/>} />
+        <Route exact path={batchDetailsPath} render={() => <BatchDetailsTab webhook={webhook} />} />
+
         <DeleteModal
           open={this.state.showDelete}
           title='Are you sure you want to delete this webhook?'

--- a/src/pages/webhooks/components/BatchDetailsTab.js
+++ b/src/pages/webhooks/components/BatchDetailsTab.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { getBatches } from 'src/actions/webhooks';
+import { selectWebhookBatches } from 'src/selectors/webhooks';
+import { Panel, Tag, Tooltip, Table } from '@sparkpost/matchbox';
+import { ArrowBack, InfoOutline } from '@sparkpost/matchbox-icons';
+import { LabelledValue, PageLink } from 'src/components';
+import _ from 'lodash';
+import styles from './BatchDetailsTab.module.scss';
+
+class BatchDetailsTab extends Component {
+  componentDidMount() {
+    this.getAttempts();
+  }
+
+  getAttempts = () => {
+    const { webhook, getBatches, match } = this.props;
+    const { id, subaccount } = webhook;
+    return getBatches({ id, subaccount, params: { batch_ids: match.params.batchId }});
+  }
+
+  render() {
+    const { batches, firstBatch = {}, webhook, loading } = this.props;
+    const refreshAction = {
+      content: loading ? 'Loading...' : 'Refresh Batches',
+      color: 'orange',
+      onClick: this.getAttempts,
+      disabled: !!loading
+    };
+
+    return (
+      <div>
+        <Panel>
+          <Panel.Section>
+            <div className={styles.BackLink}><small><PageLink to={`/webhooks/details/${webhook.id}/batches`}><ArrowBack/> Return to All Batches</PageLink></small></div>
+            <LabelledValue label='Batch ID'><h6>{firstBatch.batch_id}</h6></LabelledValue>
+            <LabelledValue label='Attempts'><h6>{firstBatch.attempts}</h6></LabelledValue>
+            <LabelledValue label='Batch Size'>
+              <h6><Tooltip dark content='Number of events in this batch'>{firstBatch.batch_size} <InfoOutline className={styles.TooltipTrigger}/></Tooltip></h6>
+            </LabelledValue>
+          </Panel.Section>
+        </Panel>
+        <Panel title='Batch Attempt History' actions={[refreshAction]}>
+          <Table>
+            <thead>
+              <Table.Row>
+                <Table.HeaderCell width='200px'>Status</Table.HeaderCell>
+                <Table.HeaderCell width='250px'>Timestamp</Table.HeaderCell>
+                <Table.HeaderCell width='200px'>Latency</Table.HeaderCell>
+                <Table.HeaderCell>Attempt</Table.HeaderCell>
+              </Table.Row>
+            </thead>
+            <tbody>
+              {batches.map((batch, i) => (
+                <Table.Row key={i}>
+                  <Table.Cell>
+                    <Tag color={batch.status === 'Success' ? 'blue' : 'yellow'}>{batch.response_code}</Tag>
+                  </Table.Cell>
+                  <Table.Cell>{batch.formatted_time}</Table.Cell>
+                  <Table.Cell>{batch.latency && `${batch.latency} ms`}</Table.Cell>
+                  <Table.Cell>{batch.attempts}</Table.Cell>
+                </Table.Row>
+              ))}
+            </tbody>
+          </Table>
+        </Panel>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => {
+  const batches = selectWebhookBatches(state);
+  return {
+    batches,
+    firstBatch: _.first(batches),
+    loading: state.webhooks.batchesLoading
+  };
+};
+
+export default withRouter(connect(mapStateToProps, { getBatches })(BatchDetailsTab));

--- a/src/pages/webhooks/components/BatchDetailsTab.js
+++ b/src/pages/webhooks/components/BatchDetailsTab.js
@@ -9,19 +9,19 @@ import { LabelledValue, PageLink } from 'src/components';
 import _ from 'lodash';
 import styles from './BatchDetailsTab.module.scss';
 
-class BatchDetailsTab extends Component {
+export class BatchDetailsTab extends Component {
   componentDidMount() {
     this.getAttempts();
   }
 
   getAttempts = () => {
-    const { webhook, getBatches, match } = this.props;
+    const { webhook, getBatches, batchId } = this.props;
     const { id, subaccount } = webhook;
-    return getBatches({ id, subaccount, params: { batch_ids: match.params.batchId }});
+    return getBatches({ id, subaccount, params: { batch_ids: batchId }});
   }
 
   render() {
-    const { batches, firstBatch = {}, webhook, loading } = this.props;
+    const { batches, firstBatch, webhook, loading } = this.props;
     const refreshAction = {
       content: loading ? 'Loading...' : 'Refresh Batches',
       color: 'orange',
@@ -74,8 +74,9 @@ const mapStateToProps = (state, props) => {
   const batches = selectWebhookBatches(state);
   return {
     batches,
-    firstBatch: _.first(batches),
-    loading: state.webhooks.batchesLoading
+    firstBatch: _.first(batches) || {},
+    loading: state.webhooks.batchesLoading,
+    batchId: props.match.params.batchId
   };
 };
 

--- a/src/pages/webhooks/components/BatchDetailsTab.module.scss
+++ b/src/pages/webhooks/components/BatchDetailsTab.module.scss
@@ -1,0 +1,9 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.BackLink {
+  margin-bottom: spacing();
+}
+
+.TooltipTrigger {
+  color: color(gray, 4);
+}

--- a/src/pages/webhooks/components/tests/BatchDetailsTab.test.js
+++ b/src/pages/webhooks/components/tests/BatchDetailsTab.test.js
@@ -1,0 +1,59 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { BatchDetailsTab } from '../BatchDetailsTab';
+
+describe('Webhook Component: Batch Status Tab', () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      getBatches: jest.fn(() => Promise.resolve()),
+      webhook: {
+        id: 'webhook-id',
+        subaccount: 101
+      },
+      batchId: 'batch_1',
+      batches: [
+        {
+          formatted_time: 'so-formatted',
+          batch_id: 'batch_1',
+          status: 'Success',
+          attempts: 2,
+          response_code: 200
+        },
+        {
+          formatted_time: 'so-formatted-2',
+          batch_id: 'batch_1',
+          status: 'f',
+          attempts: 1,
+          response_code: 500
+        }
+      ],
+      loading: false,
+      firstBatch: {
+        formatted_time: 'so-formatted',
+        batch_id: '243423423423',
+        status: 'Success',
+        attempts: 1,
+        response_code: 200
+      }
+    };
+
+    wrapper = shallow(<BatchDetailsTab {...props} />);
+  });
+
+  it('should render batch details', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should get batches on mount', () => {
+    expect(props.getBatches.mock.calls).toMatchSnapshot();
+  });
+
+  it('should handle loading state', () => {
+    wrapper.setProps({ loading: true });
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/webhooks/components/tests/BatchTab.test.js
+++ b/src/pages/webhooks/components/tests/BatchTab.test.js
@@ -43,7 +43,7 @@ describe('Webhook Component: Batch Status Tab', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should show button text as Refreshing while refreshing data', () => {
+  it('should show loading component while refreshing data', () => {
     wrapper.setProps({ batchesLoading: true });
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/webhooks/components/tests/BatchTab.test.js
+++ b/src/pages/webhooks/components/tests/BatchTab.test.js
@@ -5,9 +5,10 @@ import { BatchTab } from '../BatchTab';
 
 describe('Webhook Component: Batch Status Tab', () => {
   let wrapper;
+  let props;
 
   beforeEach(() => {
-    const props = {
+    props = {
       getBatches: jest.fn(() => Promise.resolve()),
       webhook: {
         id: 'webhook-id'
@@ -16,7 +17,7 @@ describe('Webhook Component: Batch Status Tab', () => {
         {
           formatted_time: 'so-formatted',
           batch_id: '243423423423',
-          status: 'p',
+          status: 'Success',
           attempts: 1,
           response_code: 200
         },
@@ -29,7 +30,8 @@ describe('Webhook Component: Batch Status Tab', () => {
         }
       ],
       batchesLoading: false,
-      showAlert: jest.fn()
+      showAlert: jest.fn(),
+      query: ''
     };
 
     wrapper = shallow(<BatchTab {...props} />);
@@ -41,6 +43,11 @@ describe('Webhook Component: Batch Status Tab', () => {
 
   it('should render batch status tab with table data', () => {
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render table rows correctly', () => {
+    const rows = props.batches.map(wrapper.instance().getRowData);
+    expect(rows).toMatchSnapshot();
   });
 
   it('should show loading component while refreshing data', () => {

--- a/src/pages/webhooks/components/tests/__snapshots__/BatchDetailsTab.test.js.snap
+++ b/src/pages/webhooks/components/tests/__snapshots__/BatchDetailsTab.test.js.snap
@@ -1,0 +1,291 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Webhook Component: Batch Status Tab should get batches on mount 1`] = `
+Array [
+  Array [
+    Object {
+      "id": "webhook-id",
+      "params": Object {
+        "batch_ids": "batch_1",
+      },
+      "subaccount": 101,
+    },
+  ],
+]
+`;
+
+exports[`Webhook Component: Batch Status Tab should handle loading state 1`] = `
+<div>
+  <Panel>
+    <Panel.Section>
+      <div
+        className="BackLink"
+      >
+        <small>
+          <PageLink
+            to="/webhooks/details/webhook-id/batches"
+          >
+            <ArrowBack />
+             Return to All Batches
+          </PageLink>
+        </small>
+      </div>
+      <LabelledValue
+        label="Batch ID"
+      >
+        <h6>
+          243423423423
+        </h6>
+      </LabelledValue>
+      <LabelledValue
+        label="Attempts"
+      >
+        <h6>
+          1
+        </h6>
+      </LabelledValue>
+      <LabelledValue
+        label="Batch Size"
+      >
+        <h6>
+          <Tooltip
+            bottom={true}
+            content="Number of events in this batch"
+            dark={true}
+            forcePosition={false}
+            horizontalOffset="0px"
+            preferredDirection={
+              Object {
+                "bottom": true,
+                "left": false,
+                "right": true,
+                "top": false,
+              }
+            }
+            right={true}
+          >
+             
+            <InfoOutline
+              className="TooltipTrigger"
+            />
+          </Tooltip>
+        </h6>
+      </LabelledValue>
+    </Panel.Section>
+  </Panel>
+  <Panel
+    actions={
+      Array [
+        Object {
+          "color": "orange",
+          "content": "Loading...",
+          "disabled": true,
+          "onClick": [Function],
+        },
+      ]
+    }
+    title="Batch Attempt History"
+  >
+    <Table>
+      <thead>
+        <Table.Row>
+          <Table.HeaderCell
+            width="200px"
+          >
+            Status
+          </Table.HeaderCell>
+          <Table.HeaderCell
+            width="250px"
+          >
+            Timestamp
+          </Table.HeaderCell>
+          <Table.HeaderCell
+            width="200px"
+          >
+            Latency
+          </Table.HeaderCell>
+          <Table.HeaderCell>
+            Attempt
+          </Table.HeaderCell>
+        </Table.Row>
+      </thead>
+      <tbody>
+        <Table.Row
+          key="0"
+        >
+          <Table.Cell>
+            <Tag
+              color="blue"
+            >
+              200
+            </Tag>
+          </Table.Cell>
+          <Table.Cell>
+            so-formatted
+          </Table.Cell>
+          <Table.Cell />
+          <Table.Cell>
+            2
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="1"
+        >
+          <Table.Cell>
+            <Tag
+              color="yellow"
+            >
+              500
+            </Tag>
+          </Table.Cell>
+          <Table.Cell>
+            so-formatted-2
+          </Table.Cell>
+          <Table.Cell />
+          <Table.Cell>
+            1
+          </Table.Cell>
+        </Table.Row>
+      </tbody>
+    </Table>
+  </Panel>
+</div>
+`;
+
+exports[`Webhook Component: Batch Status Tab should render batch details 1`] = `
+<div>
+  <Panel>
+    <Panel.Section>
+      <div
+        className="BackLink"
+      >
+        <small>
+          <PageLink
+            to="/webhooks/details/webhook-id/batches"
+          >
+            <ArrowBack />
+             Return to All Batches
+          </PageLink>
+        </small>
+      </div>
+      <LabelledValue
+        label="Batch ID"
+      >
+        <h6>
+          243423423423
+        </h6>
+      </LabelledValue>
+      <LabelledValue
+        label="Attempts"
+      >
+        <h6>
+          1
+        </h6>
+      </LabelledValue>
+      <LabelledValue
+        label="Batch Size"
+      >
+        <h6>
+          <Tooltip
+            bottom={true}
+            content="Number of events in this batch"
+            dark={true}
+            forcePosition={false}
+            horizontalOffset="0px"
+            preferredDirection={
+              Object {
+                "bottom": true,
+                "left": false,
+                "right": true,
+                "top": false,
+              }
+            }
+            right={true}
+          >
+             
+            <InfoOutline
+              className="TooltipTrigger"
+            />
+          </Tooltip>
+        </h6>
+      </LabelledValue>
+    </Panel.Section>
+  </Panel>
+  <Panel
+    actions={
+      Array [
+        Object {
+          "color": "orange",
+          "content": "Refresh Batches",
+          "disabled": false,
+          "onClick": [Function],
+        },
+      ]
+    }
+    title="Batch Attempt History"
+  >
+    <Table>
+      <thead>
+        <Table.Row>
+          <Table.HeaderCell
+            width="200px"
+          >
+            Status
+          </Table.HeaderCell>
+          <Table.HeaderCell
+            width="250px"
+          >
+            Timestamp
+          </Table.HeaderCell>
+          <Table.HeaderCell
+            width="200px"
+          >
+            Latency
+          </Table.HeaderCell>
+          <Table.HeaderCell>
+            Attempt
+          </Table.HeaderCell>
+        </Table.Row>
+      </thead>
+      <tbody>
+        <Table.Row
+          key="0"
+        >
+          <Table.Cell>
+            <Tag
+              color="blue"
+            >
+              200
+            </Tag>
+          </Table.Cell>
+          <Table.Cell>
+            so-formatted
+          </Table.Cell>
+          <Table.Cell />
+          <Table.Cell>
+            2
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="1"
+        >
+          <Table.Cell>
+            <Tag
+              color="yellow"
+            >
+              500
+            </Tag>
+          </Table.Cell>
+          <Table.Cell>
+            so-formatted-2
+          </Table.Cell>
+          <Table.Cell />
+          <Table.Cell>
+            1
+          </Table.Cell>
+        </Table.Row>
+      </tbody>
+    </Table>
+  </Panel>
+</div>
+`;

--- a/src/pages/webhooks/components/tests/__snapshots__/BatchTab.test.js.snap
+++ b/src/pages/webhooks/components/tests/__snapshots__/BatchTab.test.js.snap
@@ -30,7 +30,7 @@ exports[`Webhook Component: Batch Status Tab should render batch status tab with
         "batch_id": "243423423423",
         "formatted_time": "so-formatted",
         "response_code": 200,
-        "status": "p",
+        "status": "Success",
       },
       Object {
         "attempts": 4,
@@ -42,6 +42,61 @@ exports[`Webhook Component: Batch Status Tab should render batch status tab with
     ]
   }
 />
+`;
+
+exports[`Webhook Component: Batch Status Tab should render table rows correctly 1`] = `
+Array [
+  Array [
+    "so-formatted",
+    "243423423423",
+    <Tag
+      color="blue"
+    >
+      200
+    </Tag>,
+    1,
+    <div
+      style={
+        Object {
+          "textAlign": "right",
+        }
+      }
+    >
+      <Button
+        component={[Function]}
+        size="small"
+        to="/webhooks/details/webhook-id/batches/243423423423"
+      >
+        View Details
+      </Button>
+    </div>,
+  ],
+  Array [
+    "so-formatted-2",
+    "996969545",
+    <Tag
+      color="yellow"
+    >
+      500
+    </Tag>,
+    4,
+    <div
+      style={
+        Object {
+          "textAlign": "right",
+        }
+      }
+    >
+      <Button
+        component={[Function]}
+        size="small"
+        to="/webhooks/details/webhook-id/batches/996969545"
+      >
+        View Details
+      </Button>
+    </div>,
+  ],
+]
 `;
 
 exports[`Webhook Component: Batch Status Tab should show empty message when no batches exist 1`] = `

--- a/src/pages/webhooks/components/tests/__snapshots__/BatchTab.test.js.snap
+++ b/src/pages/webhooks/components/tests/__snapshots__/BatchTab.test.js.snap
@@ -1,100 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Webhook Component: Batch Status Tab should render batch status tab with table data 1`] = `
-<Panel>
-  <Panel.Section>
-    <Button
-      disabled={false}
-      onClick={[Function]}
-      primary={true}
-      size="small"
-    >
-      Refresh Batches
-    </Button>
-  </Panel.Section>
-  <TableCollection
-    columns={
-      Array [
-        Object {
-          "label": "Delivery Time",
-          "sortKey": "formatted_time",
-        },
-        Object {
-          "label": "Batch ID",
-          "sortKey": "batch_id",
-        },
-        Object {
-          "label": "Status",
-          "sortKey": "status",
-        },
-        Object {
-          "label": "Attempt #",
-          "sortKey": "attempts",
-        },
-        Object {
-          "label": "Response",
-          "sortKey": "response_code",
-        },
-      ]
-    }
-    defaultSortColumn="formatted_time"
-    defaultSortDirection="desc"
-    getRowData={[Function]}
-    pagination={true}
-    rows={
-      Array [
-        Object {
-          "attempts": 1,
-          "batch_id": "243423423423",
-          "formatted_time": "so-formatted",
-          "response_code": 200,
-          "status": "p",
-        },
-        Object {
-          "attempts": 4,
-          "batch_id": "996969545",
-          "formatted_time": "so-formatted-2",
-          "response_code": 500,
-          "status": "f",
-        },
-      ]
-    }
-  />
-</Panel>
-`;
-
-exports[`Webhook Component: Batch Status Tab should show button text as Refreshing while refreshing data 1`] = `
-<Panel>
-  <Panel.Section>
-    <Button
-      disabled={true}
-      onClick={[Function]}
-      primary={true}
-      size="small"
-    >
-      Refreshing...
-    </Button>
-  </Panel.Section>
-  <PanelLoading
-    minHeight="400px"
-  />
-</Panel>
+<TableCollection
+  columns={
+    Array [
+      Object {
+        "label": "Timestamp",
+      },
+      Object {
+        "label": "Batch ID",
+      },
+      Object {
+        "label": "Status",
+      },
+      Object {
+        "label": "Attempts",
+      },
+      null,
+    ]
+  }
+  defaultSortColumn={null}
+  defaultSortDirection="asc"
+  getRowData={[Function]}
+  pagination={true}
+  rows={
+    Array [
+      Object {
+        "attempts": 1,
+        "batch_id": "243423423423",
+        "formatted_time": "so-formatted",
+        "response_code": 200,
+        "status": "p",
+      },
+      Object {
+        "attempts": 4,
+        "batch_id": "996969545",
+        "formatted_time": "so-formatted-2",
+        "response_code": 500,
+        "status": "f",
+      },
+    ]
+  }
+/>
 `;
 
 exports[`Webhook Component: Batch Status Tab should show empty message when no batches exist 1`] = `
-<Panel>
-  <Panel.Section>
-    <Button
-      disabled={false}
-      onClick={[Function]}
-      primary={true}
-      size="small"
-    >
-      Refresh Batches
-    </Button>
-  </Panel.Section>
-  <Empty
-    message="There are no batches for your webhook"
-  />
-</Panel>
+<Empty
+  message="There are no batches for your webhook"
+/>
+`;
+
+exports[`Webhook Component: Batch Status Tab should show loading component while refreshing data 1`] = `
+<PanelLoading
+  minHeight="400px"
+/>
 `;

--- a/src/pages/webhooks/tests/__snapshots__/DetailsPage.test.js.snap
+++ b/src/pages/webhooks/tests/__snapshots__/DetailsPage.test.js.snap
@@ -38,7 +38,7 @@ exports[`Page: Webhook Details should render happy path 1`] = `
         },
         Object {
           "Component": [Function],
-          "content": "Batch Status",
+          "content": "Batches",
           "to": "/webhooks/details/my-id/batches?subaccount=101",
         },
       ]
@@ -54,7 +54,13 @@ exports[`Page: Webhook Details should render happy path 1`] = `
     render={[Function]}
   />
   <Route
+    exact={true}
     path="/webhooks/details/my-id/batches"
+    render={[Function]}
+  />
+  <Route
+    exact={true}
+    path="/webhooks/details/my-id/batches/:batchId"
     render={[Function]}
   />
   <DeleteModal


### PR DESCRIPTION
Prototype: https://invis.io/RXO6200TSC4#/321113390_Options_A
Subtask for [FE-494](https://jira.int.messagesystems.com/browse/FE-494)

---

- Replaces `batch-status` with `batches` endpoint
- Adds new batch attempt details page

**Notes:** 
- Does not include filtering.
- Does not include pagination. Will need [FE-539](https://jira.int.messagesystems.com/browse/FE-539) merged together with this ticket.
- Will need to update the list page action when [SA-284](https://jira.int.messagesystems.com/browse/SA-284) is completed


###### Batch List Page
![screen shot 2018-09-26 at 2 19 00 pm](https://user-images.githubusercontent.com/3903325/46155423-3efb7900-c245-11e8-958d-6ccb561e79ec.png)

###### Batch Details Page
![screen shot 2018-09-26 at 2 19 11 pm](https://user-images.githubusercontent.com/3903325/46155448-50448580-c245-11e8-9010-c5495b21af4f.png)
