### PR TITLE
FE-543 - Add a note about removing password upon enabling single sign on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -668,7 +668,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3167,7 +3167,7 @@
       "dependencies": {
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         }
@@ -10101,7 +10101,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10165,7 +10165,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10197,7 +10197,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/src/pages/users/EditPage.js
+++ b/src/pages/users/EditPage.js
@@ -83,8 +83,8 @@ export class EditPage extends Component {
     }
 
     const ssoHelpText = isAccountSingleSignOnEnabled
-      ? <span>Enabling single sign-on will remove your password. <br/>To use password again, you'll need to reset it from Log In page</span>
-      : <span>Single sign-on has not been configured for your account. Enable in your <PageLink to="/account/settings">account's settings</PageLink></span>;
+      ? <span>Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.</span>
+      : <span>Single sign-on has not been configured for your account. Enable in your <PageLink to="/account/settings">account's settings</PageLink>.</span>;
 
     return (
       <Page

--- a/src/pages/users/EditPage.js
+++ b/src/pages/users/EditPage.js
@@ -82,6 +82,10 @@ export class EditPage extends Component {
       });
     }
 
+    const ssoHelpText = isAccountSingleSignOnEnabled
+      ? <span>Enabling single sign-on will remove your password. <br/>To use password again, you'll need to reset it from Log In page</span>
+      : <span>Single sign-on has not been configured for your account. Enable in your <PageLink to="/account/settings">account's settings</PageLink></span>;
+
     return (
       <Page
         title={user.email}
@@ -101,15 +105,7 @@ export class EditPage extends Component {
               <Field
                 component={CheckboxWrapper}
                 disabled={!isAccountSingleSignOnEnabled}
-                helpText={
-                  isAccountSingleSignOnEnabled === false && (
-                    <span>
-                      Single sign-on has not been configured for your account. Enable in your {
-                        <PageLink to="/account/settings">account's settings</PageLink>
-                      }
-                    </span>
-                  )
-                }
+                helpText={ssoHelpText}
                 label='Enable single sign-on authentication for this user'
                 name='is_sso'
                 type="checkbox"

--- a/src/pages/users/components/RoleRadioGroup.js
+++ b/src/pages/users/components/RoleRadioGroup.js
@@ -5,12 +5,12 @@ const ROLES = [
   {
     label: <strong>Admin</strong>,
     value: 'admin',
-    helpText: 'Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting'
+    helpText: 'Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting.'
   },
   {
     label: <strong>Reporting</strong>,
     value: 'reporting',
-    helpText: 'Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them'
+    helpText: 'Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them.'
   },
   {
     label: <strong>Super User</strong>,

--- a/src/pages/users/components/tests/__snapshots__/RoleRadioGroup.test.js.snap
+++ b/src/pages/users/components/tests/__snapshots__/RoleRadioGroup.test.js.snap
@@ -13,7 +13,7 @@ exports[`Component: RoleRadioGroup should render disabled 1`] = `
     Array [
       Object {
         "disabled": true,
-        "helpText": "Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting",
+        "helpText": "Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting.",
         "label": <strong>
           Admin
         </strong>,
@@ -21,7 +21,7 @@ exports[`Component: RoleRadioGroup should render disabled 1`] = `
       },
       Object {
         "disabled": true,
-        "helpText": "Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them",
+        "helpText": "Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them.",
         "label": <strong>
           Reporting
         </strong>,
@@ -46,7 +46,7 @@ exports[`Component: RoleRadioGroup should render super user 1`] = `
     Array [
       Object {
         "disabled": false,
-        "helpText": "Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting",
+        "helpText": "Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting.",
         "label": <strong>
           Admin
         </strong>,
@@ -54,7 +54,7 @@ exports[`Component: RoleRadioGroup should render super user 1`] = `
       },
       Object {
         "disabled": false,
-        "helpText": "Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them",
+        "helpText": "Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them.",
         "label": <strong>
           Reporting
         </strong>,
@@ -86,7 +86,7 @@ exports[`Component: RoleRadioGroup should render the RadioGroup 1`] = `
     Array [
       Object {
         "disabled": false,
-        "helpText": "Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting",
+        "helpText": "Has access to all functionality in the UI. Has the ability to add additional administrators and create / invite users with a role of Reporting.",
         "label": <strong>
           Admin
         </strong>,
@@ -94,7 +94,7 @@ exports[`Component: RoleRadioGroup should render the RadioGroup 1`] = `
       },
       Object {
         "disabled": false,
-        "helpText": "Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them",
+        "helpText": "Has no access to functionality in the UI. Permissions include access to view all reports, and view all templates except being allowed to change them.",
         "label": <strong>
           Reporting
         </strong>,

--- a/src/pages/users/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/EditPage.test.js.snap
@@ -110,7 +110,13 @@ exports[`Page: Users Edit should not allow current user to delete 1`] = `
         <Field
           component={[Function]}
           disabled={false}
-          helpText={false}
+          helpText={
+            <span>
+              Enabling single sign-on will remove your password. 
+              <br />
+              To use password again, you'll need to reset it from Log In page
+            </span>
+          }
           label="Enable single sign-on authentication for this user"
           name="is_sso"
           type="checkbox"
@@ -196,7 +202,13 @@ exports[`Page: Users Edit should render correctly by default 1`] = `
         <Field
           component={[Function]}
           disabled={false}
-          helpText={false}
+          helpText={
+            <span>
+              Enabling single sign-on will remove your password. 
+              <br />
+              To use password again, you'll need to reset it from Log In page
+            </span>
+          }
           label="Enable single sign-on authentication for this user"
           name="is_sso"
           type="checkbox"
@@ -268,7 +280,13 @@ exports[`Page: Users Edit should show a delete modal 1`] = `
         <Field
           component={[Function]}
           disabled={false}
-          helpText={false}
+          helpText={
+            <span>
+              Enabling single sign-on will remove your password. 
+              <br />
+              To use password again, you'll need to reset it from Log In page
+            </span>
+          }
           label="Enable single sign-on authentication for this user"
           name="is_sso"
           type="checkbox"

--- a/src/pages/users/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/EditPage.test.js.snap
@@ -41,6 +41,7 @@ exports[`Page: Users Edit should disable single sign-on checkbox and display ins
               >
                 account's settings
               </PageLink>
+              .
             </span>
           }
           label="Enable single sign-on authentication for this user"
@@ -112,9 +113,7 @@ exports[`Page: Users Edit should not allow current user to delete 1`] = `
           disabled={false}
           helpText={
             <span>
-              Enabling single sign-on will remove your password. 
-              <br />
-              To use password again, you'll need to reset it from Log In page
+              Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.
             </span>
           }
           label="Enable single sign-on authentication for this user"
@@ -204,9 +203,7 @@ exports[`Page: Users Edit should render correctly by default 1`] = `
           disabled={false}
           helpText={
             <span>
-              Enabling single sign-on will remove your password. 
-              <br />
-              To use password again, you'll need to reset it from Log In page
+              Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.
             </span>
           }
           label="Enable single sign-on authentication for this user"
@@ -282,9 +279,7 @@ exports[`Page: Users Edit should show a delete modal 1`] = `
           disabled={false}
           helpText={
             <span>
-              Enabling single sign-on will remove your password. 
-              <br />
-              To use password again, you'll need to reset it from Log In page
+              Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.
             </span>
           }
           label="Enable single sign-on authentication for this user"


### PR DESCRIPTION

After doing this I feel like we should show this only when they check it on. so here is my thought:

Status: Unchecked
Action: Check
Note: show the note as in this PR

Status: Checked
Action: Uncheck
Note: <You'll need to reset your password....> Possibly with an action that sends password reset email directly from here rather than visiting the log in page. 