### PR TITLE
EO-581 Display subaccount when viewing subaccount only data

### DIFF
--- a/src/helpers/signals.js
+++ b/src/helpers/signals.js
@@ -1,17 +1,30 @@
-export const getFriendlyTitle = ({ prefix, facet, facetId }) => {
+import _ from 'lodash';
+
+const translateSubaccount = (id) => {
+  // Note: Subaccount -1 (aggregate of all subaccounts) does not have a details Page
+
+  if (String(id) === '0') {
+    return 'Master Account';
+  }
+
+  return `Subaccount ${id}`;
+};
+
+export const getFriendlyTitle = ({ prefix, facet, facetId, subaccountId }) => {
   if (!prefix) {
     return null;
   }
 
   let subtitle = `${prefix} ${facetId}`;
+  let suffix = '';
 
   if (facet === 'sid') {
-    subtitle = `${prefix} Subaccount ${facetId}`;
-
-    if (String(facetId) === '0') {
-      subtitle = `${prefix} Master Account`;
-    }
+    subtitle = `${prefix} ${translateSubaccount(facetId)}`;
   }
 
-  return subtitle;
+  if (!_.isNil(subaccountId)) {
+    suffix = ` (${translateSubaccount(subaccountId)})`;
+  }
+
+  return `${subtitle}${suffix}`;
 };

--- a/src/helpers/tests/signals.test.js
+++ b/src/helpers/tests/signals.test.js
@@ -32,4 +32,22 @@ describe('.getFriendlyTitle', () => {
       facetId: 0
     })).toEqual('title for Master Account');
   });
