### PR TITLE
AC-417: Add enable-tfa page to user registration flow

### DIFF
--- a/src/actions/tests/auth.test.js
+++ b/src/actions/tests/auth.test.js
@@ -99,11 +99,24 @@ describe('Action Creator: Auth', () => {
       expect(dispatchMock.mock.calls).toMatchSnapshot();
     });
 
+    it('should return auth status on login success', async () => {
+      const thunk = authActions.authenticate('bar', 'pw', true);
+      const result = await thunk(dispatchMock, getStateMock);
+      expect(result).toMatchObject({ auth: true, tfaRequired: false });
+    });
+
     it('should update TFA to required', async () => {
       mockGetTfaStatus(false, true);
       const thunk = authActions.authenticate('bar', 'pw', true);
       await thunk(dispatchMock, getStateMock);
       expect(dispatchMock.mock.calls).toMatchSnapshot();
+    });
+
+    it('should return tfa required status', async () => {
+      mockGetTfaStatus(false, true);
+      const thunk = authActions.authenticate('bar', 'pw', true);
+      const result = await thunk(dispatchMock, getStateMock);
+      expect(result).toMatchObject({ tfaRequired: true });
     });
 
     it('should login if user is not TFA', async () => {
@@ -115,18 +128,32 @@ describe('Action Creator: Auth', () => {
     });
 
     it('should dispatch a failed login if login fails', async () => {
-      sparkpostLogin.mockImplementation(() => Promise.reject({
+      sparkpostLogin.mockRejectedValue({
         response: {
           data: {
             error_description: 'login failed'
           }
         }
-      }));
+      });
 
       const thunk = authActions.authenticate('bar', 'pw', true);
       await thunk(dispatchMock, getStateMock);
       expect(dispatchMock.mock.calls).toMatchSnapshot();
 
+    });
+
+    it('should return auth status on login failure', async () => {
+      sparkpostLogin.mockRejectedValue({
+        response: {
+          data: {
+            error_description: 'login failed'
+          }
+        }
+      });
+
+      const thunk = authActions.authenticate('bar', 'pw', true);
+      const result = await thunk(dispatchMock, getStateMock);
+      expect(result).toMatchObject({ auth: false });
     });
   });
 

--- a/src/pages/register/tests/__snapshots__/RegisterPage.test.js.snap
+++ b/src/pages/register/tests/__snapshots__/RegisterPage.test.js.snap
@@ -10,12 +10,12 @@ exports[`Page: RegisterPage happy path render 1`] = `
     <Panel.Section>
       <p>
         <small>
-          jose@zamora.io
+          jose@example.com
            invited you to join their SparkPost account.
         </small>
       </p>
       <Connect(ReduxForm)
-        email="appteam@sparkpost.com"
+        email="newperson@example.com"
         onSubmit={[Function]}
       />
     </Panel.Section>


### PR DESCRIPTION
 - The `authenticate()` action creator now resolves to an object describing auth and tfa status 
 - `RegisterPage` checks `authenticate()` result and redirects to `/auth/enable-tfa` if required
 - Minor unrelated test cleanup

### Testing
 - Set `tfa_required` on your test account
 - Invite a new user to your test account
 - Hint: you can capture the invitation token using Chrome devtools - it's in the response to `POST /users/invite`
 - Either click the link in the invitation email or visit `YOUR_HOST/register?token=YOUR_INVITATION_TOKEN`
 - Verify that after setting a password, you must enable TFA
