### PR TITLE
EO-575 Add Eng Rec tooltip descriptions, Move NEW cohort

### DIFF
--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -86,6 +86,7 @@ export class EngagementRecencyPage extends Component {
                   gap={gap}
                   timeSeries={data}
                   tooltipContent={this.getTooltipContent}
+                  tooltipWidth='250px'
                   yKeys={_.keys(cohorts).map((key) => ({ key, ...cohorts[key] })).reverse()}
                   yAxisProps={this.getYAxisProps()}
                   xAxisProps={this.getXAxisProps()}

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -45,6 +45,7 @@ export class EngagementRecencyPage extends Component {
           key={key}
           color={cohorts[key].fill}
           label={cohorts[key].label}
+          description={cohorts[key].description}
           value={`${roundToPlaces(payload[key] * 100, 1)}%`}
         />
       ))}

--- a/src/pages/signals/components/charts/barchart/BarChart.js
+++ b/src/pages/signals/components/charts/barchart/BarChart.js
@@ -63,7 +63,7 @@ class BarChart extends Component {
   }
 
   render() {
-    const { gap, height, disableHover, margin, timeSeries, tooltipContent, width, xKey, xAxisProps, yDomain, yAxisProps } = this.props;
+    const { gap, height, disableHover, margin, timeSeries, tooltipContent, tooltipWidth, width, xKey, xAxisProps, yDomain, yAxisProps } = this.props;
 
     return (
       <ResponsiveContainer height={height} width={width} className='SignalsBarChart'>
@@ -101,6 +101,7 @@ class BarChart extends Component {
               cursor={false}
               isAnimationActive={false}
               content={<TooltipWrapper children={tooltipContent} />}
+              width={tooltipWidth}
             />
           )}
           {this.renderBars()}
@@ -115,6 +116,7 @@ BarChart.propTypes = {
   gap: PropTypes.number,
   onClick: PropTypes.func,
   tooltipContent: PropTypes.func,
+  tooltipWidth: PropTypes.string,
   yKeys: PropTypes.arrayOf(PropTypes.object)
 };
 

--- a/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
+++ b/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
@@ -128,7 +128,9 @@ exports[`BarChart Component renders a normal bar chart correctly 1`] = `
       animationDuration={400}
       animationEasing="ease"
       content={
-        <Tooltip>
+        <Tooltip
+          width="200px"
+        >
           [MockFunction]
         </Tooltip>
       }

--- a/src/pages/signals/components/charts/divergingBar/tests/__snapshots__/DivergingBar.test.js.snap
+++ b/src/pages/signals/components/charts/divergingBar/tests/__snapshots__/DivergingBar.test.js.snap
@@ -137,7 +137,9 @@ exports[`DivergingBar Component renders correctly 1`] = `
       animationDuration={400}
       animationEasing="ease"
       content={
-        <Tooltip>
+        <Tooltip
+          width="200px"
+        >
           [MockFunction]
         </Tooltip>
       }

--- a/src/pages/signals/components/charts/horizontalbar/tests/__snapshots__/HorizontalBar.test.js.snap
+++ b/src/pages/signals/components/charts/horizontalbar/tests/__snapshots__/HorizontalBar.test.js.snap
@@ -112,7 +112,9 @@ exports[`HorizontalBar Component renders correctly 1`] = `
         animationDuration={400}
         animationEasing="ease"
         content={
-          <Tooltip>
+          <Tooltip
+            width="200px"
+          >
             [MockFunction]
           </Tooltip>
         }

--- a/src/pages/signals/components/charts/sparkline/tests/__snapshots__/Sparkline.test.js.snap
+++ b/src/pages/signals/components/charts/sparkline/tests/__snapshots__/Sparkline.test.js.snap
@@ -93,7 +93,9 @@ exports[`Sparkline Component renders correctly 1`] = `
         animationDuration={400}
         animationEasing="ease"
         content={
-          <Tooltip>
+          <Tooltip
+            width="200px"
+          >
             [MockFunction]
           </Tooltip>
         }

--- a/src/pages/signals/components/charts/tooltip/Tooltip.js
+++ b/src/pages/signals/components/charts/tooltip/Tooltip.js
@@ -5,12 +5,12 @@ import styles from './Tooltip.module.scss';
 import _ from 'lodash';
 import './Tooltip.scss';
 
-const Tooltip = ({ children, ...props }) => {
+const Tooltip = ({ children, width, ...props }) => {
   const content = _.get(props, 'payload[0]', {});
   const date = _.get(content, 'payload.date');
 
   return (
-    <div className={styles.TooltipWrapper}>
+    <div className={styles.TooltipWrapper} style={{ width }}>
       {date && (
         <div className={styles.TooltipDate}>
           {formatDate(date)}
@@ -26,11 +26,13 @@ const Tooltip = ({ children, ...props }) => {
 const defaultChildren = ({ value }) => value;
 
 Tooltip.propTypes = {
-  children: PropTypes.func
+  children: PropTypes.func,
+  width: PropTypes.string
 };
 
 Tooltip.defaultProps = {
-  children: defaultChildren
+  children: defaultChildren,
+  width: '200px'
 };
 
 export default Tooltip;

--- a/src/pages/signals/components/charts/tooltip/Tooltip.module.scss
+++ b/src/pages/signals/components/charts/tooltip/Tooltip.module.scss
@@ -4,7 +4,6 @@
   background: color(gray, 1);
   box-shadow: shadow(deep);
   border-radius: border-radius(large);
-  width: 250px;
   user-select: none;
 }
 

--- a/src/pages/signals/components/charts/tooltip/Tooltip.module.scss
+++ b/src/pages/signals/components/charts/tooltip/Tooltip.module.scss
@@ -4,12 +4,12 @@
   background: color(gray, 1);
   box-shadow: shadow(deep);
   border-radius: border-radius(large);
-  width: 200px;
+  width: 250px;
   user-select: none;
 }
 
 .TooltipDate, .TooltipContent {
-  padding: spacing(small) spacing();
+  padding: rem(9) rem(13);
   color: color(gray, 10);
 }
 

--- a/src/pages/signals/components/charts/tooltip/TooltipMetric.js
+++ b/src/pages/signals/components/charts/tooltip/TooltipMetric.js
@@ -1,12 +1,14 @@
 import React from 'react';
+import classnames from 'classnames';
 import styles from './TooltipMetric.module.scss';
 
-const TooltipMetric = ({ label, value, color = '#6e6e73' }) => (
+const TooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
   <div className={styles.Wrapper}>
     <div className={styles.TooltipMetric}>
       <div style={{ background: color }} className={styles.Color} />
-      <div className={styles.Content}>
+      <div className={classnames(styles.Content, description && styles.hasDescription)}>
         <div className={styles.Label}>{label}</div>
+        {description && <div className={styles.Description}>{description}</div>}
         <div className={styles.Value}>{value}</div>
       </div>
     </div>

--- a/src/pages/signals/components/charts/tooltip/TooltipMetric.module.scss
+++ b/src/pages/signals/components/charts/tooltip/TooltipMetric.module.scss
@@ -6,16 +6,15 @@
   display: inline-block;
   width: 100%;
   height: rem(50);
-  margin-top: spacing(small);
+
+  &:not(:last-child) {
+    margin-bottom: spacing();
+  }
 }
 
 .TooltipMetric {
   display: flex;
   justify-content: flex-start;
-}
-
-.Content {
-  flex: 1 0 0;
 }
 
 .Color {
@@ -27,12 +26,32 @@
   background: red;
 }
 
+.Content {
+  flex: 1 0 0;
+  display: flex;
+  height: rem(50);
+  flex-direction: column;
+  justify-content: space-around;
+}
+
+.hasDescription {
+  justify-content: space-between;
+}
+
 .Label {
   font-size: rem(12);
   font-weight: 400;
+  line-height: 0.8em;
+}
+
+.Description {
+  font-size: rem(11);
+  line-height: 1em;
+  color: rgba(color(gray, 5), 0.8)
 }
 
 .Value {
   font-size: rem(22);
   font-weight: 500;
+  line-height: 0.7em;
 }

--- a/src/pages/signals/components/charts/tooltip/tests/Tooltip.test.js
+++ b/src/pages/signals/components/charts/tooltip/tests/Tooltip.test.js
@@ -32,4 +32,9 @@ describe('Signals Tooltip Component', () => {
     wrapper.setProps({ children: () => 'test' });
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('renders with a custom width correctly', () => {
+    wrapper.setProps({ width: '1200px' });
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/pages/signals/components/charts/tooltip/tests/TooltipMetric.test.js
+++ b/src/pages/signals/components/charts/tooltip/tests/TooltipMetric.test.js
@@ -22,4 +22,9 @@ describe('Signals TooltipMetric Component', () => {
     wrapper.setProps({ color: '#abc' });
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('renders correctly with description', () => {
+    wrapper.setProps({ description: 'lorem ipsum dolor' });
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/pages/signals/components/charts/tooltip/tests/__snapshots__/Tooltip.test.js.snap
+++ b/src/pages/signals/components/charts/tooltip/tests/__snapshots__/Tooltip.test.js.snap
@@ -3,6 +3,11 @@
 exports[`Signals Tooltip Component renders children correctly 1`] = `
 <div
   className="TooltipWrapper"
+  style={
+    Object {
+      "width": "200px",
+    }
+  }
 >
   <div
     className="TooltipDate"
@@ -20,6 +25,11 @@ exports[`Signals Tooltip Component renders children correctly 1`] = `
 exports[`Signals Tooltip Component renders correctly with default children 1`] = `
 <div
   className="TooltipWrapper"
+  style={
+    Object {
+      "width": "200px",
+    }
+  }
 >
   <div
     className="TooltipDate"
@@ -37,9 +47,36 @@ exports[`Signals Tooltip Component renders correctly with default children 1`] =
 exports[`Signals Tooltip Component renders correctly without date 1`] = `
 <div
   className="TooltipWrapper"
+  style={
+    Object {
+      "width": "200px",
+    }
+  }
 >
   <div
     className="TooltipContent"
   />
+</div>
+`;
+
+exports[`Signals Tooltip Component renders with a custom width correctly 1`] = `
+<div
+  className="TooltipWrapper"
+  style={
+    Object {
+      "width": "1200px",
+    }
+  }
+>
+  <div
+    className="TooltipDate"
+  >
+    Jan 1 2010
+  </div>
+  <div
+    className="TooltipContent"
+  >
+    1
+  </div>
 </div>
 `;

--- a/src/pages/signals/components/charts/tooltip/tests/__snapshots__/TooltipMetric.test.js.snap
+++ b/src/pages/signals/components/charts/tooltip/tests/__snapshots__/TooltipMetric.test.js.snap
@@ -65,3 +65,41 @@ exports[`Signals TooltipMetric Component renders correctly with color 1`] = `
   </div>
 </div>
 `;
+
+exports[`Signals TooltipMetric Component renders correctly with description 1`] = `
+<div
+  className="Wrapper"
+>
+  <div
+    className="TooltipMetric"
+  >
+    <div
+      className="Color"
+      style={
+        Object {
+          "background": "#6e6e73",
+        }
+      }
+    />
+    <div
+      className="Content hasDescription"
+    >
+      <div
+        className="Label"
+      >
+        Foo
+      </div>
+      <div
+        className="Description"
+      >
+        lorem ipsum dolor
+      </div>
+      <div
+        className="Value"
+      >
+        101
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
@@ -63,29 +63,34 @@ exports[`Signals EngagementRecencyPreview Component renders correctly 1`] = `
         yKeys={
           Array [
             Object {
+              "description": "0-14 days since last engagement",
               "fill": "#3F8B93",
-              "key": "c_new",
-              "label": "New",
-            },
-            Object {
-              "fill": "#44A8AD",
               "key": "c_14d",
               "label": "Recently Engaged",
             },
             Object {
-              "fill": "#9AD8E3",
+              "description": "14-90 days since last engagement",
+              "fill": "#44A8AD",
               "key": "c_90d",
               "label": "Semi Recently Engaged",
             },
             Object {
-              "fill": "#B9E2E9",
+              "description": "90-365 days since last engagement",
+              "fill": "#9AD8E3",
               "key": "c_365d",
               "label": "Not Recently Engaged",
             },
             Object {
-              "fill": "#E4EEF0",
+              "description": "365+ days since last engagement",
+              "fill": "#B9E2E9",
               "key": "c_uneng",
               "label": "Never Engaged",
+            },
+            Object {
+              "description": "Never engaged, first email in last 7 days",
+              "fill": "#E4EEF0",
+              "key": "c_new",
+              "label": "New",
             },
           ]
         }

--- a/src/pages/signals/constants/cohorts.js
+++ b/src/pages/signals/constants/cohorts.js
@@ -1,27 +1,27 @@
 export default {
-  c_uneng: {
+  c_new: {
     fill: '#E4EEF0',
+    label: 'New',
+    description: 'Never engaged, first email in last 7 days'
+  },
+  c_uneng: {
+    fill: '#B9E2E9',
     label: 'Never Engaged',
     description: '365+ days since last engagement'
   },
   c_365d: {
-    fill: '#B9E2E9',
+    fill: '#9AD8E3',
     label: 'Not Recently Engaged',
-    description: '90 to 365 days since last engagement'
+    description: '90-365 days since last engagement'
   },
   c_90d: {
-    fill: '#9AD8E3',
+    fill: '#44A8AD',
     label: 'Semi Recently Engaged',
-    description: '14 to 90 days since last engagement'
+    description: '14-90 days since last engagement'
   },
   c_14d: {
-    fill: '#44A8AD',
-    label: 'Recently Engaged',
-    description: '0 to 14 days since last engagement'
-  },
-  c_new: {
     fill: '#3F8B93',
-    label: 'New',
-    description: 'Never engaged, first email in last 7 days'
+    label: 'Recently Engaged',
+    description: '0-14 days since last engagement'
   }
 };

--- a/src/pages/signals/constants/cohorts.js
+++ b/src/pages/signals/constants/cohorts.js
@@ -1,7 +1,27 @@
 export default {
-  c_uneng: { fill: '#E4EEF0', label: 'Never Engaged' },
-  c_365d: { fill: '#B9E2E9', label: 'Not Recently Engaged' },
-  c_90d: { fill: '#9AD8E3', label: 'Semi Recently Engaged' },
-  c_14d: { fill: '#44A8AD', label: 'Recently Engaged' },
-  c_new: { fill: '#3F8B93', label: 'New' }
+  c_uneng: {
+    fill: '#E4EEF0',
+    label: 'Never Engaged',
+    description: '365+ days since last engagement'
+  },
+  c_365d: {
+    fill: '#B9E2E9',
+    label: 'Not Recently Engaged',
+    description: '90 to 365 days since last engagement'
+  },
+  c_90d: {
+    fill: '#9AD8E3',
+    label: 'Semi Recently Engaged',
+    description: '14 to 90 days since last engagement'
+  },
+  c_14d: {
+    fill: '#44A8AD',
+    label: 'Recently Engaged',
+    description: '0 to 14 days since last engagement'
+  },
+  c_new: {
+    fill: '#3F8B93',
+    label: 'New',
+    description: 'Never engaged, first email in last 7 days'
+  }
 };

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -102,6 +102,7 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
               ]
             }
             tooltipContent={[Function]}
+            tooltipWidth="250px"
             width="99%"
             xAxisProps={
               Object {

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -14,33 +14,38 @@ exports[`Signals Engagement Recency Page bar chart props renders tooltip content
 <Fragment>
   <TooltipMetric
     color="#E4EEF0"
+    description="Never engaged, first email in last 7 days"
+    key="c_new"
+    label="New"
+    value="50%"
+  />
+  <TooltipMetric
+    color="#B9E2E9"
+    description="365+ days since last engagement"
     key="c_uneng"
     label="Never Engaged"
     value="10%"
   />
   <TooltipMetric
-    color="#B9E2E9"
+    color="#9AD8E3"
+    description="90-365 days since last engagement"
     key="c_365d"
     label="Not Recently Engaged"
     value="20%"
   />
   <TooltipMetric
-    color="#9AD8E3"
+    color="#44A8AD"
+    description="14-90 days since last engagement"
     key="c_90d"
     label="Semi Recently Engaged"
     value="30%"
   />
   <TooltipMetric
-    color="#44A8AD"
+    color="#3F8B93"
+    description="0-14 days since last engagement"
     key="c_14d"
     label="Recently Engaged"
     value="40%"
-  />
-  <TooltipMetric
-    color="#3F8B93"
-    key="c_new"
-    label="New"
-    value="50%"
   />
 </Fragment>
 `;
@@ -128,29 +133,34 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
             yKeys={
               Array [
                 Object {
+                  "description": "0-14 days since last engagement",
                   "fill": "#3F8B93",
-                  "key": "c_new",
-                  "label": "New",
-                },
-                Object {
-                  "fill": "#44A8AD",
                   "key": "c_14d",
                   "label": "Recently Engaged",
                 },
                 Object {
-                  "fill": "#9AD8E3",
+                  "description": "14-90 days since last engagement",
+                  "fill": "#44A8AD",
                   "key": "c_90d",
                   "label": "Semi Recently Engaged",
                 },
                 Object {
-                  "fill": "#B9E2E9",
+                  "description": "90-365 days since last engagement",
+                  "fill": "#9AD8E3",
                   "key": "c_365d",
                   "label": "Not Recently Engaged",
                 },
                 Object {
-                  "fill": "#E4EEF0",
+                  "description": "365+ days since last engagement",
+                  "fill": "#B9E2E9",
                   "key": "c_uneng",
                   "label": "Never Engaged",
+                },
+                Object {
+                  "description": "Never engaged, first email in last 7 days",
+                  "fill": "#E4EEF0",
+                  "key": "c_new",
+                  "label": "New",
                 },
               ]
             }
@@ -165,24 +175,29 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
             items={
               Array [
                 Object {
+                  "description": "Never engaged, first email in last 7 days",
                   "fill": "#E4EEF0",
+                  "label": "New",
+                },
+                Object {
+                  "description": "365+ days since last engagement",
+                  "fill": "#B9E2E9",
                   "label": "Never Engaged",
                 },
                 Object {
-                  "fill": "#B9E2E9",
+                  "description": "90-365 days since last engagement",
+                  "fill": "#9AD8E3",
                   "label": "Not Recently Engaged",
                 },
                 Object {
-                  "fill": "#9AD8E3",
+                  "description": "14-90 days since last engagement",
+                  "fill": "#44A8AD",
                   "label": "Semi Recently Engaged",
                 },
                 Object {
-                  "fill": "#44A8AD",
-                  "label": "Recently Engaged",
-                },
-                Object {
+                  "description": "0-14 days since last engagement",
                   "fill": "#3F8B93",
-                  "label": "New",
+                  "label": "Recently Engaged",
                 },
               ]
             }


### PR DESCRIPTION
This PR:
- Adds in cohort `description`s into the tooltips
- Makes tooltip width configurable
- Moves the `new` cohort to the top of the graph to better illustrate its 'badness'

--- 

Difficult to verify locally / staging. I can provide reviewer with a way to view some data.