### PR TITLE
TR-949: Enable configuration to allow default bounce domains in EU

### DIFF
--- a/scripts/generateConfigs/tenants/production.js
+++ b/scripts/generateConfigs/tenants/production.js
@@ -40,7 +40,6 @@ const productionTenants = {
   spceu: {
     apiBase: 'https://api.eu.sparkpost.com/api',
     bounceDomains: {
-      allowSubaccountDefault: false,
       cnameValue: 'eu.sparkpostmail.com'
     },
     brightback: {


### PR DESCRIPTION
The [default configuration is to allow default bounce domains for subaccounts](https://github.com/SparkPost/2web2ui/blob/master/scripts/generateConfigs/defaultTemplate.js#L9).

Please note that this can only be verified from a users perspective in production.  To verify locally and in staging, we will check the built configuration for spceu.
