### PR TITLE
AC-401: Allow admin users to disable TFA for a user

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -73,7 +73,8 @@ export const FORMS = {
   LOGIN: 'loginForm',
   JOIN: 'joinForm',
   JOIN_PLAN: 'joinPlanForm',
-  JOIN_SENDING_DOMAIN: 'joinSendingDomainForm'
+  JOIN_SENDING_DOMAIN: 'joinSendingDomainForm',
+  EDIT_USER: 'userEditForm'
 };
 
 export const ANALYTICS_CREATE_ACCOUNT = 'create account';

--- a/src/pages/users/EditPage.container.js
+++ b/src/pages/users/EditPage.container.js
@@ -1,0 +1,35 @@
+import { connect } from 'react-redux';
+import { reduxForm } from 'redux-form';
+import _ from 'lodash';
+import { updateUser, listUsers, deleteUser } from 'src/actions/users';
+import { getAccountSingleSignOnDetails } from 'src/actions/accountSingleSignOn';
+import { selectUserById } from 'src/selectors/users';
+import { FORMS } from 'src/constants';
+
+import EditPage from './EditPage';
+
+const mapStateToProps = (state, props) => {
+  const user = selectUserById(state, props.match.params.id);
+
+  return {
+    accountSingleSignOn: state.accountSingleSignOn,
+    currentUser: state.currentUser,
+    isAccountSingleSignOnEnabled: state.accountSingleSignOn.enabled,
+    loadingError: state.users.error,
+    user,
+    users: state.users.entities,
+    updatePending: state.users.updatePending,
+    initialValues: {
+      access: _.get(user, 'access'),
+      is_sso: _.get(user, 'is_sso')
+    }
+  };
+};
+
+const mapDispatchToProps = { updateUser, listUsers, deleteUser, getAccountSingleSignOnDetails };
+const formOptions = { form: FORMS.EDIT_USER, enableReinitialize: true };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(reduxForm(formOptions)(EditPage));

--- a/src/pages/users/components/EditForm.js
+++ b/src/pages/users/components/EditForm.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Field } from 'redux-form';
+import { Panel, Button } from '@sparkpost/matchbox';
+import PageLink from 'src/components/pageLink/PageLink';
+import { CheckboxWrapper } from 'src/components/reduxFormWrappers';
+import RoleRadioGroup from './RoleRadioGroup';
+
+export const EditForm = ({
+  onSubmit,
+  user,
+  currentUser,
+  isAccountSingleSignOnEnabled,
+  submitting
+}) => {
+
+  const ssoHelpText = isAccountSingleSignOnEnabled
+    ? <span>Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.</span>
+    : <span>Single sign-on has not been configured for your account. Enable in your <PageLink to="/account/settings">account's settings</PageLink>.</span>;
+
+  return <Panel>
+    <form onSubmit={onSubmit}>
+      <Panel.Section>
+        <Field
+          name="access"
+          disabled={user.isCurrentUser}
+          allowSuperUser={currentUser.access === 'superuser'}
+          component={RoleRadioGroup}
+        />
+      </Panel.Section>
+      <Panel.Section>
+        <Field
+          component={CheckboxWrapper}
+          disabled={!isAccountSingleSignOnEnabled}
+          helpText={ssoHelpText}
+          label="Enable single sign-on authentication for this user"
+          name="is_sso"
+          type="checkbox"
+        />
+      </Panel.Section>
+      <Panel.Section>
+        <Button primary disabled={submitting} submit>
+          {'Update user'}
+        </Button>
+      </Panel.Section>
+    </form>
+  </Panel>;
+};
+
+export default EditForm;

