### PR TITLE
SA-448 Remove column sorting in the Events collection 

### DIFF
--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -20,7 +20,7 @@ const columns = [
   { label: 'Time' },
   { label: 'Event' },
   { label: 'Recipient' },
-  { label: 'Friendly From' },
+  { label: 'From Address' },
   null
 ];
 

--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -17,10 +17,10 @@ const errorMsg = 'Sorry, we seem to have had some trouble loading your message e
 const emptyMessage = 'There are no message events for your current query';
 
 const columns = [
-  { label: 'Time', sortKey: 'timestamp' },
-  { label: 'Event', sortKey: 'type' },
-  { label: 'Recipient', sortKey: 'rcpt_to' },
-  { label: 'Friendly From', sortKey: 'friendly_from' },
+  { label: 'Time' },
+  { label: 'Event' },
+  { label: 'Recipient' },
+  { label: 'Friendly From' },
   null
 ];
 

--- a/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
@@ -57,19 +57,15 @@ exports[`Page: Message Events tests should render page correctly 1`] = `
         Array [
           Object {
             "label": "Time",
-            "sortKey": "timestamp",
           },
           Object {
             "label": "Event",
-            "sortKey": "type",
           },
           Object {
             "label": "Recipient",
-            "sortKey": "rcpt_to",
           },
           Object {
-            "label": "Friendly From",
-            "sortKey": "friendly_from",
+            "label": "From Address",
           },
           null,
         ]


### PR DESCRIPTION
The current Events UI supports sorting but only sorts the tuples in the current page rather than all pages. This is misleading so we will remove the option to sort in the Events UI.

A/C:
  * Disable sorting on the Events Search table headers
  * Rename table header from 'Friendly From' to 'From Address'