### PR TITLE
EO-574 Display recommended actions for selected day

### DIFF
--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -23,6 +23,35 @@ import cohorts from './constants/cohorts';
 import styles from './DetailsPages.module.scss';
 
 export class EngagementRecencyPage extends Component {
+  state = {
+    selectedDate: null
+  }
+
+  componentDidMount() {
+    const { selected } = this.props;
+
+    if (selected) {
+      this.setState({ selectedDate: selected });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { data } = this.props;
+    const { selectedDate } = this.state;
+
+    const dataSetChanged = prevProps.data !== data;
+    let selectedDataByDay = _.find(data, ['date', selectedDate]);
+
+    // Select last date in time series
+    if (dataSetChanged && !selectedDataByDay) {
+      selectedDataByDay = _.last(data);
+      this.setState({ selectedDate: selectedDataByDay.date });
+    }
+  }
+
+  handleDateSelect = (node) => {
+    this.setState({ selectedDate: _.get(node, 'payload.date') });
+  }
 
   getYAxisProps = () => ({
     tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`,
@@ -54,6 +83,8 @@ export class EngagementRecencyPage extends Component {
 
   renderContent = () => {
     const { data = [], loading, gap, empty, error } = this.props;
+    const { selectedDate } = this.state;
+    const selectedData = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
 
     if (empty) {
@@ -84,6 +115,8 @@ export class EngagementRecencyPage extends Component {
               <div className='LiftTooltip'>
                 <BarChart
                   gap={gap}
+                  onClick={this.handleDateSelect}
+                  selected={selectedDate}
                   timeSeries={data}
                   tooltipContent={this.getTooltipContent}
                   tooltipWidth='250px'
@@ -101,7 +134,7 @@ export class EngagementRecencyPage extends Component {
         </Grid.Column>
         <Grid.Column sm={12} md={5} mdOffset={0}>
           <div className={styles.OffsetCol}>
-            {!chartPanel && <EngagementRecencyActions cohorts={_.last(data)} />}
+            {!chartPanel && <EngagementRecencyActions cohorts={selectedData} date={selectedDate} />}
           </div>
         </Grid.Column>
       </Grid>

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -84,7 +84,7 @@ export class EngagementRecencyPage extends Component {
   renderContent = () => {
     const { data = [], loading, gap, empty, error } = this.props;
     const { selectedDate } = this.state;
-    const selectedData = _.find(data, ['date', selectedDate]) || {};
+    const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
 
     if (empty) {
@@ -134,7 +134,7 @@ export class EngagementRecencyPage extends Component {
         </Grid.Column>
         <Grid.Column sm={12} md={5} mdOffset={0}>
           <div className={styles.OffsetCol}>
-            {!chartPanel && <EngagementRecencyActions cohorts={selectedData} date={selectedDate} />}
+            {!chartPanel && <EngagementRecencyActions cohorts={selectedCohorts} date={selectedDate} />}
           </div>
         </Grid.Column>
       </Grid>

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -77,7 +77,6 @@ export class HealthScorePage extends Component {
     const { selectedDate, selectedComponent } = this.state;
 
     const selectedWeights = _.get(_.find(data, ['date', selectedDate]), 'weights', []);
-    const currentWeights = _.get(_.last(data), 'weights');
     const selectedWeightsAreEmpty = selectedWeights.every(({ weight }) => weight === null);
     const dataForSelectedWeight = data.map(({ date, weights }) => ({ date, ..._.find(weights, ['weight_type', selectedComponent]) }));
 
@@ -164,6 +163,7 @@ export class HealthScorePage extends Component {
           <div className={styles.OffsetCol}>
             <ChartHeader
               title='Health Score Components'
+              date={selectedDate}
               hideLine
               padding='1rem 0 1rem'
               tooltipContent={HEALTH_SCORE_COMPONENT_INFO}
@@ -182,7 +182,7 @@ export class HealthScorePage extends Component {
                 selected={selectedComponent}
               />
             )}
-            {!panelContent && <HealthScoreActions weights={currentWeights} />}
+            {!panelContent && <HealthScoreActions weights={selectedWeights} date={selectedDate} />}
           </div>
         </Grid.Column>
       </Grid>

--- a/src/pages/signals/SpamTrapPage.js
+++ b/src/pages/signals/SpamTrapPage.js
@@ -87,7 +87,7 @@ export class SpamTrapPage extends Component {
   renderContent = () => {
     const { data = [], loading, gap, empty, error } = this.props;
     const { calculation, selectedDate } = this.state;
-    const selectedData = _.find(data, ['date', selectedDate]) || {};
+    const selectedSpamTrapHits = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
 
     if (empty) {
@@ -136,7 +136,7 @@ export class SpamTrapPage extends Component {
         </Grid.Column>
         <Grid.Column sm={12} md={5} mdOffset={0}>
           <div className={styles.OffsetCol}>
-            {!chartPanel && <SpamTrapActions percent={selectedData.relative_trap_hits} date={selectedDate} />}
+            {!chartPanel && <SpamTrapActions percent={selectedSpamTrapHits.relative_trap_hits} date={selectedDate} />}
           </div>
         </Grid.Column>
       </Grid>

--- a/src/pages/signals/components/ChartHeader.js
+++ b/src/pages/signals/components/ChartHeader.js
@@ -1,12 +1,13 @@
 import React, { Fragment } from 'react';
 import { Tooltip } from '@sparkpost/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
+import { formatDate } from 'src/helpers/date';
 import styles from './ChartHeader.module.scss';
 
-const ChartHeader = ({ title, primaryArea, hideLine, tooltipContent, padding = '' }) => (
+const ChartHeader = ({ date, title, primaryArea, hideLine, tooltipContent, padding = '' }) => (
   <Fragment>
     <div className={styles.ChartHeader} style={{ padding }}>
-      <h6 className={styles.Title}>{title}</h6>
+      <h6 className={styles.Title}>{title}{date && ` – ${formatDate(date)}`}</h6>
       {tooltipContent && (
         <div className={styles.Tooltip}>
           <Tooltip dark horizontalOffset='-1rem' content={tooltipContent}>

--- a/src/pages/signals/components/actionContent/EngagementRecencyActions.js
+++ b/src/pages/signals/components/actionContent/EngagementRecencyActions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Actions from '../Actions';
 import content from '../../constants/engagementRecencyContent';
 
-const EngagementRecencyActions = ({ cohorts }) => {
+const EngagementRecencyActions = ({ cohorts, date }) => {
   let actions = [];
 
   content.forEach(({ condition, ...rest }) => {
@@ -12,7 +12,7 @@ const EngagementRecencyActions = ({ cohorts }) => {
   });
 
   actions = actions.slice(0, 3);
-  return <Actions actions={actions} empty={cohorts.c_total === null} />;
+  return <Actions actions={actions} date={date} empty={cohorts.c_total === null} />;
 };
 
 export default EngagementRecencyActions;

--- a/src/pages/signals/components/actionContent/HealthScoreActions.js
+++ b/src/pages/signals/components/actionContent/HealthScoreActions.js
@@ -3,7 +3,7 @@ import Actions from '../Actions';
 import content from '../../constants/healthScoreContent.js';
 import _ from 'lodash';
 
-const HealthScoreActions = ({ weights }) => {
+const HealthScoreActions = ({ date, weights }) => {
   const actions = weights.reduce((acc, { weight, weight_type }) => {
     const parsedWeight = parseFloat(weight);
 
@@ -20,7 +20,7 @@ const HealthScoreActions = ({ weights }) => {
   }, []);
 
   const sorted = _.orderBy(actions, 'weight', 'asc').slice(0, 2);
-  return <Actions actions={sorted} empty={!actions.length}/>;
+  return <Actions actions={sorted} date={date} empty={!actions.length} />;
 };
 
 export default HealthScoreActions;

--- a/src/pages/signals/components/actionContent/SpamTrapActions.js
+++ b/src/pages/signals/components/actionContent/SpamTrapActions.js
@@ -3,9 +3,9 @@ import Actions from '../Actions';
 import content from '../../constants/spamTrapContent';
 import _ from 'lodash';
 
-const SpamTrapActions = ({ percent }) => {
+const SpamTrapActions = ({ date, percent }) => {
   const action = content.filter(({ condition, ...rest }) => condition(percent));
-  return <Actions actions={action} empty={_.isNil(percent)}/>;
+  return <Actions actions={action} date={date} empty={_.isNil(percent)}/>;
 };
 
 export default SpamTrapActions;

--- a/src/pages/signals/components/tests/ChartHeader.test.js
+++ b/src/pages/signals/components/tests/ChartHeader.test.js
@@ -8,7 +8,8 @@ describe('Signals ChartHeader Component', () => {
 
   beforeEach(() => {
     props = {
-      title: 'Foo'
+      title: 'Foo',
+      date: '2018-02-15'
     };
     wrapper = shallow(<ChartHeader {...props}/>);
   });
@@ -29,6 +30,11 @@ describe('Signals ChartHeader Component', () => {
 
   it('renders padding correctly', () => {
     wrapper.setProps({ padding: '0 0 1rem 0' });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders without date', () => {
+    wrapper.setProps({ date: null });
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/pages/signals/components/tests/__snapshots__/ChartHeader.test.js.snap
+++ b/src/pages/signals/components/tests/__snapshots__/ChartHeader.test.js.snap
@@ -14,6 +14,7 @@ exports[`Signals ChartHeader Component renders correctly 1`] = `
       className="Title"
     >
       Foo
+       – Feb 15 2018
     </h6>
   </div>
   <hr
@@ -36,6 +37,7 @@ exports[`Signals ChartHeader Component renders padding correctly 1`] = `
       className="Title"
     >
       Foo
+       – Feb 15 2018
     </h6>
   </div>
   <hr
@@ -58,6 +60,7 @@ exports[`Signals ChartHeader Component renders primaryArea correctly 1`] = `
       className="Title"
     >
       Foo
+       – Feb 15 2018
     </h6>
     <div
       className="PrimaryArea"
@@ -87,6 +90,7 @@ exports[`Signals ChartHeader Component renders tooltip content correctly 1`] = `
       className="Title"
     >
       Foo
+       – Feb 15 2018
     </h6>
     <div
       className="Tooltip"
@@ -113,6 +117,28 @@ exports[`Signals ChartHeader Component renders tooltip content correctly 1`] = `
         />
       </Tooltip>
     </div>
+  </div>
+  <hr
+    className="Line"
+  />
+</Fragment>
+`;
+
+exports[`Signals ChartHeader Component renders without date 1`] = `
+<Fragment>
+  <div
+    className="ChartHeader"
+    style={
+      Object {
+        "padding": "",
+      }
+    }
+  >
+    <h6
+      className="Title"
+    >
+      Foo
+    </h6>
   </div>
   <hr
     className="Line"

--- a/src/pages/signals/containers/EngagementRecencyDetailsContainer.js
+++ b/src/pages/signals/containers/EngagementRecencyDetailsContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getEngagementRecency } from 'src/actions/signals';
-import { selectEngagementRecencyDetails } from 'src/selectors/signals';
+import { selectEngagementRecencyDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
 
 export class WithEngagementRecencyDetails extends Component {
@@ -39,6 +39,7 @@ export class WithEngagementRecencyDetails extends Component {
       facet,
       facetId,
       filters,
+      selected,
       subaccountId
     } = this.props;
 
@@ -46,7 +47,7 @@ export class WithEngagementRecencyDetails extends Component {
     const gap = details.data && details.data.length > 15 ? 0.2 : 1;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters.relativeRange)} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
     );
   }
 }
@@ -65,7 +66,8 @@ function withEngagementRecencyDetails(WrappedComponent) {
 
   const mapStateToProps = (state, props) => ({
     ...selectEngagementRecencyDetails(state, props),
-    filters: state.signalOptions
+    filters: state.signalOptions,
+    selected: getSelectedDateFromRouter(state, props)
   });
 
   return withRouter(connect(mapStateToProps, { getEngagementRecency })(Wrapper));

--- a/src/pages/signals/containers/SpamTrapDetailsContainer.js
+++ b/src/pages/signals/containers/SpamTrapDetailsContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getSpamHits } from 'src/actions/signals';
-import { selectSpamHitsDetails } from 'src/selectors/signals';
+import { selectSpamHitsDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
 
 export class WithSpamTrapDetails extends Component {
@@ -39,6 +39,7 @@ export class WithSpamTrapDetails extends Component {
       facet,
       facetId,
       filters,
+      selected,
       subaccountId
     } = this.props;
 
@@ -46,7 +47,7 @@ export class WithSpamTrapDetails extends Component {
     const gap = details.data && details.data.length > 15 ? 0.2 : 1;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters.relativeRange)} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
     );
   }
 }
