### PR TITLE
FE-535: Message events report: event type names and descriptions

### DIFF
--- a/src/helpers/messageEvents.js
+++ b/src/helpers/messageEvents.js
@@ -3,20 +3,34 @@ import qs from 'query-string';
 import _ from 'lodash';
 import { getRelativeDates } from 'src/helpers/date';
 
-/**
- * Reshapes message event documentation for tooltips
+/*
+ * Translate the array of event definitions from /message-events/events/documentation
+ * into an map of event type to event field descriptions.
+ * [ {[fieldName]: { sampleValue, description }}, ... ] -> { type: { [fieldName]: description }, ... displayName, description }
+ * 
+ * Note: we treat display_name and event_description fields specially. They are not true event fields.
+ * They're metadata and their sampleValue fields contain their 'value'.
  */
 export function formatDocumentation(data) {
   const events = {};
 
   _.each(data, (event) => {
-    const { type, ...rest } = event;
-    events[type.sampleValue] = _.mapValues(rest, ({ description }) => description);
+    const {
+      type,
+      display_name: { sampleValue: displayName },
+      event_description: { sampleValue: description },
+      ...rest
+    } = event;
+    const fieldDescriptions = _.mapValues(rest, ({ description }) => description);
+    events[type.sampleValue] = {
+      displayName,
+      description,
+      ...fieldDescriptions
+    };
   });
 
   return events;
 }
