### PR TITLE
FE-550: offer auto billing only to folk on zuora plans

### DIFF
--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -2,6 +2,7 @@ import { any, all } from './compose';
 import _ from 'lodash';
 
 export const onPlan = (planCode) => ({ accountPlan }) => accountPlan.code === planCode;
+export const onZuoraPlan = ({ accountPlan }) => Boolean(accountPlan.billingId);
 export const onPlanWithStatus = (status) => ({ accountPlan }) => accountPlan.status === status;
 export const onServiceLevel = (level) => ({ account }) => account.service_level === level;
 export const isEnterprise = any(

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -1,5 +1,6 @@
 import {
   onPlan,
+  onZuoraPlan,
   onPlanWithStatus,
   onServiceLevel,
   isEnterprise,
@@ -16,6 +17,11 @@ test('Condition: onPlan', () => {
   const condition = onPlan('p1');
   expect(condition({ accountPlan: { code: 'p1' }})).toEqual(true);
   expect(condition({ accountPlan: { code: 'p2' }})).toEqual(false);
+});
+
+test('Condition: onZuoraPlan', () => {
+  expect(onZuoraPlan({ accountPlan: { billingId: 'uuuiiiiid' }})).toEqual(true);
+  expect(onZuoraPlan({ accountPlan: {}})).toEqual(false);
 });
 
 test('Condition: onPlanWithStatus', () => {

--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -5,8 +5,8 @@ import { fetch as fetchAccount, getPlans } from 'src/actions/account';
 import { list as getSendingIps } from 'src/actions/sendingIps';
 import { selectBillingInfo } from 'src/selectors/accountBillingInfo';
 import ConditionSwitch, { defaultCase } from 'src/components/auth/ConditionSwitch';
-import { not } from 'src/helpers/conditions';
-import { isSuspendedForBilling, isSelfServeBilling } from 'src/helpers/conditions/account';
+import { all, not } from 'src/helpers/conditions';
+import { isSuspendedForBilling, isSelfServeBilling, onZuoraPlan } from 'src/helpers/conditions/account';
 import { Loading } from 'src/components';
 import BillingSummary from './components/BillingSummary';
 import ManuallyBilledBanner from './components/ManuallyBilledBanner';
@@ -33,7 +33,7 @@ export class BillingSummaryPage extends Component {
       <Page title='Billing'>
         <ConditionSwitch>
           <SuspendedForBilling condition={isSuspendedForBilling} account={account} />
-          <ManuallyBilledBanner condition={not(isSelfServeBilling)} account={account} />
+          <ManuallyBilledBanner condition={all(not(isSelfServeBilling), onZuoraPlan)} account={account} />
           <BillingSummary condition={defaultCase} account={account} {...billingInfo} invoices={invoices} sendingIps={sendingIps} />
         </ConditionSwitch>
       </Page>

--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -5,8 +5,8 @@ import { fetch as fetchAccount, getPlans } from 'src/actions/account';
 import { list as getSendingIps } from 'src/actions/sendingIps';
 import { selectBillingInfo } from 'src/selectors/accountBillingInfo';
 import ConditionSwitch, { defaultCase } from 'src/components/auth/ConditionSwitch';
-import { all, not } from 'src/helpers/conditions';
-import { isSuspendedForBilling, isSelfServeBilling, onZuoraPlan } from 'src/helpers/conditions/account';
+import { not } from 'src/helpers/conditions';
+import { isSuspendedForBilling, isSelfServeBilling } from 'src/helpers/conditions/account';
 import { Loading } from 'src/components';
 import BillingSummary from './components/BillingSummary';
 import ManuallyBilledBanner from './components/ManuallyBilledBanner';
@@ -33,7 +33,7 @@ export class BillingSummaryPage extends Component {
       <Page title='Billing'>
         <ConditionSwitch>
           <SuspendedForBilling condition={isSuspendedForBilling} account={account} />
-          <ManuallyBilledBanner condition={all(not(isSelfServeBilling), onZuoraPlan)} account={account} />
+          <ManuallyBilledBanner condition={not(isSelfServeBilling)} account={account} onZuoraPlan={billingInfo.onZuoraPlan} />
           <BillingSummary condition={defaultCase} account={account} {...billingInfo} invoices={invoices} sendingIps={sendingIps} />
         </ConditionSwitch>
       </Page>

--- a/src/pages/billing/components/ManuallyBilledBanner.js
+++ b/src/pages/billing/components/ManuallyBilledBanner.js
@@ -17,7 +17,8 @@ const ManuallyBilledBanner = ({
       plan_volume_per_period: planVolumePerPeriod,
       recurring_charge: recurringCharge
     }
-  }
+  },
+  onZuoraPlan
 }) => {
   const localePlanVolume = (planVolumePerPeriod || planVolume).toLocaleString();
   const title = `
@@ -41,22 +42,27 @@ const ManuallyBilledBanner = ({
     );
   }
 
+  const autoBillingAvailable = !custom && onZuoraPlan;
+  const action = autoBillingAvailable
+    ? {
+      Component: PageLink,
+      content: 'Enable Automatic Billing',
+      to: custom ? '/account/billing/enable-automatic' : '/account/billing/plan'
+    }
+    : null;
+
   return (
     <Banner
       status="info"
       title={title}
-      action={{
-        Component: PageLink,
-        content: 'Enable Automatic Billing',
-        to: custom ? '/account/billing/enable-automatic' : '/account/billing/plan'
-      }}
+      action={action}
     >
       <p>
         To make changes to your plan or billing information, please {
           <SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>
         }.
       </p>
-      {!custom && (
+      {autoBillingAvailable && (
         <p>
           Enable automatic billing to self-manage your plan and add-ons.
         </p>

--- a/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
+++ b/src/pages/billing/components/tests/ManuallyBilledBanner.test.js
@@ -2,9 +2,20 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import ManuallyBilledBanner from '../ManuallyBilledBanner';
 
+const mkCustomSubs = () => ({
+  subscription: {
+    custom: true,
+    name: 'Custom',
+    period: 'year',
+    plan_volume: 10000,
+    plan_volume_per_period: 120000,
+    recurring_charge: 100
+  }
+});
+
 describe('ManuallyBilledBanner', () => {
-  const subject = ({ account = {}}) => (
-    shallow(<ManuallyBilledBanner account={account} />)
+  const subject = ({ account = {}, onZuoraPlan = false }) => (
+    shallow(<ManuallyBilledBanner account={account} onZuoraPlan={onZuoraPlan} />)
   );
 
   it('renders banner', () => {
@@ -15,7 +26,7 @@ describe('ManuallyBilledBanner', () => {
       }
     };
 
-    expect(subject({ account })).toMatchSnapshot();
+    expect(subject({ account, onZuoraPlan: true })).toMatchSnapshot();
   });
 
   it('with transitioning custom subscription when volume per period is undefined', () => {
@@ -46,18 +57,15 @@ describe('ManuallyBilledBanner', () => {
     expect(subject({ account })).toMatchSnapshot();
   });
 
-  it('with custom subscription', () => {
-    const account = {
-      subscription: {
-        custom: true,
-        name: 'Custom',
-        period: 'year',
-        plan_volume: 10000,
-        plan_volume_per_period: 120000,
-        recurring_charge: 100
-      }
-    };
+  it('with custom subscription, plan not in Zuora', () => {
+    const account = mkCustomSubs();
 
     expect(subject({ account })).toMatchSnapshot();
+  });
+
+  it('with custom subscription and plan in Zuora', () => {
+    const account = mkCustomSubs();
+
+    expect(subject({ account, onZuoraPlan: true })).toMatchSnapshot();
   });
 });

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
@@ -29,15 +29,29 @@ exports[`ManuallyBilledBanner renders banner 1`] = `
 </Banner>
 `;
 
-exports[`ManuallyBilledBanner with custom subscription 1`] = `
+exports[`ManuallyBilledBanner with custom subscription and plan in Zuora 1`] = `
 <Banner
-  action={
-    Object {
-      "Component": [Function],
-      "content": "Enable Automatic Billing",
-      "to": "/account/billing/enable-automatic",
-    }
-  }
+  action={null}
+  status="info"
+  title="
+    Your current Custom plan includes 120,000 emails per year
+  "
+>
+  <p>
+    To make changes to your plan or billing information, please 
+    <Connect(SupportTicketLink)
+      issueId="general_issue"
+    >
+      submit a support ticket
+    </Connect(SupportTicketLink)>
+    .
+  </p>
+</Banner>
+`;
+
+exports[`ManuallyBilledBanner with custom subscription, plan not in Zuora 1`] = `
+<Banner
+  action={null}
   status="info"
   title="
     Your current Custom plan includes 120,000 emails per year

--- a/src/pages/billing/tests/SummaryPage.test.js
+++ b/src/pages/billing/tests/SummaryPage.test.js
@@ -11,8 +11,7 @@ describe('Page: BillingSummaryPage', () => {
       account: {
         subscription: {}
       },
-      billingInfo: {},
-      currentPlan: { code: '10.23k-1018', billingId: 'guuuiiiiiid' },
+      billingInfo: { onZuoraPlan: true },
       loading: false,
       sendingIps: {
         list: []

--- a/src/pages/billing/tests/SummaryPage.test.js
+++ b/src/pages/billing/tests/SummaryPage.test.js
@@ -12,6 +12,7 @@ describe('Page: BillingSummaryPage', () => {
         subscription: {}
       },
       billingInfo: {},
+      currentPlan: { code: '10.23k-1018', billingId: 'guuuiiiiiid' },
       loading: false,
       sendingIps: {
         list: []

--- a/src/pages/billing/tests/__snapshots__/SummaryPage.test.js.snap
+++ b/src/pages/billing/tests/__snapshots__/SummaryPage.test.js.snap
@@ -23,6 +23,7 @@ exports[`Page: BillingSummaryPage should render correctly when not loading 1`] =
         }
       }
       condition={[Function]}
+      onZuoraPlan={true}
     />
     <BillingSummary
       account={
@@ -31,6 +32,7 @@ exports[`Page: BillingSummaryPage should render correctly when not loading 1`] =
         }
       }
       condition={[Function]}
+      onZuoraPlan={true}
       sendingIps={
         Object {
           "list": Array [],

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import _ from 'lodash';
-import { isAws, isCustomBilling, isSelfServeBilling, onPlan } from 'src/helpers/conditions/account';
+import { isAws, isCustomBilling, isSelfServeBilling, onPlan, onZuoraPlan } from 'src/helpers/conditions/account';
 import { selectCondition } from './accessConditionState';
 
 const suspendedSelector = (state) => state.account.isSuspendedForBilling;
@@ -12,6 +12,7 @@ const selectIsCustomBilling = selectCondition(isCustomBilling);
 const selectIsSelfServeBilling = selectCondition(isSelfServeBilling);
 const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
 const selectIsFree1 = selectCondition(onPlan('free1'));
+const selectOnZuoraPlan = selectCondition(onZuoraPlan);
 
 export const currentSubscriptionSelector = (state) => state.account.subscription;
 
@@ -89,14 +90,16 @@ export const selectBillingInfo = createSelector(
     canChangePlanSelector,
     canPurchaseIps,
     currentPlanSelector,
+    selectOnZuoraPlan,
     selectVisiblePlans,
     selectIsAws
   ],
-  (canUpdateBillingInfo, canChangePlan, canPurchaseIps, currentPlan, plans, isAWSAccount) => ({
+  (canUpdateBillingInfo, canChangePlan, canPurchaseIps, currentPlan, onZuoraPlan, plans, isAWSAccount) => ({
     canUpdateBillingInfo,
     canChangePlan,
     canPurchaseIps,
     currentPlan,
+    onZuoraPlan,
     plans,
     isAWSAccount
   })

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -118,6 +118,7 @@ describe('selectBillingInfo', () => {
       'canChangePlan',
       'canPurchaseIps',
       'currentPlan',
+      'onZuoraPlan',
       'plans',
       'isAWSAccount'
     ]);


### PR DESCRIPTION
 - Added a condition to detect if the current plan is "in Zuora" aka has `billingId`
 - Used the condition show/hide `ManuallyBilledBanner` on `/account/billing`

## Testing

 - Review `/account/billing` while varying the following plan fields:
    - custom - boolean - is this a custom plan?
    - billingId - string / uuid - Zuora plan ID - exists iff the plan exists in Zuora