@@ -65,7 +66,8 @@ function withSpamTrapDetails(WrappedComponent) {
 
   const mapStateToProps = (state, props) => ({
     ...selectSpamHitsDetails(state, props),
-    filters: state.signalOptions
+    filters: state.signalOptions,
+    selected: getSelectedDateFromRouter(state, props)
   });
 
   return withRouter(connect(mapStateToProps, { getSpamHits })(Wrapper));

--- a/src/pages/signals/containers/tests/EngagementRecencyDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/EngagementRecencyDetailsContainer.test.js
@@ -23,6 +23,7 @@ describe('Signals Engagement Recency Details Container', () => {
         relativeRange: '14days'
       },
       getEngagementRecency: jest.fn(),
+      selected: '2015-01-01',
       subaccountId: '101'
     };
 

--- a/src/pages/signals/containers/tests/HealthScoreDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/HealthScoreDetailsContainer.test.js
@@ -24,6 +24,7 @@ describe('Signals Health Score Details Container', () => {
       },
       getSpamHits: jest.fn(),
       getHealthScore: jest.fn(),
+      selected: '2015-01-01',
       subaccountId: '101'
     };
 

--- a/src/pages/signals/containers/tests/SpamTrapDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/SpamTrapDetailsContainer.test.js
@@ -23,6 +23,7 @@ describe('Signals Spam Trap Details Container', () => {
         relativeRange: '14days'
       },
       getSpamHits: jest.fn(),
+      selected: '2015-01-01',
       subaccountId: '101'
     };
 

--- a/src/pages/signals/containers/tests/__snapshots__/EngagementRecencyDetailsContainer.test.js.snap
+++ b/src/pages/signals/containers/tests/__snapshots__/EngagementRecencyDetailsContainer.test.js.snap
@@ -6,6 +6,7 @@ exports[`Signals Engagement Recency Details Container gets engagement recency on
   facet="sending_domain"
   facetId="test.com"
   gap={1}
+  selected="2015-01-01"
   subaccountId="101"
   xTicks={
     Array [

--- a/src/pages/signals/containers/tests/__snapshots__/HealthScoreDetailsContainer.test.js.snap
+++ b/src/pages/signals/containers/tests/__snapshots__/HealthScoreDetailsContainer.test.js.snap
@@ -6,6 +6,7 @@ exports[`Signals Health Score Details Container gets health score and spam hits 
   facet="sending_domain"
   facetId="test.com"
   gap={1}
+  selected="2015-01-01"
   subaccountId="101"
   xTicks={
     Array [

--- a/src/pages/signals/containers/tests/__snapshots__/SpamTrapDetailsContainer.test.js.snap
+++ b/src/pages/signals/containers/tests/__snapshots__/SpamTrapDetailsContainer.test.js.snap
@@ -6,6 +6,7 @@ exports[`Signals Spam Trap Details Container gets spam hits on mount correctly 1
   facet="sending_domain"
   facetId="test.com"
   gap={1}
+  selected="2015-01-01"
   subaccountId="101"
   xTicks={
     Array [

--- a/src/pages/signals/tests/EngagementRecencyPage.test.js
+++ b/src/pages/signals/tests/EngagementRecencyPage.test.js
@@ -5,6 +5,16 @@ import { EngagementRecencyPage } from '../EngagementRecencyPage';
 describe('Signals Engagement Recency Page', () => {
   let wrapper;
   let props;
+  const data = [
+    {
+      date: '2017-01-01',
+      c_total: 1
+    },
+    {
+      date: '2017-01-02',
+      c_total: 10
+    }
+  ];
 
   beforeEach(() => {
     props = {
@@ -17,6 +27,7 @@ describe('Signals Engagement Recency Page', () => {
       xTicks: [1,2]
     };
     wrapper = shallow(<EngagementRecencyPage {...props}/>);
+    wrapper.setProps({ data });
   });
 
   it('renders correctly', () => {
@@ -36,6 +47,34 @@ describe('Signals Engagement Recency Page', () => {
   it('renders error correctly', () => {
     wrapper.setProps({ error: { message: 'error message' }});
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('local state', () => {
+    it('handles date select', () => {
+      wrapper.find('BarChart').simulate('click', { payload: { date: '2017-01-02' }});
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('2017-01-02');
+      expect(wrapper.find('EngagementRecencyActions')).toMatchSnapshot();
+    });
+
+    it('sets selected date on mount if provided one', () => {
+      wrapper = shallow(<EngagementRecencyPage {...props} selected='initial-selected'/>);
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('initial-selected');
+      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('initial-selected');
+    });
+
+    it('uses last selected date if selected date is not in data', () => {
+      wrapper = shallow(<EngagementRecencyPage {...props} loading={true} selected='initial-selected'/>);
+      wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('last-date');
+      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('last-date');
+    });
+
+    it('does not use last selected date if selected date is in data', () => {
+      wrapper = shallow(<EngagementRecencyPage {...props} selected='first-date'/>);
+      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('first-date');
+      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('first-date');
+    });
   });
 
   describe('bar chart props', () => {

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -63,26 +63,31 @@ describe('Signals Health Score Page', () => {
 
   describe('local state', () => {
     it('handles date select', () => {
-      wrapper.find('BarChart').at(0).simulate('click', { payload: { date: 'test' }});
-      expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('test');
-      expect(wrapper.find('BarChart').at(1).prop('selected')).toEqual('test');
+      wrapper.find('BarChart').at(0).simulate('click', { payload: { date: '2017-01-02' }});
+      expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('2017-01-02');
+      expect(wrapper.find('BarChart').at(1).prop('selected')).toEqual('2017-01-02');
+      expect(wrapper.find('ChartHeader').at(3).prop('date')).toEqual('2017-01-02');
+      expect(wrapper.find('HealthScoreActions')).toMatchSnapshot();
     });
 
     it('sets selected date on mount if provided one', () => {
       wrapper = shallow(<HealthScorePage {...props} selected='initial-selected'/>);
       expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('initial-selected');
+      expect(wrapper.find('HealthScoreActions').prop('date')).toEqual('initial-selected');
     });
 
     it('uses last selected date if selected date is not in data', () => {
       wrapper = shallow(<HealthScorePage {...props} loading={true} selected='initial-selected'/>);
       wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
       expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('last-date');
+      expect(wrapper.find('HealthScoreActions').prop('date')).toEqual('last-date');
     });
 
     it('does not use last selected date if selected date is in data', () => {
       wrapper = shallow(<HealthScorePage {...props} selected='first-date'/>);
       wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
       expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('first-date');
+      expect(wrapper.find('HealthScoreActions').prop('date')).toEqual('first-date');
     });
 
     it('handles component select', () => {

--- a/src/pages/signals/tests/SpamTrapPage.test.js
+++ b/src/pages/signals/tests/SpamTrapPage.test.js
@@ -5,6 +5,16 @@ import { SpamTrapPage } from '../SpamTrapPage';
 describe('Signals Spam Trap Page', () => {
   let wrapper;
   let props;
+  const data = [
+    {
+      date: '2017-01-01',
+      relative_trap_hits: 0.1
+    },
+    {
+      date: '2017-01-02',
+      relative_trap_hits: 0.5
+    }
+  ];
 
   beforeEach(() => {
     props = {
@@ -14,9 +24,11 @@ describe('Signals Spam Trap Page', () => {
       gap: 0.25,
       loading: false,
       empty: false,
+      selected: '2017-01-01',
       xTicks: []
     };
     wrapper = shallow(<SpamTrapPage {...props}/>);
+    wrapper.setProps({ data });
   });
 
   it('renders correctly', () => {
@@ -43,6 +55,32 @@ describe('Signals Spam Trap Page', () => {
       const calculation = shallow(wrapper.find('ChartHeader').props().primaryArea);
       calculation.simulate('change', 'relative');
       expect(wrapper.find('BarChart').prop('yKey')).toEqual('relative_trap_hits');
+    });
+
+    it('handles date select', () => {
+      wrapper.find('BarChart').simulate('click', { payload: { date: '2017-01-02' }});
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('2017-01-02');
+      expect(wrapper.find('SpamTrapActions')).toMatchSnapshot();
+    });
+
+    it('sets selected date on mount if provided one', () => {
+      wrapper = shallow(<SpamTrapPage {...props} selected='initial-selected'/>);
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('initial-selected');
+      expect(wrapper.find('SpamTrapActions').prop('date')).toEqual('initial-selected');
+    });
+
+    it('uses last selected date if selected date is not in data', () => {
+      wrapper = shallow(<SpamTrapPage {...props} loading={true} selected='initial-selected'/>);
+      wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('last-date');
+      expect(wrapper.find('SpamTrapActions').prop('date')).toEqual('last-date');
+    });
+
+    it('does not use last selected date if selected date is in data', () => {
+      wrapper = shallow(<SpamTrapPage {...props} selected='first-date'/>);
+      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
+      expect(wrapper.find('BarChart').prop('selected')).toEqual('first-date');
+      expect(wrapper.find('SpamTrapActions').prop('date')).toEqual('first-date');
     });
   });
 

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -50,6 +50,18 @@ exports[`Signals Engagement Recency Page bar chart props renders tooltip content
 </Fragment>
 `;
 
+exports[`Signals Engagement Recency Page local state handles date select 1`] = `
+<EngagementRecencyActions
+  cohorts={
+    Object {
+      "c_total": 10,
+      "date": "2017-01-02",
+    }
+  }
+  date="2017-01-02"
+/>
+`;
+
 exports[`Signals Engagement Recency Page renders correctly 1`] = `
 <SignalsPage
   breadcrumbAction={
@@ -94,10 +106,17 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
                 "top": 12,
               }
             }
+            onClick={[Function]}
+            selected="2017-01-02"
             timeSeries={
               Array [
                 Object {
+                  "c_total": 1,
+                  "date": "2017-01-01",
+                },
+                Object {
                   "c_total": 10,
+                  "date": "2017-01-02",
                 },
               ]
             }
@@ -219,8 +238,10 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
           cohorts={
             Object {
               "c_total": 10,
+              "date": "2017-01-02",
             }
           }
+          date="2017-01-02"
         />
       </div>
     </Grid.Column>

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -37,6 +37,26 @@ exports[`Signals Health Score Page bar chart props renders tooltip content for s
 
 exports[`Signals Health Score Page bar chart props renders y label content for component weights 1`] = `"Engaged Recipients"`;
 
+exports[`Signals Health Score Page local state handles date select 1`] = `
+<HealthScoreActions
+  date="2017-01-02"
+  weights={
+    Array [
+      Object {
+        "weight": 0.8,
+        "weight_type": "List Quality",
+        "weight_value": 0.25,
+      },
+      Object {
+        "weight": -0.8,
+        "weight_type": "Other bounces",
+        "weight_value": 0.25,
+      },
+    ]
+  }
+/>
+`;
+
 exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
 <SignalsPage
   breadcrumbAction={
@@ -276,6 +296,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
         className="OffsetCol"
       >
         <ChartHeader
+          date="2017-01-01"
           hideLine={true}
           padding="1rem 0 1rem"
           title="Health Score Components"
@@ -317,16 +338,17 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
           yLabel={[Function]}
         />
         <HealthScoreActions
+          date="2017-01-01"
           weights={
             Array [
               Object {
-                "weight": 0.8,
-                "weight_type": "List Quality",
+                "weight": 0.5,
+                "weight_type": "Hard Bounces",
                 "weight_value": 0.25,
               },
               Object {
-                "weight": -0.8,
-                "weight_type": "Other bounces",
+                "weight": -0.5,
+                "weight_type": "Complaints",
                 "weight_value": 0.25,
               },
             ]
@@ -509,6 +531,7 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
         className="OffsetCol"
       >
         <ChartHeader
+          date="2017-01-01"
           hideLine={true}
           padding="1rem 0 1rem"
           title="Health Score Components"
@@ -520,7 +543,10 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
         <Callout>
           Insufficient data to populate this chart
         </Callout>
-        <HealthScoreActions />
+        <HealthScoreActions
+          date="2017-01-01"
+          weights={Array []}
+        />
       </div>
     </Grid.Column>
   </Grid>
@@ -591,6 +617,7 @@ exports[`Signals Health Score Page renders error correctly 1`] = `
         className="OffsetCol"
       >
         <ChartHeader
+          date="2017-01-01"
           hideLine={true}
           padding="1rem 0 1rem"
           title="Health Score Components"

--- a/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
@@ -24,6 +24,13 @@ exports[`Signals Spam Trap Page bar chart props renders tooltip content 1`] = `
 </Fragment>
 `;
 
+exports[`Signals Spam Trap Page local state handles date select 1`] = `
+<SpamTrapActions
+  date="2017-01-02"
+  percent={0.5}
+/>
+`;
+
 exports[`Signals Spam Trap Page renders correctly 1`] = `
 <SignalsPage
   breadcrumbAction={
@@ -71,10 +78,17 @@ exports[`Signals Spam Trap Page renders correctly 1`] = `
               "top": 12,
             }
           }
+          onClick={[Function]}
+          selected="2017-01-01"
           timeSeries={
             Array [
               Object {
+                "date": "2017-01-01",
                 "relative_trap_hits": 0.1,
+              },
+              Object {
+                "date": "2017-01-02",
+                "relative_trap_hits": 0.5,
               },
             ]
           }
@@ -115,6 +129,7 @@ exports[`Signals Spam Trap Page renders correctly 1`] = `
         className="OffsetCol"
       >
         <SpamTrapActions
+          date="2017-01-01"
           percent={0.1}
         />
       </div>


### PR DESCRIPTION
This PR:
-  Adds day selection into the engagement recency and spam trap details pages. Similar to day selection in health score.
- Displays recommended actions based on the day selected on all details pages

--- 

Difficult to verify locally / staging. I can provide reviewer with a way to view some data.