### PR TITLE
AC-402: add CSM plan note to 5M plan

### DIFF
--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { getPlanPrice } from 'src/helpers/billing';
 import styles from './PlanPrice.module.scss';
 
-const PlanPrice = ({ plan, showOverage = false, showIp = false, ...rest }) => {
+const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false, ...rest }) => {
   if (_.isEmpty(plan)) {
     return null;
   }
@@ -18,6 +18,8 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, ...rest }) => {
     ? 'First dedicated IP address is free'
     : null;
 
+  const displayCsm = showCsm && plan.includesCsm;
+
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
@@ -27,9 +29,9 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, ...rest }) => {
       </span>
       <span className={styles.SupportLabel}>
         {showOverage && overage}
-
         {showIp && ip}
       </span>
+      {displayCsm && <span className={styles.SupportLabel}>Customer Success Manager included.</span>}
     </span>
   );
 };

--- a/src/components/billing/tests/PlanPrice.test.js
+++ b/src/components/billing/tests/PlanPrice.test.js
@@ -66,5 +66,9 @@ describe('PlanPrice', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-
+  it('renders correctly for CSM inclusion', () => {
+    plan.includesCsm = true;
+    wrapper.setProps({ plan, showCsm: true });
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -54,6 +54,38 @@ exports[`PlanPrice renders correctly 1`] = `
 </span>
 `;
 
+exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
+<span
+  className="notranslate"
+>
+  <span
+    className="MainLabel"
+  >
+    <strong>
+      50,000
+    </strong>
+     emails/month
+    <span>
+       at 
+      <strong>
+        $
+        9
+      </strong>
+      /
+      mo
+    </span>
+  </span>
+  <span
+    className="SupportLabel"
+  />
+  <span
+    className="SupportLabel"
+  >
+    Customer Success Manager included.
+  </span>
+</span>
+`;
+
 exports[`PlanPrice renders correctly for free plan 1`] = `
 <span
   className="notranslate"

--- a/src/components/planPicker/Plan.js
+++ b/src/components/planPicker/Plan.js
@@ -10,7 +10,7 @@ class Plan extends React.Component {
 
     return (
       <a className={className} {...rest} >
-        <PlanPrice plan={plan} showOverage={true} showIp={true} className={styles.MainLabel} />
+        <PlanPrice plan={plan} showOverage showIp showCsm className={styles.MainLabel} />
       </a>
     );
   }

--- a/src/components/planPicker/tests/__snapshots__/Plan.test.js.snap
+++ b/src/components/planPicker/tests/__snapshots__/Plan.test.js.snap
@@ -11,6 +11,7 @@ exports[`Plan: renders correctly 1`] = `
         "volume": 200,
       }
     }
+    showCsm={true}
     showIp={true}
     showOverage={true}
   />
@@ -30,6 +31,7 @@ exports[`Plan: renders free and ip correctly 1`] = `
         "volume": 300,
       }
     }
+    showCsm={true}
     showIp={true}
     showOverage={true}
   />
@@ -48,6 +50,7 @@ exports[`Plan: renders hourly plan correctly 1`] = `
         "volume": 300,
       }
     }
+    showCsm={true}
     showIp={true}
     showOverage={true}
   />

--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -5,6 +5,7 @@ import { getPlanPrice } from 'src/helpers/billing';
 import PlanPrice from 'src/components/billing/PlanPrice';
 import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 import Brightback from 'src/components/brightback/Brightback';
+import styles from './Confirmation.module.scss';
 
 export class Confirmation extends React.Component {
   renderSelectedPlanMarkup() {
@@ -14,7 +15,7 @@ export class Confirmation extends React.Component {
       ? <p>Select a plan on the left to update your subscription</p>
       : <div>
         <small>New Plan</small>
-        <h5><PlanPrice plan={selected}/></h5>
+        <h5><PlanPrice className={styles.MainLabel} plan={selected}/></h5>
       </div>;
   }
 

--- a/src/pages/billing/components/Confirmation.module.scss
+++ b/src/pages/billing/components/Confirmation.module.scss
@@ -1,0 +1,6 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.MainLabel {
+  display: block;
+  color: color(orange);
+}

--- a/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
@@ -70,6 +70,7 @@ exports[`Confirmation:  should render correctly for an upgrade effectively immed
       </small>
       <h5>
         <PlanPrice
+          className="MainLabel"
           plan={
             Object {
               "code": "twohundred",
@@ -141,6 +142,7 @@ exports[`Confirmation:  should render correctly with a downgrade 1`] = `
       </small>
       <h5>
         <PlanPrice
+          className="MainLabel"
           plan={
             Object {
               "code": "fifty",
@@ -232,6 +234,7 @@ exports[`Confirmation:  should render correctly with a downgrade to free 1`] = `
       </small>
       <h5>
         <PlanPrice
+          className="MainLabel"
           plan={
             Object {
               "code": "zero",
@@ -307,6 +310,7 @@ exports[`Confirmation:  should render correctly with an upgrade 1`] = `
       </small>
       <h5>
         <PlanPrice
+          className="MainLabel"
           plan={
             Object {
               "code": "twohundred",
@@ -378,6 +382,7 @@ exports[`Confirmation:  should render correctly with an upgrade with IP 1`] = `
       </small>
       <h5>
         <PlanPrice
+          className="MainLabel"
           plan={
             Object {
               "code": "twohundred",


### PR DESCRIPTION
 - Plan picker shows new CSM note
 - Plan summary test on billing page is now orange

### Testing
 - Use a free or CC-billing account
 - Navigate to billing page from account top nav dropdown `/account/billing/plan`
 - Select the 5M plan :)
