### PR TITLE
SA-393 Add "top domains" functionality in Summary Report for Recipient Domains grouping

### DIFF
--- a/src/actions/messageEvents.js
+++ b/src/actions/messageEvents.js
@@ -57,7 +57,7 @@ export function changePage(currentPage) {
           url: '/v1/events/message',
           params,
           showErrorAlert: false,
-          currentPageIndex
+          currentPageIndex //may need to move to context object (see actions/templates)
         }
       }));
     }

--- a/src/actions/metrics.js
+++ b/src/actions/metrics.js
@@ -1,15 +1,21 @@
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
 
-export function fetch({ type = 'FETCH_METRICS', path, params = {}}) {
+export function fetch({ type = 'FETCH_METRICS', path, params = {}, context }) {
+  const meta = {
+    method: 'GET',
+    url: `/v1/metrics/${path}`,
+    params: {
+      ...params
+    }
+  };
+
+  if (context) {
+    meta.context = context;
+  }
+
   return sparkpostApiRequest({
     type,
-    meta: {
-      method: 'GET',
-      url: `/v1/metrics/${path}`,
-      params: {
-        ...params
-      }
-    }
+    meta
   });
 }
 

--- a/src/actions/summaryChart.js
+++ b/src/actions/summaryChart.js
@@ -69,7 +69,8 @@ export function _getTableData({ params, metrics, groupBy }) {
     const options = {
       type: 'FETCH_TABLE_DATA',
       path,
-      params
+      params,
+      context: { groupBy: activeGroup }
     };
 
     return dispatch(fetchMetrics(options)).then((results) => {
@@ -77,7 +78,6 @@ export function _getTableData({ params, metrics, groupBy }) {
         type: 'REFRESH_SUMMARY_TABLE',
         payload: {
           data: results,
-          groupBy: activeGroup,
           metrics: activeMetrics
         }
       });

--- a/src/actions/tests/summaryChart.test.js
+++ b/src/actions/tests/summaryChart.test.js
@@ -108,7 +108,7 @@ describe('Action Creator: Refresh Summary Report', () => {
       metricsActions.fetch = jest.fn((a) => Promise.resolve(fetchResult));
     });
 
-    test('_getChartData should dispatch the correct actions', async() => {
+    test('_getChartData should dispatch the correct actions', async () => {
       const params = { precision: 'test' };
       const metrics = {};
 
@@ -130,7 +130,7 @@ describe('Action Creator: Refresh Summary Report', () => {
       });
     });
 
-    test('_getTableData should dispatch the correct actions, with passed in args', async() => {
+    test('_getTableData should dispatch the correct actions, with passed in args', async () => {
       const params = {};
       const groupBy = 'groupby-args';
       const metrics = 'metrics-args';
@@ -142,20 +142,20 @@ describe('Action Creator: Refresh Summary Report', () => {
       expect(metricsActions.fetch).toHaveBeenCalledWith({
         type: 'FETCH_TABLE_DATA',
         path: 'deliverability/groupby-args',
-        params
+        params,
+        context: { groupBy }
       });
 
       expect(dispatchMock).toHaveBeenLastCalledWith({
         type: 'REFRESH_SUMMARY_TABLE',
         payload: {
           data: fetchResult,
-          groupBy: 'groupby-args',
           metrics: 'metrics-args'
         }
       });
     });
 
-    test('_getTableData should dispatch the correct actions, with defaults', async() => {
+    test('_getTableData should dispatch the correct actions, with defaults', async () => {
       const params = {};
       testState.summaryChart.groupBy = 'groupby-state';
       testState.summaryChart.metrics = 'metrics-state';
@@ -167,14 +167,14 @@ describe('Action Creator: Refresh Summary Report', () => {
       expect(metricsActions.fetch).toHaveBeenCalledWith({
         type: 'FETCH_TABLE_DATA',
         path: 'deliverability/groupby-state',
-        params
+        params,
+        context: { groupBy: testState.summaryChart.groupBy }
       });
 
       expect(dispatchMock).toHaveBeenLastCalledWith({
         type: 'REFRESH_SUMMARY_TABLE',
         payload: {
           data: fetchResult,
-          groupBy: 'groupby-state',
           metrics: 'metrics-state'
         }
       });
@@ -192,7 +192,8 @@ describe('Action Creator: Refresh Summary Report', () => {
       expect(metricsActions.fetch).toHaveBeenCalledWith({
         type: 'FETCH_TABLE_DATA',
         path: 'deliverability',
-        params
+        params,
+        context: { groupBy: testState.summaryChart.groupBy }
       });
     });
 

--- a/src/pages/reports/summary/components/GroupByOption.js
+++ b/src/pages/reports/summary/components/GroupByOption.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import styles from './Table.module.scss';
+import { connect } from 'react-redux';
+
+import { Checkbox, Grid, Select } from '@sparkpost/matchbox';
+import { _getTableData } from 'src/actions/summaryChart';
+import { hasSubaccounts } from 'src/selectors/subaccounts';
+
+import _ from 'lodash';
+import { GROUP_CONFIG } from './tableConfig';
+
+
+export class GroupByOption extends Component {
+
+  state = {
+    topDomainsOnly: true
+  }
+
+  handleGroupChange = (e) => {
+    this.props._getTableData({ groupBy: e.target.value });
+  }
+
+  handleDomainsCheckboxChange = () => {
+    const topDomainsOnly = !this.state.topDomainsOnly;
+    this.setState({ topDomainsOnly });
+    const groupBy = topDomainsOnly ? 'watched-domain' : 'domain';
+    this.props._getTableData({ groupBy });
+  }
+
+  getSelectOptions = () => {
+    const domainOmittedGroup = this.state.topDomainsOnly ? _.omit(GROUP_CONFIG, 'domain') : _.omit(GROUP_CONFIG, 'watched-domain');
+    const options = _.keys(domainOmittedGroup).map((key) => ({
+      value: key,
+      label: domainOmittedGroup[key].label
+    }));
+
+    if (!this.props.hasSubaccounts) {
+      _.remove(options, { value: 'subaccount' });
+    }
+
+    return options;
+  }
+
+  renderDomainsCheckbox() {
+    const { tableLoading, groupBy } = this.props;
+    const { topDomainsOnly } = this.state;
+
+    //Only show 'Top Domains Only' checkbox when on the recipient domains grouping
+    if (!(groupBy === 'watched-domain' || groupBy === 'domain')) {
+      return null;
+    }
+    return (
+      <div className={styles.TopDomainsCheckbox}>
+        <Checkbox
+          id="watchedDomains"
+          label="Top Domains Only"
+          checked={topDomainsOnly}
+          onChange={this.handleDomainsCheckboxChange}
+          disabled={tableLoading}
+        />
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Grid>
+        <Grid.Column xs={12} md={5} lg={4}>
+          <Select
+            label='Group By'
+            options={this.getSelectOptions()}
+            value={this.props.groupBy}
+            disabled={this.props.tableLoading}
+            onChange={this.handleGroupChange}/>
+        </Grid.Column>
+        <Grid.Column xs={12} md={4} mdOffset={3} lg={3} lgOffset={5}>
+          {this.renderDomainsCheckbox()}
+        </Grid.Column>
+      </Grid>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  hasSubaccounts: hasSubaccounts(state),
+  ...state.summaryChart
+});
+export default connect(mapStateToProps, { _getTableData })(GroupByOption);

--- a/src/pages/reports/summary/components/Table.js
+++ b/src/pages/reports/summary/components/Table.js
@@ -143,10 +143,10 @@ export class Table extends Component {
       <Panel>
         <Panel.Section>
           <GroupByOption
-            _getTableData = {_getTableData}
-            groupBy = {groupBy}
-            hasSubaccounts = {hasSubaccounts}
-            tableLoading = {tableLoading} />
+            _getTableData={_getTableData}
+            groupBy={groupBy}
+            hasSubaccounts={hasSubaccounts}
+            tableLoading={tableLoading} />
         </Panel.Section>
         {this.renderTable()}
       </Panel>

--- a/src/pages/reports/summary/components/Table.js
+++ b/src/pages/reports/summary/components/Table.js
@@ -5,20 +5,17 @@ import cx from 'classnames';
 import { _getTableData } from 'src/actions/summaryChart';
 import { addFilters } from 'src/actions/reportOptions';
 import typeaheadCacheSelector from 'src/selectors/reportFilterTypeaheadCache';
-import { hasSubaccounts } from 'src/selectors/subaccounts';
 
 import { TableCollection, TableHeader, Unit, Loading } from 'src/components';
+import GroupByOption from './GroupByOption';
 import { Empty } from 'src/components';
-import { Panel, Select, Grid, UnstyledLink } from '@sparkpost/matchbox';
+import { Panel, UnstyledLink } from '@sparkpost/matchbox';
 import { GROUP_CONFIG } from './tableConfig';
 import _ from 'lodash';
 
 import styles from './Table.module.scss';
 
 export class Table extends Component {
-  handleGroupChange = (e) => {
-    this.props._getTableData({ groupBy: e.target.value });
-  }
 
   handleRowClick = (item) => {
     this.props.addFilters([item]);
@@ -38,7 +35,7 @@ export class Table extends Component {
 
     const metricCols = metrics.map(({ label, key }) => ({
       key,
-      label: <div className={styles.RightAlign}>{ label }</div>,
+      label: <div className={styles.RightAlign}>{label}</div>,
       className: cx(styles.HeaderCell, styles.NumericalHeader),
       sortKey: isAggColumn ? null : key
     }));
@@ -70,7 +67,7 @@ export class Table extends Component {
         filter = { ...filter, value, id };
       }
 
-      const primaryCol = groupBy === 'aggregate' ? 'Aggregate Total' : <UnstyledLink onClick={() => this.handleRowClick(filter)}>{ value }</UnstyledLink>;
+      const primaryCol = groupBy === 'aggregate' ? 'Aggregate Total' : <UnstyledLink onClick={() => this.handleRowClick(filter)}>{value}</UnstyledLink>;
 
       const metricCols = metrics.map((metric) => (
         <div className={styles.RightAlign}>
@@ -85,16 +82,6 @@ export class Table extends Component {
   getDefaultSortColumn = () => {
     const { metrics } = this.props;
     return metrics[0].key;
-  }
-
-  getSelectOptions = () => {
-    const options = _.keys(GROUP_CONFIG).map((key) => ({ value: key, label: GROUP_CONFIG[key].label }));
-
-    if (!this.props.hasSubaccounts) {
-      _.remove(options, { value: 'subaccount' });
-    }
-
-    return options;
   }
 
   renderAggregateTable() {
@@ -153,19 +140,9 @@ export class Table extends Component {
     return (
       <Panel>
         <Panel.Section>
-          <Grid>
-            <Grid.Column xs={12} md={5} lg={4}>
-              <Select
-                label='Group By'
-                options={this.getSelectOptions()}
-                value={this.props.groupBy}
-                disabled={this.props.tableLoading}
-                onChange={this.handleGroupChange}/>
-            </Grid.Column>
-            <Grid.Column></Grid.Column>
-          </Grid>
+          <GroupByOption/>
         </Panel.Section>
-        { this.renderTable() }
+        {this.renderTable()}
       </Panel>
     );
   }
@@ -173,7 +150,6 @@ export class Table extends Component {
 
 const mapStateToProps = (state) => ({
   typeaheadCache: typeaheadCacheSelector(state),
-  hasSubaccounts: hasSubaccounts(state),
   ...state.summaryChart
 });
 export default connect(mapStateToProps, { _getTableData, addFilters })(Table);

--- a/src/pages/reports/summary/components/Table.js
+++ b/src/pages/reports/summary/components/Table.js
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import { _getTableData } from 'src/actions/summaryChart';
 import { addFilters } from 'src/actions/reportOptions';
 import typeaheadCacheSelector from 'src/selectors/reportFilterTypeaheadCache';
+import { hasSubaccounts } from 'src/selectors/subaccounts';
 
 import { TableCollection, TableHeader, Unit, Loading } from 'src/components';
 import GroupByOption from './GroupByOption';
@@ -137,10 +138,15 @@ export class Table extends Component {
   }
 
   render() {
+    const { groupBy, hasSubaccounts, tableLoading, _getTableData } = this.props;
     return (
       <Panel>
         <Panel.Section>
-          <GroupByOption/>
+          <GroupByOption
+            _getTableData = {_getTableData}
+            groupBy = {groupBy}
+            hasSubaccounts = {hasSubaccounts}
+            tableLoading = {tableLoading} />
         </Panel.Section>
         {this.renderTable()}
       </Panel>
@@ -150,6 +156,7 @@ export class Table extends Component {
 
 const mapStateToProps = (state) => ({
   typeaheadCache: typeaheadCacheSelector(state),
+  hasSubaccounts: hasSubaccounts(state),
   ...state.summaryChart
 });
 export default connect(mapStateToProps, { _getTableData, addFilters })(Table);

--- a/src/pages/reports/summary/components/Table.module.scss
+++ b/src/pages/reports/summary/components/Table.module.scss
@@ -16,6 +16,15 @@
   text-align: right;
 }
 
+.TopDomainsCheckbox {
+  display: inline-block;
+  margin-top: spacing(larger);
+
+  @media screen and (min-width: breakpoint(small)) {
+    float: right;
+  }
+}
+
 .HeaderCell {
   font-size: rem(13);
   line-height: rem(18);

--- a/src/pages/reports/summary/components/tableConfig.js
+++ b/src/pages/reports/summary/components/tableConfig.js
@@ -7,6 +7,10 @@ export const GROUP_CONFIG = {
     label: 'Recipient Domain',
     keyName: 'domain'
   },
+  'watched-domain': {
+    label: 'Recipient Domain',
+    keyName: 'watched_domain'
+  },
   'sending-domain': {
     label: 'Sending Domain',
     keyName: 'sending_domain'

--- a/src/pages/reports/summary/components/tests/GroupByOption.test.js
+++ b/src/pages/reports/summary/components/tests/GroupByOption.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { GroupByOption } from '../GroupByOption';
+import { shallow } from 'enzyme';
+
+describe('Group By Option', () => {
+
+  let wrapper;
+
+  const props = {
+    _getTableData: jest.fn(),
+    groupBy: 'watched-domain',
+    tableData: [],
+    tableLoading: false,
+    hasSubaccounts: false
+  };
+
+  beforeEach(() => {
+    wrapper = shallow(<GroupByOption {...props} />);
+    wrapper.setState({ topDomainsOnly: true });
+  });
+
+  it('should render correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render subaccount option', () => {
+    wrapper.setProps({ hasSubaccounts: true });
+    expect(wrapper.find('Select').prop('options')).toContainEqual({ label: 'Subaccount',
+      value: 'subaccount' });
+    expect(wrapper.find('Select').prop('options')).toMatchSnapshot();
+  });
+
+  it('should handle select change', () => {
+    wrapper.find('Select').simulate('change', { target: { value: 'campaign' }});
+    expect(props._getTableData).toHaveBeenCalledWith({ groupBy: 'campaign' });
+  });
+
+  it('should correctly show watched domain in the select options when "Only Top Domains" is checked', () => {
+    wrapper.setState({ topDomainsOnly: true });
+    expect(wrapper.find('Select').prop('options')).toContainEqual({ label: 'Recipient Domain',
+      value: 'watched-domain' });
+    expect(wrapper.find('Select').prop('options')).toMatchSnapshot();
+  });
+
+  it('should correctly show domain in the select options when "Only Top Domains" is not checked', () => {
+    wrapper.setState({ topDomainsOnly: false });
+    expect(wrapper.find('Select').prop('options')).toContainEqual({ label: 'Recipient Domain',
+      value: 'domain' });
+    expect(wrapper.find('Select').prop('options')).toMatchSnapshot();
+  });
+
+  it('should make new domain api call when unchecking the "Only Top Domains" checkbox', () => {
+    wrapper.setState({ topDomainsOnly: true });
+    wrapper.find('Checkbox').simulate('change', {});
+    expect(props._getTableData).toHaveBeenCalledWith({ groupBy: 'domain' });
+    expect(wrapper.find('Checkbox').props().checked).toEqual(false);
+  });
+
+  it('should make new watched-domain api call when checking the "Only Top Domains" checkbox', () => {
+    wrapper.setState({ topDomainsOnly: false });
+    wrapper.find('Checkbox').simulate('change', {});
+    expect(props._getTableData).toHaveBeenCalledWith({ groupBy: 'watched-domain' });
+    expect(wrapper.find('Checkbox').props().checked).toEqual(true);
+  });
+});

--- a/src/pages/reports/summary/components/tests/GroupByOption.test.js
+++ b/src/pages/reports/summary/components/tests/GroupByOption.test.js
@@ -9,14 +9,12 @@ describe('Group By Option', () => {
   const props = {
     _getTableData: jest.fn(),
     groupBy: 'watched-domain',
-    tableData: [],
     tableLoading: false,
     hasSubaccounts: false
   };
 
   beforeEach(() => {
     wrapper = shallow(<GroupByOption {...props} />);
-    wrapper.setState({ topDomainsOnly: true });
   });
 
   it('should render correctly with both selector and checkbox', () => {
@@ -25,7 +23,7 @@ describe('Group By Option', () => {
 
   it('should render correctly with selector only and not the checkbox', () => {
     wrapper.setProps({ groupBy: 'campaign' });
-    expect(wrapper.find('Checkbox')).toHaveLength(0);
+    expect(wrapper.find('Checkbox')).not.toExist();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -57,15 +55,15 @@ describe('Group By Option', () => {
 
   it('should make new domain api call when unchecking the "Only Top Domains" checkbox', () => {
     wrapper.setState({ topDomainsOnly: true });
-    wrapper.find('Checkbox').simulate('change', {});
+    wrapper.find('Checkbox').simulate('change');
     expect(props._getTableData).toHaveBeenCalledWith({ groupBy: 'domain' });
-    expect(wrapper.find('Checkbox').props().checked).toEqual(false);
+    expect(wrapper.find('Checkbox')).toHaveProp('checked', false);
   });
 
   it('should make new watched-domain api call when checking the "Only Top Domains" checkbox', () => {
     wrapper.setState({ topDomainsOnly: false });
-    wrapper.find('Checkbox').simulate('change', {});
+    wrapper.find('Checkbox').simulate('change');
     expect(props._getTableData).toHaveBeenCalledWith({ groupBy: 'watched-domain' });
-    expect(wrapper.find('Checkbox').props().checked).toEqual(true);
+    expect(wrapper.find('Checkbox')).toHaveProp('checked', true);
   });
 });

--- a/src/pages/reports/summary/components/tests/GroupByOption.test.js
+++ b/src/pages/reports/summary/components/tests/GroupByOption.test.js
@@ -19,7 +19,13 @@ describe('Group By Option', () => {
     wrapper.setState({ topDomainsOnly: true });
   });
 
-  it('should render correctly', () => {
+  it('should render correctly with both selector and checkbox', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render correctly with selector only and not the checkbox', () => {
+    wrapper.setProps({ groupBy: 'campaign' });
+    expect(wrapper.find('Checkbox')).toHaveLength(0);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/reports/summary/components/tests/Table.test.js
+++ b/src/pages/reports/summary/components/tests/Table.test.js
@@ -20,7 +20,8 @@ describe('Summary Table ', () => {
       { type: 'Subaccount', id: 555, value: 'sub 1 name' }
     ],
     tableData: [],
-    tableLoading: false
+    tableLoading: false,
+    hasSubaccounts: false
   };
 
   const data = [

--- a/src/pages/reports/summary/components/tests/Table.test.js
+++ b/src/pages/reports/summary/components/tests/Table.test.js
@@ -20,8 +20,7 @@ describe('Summary Table ', () => {
       { type: 'Subaccount', id: 555, value: 'sub 1 name' }
     ],
     tableData: [],
-    tableLoading: false,
-    hasSubaccounts: false
+    tableLoading: false
   };
 
   const data = [
@@ -48,14 +47,9 @@ describe('Summary Table ', () => {
     expect(wrapper.find('Loading')).toHaveLength(1);
   });
 
-  it('should render subaccount option', () => {
-    wrapper.setProps({ hasSubaccounts: true });
-    expect(wrapper.find('Select')).toMatchSnapshot();
-  });
-
   it('should render row data & handle click', () => {
     const snaps = [];
-    wrapper.setProps({ hasSubaccounts: true, groupBy: 'subaccount' });
+    wrapper.setProps({ groupBy: 'subaccount' });
     const func = wrapper.instance().getRowData();
     const results = _.flatten(data.map(func));
 
@@ -67,11 +61,6 @@ describe('Summary Table ', () => {
 
     snaps[0].find('UnstyledLink').simulate('click');
     expect(props.addFilters).toHaveBeenCalledWith([{ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' }]);
-  });
-
-  it('should handle select change', () => {
-    wrapper.find('Select').simulate('change', { target: { value: 'campaign' }});
-    expect(props._getTableData).toHaveBeenCalledWith({ groupBy: 'campaign' });
   });
 
   it('should render with aggregate data', () => {

--- a/src/pages/reports/summary/components/tests/__snapshots__/GroupByOption.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/GroupByOption.test.js.snap
@@ -66,7 +66,7 @@ Array [
 ]
 `;
 
-exports[`Group By Option should render correctly 1`] = `
+exports[`Group By Option should render correctly with both selector and checkbox 1`] = `
 <Grid>
   <Grid.Column
     lg={4}
@@ -131,6 +131,62 @@ exports[`Group By Option should render correctly 1`] = `
       />
     </div>
   </Grid.Column>
+</Grid>
+`;
+
+exports[`Group By Option should render correctly with selector only and not the checkbox 1`] = `
+<Grid>
+  <Grid.Column
+    lg={4}
+    md={5}
+    xs={12}
+  >
+    <Select
+      disabled={false}
+      label="Group By"
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Aggregate Total",
+            "value": "aggregate",
+          },
+          Object {
+            "label": "Recipient Domain",
+            "value": "watched-domain",
+          },
+          Object {
+            "label": "Sending Domain",
+            "value": "sending-domain",
+          },
+          Object {
+            "label": "Campaign",
+            "value": "campaign",
+          },
+          Object {
+            "label": "Template",
+            "value": "template",
+          },
+          Object {
+            "label": "Sending IP",
+            "value": "sending-ip",
+          },
+          Object {
+            "label": "IP Pool",
+            "value": "ip-pool",
+          },
+        ]
+      }
+      value="campaign"
+    />
+  </Grid.Column>
+  <Grid.Column
+    lg={3}
+    lgOffset={5}
+    md={4}
+    mdOffset={3}
+    xs={12}
+  />
 </Grid>
 `;
 

--- a/src/pages/reports/summary/components/tests/__snapshots__/GroupByOption.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/GroupByOption.test.js.snap
@@ -1,0 +1,172 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Group By Option should correctly show domain in the select options when "Only Top Domains" is not checked 1`] = `
+Array [
+  Object {
+    "label": "Aggregate Total",
+    "value": "aggregate",
+  },
+  Object {
+    "label": "Recipient Domain",
+    "value": "domain",
+  },
+  Object {
+    "label": "Sending Domain",
+    "value": "sending-domain",
+  },
+  Object {
+    "label": "Campaign",
+    "value": "campaign",
+  },
+  Object {
+    "label": "Template",
+    "value": "template",
+  },
+  Object {
+    "label": "Sending IP",
+    "value": "sending-ip",
+  },
+  Object {
+    "label": "IP Pool",
+    "value": "ip-pool",
+  },
+]
+`;
+
+exports[`Group By Option should correctly show watched domain in the select options when "Only Top Domains" is checked 1`] = `
+Array [
+  Object {
+    "label": "Aggregate Total",
+    "value": "aggregate",
+  },
+  Object {
+    "label": "Recipient Domain",
+    "value": "watched-domain",
+  },
+  Object {
+    "label": "Sending Domain",
+    "value": "sending-domain",
+  },
+  Object {
+    "label": "Campaign",
+    "value": "campaign",
+  },
+  Object {
+    "label": "Template",
+    "value": "template",
+  },
+  Object {
+    "label": "Sending IP",
+    "value": "sending-ip",
+  },
+  Object {
+    "label": "IP Pool",
+    "value": "ip-pool",
+  },
+]
+`;
+
+exports[`Group By Option should render correctly 1`] = `
+<Grid>
+  <Grid.Column
+    lg={4}
+    md={5}
+    xs={12}
+  >
+    <Select
+      disabled={false}
+      label="Group By"
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Aggregate Total",
+            "value": "aggregate",
+          },
+          Object {
+            "label": "Recipient Domain",
+            "value": "watched-domain",
+          },
+          Object {
+            "label": "Sending Domain",
+            "value": "sending-domain",
+          },
+          Object {
+            "label": "Campaign",
+            "value": "campaign",
+          },
+          Object {
+            "label": "Template",
+            "value": "template",
+          },
+          Object {
+            "label": "Sending IP",
+            "value": "sending-ip",
+          },
+          Object {
+            "label": "IP Pool",
+            "value": "ip-pool",
+          },
+        ]
+      }
+      value="watched-domain"
+    />
+  </Grid.Column>
+  <Grid.Column
+    lg={3}
+    lgOffset={5}
+    md={4}
+    mdOffset={3}
+    xs={12}
+  >
+    <div
+      className="TopDomainsCheckbox"
+    >
+      <Checkbox
+        checked={true}
+        disabled={false}
+        id="watchedDomains"
+        label="Top Domains Only"
+        onChange={[Function]}
+      />
+    </div>
+  </Grid.Column>
+</Grid>
+`;
+
+exports[`Group By Option should render subaccount option 1`] = `
+Array [
+  Object {
+    "label": "Aggregate Total",
+    "value": "aggregate",
+  },
+  Object {
+    "label": "Recipient Domain",
+    "value": "watched-domain",
+  },
+  Object {
+    "label": "Sending Domain",
+    "value": "sending-domain",
+  },
+  Object {
+    "label": "Campaign",
+    "value": "campaign",
+  },
+  Object {
+    "label": "Template",
+    "value": "template",
+  },
+  Object {
+    "label": "Subaccount",
+    "value": "subaccount",
+  },
+  Object {
+    "label": "Sending IP",
+    "value": "sending-ip",
+  },
+  Object {
+    "label": "IP Pool",
+    "value": "ip-pool",
+  },
+]
+`;

--- a/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
@@ -89,51 +89,6 @@ Array [
 ]
 `;
 
-exports[`Summary Table  should render subaccount option 1`] = `
-<Select
-  disabled={false}
-  label="Group By"
-  onChange={[Function]}
-  options={
-    Array [
-      Object {
-        "label": "Aggregate Total",
-        "value": "aggregate",
-      },
-      Object {
-        "label": "Recipient Domain",
-        "value": "domain",
-      },
-      Object {
-        "label": "Sending Domain",
-        "value": "sending-domain",
-      },
-      Object {
-        "label": "Campaign",
-        "value": "campaign",
-      },
-      Object {
-        "label": "Template",
-        "value": "template",
-      },
-      Object {
-        "label": "Subaccount",
-        "value": "subaccount",
-      },
-      Object {
-        "label": "Sending IP",
-        "value": "sending-ip",
-      },
-      Object {
-        "label": "IP Pool",
-        "value": "ip-pool",
-      },
-    ]
-  }
-  value="domain"
-/>
-`;
-
 exports[`Summary Table  should render with aggregate data 1`] = `
 <TableCollection
   defaultSortColumn={null}
@@ -210,53 +165,7 @@ exports[`Summary Table  should render with data 1`] = `
 exports[`Summary Table  should render with no data 1`] = `
 <Panel>
   <Panel.Section>
-    <Grid>
-      <Grid.Column
-        lg={4}
-        md={5}
-        xs={12}
-      >
-        <Select
-          disabled={false}
-          label="Group By"
-          onChange={[Function]}
-          options={
-            Array [
-              Object {
-                "label": "Aggregate Total",
-                "value": "aggregate",
-              },
-              Object {
-                "label": "Recipient Domain",
-                "value": "domain",
-              },
-              Object {
-                "label": "Sending Domain",
-                "value": "sending-domain",
-              },
-              Object {
-                "label": "Campaign",
-                "value": "campaign",
-              },
-              Object {
-                "label": "Template",
-                "value": "template",
-              },
-              Object {
-                "label": "Sending IP",
-                "value": "sending-ip",
-              },
-              Object {
-                "label": "IP Pool",
-                "value": "ip-pool",
-              },
-            ]
-          }
-          value="domain"
-        />
-      </Grid.Column>
-      <Grid.Column />
-    </Grid>
+    <Connect(GroupByOption) />
   </Panel.Section>
   <Empty
     message="There is no data to display"

--- a/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
@@ -165,7 +165,12 @@ exports[`Summary Table  should render with data 1`] = `
 exports[`Summary Table  should render with no data 1`] = `
 <Panel>
   <Panel.Section>
-    <Connect(GroupByOption) />
+    <GroupByOption
+      _getTableData={[MockFunction]}
+      groupBy="domain"
+      hasSubaccounts={false}
+      tableLoading={false}
+    />
   </Panel.Section>
   <Empty
     message="There is no data to display"

--- a/src/reducers/summaryChart.js
+++ b/src/reducers/summaryChart.js
@@ -11,7 +11,7 @@ const initialState = {
   groupBy: 'aggregate'
 };
 
-export default (state = initialState, { type, payload }) => {
+export default (state = initialState, { type, payload, meta }) => {
   switch (type) {
     case 'FETCH_CHART_DATA_PENDING':
       return { ...state, chartLoading: true };
@@ -20,8 +20,10 @@ export default (state = initialState, { type, payload }) => {
     case 'FETCH_CHART_DATA_FAIL':
       return { ...state, chartLoading: false };
 
-    case 'FETCH_TABLE_DATA_PENDING':
-      return { ...state, tableLoading: true };
+    case 'FETCH_TABLE_DATA_PENDING': {
+      const { context: { groupBy }} = meta;
+      return { ...state, tableLoading: true, tableData: [], groupBy };
+    }
 
     case 'FETCH_TABLE_DATA_SUCCESS':
     case 'FETCH_TABLE_DATA_FAIL':
@@ -33,8 +35,8 @@ export default (state = initialState, { type, payload }) => {
     }
 
     case 'REFRESH_SUMMARY_TABLE': {
-      const { data, metrics, groupBy } = payload;
-      return { ...state, tableData: transformData(data, metrics), groupBy };
+      const { data, metrics } = payload;
+      return { ...state, tableData: transformData(data, metrics) };
     }
 
     default:


### PR DESCRIPTION
Add checkbox for "Top Domains Only" in summary report. 

My Changes:

* Added watched-domain to the selector options but removed one of domain/watched-domain depending on the checkbox.
* Split the selector and checkbox into its own component. 

AC: 
* Checkbox only appears when selecting Recipient Domain as group by option.
* When first time selecting Recipient Domain, the checkbox should be checked.
* When checked, the API call should be to  ```http://api.sparkpost.test/api/v1/metrics/deliverability/watched-domain```
* When unchecked, the API call should be to ```http://api.sparkpost.test/api/v1/metrics/deliverability/domain```