### PR TITLE
FE-561: Unhandled promise rejection in unit tests

### DIFF
--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -47,3 +47,9 @@ jest.mock('moment', () => {
 
 Object.defineProperty(global.navigator, 'userAgent', { value: 'node.js', configurable: true });
 Object.defineProperty(global.navigator, 'language', { value: 'en-US', configurable: true });
+
+// Show a stack track for unhandled rejections to help
+// track them down.
+process.on('unhandledRejection', (reason) => {
+	console.log(reason)
+});

--- a/src/pages/sendingDomains/components/tests/SetupSending.test.js
+++ b/src/pages/sendingDomains/components/tests/SetupSending.test.js
@@ -28,7 +28,7 @@ describe('Component: SetupSending', () => {
         status
       },
       verifyDkimLoading: false,
-      verifyDkim: jest.fn(() => Promise.resolve()),
+      verifyDkim: jest.fn(() => Promise.resolve({ ownership_verified: true, dkim_status: 'valid' })),
       showAlert: jest.fn()
     };
 
@@ -58,7 +58,7 @@ describe('Component: SetupSending', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('disables the verification button while submitting', async() => {
+  it('disables the verification button while submitting', async () => {
     wrapper.setProps({ verifyDkimLoading: true });
     expect(wrapper.find('Panel').props().actions).toMatchSnapshot();
   });
@@ -88,7 +88,7 @@ describe('Component: SetupSending', () => {
       instance = wrapper.instance();
     });
 
-    it('verifies domain and alerts when verification successful', async() => {
+    it('verifies domain and alerts when verification successful', async () => {
       props.verifyDkim.mockReturnValue(Promise.resolve({ dkim_status: 'valid' }));
       await instance.verifyDomain();
       expect(props.verifyDkim).toHaveBeenCalledTimes(1);
@@ -97,7 +97,7 @@ describe('Component: SetupSending', () => {
       expect(props.showAlert).toHaveBeenCalledWith({ type: 'success', message: 'You have successfully verified DKIM record of xyz.com' });
     });
 
-    it('alerts error when verification req is successful but verification is failed', async() => {
+    it('alerts error when verification req is successful but verification is failed', async () => {
       props.verifyDkim.mockReturnValue(Promise.resolve({ dkim_status: 'invalid', dns: { dkim_error: 'nope!' }}));
       await instance.verifyDomain();
       expect(props.verifyDkim).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This is the same old bug-in-promise-chain issue.

 - Chased down a bug in `SetupSending.test.js` mock function.
 - Added an unhandled reject handler (!) to Jest setup.

### Testing
1. Run `npm test` on master to see the unhandled rejection message fly by without useful diagnostic context.
1. Run `npm test` on FE-561 to see no message.
1. Undo the fix in `SetupSending.test.js and tun `npm test` on FE-561 to see a more useful rejection message.

Note that these messages are emitted async so we can't easily diagnose them from their location in the output stream.

FWIW, Jest _should_ be reporting unhandled rejections and failing the related tests where possible

Hint: use `CI=true npm test` to run the whole suite in about a minute with no frills output.
