### PR TITLE
SA-449 Add 'NEW' tag to Events Search

### DIFF
--- a/src/config/navItems.js
+++ b/src/config/navItems.js
@@ -37,7 +37,8 @@ export default [
       },
       {
         label: 'Events Search',
-        to: '/reports/message-events'
+        to: '/reports/message-events',
+        tag: 'new'
       }
     ]
   },


### PR DESCRIPTION
Added 'NEW' tag to the Events Search link in the left navigation panel under reports.