### PR TITLE
FE-485 Implement template for CodeBuild infrastructure creation

### DIFF
--- a/ci/appspec.yml
+++ b/ci/appspec.yml
@@ -1,0 +1,19 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /opt/msys/app/phoenix
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ubuntu
+    group: ubuntu
+hooks:
+  ApplicationStop:
+    - location: scripts/stop.sh
+      timeout: 10
+      runas: ubuntu
+  ApplicationStart:
+    - location: scripts/start.sh
+      timeout: 20
+      runas: ubuntu

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - npm install
+  pre_build:
+    commands:
+      - npm run test-ci
+      - rm -rf node_modules
+  build:
+    commands:
+      - npm install
+      - npm run build
+
+artifacts:
+  files:
+    - 'build/**/*'

--- a/ci/codebuild.yml
+++ b/ci/codebuild.yml
@@ -1,0 +1,85 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Create Phoenix CodeBuild Infrastructures
+
+Resources:
+  ArtifactS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: phoenix-artifacts
+      AccessControl: Private
+      VersioningConfiguration:
+        Status: Suspended
+
+  CodeBuildIAMServiceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Sub 'CodeBuildIAMServiceRole-${AWS::StackName}'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com #todo limit to certain AZ?
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: PhoenixCodeBuildRolePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:PutObject"
+                  - "s3:GetObject"
+                  - "s3:GetObjectVersion"
+                Resource:
+                   - !Sub 'arn:aws:s3:::${ArtifactS3Bucket}'
+                   - !Sub 'arn:aws:s3:::${ArtifactS3Bucket}/*'
+              - Effect: Allow
+                Action:
+                  - "logs:Describe*"
+                  - "logs:Get*"
+                  - "tag:Get*"
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource:
+                  - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*
+
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name:
+        Fn::Sub: CodeBuild-${AWS::StackName}
+      Description: Phoenix UI CodeBuild plan
+      ServiceRole:
+        Fn::GetAtt: [ CodeBuildIAMServiceRole, Arn ]
+      Artifacts:
+        Type: S3
+        Packaging: ZIP
+        Location:
+          Ref: ArtifactS3Bucket
+        Name:
+          Fn::Sub: Build-${AWS::StackName}.zip
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_MEDIUM
+        Image: aws/codebuild/nodejs:8.11.0
+        EnvironmentVariables:
+          - Name: TEMPLATE_BUCKET
+            Value:
+              Ref: ArtifactS3Bucket
+      Source:
+        Location: https://github.com/SparkPost/2web2ui
+        Type: GITHUB
+        BuildSpec: ci/buildspec.yml
+
+      TimeoutInMinutes: 15
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+        S3Logs:
+          Status: DISABLED
+

--- a/ci/runbook.md
+++ b/ci/runbook.md
@@ -1,0 +1,25 @@
+# AWS CI/CD Runbook
+
+## Pre-requisites
+
+- Authenticate github account.
+- Enough privilege ("god mode") to create the resources.  
+
+## CodeBuild
+To create CodeBuild resources, we need to use codebuild.yml. 
+Either, use this file using CloudFormation UI or run the following command from aws cli. 
+
+```
+aws cloudformation create-stack --stack-name <stack_name> --template-body file://<path>/codebuild.yml  --capabilities CAPABILITY_NAMED_IAM
+``` 
+
+To update stack:
+
+```
+aws cloudformation update-stack --stack-name <stack_name> --template-body file://<path>/codebuild.yml  --capabilities CAPABILITY_NAMED_IAM
+``` 
+
+What this will do? 
+- Create S3 Bucket
+- Create CodeBuild Service Role including Policy doc
+- Create CodeBuild Project

--- a/config/paths.js
+++ b/config/paths.js
@@ -52,5 +52,8 @@ module.exports = {
   testsSetup: resolveApp('src/setupTests.js'),
   appNodeModules: resolveApp(''),
   publicUrl: getPublicUrl(resolveApp('package.json')),
-  servedPath: getServedPath(resolveApp('package.json'))
+  servedPath: getServedPath(resolveApp('package.json')),
+  copyPaths: [
+    [`${appDirectory}/ci/appspec.yml`, 'appspec.yml']
+  ]
 };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -55,6 +55,7 @@ measureFileSizesBeforeBuild(paths.appBuild)
     // Generate and merge tenant configurations in public/static/tenant-config
     generateConfigs();
 
+    copyPaths();
     // Start the webpack build
     return build(previousFileSizes);
   })
@@ -85,7 +86,6 @@ measureFileSizesBeforeBuild(paths.appBuild)
         WARN_AFTER_BUNDLE_GZIP_SIZE,
         WARN_AFTER_CHUNK_GZIP_SIZE
       );
-      console.log();
 
       const appPackage = require(paths.appPackageJson);
       const publicUrl = paths.publicUrl;
@@ -153,4 +153,15 @@ function copyPublicFolder() {
     dereference: true,
     filter: file => file !== paths.appHtml,
   });
+}
+
+function copyPaths() {
+
+  console.log('copying static paths', paths.copyPaths);
+  paths.copyPaths.forEach((path) => {
+    fs.copySync(path[0], `${paths.appBuild}/${path[1]}`, {
+      dereference: true
+    })
+  });
+
 }


### PR DESCRIPTION
This PR implements cloudformation template for building AWS CodeBuild project. 

- Implements a functional appspec.yml (needed for CodeBuild)
- Implements a fake buildspec.yml which is needed for CodeDeploy. This is put here just to glue to build process so that it's attached to build artifacts. This will be fixed FE-484.
- Updates build process to include buildspec.yml in the build artifact. 


Running:
- There is a great chance we can't run it ourselves. We need someone from SRE team to run on behalf us. See the runbook for instructions how to run it. 
- Currently, we'll have to trigger a build from AWS Console. When testing this branch, we'll either have to specify branch name or last commit hash (in this branch) to make sure correct codes are there. 


I'm going to create individual template for now. Upon creation of all templates, I'll see how can we create one template to run all at once.