### PR TITLE
FE-560 Show template loading error

### DIFF
--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -2,12 +2,11 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import _ from 'lodash';
-
 // Components
 import ContentEditor from 'src/components/contentEditor';
 import Form from './components/containers/Form.container';
-import { Loading, DeleteModal } from 'src/components';
-import { Page, Grid } from '@sparkpost/matchbox';
+import { DeleteModal, Loading } from 'src/components';
+import { Grid, Page } from '@sparkpost/matchbox';
 
 export default class EditPage extends Component {
   state = {
@@ -22,7 +21,10 @@ export default class EditPage extends Component {
   }
 
   componentDidUpdate() {
-    if (this.props.getDraftError) {
+    const { showAlert, getDraftError } = this.props;
+
+    if (getDraftError) {
+      showAlert({ type: 'error', message: 'Unable to load template' });
       this.props.history.push('/templates/');
     }
   }

--- a/src/pages/templates/PublishedPage.js
+++ b/src/pages/templates/PublishedPage.js
@@ -14,7 +14,10 @@ export default class PublishedPage extends Component {
   }
 
   componentDidUpdate() {
-    if (this.props.getPublishedError) {
+    const { showAlert, getPublishedError } = this.props;
+
+    if (getPublishedError) {
+      showAlert({ type: 'error', message: 'Unable to load template' });
       this.props.history.push('/templates/');
     }
   }

--- a/src/pages/templates/containers/PublishedPage.container.js
+++ b/src/pages/templates/containers/PublishedPage.container.js
@@ -7,6 +7,7 @@ import { hasGrants } from 'src/helpers/conditions';
 import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
+import { showAlert } from 'src/actions/globalAlert';
 
 import PublishedPage from '../PublishedPage';
 
@@ -36,4 +37,4 @@ const formOptions = {
   enableReinitialize: true // required to update initial values from redux state
 };
 
-export default withRouter(connect(mapStateToProps, { getPublished, getTestData, setTestData })(reduxForm(formOptions)(PublishedPage)));
+export default withRouter(connect(mapStateToProps, { getPublished, getTestData, setTestData, showAlert })(reduxForm(formOptions)(PublishedPage)));

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -50,7 +50,6 @@ describe('Template EditPage', () => {
   it('should handle errors when getting template', () => {
     wrapper.setProps({ getDraftError: 'error' });
     expect(props.history.push).toHaveBeenCalledWith('/templates/');
-
     expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: 'Unable to load template' });
   });
 

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -50,6 +50,7 @@ describe('Template EditPage', () => {
   it('should handle errors when getting template', () => {
     wrapper.setProps({ getDraftError: 'error' });
     expect(props.history.push).toHaveBeenCalledWith('/templates/');
+
     expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: 'Unable to load template' });
   });
 

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -50,6 +50,7 @@ describe('Template EditPage', () => {
   it('should handle errors when getting template', () => {
     wrapper.setProps({ getDraftError: 'error' });
     expect(props.history.push).toHaveBeenCalledWith('/templates/');
+    expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: 'Unable to load template' });
   });
 
   it('should render loading', () => {

--- a/src/pages/templates/tests/PublishedPage.test.js
+++ b/src/pages/templates/tests/PublishedPage.test.js
@@ -19,7 +19,8 @@ describe('Template PublishedPage', () => {
       handleSubmit: jest.fn(),
       canModify: true,
       history: { push: jest.fn() },
-      getPublishedError: null
+      getPublishedError: null,
+      showAlert: jest.fn()
     };
   });
 
@@ -43,6 +44,7 @@ describe('Template PublishedPage', () => {
     wrapper = shallow(<PublishedPage {...props} />);
     wrapper.setProps({ getPublishedError: 'error' });
     expect(props.history.push).toHaveBeenCalledWith('/templates/');
+    expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: 'Unable to load template' });
   });
 
   it('should handle preview', async () => {


### PR DESCRIPTION
Show message when error in loading template


Test:
- In `master`, try visiting a non-existing template edit url. You can change directly in URL. It would redirect to list page without any message. However, doing same in this branch would show a message. 