### PR TITLE
Fix for AC-287: Custom billing page for customers on annual plans

### DIFF
--- a/src/pages/billing/components/ManuallyBilledBanner.js
+++ b/src/pages/billing/components/ManuallyBilledBanner.js
@@ -14,7 +14,8 @@ const ManuallyBilledBanner = ({
       name: subscriptionName,
       period = 'month',
       plan_volume: planVolume,
-      plan_volume_per_period: planVolumePerPeriod
+      plan_volume_per_period: planVolumePerPeriod,
+      recurring_charge: recurringCharge
     }
   }
 }) => {
@@ -23,8 +24,9 @@ const ManuallyBilledBanner = ({
     Your current ${subscriptionName} plan includes ${localePlanVolume} emails per ${period}
   `;
 
-  // this is an edge case and should not happen often
-  if (custom && !planVolumePerPeriod) {
+  // this is an edge case that will only happen if the custom plan is not configured correctly
+  // with charge and volume
+  if (custom && (!planVolumePerPeriod || !recurringCharge)) {
     return (
       <Banner
         status="warning"

--- a/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
+++ b/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
@@ -18,13 +18,28 @@ describe('ManuallyBilledBanner', () => {
     expect(subject({ account })).toMatchSnapshot();
   });
 
-  it('with transitioning custom subscription', () => {
+  it('with transitioning custom subscription when volume per period is undefined', () => {
     const account = {
       subscription: {
         custom: true,
         name: 'Custom',
         plan_volume: 15000,
-        plan_volume_per_period: undefined
+        plan_volume_per_period: undefined,
+        recurring_charge: 100
+      }
+    };
+
+    expect(subject({ account })).toMatchSnapshot();
+  });
+
+  it('with transitioning custom subscription when charge is undefined', () => {
+    const account = {
+      subscription: {
+        custom: true,
+        name: 'Custom',
+        plan_volume: 15000,
+        plan_volume_per_period: 180000,
+        recurring_charge: undefined
       }
     };
 
@@ -38,7 +53,8 @@ describe('ManuallyBilledBanner', () => {
         name: 'Custom',
         period: 'year',
         plan_volume: 10000,
-        plan_volume_per_period: 120000
+        plan_volume_per_period: 120000,
+        recurring_charge: 100
       }
     };
 

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
@@ -55,7 +55,24 @@ exports[`ManuallyBilledBanner with custom subscription 1`] = `
 </Banner>
 `;
 
-exports[`ManuallyBilledBanner with transitioning custom subscription 1`] = `
+exports[`ManuallyBilledBanner with transitioning custom subscription when charge is undefined 1`] = `
+<Banner
+  status="warning"
+  title="Your current plan is being transitioned to a Custom plan"
+>
+  <p>
+    If your account should not be transitioned, please 
+    <Connect(SupportTicketLink)
+      issueId="general_issue"
+    >
+      submit a support ticket
+    </Connect(SupportTicketLink)>
+    .
+  </p>
+</Banner>
+`;
+
+exports[`ManuallyBilledBanner with transitioning custom subscription when volume per period is undefined 1`] = `
 <Banner
   status="warning"
   title="Your current plan is being transitioned to a Custom plan"


### PR DESCRIPTION
When in staging, it was found that we should enforce the existence of `recurring_charge` before allowing a custom plan to enable automatic billing.