### PR TITLE
TR-938: Do not wait for supporting data to render template form

### DIFF
--- a/src/pages/templates/components/Form.js
+++ b/src/pages/templates/components/Form.js
@@ -114,7 +114,7 @@ export default class Form extends Component {
               component={FromEmailWrapper}
               placeholder='example@email.com'
               label='From Email'
-              disabled={!domains.length || readOnly}
+              disabled={readOnly}
               validate={[required, emailOrSubstitution, this.validateDomain]}
               domains={domains}
               helpText={this.fromEmailWarning()}

--- a/src/pages/templates/components/Form.js
+++ b/src/pages/templates/components/Form.js
@@ -8,7 +8,7 @@ import { Panel } from '@sparkpost/matchbox';
 import ToggleBlock from 'src/components/toggleBlock/ToggleBlock';
 import SubaccountSection from 'src/components/subaccountSection';
 import { TextFieldWrapper } from 'src/components';
-import FromEmailWrapper from './FromEmail';
+import FromEmailWrapper from './FromEmailWrapper';
 
 // Helpers & Validation
 import { required, slug } from 'src/helpers/validation';

--- a/src/pages/templates/components/Form.js
+++ b/src/pages/templates/components/Form.js
@@ -7,8 +7,8 @@ import config from 'src/config';
 import { Panel } from '@sparkpost/matchbox';
 import ToggleBlock from 'src/components/toggleBlock/ToggleBlock';
 import SubaccountSection from 'src/components/subaccountSection';
-import { TextFieldWrapper, PanelLoading } from 'src/components';
-import FromEmailWrapper from './FromEmailWrapper';
+import { TextFieldWrapper } from 'src/components';
+import FromEmailWrapper from './FromEmail';
 
 // Helpers & Validation
 import { required, slug } from 'src/helpers/validation';
@@ -73,11 +73,7 @@ export default class Form extends Component {
   }
 
   render() {
-    const { newTemplate, readOnly, domains, hasSubaccounts, domainsLoading } = this.props;
-
-    if (domainsLoading) {
-      return <PanelLoading />;
-    }
+    const { newTemplate, readOnly, domains, hasSubaccounts } = this.props;
 
     return (
       <div>

--- a/src/pages/templates/components/Form.js
+++ b/src/pages/templates/components/Form.js
@@ -13,7 +13,7 @@ import FromEmailWrapper from './FromEmail';
 // Helpers & Validation
 import { required, slug } from 'src/helpers/validation';
 import { slugify } from 'src/helpers/string';
-import { emailOrSubstitution, looseSubstitution } from './validation';
+import { emailOrSubstitution } from './validation';
 
 import styles from './FormEditor.module.scss';
 
@@ -40,21 +40,6 @@ export default class Form extends Component {
     if (newTemplate && !domains.length) {
       change(name, 'content.from.email', `${config.sandbox.localpart}@${config.sandbox.domain}`);
     }
-  }
-
-  validateDomain = (value) => {
-    const { domains } = this.props;
-
-    const parts = value.split('@');
-
-    if (parts.length > 1) {
-      const validSandboxDomain = parts[1] === config.sandbox.domain;
-      const validDomain = parts[1] && (domains.map(({ domain }) => domain).includes(parts[1]) || !looseSubstitution(parts[1]));
-
-      return validSandboxDomain || validDomain ? undefined : 'Must use a verified sending domain';
-    }
-
-    return undefined;
   }
 
   // Prevents unchecked value from equaling ""
@@ -115,7 +100,7 @@ export default class Form extends Component {
               placeholder='example@email.com'
               label='From Email'
               disabled={readOnly}
-              validate={[required, emailOrSubstitution, this.validateDomain]}
+              validate={[required, emailOrSubstitution]}
               domains={domains}
               helpText={this.fromEmailWarning()}
             />

--- a/src/pages/templates/components/FromEmail.js
+++ b/src/pages/templates/components/FromEmail.js
@@ -27,13 +27,6 @@ class FromEmail extends Component {
   }
 
   handleStateChange = (changes, downshift) => {
-    const { onChange } = this.props;
-
-    // Push changes to redux form store
-    if (changes.hasOwnProperty('selectedItem')) {
-      onChange && onChange(changes.selectedItem);
-    }
-
     // Highlights first item in list by default
     if (!downshift.highlightedIndex) {
       downshift.setHighlightedIndex(0);

--- a/src/pages/templates/components/FromEmailInput.js
+++ b/src/pages/templates/components/FromEmailInput.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { TextField } from '@sparkpost/matchbox';
 
 // note, do not override value, let Downshift control it (provided by getInputProps)
+// note, do not override onChange, it is needed to update the redux store
 const FromEmailInput = ({ downshift: { getInputProps, isOpen }, error, value, ...rest }) => {
   const props = getInputProps({
     ...rest,

--- a/src/pages/templates/components/containers/Form.container.js
+++ b/src/pages/templates/components/containers/Form.container.js
@@ -8,8 +8,7 @@ import Form from '../Form';
 
 const mapStateToProps = (state, props) => ({
   domains: selectDomainsBySubaccount(state, props),
-  hasSubaccounts: hasSubaccounts(state),
-  domainsLoading: state.sendingDomains.listLoading
+  hasSubaccounts: hasSubaccounts(state)
 });
 
 export default connect(mapStateToProps, { change, listDomains })(Form);

--- a/src/pages/templates/components/tests/Form.test.js
+++ b/src/pages/templates/components/tests/Form.test.js
@@ -91,40 +91,4 @@ describe('Template Form', () => {
     expect(parse('true')).toEqual(true);
     expect(parse(true)).toEqual(true);
   });
-
-  describe('domain validator', () => {
-    it('should not validate if input has no domain part', () => {
-      const result = wrapper.instance().validateDomain('email');
-      expect(result).toEqual(undefined);
-    });
-
-    it('should validate verified domain', () => {
-      wrapper.setProps({ domains: [{ domain: 'valid.com' }]});
-      const result = wrapper.instance().validateDomain('email@valid.com');
-      expect(result).toEqual(undefined);
-    });
-
-    it('should validate sandbox domain', () => {
-      const result = wrapper.instance().validateDomain('sandbox@sparkpostbox.com');
-      expect(result).toEqual(undefined);
-    });
-
-    it('should validate unverified domain', () => {
-      wrapper.setProps({ domains: [{ domain: 'valid.com' }]});
-      const result = wrapper.instance().validateDomain('email@notvalid.com');
-      expect(result).toEqual('Must use a verified sending domain');
-    });
-
-    it('should validate substituted domain', () => {
-      wrapper.setProps({ domains: [{ domain: 'valid.com' }]});
-      const result = wrapper.instance().validateDomain('email@{{domain}}');
-      expect(result).toEqual(undefined);
-    });
-
-    it('should validate complicated substituted domain', () => {
-      wrapper.setProps({ domains: [{ domain: 'valid.com' }]});
-      const result = wrapper.instance().validateDomain('email@{{if sending_domain}}{{domain}}{{else}}domain.com{{end}}');
-      expect(result).toEqual(undefined);
-    });
-  });
 });

--- a/src/pages/templates/components/tests/Form.test.js
+++ b/src/pages/templates/components/tests/Form.test.js
@@ -17,8 +17,7 @@ describe('Template Form', () => {
       change: jest.fn(),
       newTemplate: false,
       readOnly: false,
-      hasSubaccounts: false,
-      domainsLoading: false
+      hasSubaccounts: false
     };
 
     wrapper = shallow(<Form {...props} />);
@@ -32,11 +31,6 @@ describe('Template Form', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.instance().props.listDomains).toHaveBeenCalled();
     expect(wrapper.find(SubaccountSection)).toHaveLength(0);
-  });
-
-  it('renders correctly when domainsLoading', () => {
-    wrapper.setProps({ domainsLoading: true });
-    expect(wrapper).toMatchSnapshot();
   });
 
   it('should render subaccount fields if has subaccounts', () => {

--- a/src/pages/templates/components/tests/FromEmail.test.js
+++ b/src/pages/templates/components/tests/FromEmail.test.js
@@ -26,13 +26,13 @@ describe('FromEmail', () => {
     expect(subject()).toHaveProp('selectedItem', 'test@a');
   });
 
-  it('calls onChange when state changes', () => {
+  it('calls onChange when ', () => {
     const onChange = jest.fn();
     const wrapper = subject({ onChange });
-    const changes = { selectedItem: 'test@b' };
-    const downshift = { highlightedIndex: 1 };
 
-    wrapper.simulate('stateChange', changes, downshift);
+    wrapper.shallow()
+      .find('FromEmailInput')
+      .simulate('change', 'test@b');
 
     expect(onChange).toHaveBeenCalledWith('test@b');
   });

--- a/src/pages/templates/components/tests/__snapshots__/Form.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/Form.test.js.snap
@@ -54,7 +54,6 @@ exports[`Template Form should disable fields for read-only users 1`] = `
           Array [
             [Function],
             [Function],
-            [Function],
           ]
         }
       />
@@ -175,7 +174,6 @@ exports[`Template Form should render 1`] = `
         placeholder="example@email.com"
         validate={
           Array [
-            [Function],
             [Function],
             [Function],
           ]

--- a/src/pages/templates/components/tests/__snapshots__/Form.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/Form.test.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Template Form renders correctly when domainsLoading 1`] = `
-<PanelLoading
-  minHeight="400px"
-/>
-`;
-
 exports[`Template Form should disable fields for read-only users 1`] = `
 <div>
   <Panel


### PR DESCRIPTION
**What changed?**

- Template form will load immediately (previously, it would show a spinner while loading sending domains which could be 30+ seconds for some of our accounts with a large number of sending domains)
- Let API validate sending domain in the "From Email" field

<img width="1384" alt="screen shot 2019-01-31 at 3 10 39 pm" src="https://user-images.githubusercontent.com/1335605/52082278-67d0a980-256a-11e9-9a74-ad53a101b29d.png">
This is the error that users should receive if they provide an invalid sending domain.