-
 export function parseSearch(search) {
   const { from, to, range, ...rest } = qs.parse(search);
   let dateOptions = {};

--- a/src/helpers/tests/__snapshots__/messageEvents.test.js.snap
+++ b/src/helpers/tests/__snapshots__/messageEvents.test.js.snap
@@ -5,10 +5,14 @@ Object {
   "bounce": Object {
     "bounce_class": "Classification code for a given message (see [Bounce Classification Codes](https://support.sparkpost.com/customer/portal/articles/1929896))",
     "campaign_id": "Campaign of which this message was a part",
+    "description": "This event type is for testing event stuff",
+    "displayName": "A test event type",
   },
   "delivery": Object {
     "campaign_id": "Campaign of which this message was a part",
     "customer_id": "SparkPost-customer identifier through which this message was sent",
+    "description": "This event type is also for testing event stuff",
+    "displayName": "A second test event type",
   },
 }
 `;

--- a/src/helpers/tests/messageEvents.test.js
+++ b/src/helpers/tests/messageEvents.test.js
@@ -9,6 +9,8 @@ describe('messageEvents helpers', () => {
     beforeEach(() => {
       data = [{
         'type': { 'description': 'Type of event this record describes', 'sampleValue': 'bounce' },
+        'display_name': { 'description': 'A description of this event', 'sampleValue': 'A test event type' },
+        'event_description': { 'description': 'A description of the description', 'sampleValue': 'This event type is for testing event stuff' },
         'bounce_class': {
           'description': 'Classification code for a given message (see [Bounce Classification Codes](https://support.sparkpost.com/customer/portal/articles/1929896))',
           'sampleValue': '1'
@@ -19,6 +21,8 @@ describe('messageEvents helpers', () => {
         }
       }, {
         'type': { 'description': 'Type of event this record describes', 'sampleValue': 'delivery' },
+        'display_name': { 'description': 'A description of this event', 'sampleValue': 'A second test event type' },
+        'event_description': { 'description': 'A description of the description', 'sampleValue': 'This event type is also for testing event stuff' },
         'campaign_id': {
           'description': 'Campaign of which this message was a part',
           'sampleValue': 'Example Campaign Name'

--- a/src/pages/reports/messageEvents/components/AdvancedFilters.js
+++ b/src/pages/reports/messageEvents/components/AdvancedFilters.js
@@ -94,7 +94,7 @@ export class AdvancedFilters extends Component {
           <Panel title='Advanced Filters'>
             <Panel.Section>
               <EventTypeFilters
-                eventTypes={this.props.eventListing}
+                eventTypeDocs={this.props.eventListing}
                 checkedTypes={this.state.search.events}
                 onChange={this.handleCheckbox}
               />

--- a/src/pages/reports/messageEvents/components/AdvancedFilters.module.scss
+++ b/src/pages/reports/messageEvents/components/AdvancedFilters.module.scss
@@ -2,22 +2,15 @@
 
 .CheckBoxGrid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 1fr 1fr;
 
   fieldset {
     white-space: normal;
+    margin: 0;
   }
 
   @media screen and (min-width: breakpoint(medium)) {
-    grid-template-columns: 1fr 1fr;
-    grid-column-gap: 20px;
-    grid-row-gap: 15px;
-  }
-
-  @media screen and (min-width: breakpoint(larger)) {
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-column-gap: 50px;
-    grid-row-gap: 25px;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 }
 

--- a/src/pages/reports/messageEvents/components/AdvancedFilters.module.scss
+++ b/src/pages/reports/messageEvents/components/AdvancedFilters.module.scss
@@ -1,11 +1,23 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-.CheckWrapper {
-  display: inline-block;
-  width: 50%;
+.CheckBoxGrid {
+  display: grid;
+  grid-template-columns: 1fr;
 
-  @media screen and (min-width: breakpoint(small)) {
-    width: 25%;
+  fieldset {
+    white-space: normal;
+  }
+
+  @media screen and (min-width: breakpoint(medium)) {
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: 20px;
+    grid-row-gap: 15px;
+  }
+
+  @media screen and (min-width: breakpoint(larger)) {
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-column-gap: 50px;
+    grid-row-gap: 25px;
   }
 }
 

--- a/src/pages/reports/messageEvents/components/EventTypeFilters.js
+++ b/src/pages/reports/messageEvents/components/EventTypeFilters.js
@@ -1,17 +1,18 @@
 import React from 'react';
-import { Checkbox } from '@sparkpost/matchbox';
+import { Checkbox, Tooltip } from '@sparkpost/matchbox';
+
 import styles from './AdvancedFilters.module.scss';
 
 const EventTypeFilters = ({ eventTypeDocs, checkedTypes, onChange }) => <Checkbox.Group label='Event Type'>
   <div className={styles.CheckBoxGrid}>
-    {eventTypeDocs.map((evtDoc) => <Checkbox
-      id={evtDoc.type}
-      key={evtDoc.type}
-      onChange={() => onChange(evtDoc.type)}
-      label={evtDoc.displayName}
-      helpText={evtDoc.description}
-      checked={checkedTypes[evtDoc.type] || false}
-    />
+    {eventTypeDocs.map((evtDoc) =>
+      <Checkbox
+        id={evtDoc.type}
+        key={evtDoc.type}
+        onChange={() => onChange(evtDoc.type)}
+        label={<Tooltip content={evtDoc.description}>{evtDoc.displayName}</Tooltip>}
+        checked={checkedTypes[evtDoc.type] || false}
+      />
     )}
   </div>
 </Checkbox.Group>;

--- a/src/pages/reports/messageEvents/components/EventTypeFilters.js
+++ b/src/pages/reports/messageEvents/components/EventTypeFilters.js
@@ -10,7 +10,7 @@ const EventTypeFilters = ({ eventTypeDocs, checkedTypes, onChange }) => <Checkbo
         id={evtDoc.type}
         key={evtDoc.type}
         onChange={() => onChange(evtDoc.type)}
-        label={<Tooltip content={evtDoc.description}>{evtDoc.displayName}</Tooltip>}
+        label={<Tooltip dark content={evtDoc.description}>{evtDoc.displayName}</Tooltip>}
         checked={checkedTypes[evtDoc.type] || false}
       />
     )}

--- a/src/pages/reports/messageEvents/components/EventTypeFilters.js
+++ b/src/pages/reports/messageEvents/components/EventTypeFilters.js
@@ -1,18 +1,19 @@
 import React from 'react';
 import { Checkbox } from '@sparkpost/matchbox';
 import styles from './AdvancedFilters.module.scss';
-import { snakeToFriendly } from 'src/helpers/string';
 
-const EventTypeFilters = ({ eventTypes, checkedTypes, onChange }) => <Checkbox.Group label='Event Type'>
-  {eventTypes.map((evtType) => <div className={styles.CheckWrapper} key={evtType}>
-    <Checkbox
-      id={evtType}
-      onChange={() => onChange(evtType)}
-      label={snakeToFriendly(evtType)}
-      checked={checkedTypes[evtType] || false}
+const EventTypeFilters = ({ eventTypeDocs, checkedTypes, onChange }) => <Checkbox.Group label='Event Type'>
+  <div className={styles.CheckBoxGrid}>
+    {eventTypeDocs.map((evtDoc) => <Checkbox
+      id={evtDoc.type}
+      key={evtDoc.type}
+      onChange={() => onChange(evtDoc.type)}
+      label={evtDoc.displayName}
+      helpText={evtDoc.description}
+      checked={checkedTypes[evtDoc.type] || false}
     />
+    )}
   </div>
-  )}
 </Checkbox.Group>;
 
 export default EventTypeFilters;

--- a/src/pages/reports/messageEvents/components/tests/AdvancedFilters.test.js
+++ b/src/pages/reports/messageEvents/components/tests/AdvancedFilters.test.js
@@ -2,12 +2,17 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { AdvancedFilters } from '../AdvancedFilters';
 
-describe('Component: ActiveFilters', () => {
+describe('Component: AdvancedFilters', () => {
   let wrapper;
   const props = {
     updateMessageEventsSearchOptions: jest.fn(),
     getDocumentation: jest.fn(),
-    eventListing: ['amp_open', 'bounce', 'click', 'delivery'],
+    eventListing: [
+      { type: 'amp_open', displayName: 'AMP Open', description: 'AMP open desc' },
+      { type: 'bounce', displayName: 'Bounce', description: 'Bounce desc' },
+      { type: 'click', displayName: 'Click', description: 'Click desc' },
+      { type: 'delivery', displayName: 'Delivery', description: 'Delivery desc' }
+    ],
     search: {
       events: ['bounce', 'click'],
       friendly_froms: ['test@testy.co'],

--- a/src/pages/reports/messageEvents/components/tests/EventTypeFilters.test.js
+++ b/src/pages/reports/messageEvents/components/tests/EventTypeFilters.test.js
@@ -7,7 +7,10 @@ describe('EventTypeFilters', () => {
 
   beforeEach(() => {
     props = {
-      eventTypes: ['amp_open', 'bounce'],
+      eventTypeDocs: [
+        { type: 'amp_open', displayName: 'AMP Open', description: 'AMP open desc' },
+        { type: 'bounce' , displayName: 'Bounce', description: 'Bounce desc' }
+      ],
       checkedTypes: {},
       onChange: jest.fn()
     };

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/AdvancedFilters.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/AdvancedFilters.test.js.snap
@@ -15,7 +15,7 @@ Object {
 }
 `;
 
-exports[`Component: ActiveFilters should render initially and sync to state correctly 1`] = `
+exports[`Component: AdvancedFilters should render initially and sync to state correctly 1`] = `
 <Fragment>
   <Button
     onClick={[Function]}

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/AdvancedFilters.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/AdvancedFilters.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: ActiveFilters should handle filter changes and correctly apply 1`] = `
+exports[`Component: AdvancedFilters should handle filter changes and correctly apply 1`] = `
 Object {
   "campaign_ids": Array [],
   "events": Object {
@@ -42,12 +42,28 @@ exports[`Component: ActiveFilters should render initially and sync to state corr
               "click": true,
             }
           }
