### PR TITLE
AC-446: mandatory TFA for all

### DIFF
--- a/src/pages/account/AccountSettingsPage.js
+++ b/src/pages/account/AccountSettingsPage.js
@@ -5,8 +5,6 @@ import LabelledValue from 'src/components/labelledValue/LabelledValue';
 import CancellationPanel from './components/CancellationPanel';
 import SingleSignOnPanel from './components/SingleSignOnPanel';
 import EnforceTfaPanel from './components/EnforceTfaPanel';
-import { AccessControl } from 'src/components/auth';
-import { hasUiOption } from 'src/helpers/conditions/account';
 
 export function AccountSettingsPage({ currentUser }) {
   return (
@@ -17,9 +15,7 @@ export function AccountSettingsPage({ currentUser }) {
         </LabelledValue>
       </Panel>
       <SingleSignOnPanel />
-      <AccessControl condition={hasUiOption('tfaRequired')}>
-        <EnforceTfaPanel />
-      </AccessControl>
+      <EnforceTfaPanel />
       <CancellationPanel />
     </Page>
   );

--- a/src/pages/account/tests/AccountSettingsPage.test.js
+++ b/src/pages/account/tests/AccountSettingsPage.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { AccountSettingsPage } from '../AccountSettingsPage';
-import { AccessControl } from 'src/components/auth';
-import cases from 'jest-in-case';
 
 describe('AccountSettingsPage', () => {
   const baseProps = {
@@ -18,21 +16,4 @@ describe('AccountSettingsPage', () => {
   it('renders', () => {
     expect(subject()).toMatchSnapshot();
   });
-
-  cases(
-    'enforce-TFA panel access control',
-    (opts) => {
-      const wrapper = subject();
-      const condition = wrapper
-        .find(AccessControl)
-        .first()
-        .prop('condition');
-      expect(
-        condition({
-          account: { options: { ui: opts.options }}
-        })
-      ).toEqual(opts.expectation);
-    },
-    [{ options: { tfaRequired: true }, expectation: true }, { options: {}, expectation: false }]
-  );
 });

--- a/src/pages/account/tests/__snapshots__/AccountSettingsPage.test.js.snap
+++ b/src/pages/account/tests/__snapshots__/AccountSettingsPage.test.js.snap
@@ -15,11 +15,7 @@ exports[`AccountSettingsPage renders 1`] = `
     </LabelledValue>
   </Panel>
   <Connect(SingleSignOnPanel) />
-  <Connect(AccessControl)
-    condition={[Function]}
-  >
-    <Connect(EnforceTFAPanel) />
-  </Connect(AccessControl)>
+  <Connect(EnforceTFAPanel) />
   <Connect(CancellationPanel) />
 </Page>
 `;

--- a/src/pages/profile/components/TfaManager.js
+++ b/src/pages/profile/components/TfaManager.js
@@ -54,9 +54,9 @@ export class TfaManager extends Component {
   }
 
   render() {
-    const { enabled, required } = this.props;
+    const { statusUnknown, enabled, required } = this.props;
 
-    if (this.props.statusUnknown) {
+    if (statusUnknown) {
       return <PanelLoading minHeight='100px' />;
     }
 
@@ -118,10 +118,11 @@ export class TfaManager extends Component {
 
 }
 
-const mapStateToProps = ({ tfa, tfaBackupCodes }) => ({
+const mapStateToProps = ({ account, tfa, tfaBackupCodes }) => ({
   ...tfa,
   statusUnknown: tfa.enabled === null,
   enabled: tfa.enabled === true,
+  required: account.tfa_required,
   backupCodes: tfaBackupCodes
 });
 

--- a/src/pages/profile/components/tests/TfaManager.test.js
+++ b/src/pages/profile/components/tests/TfaManager.test.js
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import { TfaManager } from '../TfaManager';
-import _ from 'lodash';
 
 describe('EnableTfaModal tests', () => {
   let wrapper;
@@ -17,6 +16,7 @@ describe('EnableTfaModal tests', () => {
       generateBackupCodes: jest.fn().mockImplementation(() => Promise.resolve(null)),
       toggleTfa: jest.fn().mockImplementation(() => Promise.resolve(null)),
       enabled: false,
+      required: false,
       secret: 'shhh',
       username: 'kevin-mitnick',
       togglePending: false,
@@ -27,8 +27,6 @@ describe('EnableTfaModal tests', () => {
 
     wrapper = shallow(<TfaManager {...props} />);
     instance = wrapper.instance();
-    _.functions(instance).forEach((f) => jest.spyOn(instance, f));
-    jest.spyOn(instance, 'setState');
   });
 
   it('should render correctly', () => {
@@ -37,7 +35,7 @@ describe('EnableTfaModal tests', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should show panel loading while status uknown', () => {
+  it('should show panel loading while status unknown', () => {
     wrapper.setProps({ statusUnknown: true });
     expect(wrapper).toMatchSnapshot();
   });
@@ -80,15 +78,23 @@ describe('EnableTfaModal tests', () => {
   });
 
   it('should close modal when closing backup modal', () => {
+    jest.spyOn(instance, 'closeModals');
     wrapper.find('BackupCodesModal').simulate('close');
     expect(instance.closeModals).toHaveBeenCalled();
   });
 
   it('should close enable modal on close', () => {
     wrapper.find('EnableTfaModal').simulate('close');
-    expect(instance.setState).toHaveBeenCalledWith({ openModal: null });
+    expect(wrapper.state('openModal')).toEqual(null);
     wrapper.find('DisableTfaModal').simulate('close');
-    expect(instance.setState).toHaveBeenCalledWith({ openModal: null });
+    expect(wrapper.state('openModal')).toEqual(null);
+  });
+
+  it('should not allow disable when required', () => {
+    wrapper.setProps({ enabled: true, required: true });
+    const actions = wrapper.find('Panel').props().actions;
+    expect(actions).toHaveLength(1);
+    expect(actions[0].content).not.toContain('Disable');
   });
 });
 

--- a/src/pages/profile/components/tests/__snapshots__/TfaManager.test.js.snap
+++ b/src/pages/profile/components/tests/__snapshots__/TfaManager.test.js.snap
@@ -92,20 +92,20 @@ exports[`EnableTfaModal tests should show a message about 0 codes 1`] = `
   <BackupCodesModal
     activeCount={0}
     clearCodes={[MockFunction]}
-    generate={[MockFunction]}
-    onClose={[MockFunction]}
+    generate={[Function]}
+    onClose={[Function]}
     open={false}
   />
   <EnableTfaModal
     enabled={true}
-    onClose={[MockFunction]}
-    onEnable={[MockFunction]}
+    onClose={[Function]}
+    onEnable={[Function]}
     open={false}
   />
   <DisableTfaModal
-    disable={[MockFunction]}
+    disable={[Function]}
     enabled={true}
-    onClose={[MockFunction]}
+    onClose={[Function]}
     open={false}
     toggleError={false}
     togglePending={false}
@@ -113,7 +113,7 @@ exports[`EnableTfaModal tests should show a message about 0 codes 1`] = `
 </Panel>
 `;
 
-exports[`EnableTfaModal tests should show panel loading while status uknown 1`] = `
+exports[`EnableTfaModal tests should show panel loading while status unknown 1`] = `
 <PanelLoading
   minHeight="100px"
 />
@@ -155,20 +155,20 @@ exports[`EnableTfaModal tests should toggle status text when enabled 1`] = `
   <BackupCodesModal
     activeCount={1}
     clearCodes={[MockFunction]}
-    generate={[MockFunction]}
-    onClose={[MockFunction]}
+    generate={[Function]}
+    onClose={[Function]}
     open={false}
   />
   <EnableTfaModal
     enabled={true}
-    onClose={[MockFunction]}
-    onEnable={[MockFunction]}
+    onClose={[Function]}
+    onEnable={[Function]}
     open={false}
   />
   <DisableTfaModal
-    disable={[MockFunction]}
+    disable={[Function]}
     enabled={true}
-    onClose={[MockFunction]}
+    onClose={[Function]}
     open={false}
     toggleError={false}
     togglePending={false}

--- a/src/pages/users/EditPage.container.js
+++ b/src/pages/users/EditPage.container.js
@@ -19,6 +19,7 @@ const mapStateToProps = (state, props) => {
     user,
     users: state.users.entities,
     updatePending: state.users.updatePending,
+    tfaRequired: state.account.tfa_required,
     initialValues: {
       access: _.get(user, 'access'),
       is_sso: _.get(user, 'is_sso')

--- a/src/pages/users/EditPage.js
+++ b/src/pages/users/EditPage.js
@@ -65,7 +65,8 @@ export class EditPage extends Component {
       submitting,
       updatePending,
       user,
-      users
+      users,
+      tfaRequired
     } = this.props;
 
     if (loadingError) {
@@ -89,7 +90,7 @@ export class EditPage extends Component {
         onClick: this.toggleDelete
       });
 
-      if (user.tfa_enabled) {
+      if (user.tfa_enabled && !tfaRequired) {
         secondaryActions.push({
           content: 'Disable Two-Factor Authentication',
           onClick: this.toggleTfaModal

--- a/src/pages/users/tests/EditPage.test.js
+++ b/src/pages/users/tests/EditPage.test.js
@@ -28,7 +28,8 @@ describe('Page: Users Edit', () => {
       users: {
         'current-user': { access: 'admin', email: 'current-user@test.com', name: 'current-user' },
         'test-user': { access: 'admin', email: 'test-user@test.com', name: 'test-user' }
-      }
+      },
+      tfaRequired: false
     };
     wrapper = shallow(<EditPage {...props} />);
     instance = wrapper.instance();
@@ -113,5 +114,12 @@ describe('Page: Users Edit', () => {
       .prop('onConfirm')();
     expect(props.updateUser).toHaveBeenCalledTimes(1);
     expect(props.updateUser.mock.calls[0][1]).toMatchObject({ tfa_enabled: false });
+  });
+
+  it('should allow TFA disabling when mandatory', () => {
+    wrapper.setProps({ tfaRequired: true });
+    const actions = wrapper.find('Page').props().secondaryActions;
+    expect(actions).toHaveLength(1);
+    expect(actions[0].content).not.toContain('Disable');
   });
 });


### PR DESCRIPTION
 - Removed the `tfaRequired` feature flag check so any admin can make TFA mandatory
 - Fixed an issue where you could still disable your own TFA when mandatory
 - Fixed an issue where an admin could still disable another user's TFA when mandatory

### Testing
 - Verify an account without `options.ui.tfaRequired` can set TFA to required in `/account/settings`
 - Enable mandatory TFA
 - Verify users cannot disable their own TFA
 - Verify admins cannot disable others' TFA
