### PR TITLE
EO-433 Create Presentational Table Control Components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -298,9 +298,9 @@
       }
     },
     "@sparkpost/matchbox-icons": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox-icons/-/matchbox-icons-1.1.4.tgz",
-      "integrity": "sha512-gkIeGjoRAWa0B4yi0eLq85S963Vz0/JD2hgU4UEpNypyq4iBtXDkx2VOrJcVU0xqTXSMMZoZdcytPUO01bOQeQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox-icons/-/matchbox-icons-1.1.5.tgz",
+      "integrity": "sha512-W3FCqkZdxsxMWtFABbluNklbWdVl0hp8e79NRo57RFRKf6L4OrIIo6g1vEvFCRZivM8HUQAsMaLp99kcK2O3Gw==",
       "requires": {
         "prop-types": "^15.6.1",
         "react": "^15.3.0 || ^16.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@sparkpost/boomerang": "^1.0.6",
     "@sparkpost/matchbox": "^3.3.0",
-    "@sparkpost/matchbox-icons": "^1.1.4",
+    "@sparkpost/matchbox-icons": "^1.1.5",
     "axios": "^0.17.1",
     "bowser": "2.0.0-alpha.4",
     "classnames": "^2.2.5",

--- a/src/pages/signals/OverviewPage.js
+++ b/src/pages/signals/OverviewPage.js
@@ -4,6 +4,9 @@ import SummaryTable from './components/SummaryTable';
 import FacetFilter from './components/filters/FacetFilter';
 import DateFilter from './components/filters/DateFilter';
 import SubaccountFilter from './components/filters/SubaccountFilter';
+import { Panel } from '@sparkpost/matchbox';
+import Calculation from './components/viewControls/Calculation';
+import ChartType from './components/viewControls/ChartType';
 
 export class OverviewPage extends Component {
   render() {
@@ -18,6 +21,20 @@ export class OverviewPage extends Component {
         <SummaryTable title='Health Score' />
         <SummaryTable title='Spam Traps' />
         <SummaryTable title='Engagement Cohort' />
+
+        <Panel>
+          <Panel.Section>
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Calculation
+                initialSelected='absolute'
+                // onChange={(n) => console.log(n)}
+              />
+              <ChartType
+                // onChange={(n) => console.log(n)}
+              />
+            </div>
+          </Panel.Section>
+        </Panel>
       </Page>
     );
   }

--- a/src/pages/signals/OverviewPage.js
+++ b/src/pages/signals/OverviewPage.js
@@ -4,9 +4,6 @@ import SummaryTable from './components/SummaryTable';
 import FacetFilter from './components/filters/FacetFilter';
 import DateFilter from './components/filters/DateFilter';
 import SubaccountFilter from './components/filters/SubaccountFilter';
-import { Panel } from '@sparkpost/matchbox';
-import Calculation from './components/viewControls/Calculation';
-import ChartType from './components/viewControls/ChartType';
 
 export class OverviewPage extends Component {
   render() {
@@ -21,20 +18,6 @@ export class OverviewPage extends Component {
         <SummaryTable title='Health Score' />
         <SummaryTable title='Spam Traps' />
         <SummaryTable title='Engagement Cohort' />
-
-        <Panel>
-          <Panel.Section>
-            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <Calculation
-                initialSelected='absolute'
-                // onChange={(n) => console.log(n)}
-              />
-              <ChartType
-                // onChange={(n) => console.log(n)}
-              />
-            </div>
-          </Panel.Section>
-        </Panel>
       </Page>
     );
   }

--- a/src/pages/signals/components/viewControls/Calculation.js
+++ b/src/pages/signals/components/viewControls/Calculation.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ControlGroup from './ControlGroup';
+
+const options = {
+  absolute: 'Absolute',
+  relative: <span>testing a node Relative</span>
+};
+
+const Calculation = (props) => (
+  <ControlGroup {...props} options={options} />
+);
+
+Calculation.propTypes = {
+  initialSelected: PropTypes.oneOf(['absolute', 'relative']),
+  onChange: PropTypes.func
+};
+
+Calculation.defaultProps = {
+  initialSelected: 'absolute'
+};
+
+export default Calculation;

--- a/src/pages/signals/components/viewControls/Calculation.js
+++ b/src/pages/signals/components/viewControls/Calculation.js
@@ -4,7 +4,7 @@ import ControlGroup from './ControlGroup';
 
 const options = {
   absolute: 'Absolute',
-  relative: <span>testing a node Relative</span>
+  relative: 'Relative'
 };
 
 const Calculation = (props) => (

--- a/src/pages/signals/components/viewControls/ChartType.js
+++ b/src/pages/signals/components/viewControls/ChartType.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ControlGroup from './ControlGroup';
+
+const options = {
+  line: 'Line',
+  bar: 'Bar'
+};
+
+const ChartType = (props) => (
+  <ControlGroup {...props} options={options} />
+);
+
+ChartType.propTypes = {
+  initialSelected: PropTypes.oneOf(['bar', 'line']),
+  onChange: PropTypes.func
+};
+
+ChartType.defaultProps = {
+  initialSelected: 'line'
+};
+
+export default ChartType;

--- a/src/pages/signals/components/viewControls/ChartType.js
+++ b/src/pages/signals/components/viewControls/ChartType.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ControlGroup from './ControlGroup';
+import { ShowChart, BarChart } from '@sparkpost/matchbox-icons';
 
 const options = {
-  line: 'Line',
-  bar: 'Bar'
+  line: <ShowChart/>,
+  bar: <BarChart/>
 };
 
 const ChartType = (props) => (

--- a/src/pages/signals/components/viewControls/ControlGroup.js
+++ b/src/pages/signals/components/viewControls/ControlGroup.js
@@ -33,10 +33,10 @@ class ControlGroup extends Component {
     const { selected } = this.state;
 
     return _.keys(options).map((key) => {
-      const classes = classnames(styles.Content, selected === key && styles.Selected);
+      const classes = classnames(styles.Button, selected === key && styles.Selected);
       return (
-        <Button key={key} outline onClick={() => this.handleChange(key)}>
-          <span className={classes}>{options[key]}</span>
+        <Button key={key} onClick={() => this.handleChange(key)} className={classes}>
+          {options[key]}
         </Button>
       );
     });

--- a/src/pages/signals/components/viewControls/ControlGroup.js
+++ b/src/pages/signals/components/viewControls/ControlGroup.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { Button } from '@sparkpost/matchbox';
+import _ from 'lodash';
+import styles from './ControlGroup.module.scss';
+
+class ControlGroup extends Component {
+  state = {
+    selected: ''
+  }
+
+  componentDidMount() {
+    const { initialSelected } = this.props;
+
+    if (initialSelected) {
+      this.setState({ selected: initialSelected });
+    }
+  }
+
+  handleChange = (selected) => {
+    const { onChange } = this.props;
+
+    this.setState({ selected });
+
+    if (onChange) {
+      onChange(selected);
+    }
+  }
+
+  renderButtons = () => {
+    const { options } = this.props;
+    const { selected } = this.state;
+
+    return _.keys(options).map((key) => {
+      const classes = classnames(styles.Content, selected === key && styles.Selected);
+      return (
+        <Button key={key} outline onClick={() => this.handleChange(key)}>
+          <span className={classes}>{options[key]}</span>
+        </Button>
+      );
+    });
+  }
+
+  render() {
+    return (
+      <Button.Group className={styles.Group}>
+        {this.renderButtons()}
+      </Button.Group>
+    );
+  }
+}
+
+ControlGroup.propTypes = {
+  options: PropTypes.object.isRequired,
+  initialSelected: PropTypes.string,
+  onChange: PropTypes.func
+};
+
+export default ControlGroup;

--- a/src/pages/signals/components/viewControls/ControlGroup.module.scss
+++ b/src/pages/signals/components/viewControls/ControlGroup.module.scss
@@ -1,14 +1,15 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-.Content {
-  opacity: 0.8;
+.Button {
+  position: relative;
+  color: color(gray, 5) !important;
 }
 
-.Selected {
-  color: color(orange);
-  opacity: 1;
+.Selected, .Selected:hover {
+  color: color(gray, 1) !important;
+  background: color(gray, 9);
 }
 
-.Group {
+.Group:not(:first-child) {
   margin-left: spacing();
 }

--- a/src/pages/signals/components/viewControls/ControlGroup.module.scss
+++ b/src/pages/signals/components/viewControls/ControlGroup.module.scss
@@ -1,0 +1,14 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.Content {
+  opacity: 0.8;
+}
+
+.Selected {
+  color: color(orange);
+  opacity: 1;
+}
+
+.Group {
+  margin-left: spacing();
+}

--- a/src/pages/signals/components/viewControls/tests/Calculation.test.js
+++ b/src/pages/signals/components/viewControls/tests/Calculation.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Calculation from '../Calculation';
+
+describe('Signals View Calculation Component', () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      onChange: jest.fn()
+    };
+    wrapper = shallow(<Calculation {...props}/>);
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/signals/components/viewControls/tests/ChartType.test.js
+++ b/src/pages/signals/components/viewControls/tests/ChartType.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import ChartType from '../ChartType';
+
+describe('Signals View ChartType Component', () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      onChange: jest.fn()
+    };
+    wrapper = shallow(<ChartType {...props}/>);
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/signals/components/viewControls/tests/ControlGroup.test.js
+++ b/src/pages/signals/components/viewControls/tests/ControlGroup.test.js
@@ -33,4 +33,9 @@ describe('Signals View ControlGroup Component', () => {
     wrapper.find('Button').first().simulate('click');
     expect(props.onChange).not.toHaveBeenCalled();
   });
+
+  it('does not set selected initially if not provided', () => {
+    wrapper = shallow(<ControlGroup options={props.options} />);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/pages/signals/components/viewControls/tests/ControlGroup.test.js
+++ b/src/pages/signals/components/viewControls/tests/ControlGroup.test.js
@@ -1,0 +1,36 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import ControlGroup from '../ControlGroup';
+
+describe('Signals View ControlGroup Component', () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      options: {
+        foo: 'fOo',
+        bar: <test>BaR</test>
+      },
+      initialSelected: 'bar',
+      onChange: jest.fn()
+    };
+    wrapper = shallow(<ControlGroup {...props}/>);
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('handles a select correctly', () => {
+    wrapper.find('Button').first().simulate('click');
+    expect(wrapper.find('Button').first()).toMatchSnapshot();
+    expect(props.onChange).toHaveBeenCalledWith('foo');
+  });
+
+  it('does not call onChange if not provided a callback', () => {
+    wrapper.setProps({ onChange: null });
+    wrapper.find('Button').first().simulate('click');
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/signals/components/viewControls/tests/__snapshots__/Calculation.test.js.snap
+++ b/src/pages/signals/components/viewControls/tests/__snapshots__/Calculation.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals View Calculation Component renders correctly 1`] = `
+<ControlGroup
+  initialSelected="absolute"
+  onChange={[MockFunction]}
+  options={
+    Object {
+      "absolute": "Absolute",
+      "relative": "Relative",
+    }
+  }
+/>
+`;

--- a/src/pages/signals/components/viewControls/tests/__snapshots__/ChartType.test.js.snap
+++ b/src/pages/signals/components/viewControls/tests/__snapshots__/ChartType.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals View ChartType Component renders correctly 1`] = `
+<ControlGroup
+  initialSelected="line"
+  onChange={[MockFunction]}
+  options={
+    Object {
+      "bar": <BarChart />,
+      "line": <ShowChart />,
+    }
+  }
+/>
+`;

--- a/src/pages/signals/components/viewControls/tests/__snapshots__/ControlGroup.test.js.snap
+++ b/src/pages/signals/components/viewControls/tests/__snapshots__/ControlGroup.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals View ControlGroup Component handles a select correctly 1`] = `
+<Button
+  key="foo"
+  onClick={[Function]}
+  outline={true}
+  size="default"
+>
+  <span
+    className="Content Selected"
+  >
+    fOo
+  </span>
+</Button>
+`;
+
+exports[`Signals View ControlGroup Component renders correctly 1`] = `
+<Button.Group
+  className="Group"
+>
+  <Button
+    key="foo"
+    onClick={[Function]}
+    outline={true}
+    size="default"
+  >
+    <span
+      className="Content"
+    >
+      fOo
+    </span>
+  </Button>
+  <Button
+    key="bar"
+    onClick={[Function]}
+    outline={true}
+    size="default"
+  >
+    <span
+      className="Content Selected"
+    >
+      <test>
+        BaR
+      </test>
+    </span>
+  </Button>
+</Button.Group>
+`;

--- a/src/pages/signals/components/viewControls/tests/__snapshots__/ControlGroup.test.js.snap
+++ b/src/pages/signals/components/viewControls/tests/__snapshots__/ControlGroup.test.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Signals View ControlGroup Component does not set selected initially if not provided 1`] = `
+<Button.Group
+  className="Group"
+>
+  <Button
+    className="Button"
+    key="foo"
+    onClick={[Function]}
+    size="default"
+  >
+    fOo
+  </Button>
+  <Button
+    className="Button"
+    key="bar"
+    onClick={[Function]}
+    size="default"
+  >
+    <test>
+      BaR
+    </test>
+  </Button>
+</Button.Group>
+`;
+
 exports[`Signals View ControlGroup Component handles a select correctly 1`] = `
 <Button
   className="Button Selected"

--- a/src/pages/signals/components/viewControls/tests/__snapshots__/ControlGroup.test.js.snap
+++ b/src/pages/signals/components/viewControls/tests/__snapshots__/ControlGroup.test.js.snap
@@ -2,16 +2,12 @@
 
 exports[`Signals View ControlGroup Component handles a select correctly 1`] = `
 <Button
+  className="Button Selected"
   key="foo"
   onClick={[Function]}
-  outline={true}
   size="default"
 >
-  <span
-    className="Content Selected"
-  >
-    fOo
-  </span>
+  fOo
 </Button>
 `;
 
@@ -20,30 +16,22 @@ exports[`Signals View ControlGroup Component renders correctly 1`] = `
   className="Group"
 >
   <Button
+    className="Button"
     key="foo"
     onClick={[Function]}
-    outline={true}
     size="default"
   >
-    <span
-      className="Content"
-    >
-      fOo
-    </span>
+    fOo
   </Button>
   <Button
+    className="Button Selected"
     key="bar"
     onClick={[Function]}
-    outline={true}
     size="default"
   >
-    <span
-      className="Content Selected"
-    >
-      <test>
-        BaR
-      </test>
-    </span>
+    <test>
+      BaR
+    </test>
   </Button>
 </Button.Group>
 `;


### PR DESCRIPTION
Adds a control group component, and two wrappers for Chart Type and Calculation:


```js
// Usage
<Calculation initialSelected='absolute' onChange={(selected) => ()} />
<ChartType onChange={(selected) => ()} />

// ControlGroup usage
const Foo = () => (
  <ControlGroup 
    options={{
      foo: 'Friendly Label',
      bar: <CustomComponent/>
    }}
    onChange={(selected) => ()}
    initialSelected='foo'
  />
);
```