-          eventTypes={
+          eventTypeDocs={
             Array [
-              "amp_open",
-              "bounce",
-              "click",
-              "delivery",
+              Object {
+                "description": "AMP open desc",
+                "displayName": "AMP Open",
+                "type": "amp_open",
+              },
+              Object {
+                "description": "Bounce desc",
+                "displayName": "Bounce",
+                "type": "bounce",
+              },
+              Object {
+                "description": "Click desc",
+                "displayName": "Click",
+                "type": "click",
+              },
+              Object {
+                "description": "Delivery desc",
+                "displayName": "Delivery",
+                "type": "delivery",
+              },
             ]
           }
           onChange={[Function]}

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/EventTypeFilters.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/EventTypeFilters.test.js.snap
@@ -5,24 +5,56 @@ exports[`EventTypeFilters should render checked state 1`] = `
   label="Event Type"
 >
   <div
-    className="CheckWrapper"
-    key="amp_open"
+    className="CheckBoxGrid"
   >
     <Checkbox
       checked={false}
       id="amp_open"
-      label="Amp Open"
+      key="amp_open"
+      label={
+        <Tooltip
+          bottom={true}
+          content="AMP open desc"
+          forcePosition={false}
+          horizontalOffset="0px"
+          preferredDirection={
+            Object {
+              "bottom": true,
+              "left": false,
+              "right": true,
+              "top": false,
+            }
+          }
+          right={true}
+        >
+          AMP Open
+        </Tooltip>
+      }
       onChange={[Function]}
     />
-  </div>
-  <div
-    className="CheckWrapper"
-    key="bounce"
-  >
     <Checkbox
       checked={true}
       id="bounce"
-      label="Bounce"
+      key="bounce"
+      label={
+        <Tooltip
+          bottom={true}
+          content="Bounce desc"
+          forcePosition={false}
+          horizontalOffset="0px"
+          preferredDirection={
+            Object {
+              "bottom": true,
+              "left": false,
+              "right": true,
+              "top": false,
+            }
+          }
+          right={true}
+        >
+          Bounce
+        </Tooltip>
+      }
       onChange={[Function]}
     />
   </div>
@@ -34,24 +66,56 @@ exports[`EventTypeFilters should render from a list of event types 1`] = `
   label="Event Type"
 >
   <div
-    className="CheckWrapper"
-    key="amp_open"
+    className="CheckBoxGrid"
   >
     <Checkbox
       checked={false}
       id="amp_open"
-      label="Amp Open"
+      key="amp_open"
+      label={
+        <Tooltip
+          bottom={true}
+          content="AMP open desc"
+          forcePosition={false}
+          horizontalOffset="0px"
+          preferredDirection={
+            Object {
+              "bottom": true,
+              "left": false,
+              "right": true,
+              "top": false,
+            }
+          }
+          right={true}
+        >
+          AMP Open
+        </Tooltip>
+      }
       onChange={[Function]}
     />
-  </div>
-  <div
-    className="CheckWrapper"
-    key="bounce"
-  >
     <Checkbox
       checked={false}
       id="bounce"
-      label="Bounce"
+      key="bounce"
+      label={
+        <Tooltip
+          bottom={true}
+          content="Bounce desc"
+          forcePosition={false}
+          horizontalOffset="0px"
+          preferredDirection={
+            Object {
+              "bottom": true,
+              "left": false,
+              "right": true,
+              "top": false,
+            }
+          }
+          right={true}
+        >
+          Bounce
+        </Tooltip>
+      }
       onChange={[Function]}
     />
   </div>

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/EventTypeFilters.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/EventTypeFilters.test.js.snap
@@ -15,6 +15,7 @@ exports[`EventTypeFilters should render checked state 1`] = `
         <Tooltip
           bottom={true}
           content="AMP open desc"
+          dark={true}
           forcePosition={false}
           horizontalOffset="0px"
           preferredDirection={
@@ -40,6 +41,7 @@ exports[`EventTypeFilters should render checked state 1`] = `
         <Tooltip
           bottom={true}
           content="Bounce desc"
+          dark={true}
           forcePosition={false}
           horizontalOffset="0px"
           preferredDirection={
@@ -76,6 +78,7 @@ exports[`EventTypeFilters should render from a list of event types 1`] = `
         <Tooltip
           bottom={true}
           content="AMP open desc"
+          dark={true}
           forcePosition={false}
           horizontalOffset="0px"
           preferredDirection={
@@ -101,6 +104,7 @@ exports[`EventTypeFilters should render from a list of event types 1`] = `
         <Tooltip
           bottom={true}
           content="Bounce desc"
+          dark={true}
           forcePosition={false}
           horizontalOffset="0px"
           preferredDirection={

--- a/src/selectors/eventListing.js
+++ b/src/selectors/eventListing.js
@@ -23,5 +23,12 @@ export const selectWebhookEventListing = createSelector(
 
 export const selectMessageEventListing = createSelector(
   [selectMessageEventsDocs],
-  (docs) => Object.keys(docs).sort()
+  (docs) => Object.keys(docs).sort().map((type) => {
+    const evt = docs[type];
+    return {
+      type,
+      displayName: evt.displayName,
+      description: evt.description
+    };
+  })
 );

--- a/src/selectors/tests/__snapshots__/eventListing.test.js.snap
+++ b/src/selectors/tests/__snapshots__/eventListing.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return a sorted list of message event doc objects 1`] = `
+Array [
+  Object {
+    "description": "When a thing opens early",
+    "displayName": "Initial open",
+    "type": "initial_open",
+  },
+  Object {
+    "description": "When a thing opens",
+    "displayName": "Open",
+    "type": "open",
+  },
+]
+`;

--- a/src/selectors/tests/eventListing.test.js
+++ b/src/selectors/tests/eventListing.test.js
@@ -28,17 +28,14 @@ test('eventListing should transform event docs, sorted alpha-order by display_na
   ]);
 });
 
-test('should return a sorted list of message event doc keys', () => {
+test('should return a sorted list of message event doc objects', () => {
   const state = {
     messageEvents: {
       documentation: {
-        open: {},
-        initial_open: {}
+        open: { displayName: 'Open', description: 'When a thing opens' },
+        initial_open: { displayName: 'Initial open', description: 'When a thing opens early' }
       }
     }
   };
-  expect(selectMessageEventListing(state)).toEqual([
-    'initial_open',
-    'open'
-  ]);
+  expect(selectMessageEventListing(state)).toMatchSnapshot();
 });


### PR DESCRIPTION
Updated msg events report advanced filters to use new `displayName` and `description` fields from the msg events documentation endpoint.

2 design options:
 - Reuse existing design. Surface event type descriptions as tooltips. ([video](https://www.useloom.com/share/da1e3c8f4ec04f9d912184abdcb699b0))
 - Use webhooks create form style: checkbox+title+description in long form, 2-column layout. ([video](https://www.useloom.com/share/ed8a03c9da6149c180d3ab701536fb41))