### PR TITLE
SA-453 Filter and transform events query parameters from URL link

### DIFF
--- a/src/helpers/tests/__snapshots__/messageEvents.test.js.snap
+++ b/src/helpers/tests/__snapshots__/messageEvents.test.js.snap
@@ -17,6 +17,16 @@ Object {
 }
 `;
 
+exports[`messageEvents helpers parseSearch parses correctly when adding in unsupported filters by removing them 1`] = `
+Object {
+  "dateOptions": Object {
+    "from": "2018-02-23T03:02:32Z",
+    "relativeRange": "hour",
+    "to": "2018-03-22T03:02:32Z",
+  },
+}
+`;
+
 exports[`messageEvents helpers parseSearch parses correctly when all param exists 1`] = `
 Object {
   "dateOptions": Object {
@@ -86,6 +96,34 @@ Object {
   ],
   "filter2": Array [
     "bar",
+  ],
+}
+`;
+
+exports[`messageEvents helpers parseSearch parses correctly when using old message events filters by transforming them into the new events filters 1`] = `
+Object {
+  "ab_tests": Array [
+    "foo",
+  ],
+  "campaigns": Array [
+    "foo",
+  ],
+  "dateOptions": Object {
+    "from": "2018-02-23T03:02:32Z",
+    "relativeRange": "hour",
+    "to": "2018-03-22T03:02:32Z",
+  },
+  "from_addresses": Array [
+    "foo",
+  ],
+  "messages": Array [
+    "foo",
+  ],
+  "templates": Array [
+    "foo",
+  ],
+  "transmissions": Array [
+    "foo",
   ],
 }
 `;

--- a/src/helpers/tests/messageEvents.test.js
+++ b/src/helpers/tests/messageEvents.test.js
@@ -2,6 +2,13 @@ import cases from 'jest-in-case';
 import * as messageEventHelpers from '../messageEvents';
 import * as dateHelpers from 'src/helpers/date';
 
+jest.mock('src/constants', () => ({
+  EVENTS_SEARCH_FILTERS: {
+    filter1: {},
+    filter2: {}
+  }
+}));
+
 describe('messageEvents helpers', () => {
 
   describe('formatDocumentation', () => {
@@ -45,7 +52,11 @@ describe('messageEvents helpers', () => {
     'parses correctly when from does not exist': { searchText: '?range=hour&to=2018-03-23T04:02:32Z&filter1=foo&filter2=bar' },
     'parses correctly when to does not exist': { searchText: '?from=2018-03-23T03:02:32Z&range=hour&filter1=foo&filter2=bar' },
     'parses correctly when range does not exist (does not override from, to)': { searchText: '?from=2018-03-23T03:02:32Z&to=2018-03-23T04:02:32Z&filter1=foo&filter2=bar' },
-    'parses correctly when extra filters do not exist': { searchText: '?from=2018-03-23T03:02:32Z&range=hour&to=2018-03-23T04:02:32Z' }
+    'parses correctly when extra filters do not exist': { searchText: '?from=2018-03-23T03:02:32Z&range=hour&to=2018-03-23T04:02:32Z' },
+    'parses correctly when using old message events filters by transforming them into the new events filters': {
+      searchText: '?from=2018-03-23T03:02:32Z&range=hour&to=2018-03-23T04:02:32Z&campaign_ids=foo&message_ids=foo&transmission_ids=foo&ab_test_ids=foo&template_ids=foo&friendly_froms=foo'
+    },
+    'parses correctly when adding in unsupported filters by removing them': { searchText: '?from=2018-03-23T03:02:32Z&range=hour&to=2018-03-23T04:02:32Z&filter3' }
   };
   cases('parseSearch', ({ searchText }) => {
     const mockRelativeRangeToDate = { from: '2018-02-23T03:02:32Z', to: '2018-03-22T03:02:32Z', relativeRange: 'hour' };


### PR DESCRIPTION
Some query parameters in URLs saved from old message events page do not correspond with the new Events UI. This causes errors in both the customer's expected results as well as placeholder text lookup. 

Fix:
* Translate all old message events query params to the corresponding new events query params.  
  * message_ids->messages
  * campaign_ids->campaigns
  * template_ids->templates
  * ab_test_ids->ab_tests
  * transmission_ids->transmissions
  * friendly_froms -> from_addresses

You can see an example using this link: (https://app.sparkpost.com/reports/message-events?friendly_froms=sender%40ymail.com)