+
+  it('returns correct suffix with a facet and non-master subaccount', () => {
+    expect(getFriendlyTitle({
+      prefix: 'title for',
+      facet: 'facet',
+      facetId: 'facetId',
+      subaccountId: 23
+    })).toEqual('title for facetId (Subaccount 23)');
+  });
+
+  it('returns correct suffix with a facet and master subaccount', () => {
+    expect(getFriendlyTitle({
+      prefix: 'title for',
+      facet: 'facet',
+      facetId: 'facetId',
+      subaccountId: 0
+    })).toEqual('title for facetId (Master Account)');
+  });
 });

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -107,7 +107,7 @@ export class EngagementRecencyPage extends Component {
   }
 
   render() {
-    const { facet, facetId } = this.props;
+    const { facet, facetId, subaccountId } = this.props;
 
     return (
       <Page
@@ -115,6 +115,7 @@ export class EngagementRecencyPage extends Component {
         dimensionPrefix='Engagement Recency for'
         facet={facet}
         facetId={facetId}
+        subaccountId={subaccountId}
         primaryArea={<DateFilter />}>
         {this.renderContent()}
         <OtherChartsHeader facet={facet} facetId={facetId} />

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -118,7 +118,7 @@ export class EngagementRecencyPage extends Component {
         subaccountId={subaccountId}
         primaryArea={<DateFilter />}>
         {this.renderContent()}
-        <OtherChartsHeader facet={facet} facetId={facetId} />
+        <OtherChartsHeader facet={facet} facetId={facetId} subaccountId={subaccountId} />
         <Grid>
           <Grid.Column xs={12} sm={6}>
             <SpamTrapsPreview />

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -190,7 +190,7 @@ export class HealthScorePage extends Component {
   }
 
   render() {
-    const { facet, facetId } = this.props;
+    const { facet, facetId, subaccountId } = this.props;
 
     return (
       <Page
@@ -198,6 +198,7 @@ export class HealthScorePage extends Component {
         dimensionPrefix='Health Score for'
         facet={facet}
         facetId={facetId}
+        subaccountId={subaccountId}
         primaryArea={<DateFilter />}>
         {this.renderContent()}
         <OtherChartsHeader facet={facet} facetId={facetId} />

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -201,7 +201,7 @@ export class HealthScorePage extends Component {
         subaccountId={subaccountId}
         primaryArea={<DateFilter />}>
         {this.renderContent()}
-        <OtherChartsHeader facet={facet} facetId={facetId} />
+        <OtherChartsHeader facet={facet} facetId={facetId} subaccountId={subaccountId} />
         <Grid>
           <Grid.Column xs={12} sm={6}>
             <SpamTrapsPreview />

--- a/src/pages/signals/SpamTrapPage.js
+++ b/src/pages/signals/SpamTrapPage.js
@@ -125,7 +125,7 @@ export class SpamTrapPage extends Component {
         subaccountId={subaccountId}
         primaryArea={<DateFilter />}>
         {this.renderContent()}
-        <OtherChartsHeader facet={facet} facetId={facetId} />
+        <OtherChartsHeader facet={facet} facetId={facetId} subaccountId={subaccountId} />
         <Grid>
           <Grid.Column xs={12} sm={6}>
             <EngagementRecencyPreview />

--- a/src/pages/signals/SpamTrapPage.js
+++ b/src/pages/signals/SpamTrapPage.js
@@ -114,14 +114,15 @@ export class SpamTrapPage extends Component {
   }
 
   render() {
-    const { facet, facetId } = this.props;
+    const { facet, facetId, subaccountId } = this.props;
 
     return (
       <Page
         breadcrumbAction={{ content: 'Back to Overview', to: '/signals', component: Link }}
-        dimensionPrefix='Spam Trap Monitoring for'
+        dimensionPrefix='Spam Traps for'
         facet={facet}
         facetId={facetId}
+        subaccountId={subaccountId}
         primaryArea={<DateFilter />}>
         {this.renderContent()}
         <OtherChartsHeader facet={facet} facetId={facetId} />

--- a/src/pages/signals/components/OtherChartsHeader.js
+++ b/src/pages/signals/components/OtherChartsHeader.js
@@ -2,13 +2,14 @@ import React, { Fragment } from 'react';
 import { getFriendlyTitle } from 'src/helpers/signals';
 import styles from './OtherChartsHeader.module.scss';
 
-const OtherChartsHeader = ({ facet, facetId }) => (
+const OtherChartsHeader = ({ facet, facetId, subaccountId }) => (
   <Fragment>
     <h2 className={styles.Header}>
       {getFriendlyTitle({
         prefix: 'Other charts for',
         facet,
-        facetId
+        facetId,
+        subaccountId
       })}
     </h2>
     <hr className={styles.Line} />

--- a/src/pages/signals/components/SignalsPage.js
+++ b/src/pages/signals/components/SignalsPage.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { Page } from '@sparkpost/matchbox';
 import { getFriendlyTitle } from 'src/helpers/signals';
 
-const SignalsPage = ({ dimensionPrefix, facet, facetId, title = 'Signals', ...props }) => (
+const SignalsPage = ({ dimensionPrefix, facet, facetId, subaccountId, title = 'Signals', ...props }) => (
   <Page
     {...props}
     title={title}
-    subtitle={getFriendlyTitle({ prefix: dimensionPrefix, facet, facetId })}
+    subtitle={getFriendlyTitle({ prefix: dimensionPrefix, facet, facetId, subaccountId })}
   />
 );
 

--- a/src/pages/signals/components/tests/OtherChartsHeader.test.js
+++ b/src/pages/signals/components/tests/OtherChartsHeader.test.js
@@ -9,7 +9,8 @@ describe('Signals OtherChartsHeader Component', () => {
   beforeEach(() => {
     props = {
       facet: 'facet',
-      facetId: 'Foo1'
+      facetId: 'Foo1',
+      subaccountId: 22
     };
     wrapper = shallow(<OtherChartsHeader {...props}/>);
   });

--- a/src/pages/signals/components/tests/SignalsPage.test.js
+++ b/src/pages/signals/components/tests/SignalsPage.test.js
@@ -14,7 +14,8 @@ describe('Signals Page Component', () => {
       pass: 'through',
       facet: 'facet',
       facetId: 'facetId',
-      dimensionPrefix: 'test prefix'
+      dimensionPrefix: 'test prefix',
+      subaccountId: 22
     };
     helpers.getFriendlyTitle = jest.fn();
     wrapper = shallow(<SignalsPage {...props}/>);
@@ -22,7 +23,7 @@ describe('Signals Page Component', () => {
 
   it('renders correctly with title', () => {
     expect(wrapper).toMatchSnapshot();
-    expect(helpers.getFriendlyTitle).toHaveBeenCalledWith({ facet: 'facet', facetId: 'facetId', prefix: 'test prefix' });
+    expect(helpers.getFriendlyTitle).toHaveBeenCalledWith({ facet: 'facet', facetId: 'facetId', prefix: 'test prefix', subaccountId: 22 });
   });
 
   it('renders with default title', () => {

--- a/src/pages/signals/components/tests/__snapshots__/OtherChartsHeader.test.js.snap
+++ b/src/pages/signals/components/tests/__snapshots__/OtherChartsHeader.test.js.snap
@@ -5,7 +5,7 @@ exports[`Signals OtherChartsHeader Component renders correctly 1`] = `
   <h2
     className="Header"
   >
-    Other charts for Foo1
+    Other charts for Foo1 (Subaccount 22)
   </h2>
   <hr
     className="Line"

--- a/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
@@ -33,7 +33,7 @@ exports[`Signals Spam Trap Page renders correctly 1`] = `
       "to": "/signals",
     }
   }
-  dimensionPrefix="Spam Trap Monitoring for"
+  dimensionPrefix="Spam Traps for"
   facet="sending-domain"
   facetId="test.com"
   primaryArea={<Connect(DateFilter) />}
@@ -175,7 +175,7 @@ exports[`Signals Spam Trap Page renders error correctly 1`] = `
       "to": "/signals",
     }
   }
-  dimensionPrefix="Spam Trap Monitoring for"
+  dimensionPrefix="Spam Traps for"
   facet="sending-domain"
   facetId="test.com"
   primaryArea={<Connect(DateFilter) />}


### PR DESCRIPTION
This PR:
- Appends either `subaccount ID` or `master account` to all Signals details page titles when viewing data pertaining to a single subaccount