### PR TITLE
FE-577: reinstate user edit form submission handler

### DIFF
--- a/src/pages/users/EditPage.js
+++ b/src/pages/users/EditPage.js
@@ -104,7 +104,7 @@ export class EditPage extends Component {
         secondaryActions={secondaryActions}
       >
         <EditForm
-          onSubmit={() => handleSubmit(this.handleUserUpdate)}
+          onSubmit={handleSubmit(this.handleUserUpdate)}
           user={user}
           currentUser={currentUser}
           isAccountSingleSignOnEnabled={isAccountSingleSignOnEnabled}

--- a/src/pages/users/tests/EditPage.test.js
+++ b/src/pages/users/tests/EditPage.test.js
@@ -10,7 +10,7 @@ describe('Page: Users Edit', () => {
 
   beforeEach(() => {
     props = {
-      handleSubmit: jest.fn(),
+      handleSubmit: jest.fn((handler) => handler),
       loadingError: false,
       listUsers: jest.fn(),
       deleteUser: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
`s/() => handleSubmit(...)/handleSubmit(...)/`

There is a separate issue with `PUT /users/:username` where setting `is_sso` doesn't stick. This is unrelated.

### Testing
 - Manage users -> click on a username (not your current login)
 - Make a change on the edit form
 - Submit
 - Verify the `PUT /users/:username` call matches your form content.
