### PR TITLE
FE-553: report now refreshes after mount

### DIFF
--- a/src/pages/reports/engagement/EngagementPage.js
+++ b/src/pages/reports/engagement/EngagementPage.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import _ from 'lodash';
 import { Page } from '@sparkpost/matchbox';
 import { refreshEngagementReport } from 'src/actions/engagementReport';
 import { selectReportSearchOptions } from 'src/selectors/reportSearchOptions';
@@ -10,14 +9,13 @@ import EngagementSummary from './components/EngagementSummary';
 import EngagementTable from './components/EngagementTable';
 
 export class EngagementPage extends Component {
-
-  componentDidUpdate (prevProps) {
-    if (!_.isEqual(prevProps.reportOptions, this.props.reportOptions)) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.reportOptions !== this.props.reportOptions) {
       this.props.refreshEngagementReport(this.props.reportOptions);
     }
   }
 
-  render () {
+  render() {
     const { loading, aggregateMetrics, linkMetrics, engagementSearchOptions } = this.props;
 
     return (

--- a/src/pages/reports/engagement/tests/EngagementPage.test.js
+++ b/src/pages/reports/engagement/tests/EngagementPage.test.js
@@ -42,7 +42,7 @@ describe('Engagement Report Page', () => {
 
   it('should not refresh when report options reference is unchanged', () => {
     wrapper.setProps({ reportOptions: {}});
-    expect(props.refreshEngagementReport).toHaveBeenCalledTimes(0);
+    expect(props.refreshEngagementReport).toHaveBeenCalledTimes(1);
   });
 
 });

--- a/src/pages/reports/engagement/tests/EngagementPage.test.js
+++ b/src/pages/reports/engagement/tests/EngagementPage.test.js
@@ -35,14 +35,17 @@ describe('Engagement Report Page', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should refresh when report options reference changes', () => {
-    wrapper.setProps({ reportOptions: { relativeRange: 'day' }});
-    expect(props.refreshEngagementReport).toHaveBeenLastCalledWith({ relativeRange: 'day' });
+  it('should not refresh when report options reference is unchanged', () => {
+    expect(props.refreshEngagementReport).toHaveBeenCalledTimes(0);
   });
 
-  it('should not refresh when report options reference is unchanged', () => {
+  it('should refresh when report options reference changes', () => {
     wrapper.setProps({ reportOptions: {}});
     expect(props.refreshEngagementReport).toHaveBeenCalledTimes(1);
   });
 
+  it('should refresh when report options change', () => {
+    wrapper.setProps({ reportOptions: { relativeRange: 'day' }});
+    expect(props.refreshEngagementReport).toHaveBeenLastCalledWith({ relativeRange: 'day' });
+  });
 });


### PR DESCRIPTION
`EngagementPage` used a deep comparison of `prevProps` with `this.props` in `cDU` to control its refresh logic:

```js
  componentDidUpdate(prevProps) {
    if (_.isEqual(prevProps.reportOptions, this.props.reportOptions)) {
      this.props.refreshEngagementReport(this.props.reportOptions);
    }
  }
```
`props.reportOptions` does not spontaneously change after mount so the refresh action is not dispatched until the user changes a report option.

The other report pages use an identity check:
```js
  componentDidUpdate(prevProps) {
    if (prevProps.reportOptions !== this.props.reportOptions) {
      this.props.refreshEngagementReport(this.props.reportOptions);
    }
  }
```
...which does trigger after mount since the `ReportOptions` child component always dispatches `REFRESH_REPORT_OPTIONS` on mount.

### Testing
 - Visit the engagement report and verify that it loads and displays the summary, chart and table
 - Roll back this change and then visit the engagement report to see the issue.
