### PR TITLE
AC-357 updates language during onboarding for new free plans

### DIFF
--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -60,9 +60,9 @@ export class OnboardingPlanPage extends Component {
     if (selectedPlan.isFree) {
       return (
         <Panel.Section>
-          <p>Our full-featured, free account designed for developers:</p>
+          <p>Our full-featured, free account provides you:</p>
           <ul>
-            <li>Up to 15,000 free messages per month, forever.</li>
+            <li>Up to 15,000 free messages for first 30 days, then 500/month forever.</li>
             <li>Access to all of our powerful API features.</li>
             <li>30 days of free technical support to get you up and running.</li>
           </ul>

--- a/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
+++ b/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
@@ -113,11 +113,11 @@ exports[`ChoosePlan page tests should show free bullets when isFree is selected 
         >
           <Panel.Section>
             <p>
-              Our full-featured, free account designed for developers:
+              Our full-featured, free account provides you:
             </p>
             <ul>
               <li>
-                Up to 15,000 free messages per month, forever.
+                Up to 15,000 free messages for first 30 days, then 500/month forever.
               </li>
               <li>
                 Access to all of our powerful API features.


### PR DESCRIPTION
See convo for details: https://msys.slack.com/archives/CDLSCST38/p1540228840000100

Copy: https://docs.google.com/document/d/1fqioihD4JpXHB_zhOe3uYq9tULp_qLPFDUT9OkyJRMQ/edit

Note: I wasn't able to update the subheading under the free plan. We tried to have "15,000 free emails for first 30 days, then 500/month forever" as a subheading. However this would also be shown when downgrading to the 500 free plan on the billing page and would be misleading. We opted to not change the subheading for free plans.