--- a/src/pages/users/components/tests/EditForm.test.js
+++ b/src/pages/users/components/tests/EditForm.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import EditForm from '../EditForm';
+
+describe('Component: EditForm', () => {
+  const baseProps = {
+    isAccountSingleSignOnEnabled: true,
+    currentUser: { name: 'current-user' },
+    user: { access: 'admin', email: 'test-user@test.com', name: 'test-user' }
+  };
+
+  function subject(props) {
+    return shallow(<EditForm {...baseProps} {...props} />);
+  }
+
+  it('should render', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('should disable single sign-on checkbox and display instructions', () => {
+    expect(subject({ isAccountSingleSignOnEnabled: false })).toMatchSnapshot();
+  });
+
+  it('should call submit handler', () => {
+    const onSubmit = jest.fn();
+    subject({ onSubmit }).find('form').first().simulate('submit');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/users/components/tests/__snapshots__/EditForm.test.js.snap
+++ b/src/pages/users/components/tests/__snapshots__/EditForm.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: EditForm should disable single sign-on checkbox and display instructions 1`] = `
+<Panel>
+  <form>
+    <Panel.Section>
+      <Field
+        allowSuperUser={false}
+        component={[Function]}
+        name="access"
+      />
+    </Panel.Section>
+    <Panel.Section>
+      <Field
+        component={[Function]}
+        disabled={true}
+        helpText={
+          <span>
+            Single sign-on has not been configured for your account. Enable in your 
+            <PageLink
+              to="/account/settings"
+            >
+              account's settings
+            </PageLink>
+            .
+          </span>
+        }
+        label="Enable single sign-on authentication for this user"
+        name="is_sso"
+        type="checkbox"
+      />
+    </Panel.Section>
+    <Panel.Section>
+      <Button
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Update user
+      </Button>
+    </Panel.Section>
+  </form>
+</Panel>
+`;
+
+exports[`Component: EditForm should render 1`] = `
+<Panel>
+  <form>
+    <Panel.Section>
+      <Field
+        allowSuperUser={false}
+        component={[Function]}
+        name="access"
+      />
+    </Panel.Section>
+    <Panel.Section>
+      <Field
+        component={[Function]}
+        disabled={false}
+        helpText={
+          <span>
+            Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.
+          </span>
+        }
+        label="Enable single sign-on authentication for this user"
+        name="is_sso"
+        type="checkbox"
+      />
+    </Panel.Section>
+    <Panel.Section>
+      <Button
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Update user
+      </Button>
+    </Panel.Section>
+  </form>
+</Panel>
+`;

--- a/src/pages/users/index.js
+++ b/src/pages/users/index.js
@@ -1,5 +1,5 @@
 import ListPage from './ListPage';
 import CreatePage from './CreatePage';
-import EditPage from './EditPage';
+import EditPage from './EditPage.container';
 
 export default { ListPage, CreatePage, EditPage };

--- a/src/pages/users/tests/EditPage.test.js
+++ b/src/pages/users/tests/EditPage.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { EditPage } from '../EditPage';
+import ConfirmationModal from 'src/components/modals/ConfirmationModal';
 
 describe('Page: Users Edit', () => {
   let props;
@@ -60,11 +61,6 @@ describe('Page: Users Edit', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should disable single sign-on checkbox and display instructions', () => {
-    wrapper.setProps({ isAccountSingleSignOnEnabled: false });
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('should not allow current user to delete', () => {
     wrapper.setProps({
       user: {
@@ -84,7 +80,10 @@ describe('Page: Users Edit', () => {
 
   it('should update a user', async () => {
     await instance.handleUserUpdate({ is_sso: true, access: 'admin' });
-    expect(props.updateUser).toHaveBeenCalledWith('test-user', { is_sso: true, access_level: 'admin' });
+    expect(props.updateUser).toHaveBeenCalledWith('test-user', {
+      is_sso: true,
+      access_level: 'admin'
+    });
   });
 
   it('should delete a user', async () => {
@@ -95,5 +94,24 @@ describe('Page: Users Edit', () => {
   it('should redirect after delete or if user does not exist', () => {
     wrapper.setProps({ user: undefined });
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should show a disable-tfa modal', () => {
+    instance.toggleTfaModal();
+    expect(
+      wrapper
+        .find(ConfirmationModal)
+        .first()
+        .prop('open')
+    ).toEqual(true);
+  });
+
+  it('should disable tfa', () => {
+    wrapper
+      .find(ConfirmationModal)
+      .first()
+      .prop('onConfirm')();
+    expect(props.updateUser).toHaveBeenCalledTimes(1);
+    expect(props.updateUser.mock.calls[0][1]).toMatchObject({ tfa_enabled: false });
   });
 });

--- a/src/pages/users/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/EditPage.test.js.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Page: Users Edit should disable single sign-on checkbox and display instructions 1`] = `
+exports[`Page: Users Edit should load until we have a list of users 1`] = `<Loading />`;
+
+exports[`Page: Users Edit should not allow current user to delete 1`] = `
 <Page
   breadcrumbAction={
     Object {
@@ -10,56 +12,26 @@ exports[`Page: Users Edit should disable single sign-on checkbox and display ins
     }
   }
   empty={Object {}}
-  secondaryActions={
-    Array [
-      Object {
-        "content": "Delete",
-        "onClick": [Function],
-      },
-    ]
-  }
+  secondaryActions={Array []}
   title="test-user@test.com"
 >
-  <Panel>
-    <form>
-      <Panel.Section>
-        <Field
-          allowSuperUser={false}
-          component={[Function]}
-          name="access"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          disabled={true}
-          helpText={
-            <span>
-              Single sign-on has not been configured for your account. Enable in your 
-              <PageLink
-                to="/account/settings"
-              >
-                account's settings
-              </PageLink>
-              .
-            </span>
-          }
-          label="Enable single sign-on authentication for this user"
-          name="is_sso"
-          type="checkbox"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Update user
-        </Button>
-      </Panel.Section>
-    </form>
-  </Panel>
+  <Component
+    currentUser={
+      Object {
+        "name": "current-user",
+      }
+    }
+    isAccountSingleSignOnEnabled={true}
+    onSubmit={[Function]}
+    user={
+      Object {
+        "access": "admin",
+        "email": "test-user@test.com",
+        "isCurrentUser": true,
+        "name": "test-user",
+      }
+    }
+  />
   <DeleteModal
     content={
       <p>
@@ -79,77 +51,17 @@ exports[`Page: Users Edit should disable single sign-on checkbox and display ins
     open={false}
     title="Are you sure you want to delete this user?"
   />
-</Page>
-`;
-
-exports[`Page: Users Edit should load until we have a list of users 1`] = `<Loading />`;
-
-exports[`Page: Users Edit should not allow current user to delete 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "Users",
-      "to": "/account/users",
-    }
-  }
-  empty={Object {}}
-  secondaryActions={Array []}
-  title="test-user@test.com"
->
-  <Panel>
-    <form>
-      <Panel.Section>
-        <Field
-          allowSuperUser={false}
-          component={[Function]}
-          disabled={true}
-          name="access"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          disabled={false}
-          helpText={
-            <span>
-              Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.
-            </span>
-          }
-          label="Enable single sign-on authentication for this user"
-          name="is_sso"
-          type="checkbox"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Update user
-        </Button>
-      </Panel.Section>
-    </form>
-  </Panel>
-  <DeleteModal
+  <ConfirmationModal
+    confirmVerb="Disable"
     content={
       <p>
-        <span>
-          User "
-        </span>
-        <span>
-          test-user
-        </span>
-        <span>
-          " will no longer be able to log in or access this SparkPost account. All API keys associated with this user will be transferred to you.
-        </span>
+        Disabling two-factor authentication will also delete their two-factor backup codes. The next time they log in, they'll have to use their password or single sign-on if available.
       </p>
     }
     onCancel={[Function]}
-    onDelete={[Function]}
+    onConfirm={[Function]}
     open={false}
-    title="Are you sure you want to delete this user?"
+    title="Are you sure you want to disable two-factor authentication for this user?"
   />
 </Page>
 `;
@@ -188,40 +100,22 @@ exports[`Page: Users Edit should render correctly by default 1`] = `
   }
   title="test-user@test.com"
 >
-  <Panel>
-    <form>
-      <Panel.Section>
-        <Field
-          allowSuperUser={false}
-          component={[Function]}
-          name="access"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          disabled={false}
-          helpText={
-            <span>
-              Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.
-            </span>
-          }
-          label="Enable single sign-on authentication for this user"
-          name="is_sso"
-          type="checkbox"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Update user
-        </Button>
-      </Panel.Section>
-    </form>
-  </Panel>
+  <Component
+    currentUser={
+      Object {
+        "name": "current-user",
+      }
+    }
+    isAccountSingleSignOnEnabled={true}
+    onSubmit={[Function]}
+    user={
+      Object {
+        "access": "admin",
+        "email": "test-user@test.com",
+        "name": "test-user",
+      }
+    }
+  />
   <DeleteModal
     content={
       <p>
@@ -240,6 +134,18 @@ exports[`Page: Users Edit should render correctly by default 1`] = `
     onDelete={[Function]}
     open={false}
     title="Are you sure you want to delete this user?"
+  />
+  <ConfirmationModal
+    confirmVerb="Disable"
+    content={
+      <p>
+        Disabling two-factor authentication will also delete their two-factor backup codes. The next time they log in, they'll have to use their password or single sign-on if available.
+      </p>
+    }
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    open={false}
+    title="Are you sure you want to disable two-factor authentication for this user?"
   />
 </Page>
 `;
@@ -264,40 +170,22 @@ exports[`Page: Users Edit should show a delete modal 1`] = `
   }
   title="test-user@test.com"
 >
-  <Panel>
-    <form>
-      <Panel.Section>
-        <Field
-          allowSuperUser={false}
-          component={[Function]}
-          name="access"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          disabled={false}
-          helpText={
-            <span>
-              Enabling single sign-on will delete this user's password. If they switch back to password-based authentication, they'll need to reset their password on login.
-            </span>
-          }
-          label="Enable single sign-on authentication for this user"
-          name="is_sso"
-          type="checkbox"
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Update user
-        </Button>
-      </Panel.Section>
-    </form>
-  </Panel>
+  <Component
+    currentUser={
+      Object {
+        "name": "current-user",
+      }
+    }
+    isAccountSingleSignOnEnabled={true}
+    onSubmit={[Function]}
+    user={
+      Object {
+        "access": "admin",
+        "email": "test-user@test.com",
+        "name": "test-user",
+      }
+    }
+  />
   <DeleteModal
     content={
       <p>
@@ -316,6 +204,18 @@ exports[`Page: Users Edit should show a delete modal 1`] = `
     onDelete={[Function]}
     open={true}
     title="Are you sure you want to delete this user?"
+  />
+  <ConfirmationModal
+    confirmVerb="Disable"
+    content={
+      <p>
+        Disabling two-factor authentication will also delete their two-factor backup codes. The next time they log in, they'll have to use their password or single sign-on if available.
+      </p>
+    }
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    open={false}
+    title="Are you sure you want to disable two-factor authentication for this user?"
   />
 </Page>
 `;

--- a/src/reducers/tests/__snapshots__/users.test.js.snap
+++ b/src/reducers/tests/__snapshots__/users.test.js.snap
@@ -43,6 +43,7 @@ Object {
     "test-user-one": Object {
       "access": "reporting",
       "is_sso": undefined,
+      "tfa_enabled": undefined,
       "username": "test-user-one",
     },
     "test-user-two": Object {
@@ -64,6 +65,7 @@ Object {
     "test-user-one": Object {
       "access": undefined,
       "is_sso": true,
+      "tfa_enabled": undefined,
       "username": "test-user-one",
     },
     "test-user-two": Object {

--- a/src/reducers/users.js
+++ b/src/reducers/users.js
@@ -27,8 +27,14 @@ export default (state = initialState, action) => {
     case 'LIST_USERS_SUCCESS':
       return { ...initialState, entities: reduceUsers(action.payload) };
 
+    case 'UPDATE_USER_PENDING':
+      return { ...state, updatePending: true };
+
+    case 'UPDATE_USER_FAIL':
+      return { ...state, updatePending: false };
+
     case 'UPDATE_USER_SUCCESS': {
-      const { access_level, is_sso, username } = action.meta.data;
+      const { access_level, is_sso, tfa_enabled, username } = action.meta.data;
       const user = fp.get(username)(state.entities);
 
       if (fp.isUndefined(user)) { return state; } // ignore
@@ -36,7 +42,8 @@ export default (state = initialState, action) => {
       return fp.set(['entities', username], {
         ...state.entities[username],
         access: access_level,
-        is_sso
+        is_sso,
+        tfa_enabled
       })(state);
     }
 


### PR DESCRIPTION
 - `/account/users/edit/:user` now has a secondary action named `Disable Two-Factor Authentication` when `:user` has it enabled.
 - Refactored `users.EditPage` into a container, page and form components.
 - Updated users reducer to allow updating `tfa_enabled`.
