### PR TITLE
FE-617: List page pattern

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,9 @@
+<script>
+console.log('manager-head')
+  document.addEventListener('DOMContentLoaded', function() {
+    // Modals need this portal element in place _before_ they render.
+    var modalPortal = document.createElement('div');
+    modalPortal.id = 'modal-portal';
+    document.body.appendChild(modalPortal);
+  });
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7650,6 +7650,11 @@
       "integrity": "sha512-qxUOHr5mTaadWH1ap0ueivHd8x42Bnemcn+JutVr7GWmm2bU4zoBhjuv5QdXgALQnnT626lOQros7cCDf8PwCg==",
       "dev": true
     },
+    "capitalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-2.0.0.tgz",
+      "integrity": "sha512-HwGrAbSn44Tm5Nz+m02oQHf+9y771rmb/cTbXFcoADy29LFRCj4PhWBT54qxfY2HJBWBplwx17Pd4ek6OFbr/Q=="
+    },
     "capture-exit": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
@@ -12671,7 +12676,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12692,12 +12698,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12712,17 +12720,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12839,7 +12850,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12851,6 +12863,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12865,6 +12878,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12872,12 +12886,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12896,6 +12912,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12976,7 +12993,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12988,6 +13006,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13073,7 +13092,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13109,6 +13129,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13128,6 +13149,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13171,12 +13193,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@sparkpost/matchbox-icons": "^1.1.5",
     "axios": "^0.18.0",
     "bowser": "2.1.0",
+    "capitalize": "^2.0.0",
     "classnames": "^2.2.5",
     "color": "^3.0.0",
     "copy-to-clipboard": "^3.0.8",

--- a/src/components/actionPopover/ActionPopover.js
+++ b/src/components/actionPopover/ActionPopover.js
@@ -8,4 +8,8 @@ const ActionPopover = ({ actions }) => (
   </Popover>
 );
 
+ActionPopover.propTypes = {
+  actions: ActionList.propTypes.actions
+};
+
 export default ActionPopover;

--- a/src/components/listPage/Actions.js
+++ b/src/components/listPage/Actions.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import PageLink from 'src/components/pageLink';
+import { ActionPopover } from 'src/components';
+
+const Actions = ({ item, editRoute, deletable, onDelete, customActions }) => {
+  const baseActions = [
+    editRoute && {
+      component: PageLink,
+      content: 'Edit',
+      to: editRoute
+    },
+    deletable && {
+      content: 'Delete',
+      onClick: () => onDelete(item)
+    }
+  ].filter(Boolean);
+
+  const actions = [...baseActions, ...customActions];
+  return <ActionPopover actions={actions} />;
+};
+
+Actions.propTypes = {
+  item: propTypes.object.isRequired,
+  onDelete: propTypes.func,
+  editRoute: propTypes.string,
+  deletable: propTypes.bool,
+  customActions: ActionPopover.propTypes.actions
+};
+
+Actions.defaultProps = {
+  customActions: []
+};
+
+export default Actions;

--- a/src/components/listPage/ListPage.js
+++ b/src/components/listPage/ListPage.js
@@ -32,8 +32,8 @@ class ListPage extends React.Component {
     const { onDelete } = this.props;
     const { itemToDelete } = this.state;
 
-    this.setState(DEFAULT_STATE, () => {
-      onDelete(itemToDelete);
+    onDelete(itemToDelete).then(() => {
+      this.setState(DEFAULT_STATE);
     });
   };
 

--- a/src/components/listPage/ListPage.js
+++ b/src/components/listPage/ListPage.js
@@ -108,8 +108,7 @@ class ListPage extends React.Component {
     const { itemToDelete } = this.state;
     const {
       noun,
-      primaryActionTitle,
-      onCreate,
+      primaryAction,
       loading,
       error,
       banner,
@@ -117,9 +116,9 @@ class ListPage extends React.Component {
       additionalActions
     } = this.props;
     const capsNoun = capitalize(noun);
-    const primaryAction = onCreate && {
-      content: primaryActionTitle || `Create ${capsNoun}`,
-      onClick: onCreate
+    const primaryActionProp = {
+      content: `Create ${capsNoun}`,
+      ...primaryAction
     };
 
     if (loading) {
@@ -131,7 +130,7 @@ class ListPage extends React.Component {
     return (
       <Page
         title={`${capsNoun}s`}
-        primaryAction={primaryAction}
+        primaryAction={primaryActionProp}
         secondaryActions={additionalActions}
         empty={empty}
       >

--- a/src/components/listPage/ListPage.js
+++ b/src/components/listPage/ListPage.js
@@ -1,0 +1,155 @@
+/* eslint-max-lines: ["error": 180] */
+import React from 'react';
+
+import { Page } from '@sparkpost/matchbox';
+import {
+  Loading,
+  ApiErrorBanner,
+  TableCollection,
+  DeleteModal
+} from 'src/components';
+import { capitalize } from 'src/helpers/string';
+
+import Actions from './Actions';
+import ListPagePropTypes from './ListPage.propTypes';
+
+const DEFAULT_STATE = {
+  itemToDelete: null
+};
+
+class ListPage extends React.Component {
+  state = DEFAULT_STATE;
+
+  componentDidMount() {
+    this.props.loadItems();
+  }
+
+  handleCancel = () => {
+    this.setState(DEFAULT_STATE);
+  };
+
+  handleDelete = () => {
+    const { onDelete } = this.props;
+    const { itemToDelete } = this.state;
+
+    this.setState(DEFAULT_STATE, () => {
+      onDelete(itemToDelete);
+    });
+  };
+
+  showDeleteModal = (item) => {
+    this.setState({ itemToDelete: item });
+  };
+
+  renderError() {
+    const { loadItems, error, noun } = this.props;
+    return (
+      <ApiErrorBanner
+        errorDetails={error.message}
+        message={`Sorry, we seem to have had some trouble loading your ${noun.toLowerCase()}s .`}
+        reload={loadItems}
+      />
+    );
+  }
+
+  formatRowWithActions = (row) => {
+    const { formatRow } = this.props;
+    const formatted = formatRow(row);
+    const fields = formatted.fields || formatted;
+    const actions = formatted.actions || {};
+    return [
+      ...fields,
+      <Actions
+        item={row}
+        editRoute={actions.editRoute}
+        deletable={actions.deletable}
+        onDelete={this.showDeleteModal}
+        customActions={actions.customActions}
+      />
+    ];
+  };
+
+  renderItems() {
+    const {
+      columns,
+      items,
+      filterBox,
+      defaultSortColumn
+    } = this.props;
+    const filterBoxOptions = filterBox ? { show: true, ...filterBox } : { show: false };
+    return (
+      <TableCollection
+        columns={columns}
+        getRowData={this.formatRowWithActions}
+        pagination={true}
+        rows={items}
+        filterBox={filterBoxOptions}
+        defaultSortColumn={defaultSortColumn || columns[0]}
+      />
+    );
+  }
+
+  renderDeleteWarning() {
+    const { itemToDelete } = this.state;
+    const { deleteWarning } = this.props;
+
+    if (!itemToDelete) {
+      return null;
+    }
+    if (typeof deleteWarning === 'function') {
+      return deleteWarning(itemToDelete);
+    }
+    return deleteWarning;
+  }
+
+  render() {
+    const { itemToDelete } = this.state;
+    const {
+      noun,
+      primaryActionTitle,
+      onCreate,
+      loading,
+      error,
+      banner,
+      empty,
+      additionalActions
+    } = this.props;
+    const capsNoun = capitalize(noun);
+    const primaryAction = onCreate && {
+      content: primaryActionTitle || `Create ${capsNoun}`,
+      onClick: onCreate
+    };
+
+    if (loading) {
+      return <Loading />;
+    }
+
+    const modalContent = this.renderDeleteWarning();
+
+    return (
+      <Page
+        title={`${capsNoun}s`}
+        primaryAction={primaryAction}
+        secondaryActions={additionalActions}
+        empty={empty}
+      >
+        {banner}
+        {error ? this.renderError() : this.renderItems()}
+        <DeleteModal
+          open={Boolean(itemToDelete)}
+          onCancel={this.handleCancel}
+          onDelete={this.handleDelete}
+          title={`Are you sure you want to delete this ${noun}?`}
+          content={modalContent}
+        />
+      </Page>
+    );
+  }
+}
+
+ListPage.propTypes = ListPagePropTypes;
+ListPage.defaultProps = {
+  items: []
+};
+
+export default ListPage;

--- a/src/components/listPage/ListPage.js
+++ b/src/components/listPage/ListPage.js
@@ -52,9 +52,9 @@ class ListPage extends React.Component {
     );
   }
 
-  formatRowWithActions = (row) => {
-    const { formatRow } = this.props;
-    const formatted = formatRow(row);
+  renderRowWithActions = (row) => {
+    const { renderRow } = this.props;
+    const formatted = renderRow(row);
     const fields = formatted.fields || formatted;
     const actions = formatted.actions || {};
     return [
@@ -80,7 +80,7 @@ class ListPage extends React.Component {
     return (
       <TableCollection
         columns={columns}
-        getRowData={this.formatRowWithActions}
+        getRowData={this.renderRowWithActions}
         pagination={true}
         rows={items}
         filterBox={filterBoxOptions}

--- a/src/components/listPage/ListPage.js
+++ b/src/components/listPage/ListPage.js
@@ -91,15 +91,17 @@ class ListPage extends React.Component {
 
   renderDeleteWarning() {
     const { itemToDelete } = this.state;
-    const { deleteWarning } = this.props;
+    const { renderDeleteWarning } = this.props;
 
     if (!itemToDelete) {
       return null;
     }
-    if (typeof deleteWarning === 'function') {
-      return deleteWarning(itemToDelete);
+
+    if (!renderDeleteWarning) {
+      return null;
     }
-    return deleteWarning;
+
+    return renderDeleteWarning(itemToDelete);
   }
 
   render() {

--- a/src/components/listPage/ListPage.propTypes.js
+++ b/src/components/listPage/ListPage.propTypes.js
@@ -18,6 +18,9 @@ export default {
   noun: propTypes.string.isRequired,
   onCreate: propTypes.func,
   onDelete: propTypes.func,
-  primaryActionTitle: propTypes.string,
+  primaryAction: propTypes.shape({
+    content: propTypes.node,
+    to: propTypes.string.isRequired
+  }),
   additionalActions: propTypes.arrayOf(propTypes.object)
 };

--- a/src/components/listPage/ListPage.propTypes.js
+++ b/src/components/listPage/ListPage.propTypes.js
@@ -16,7 +16,6 @@ export default {
   loading: propTypes.bool,
   loadItems: propTypes.func.isRequired,
   noun: propTypes.string.isRequired,
-  onCreate: propTypes.func,
   onDelete: propTypes.func,
   primaryAction: propTypes.shape({
     content: propTypes.node,

--- a/src/components/listPage/ListPage.propTypes.js
+++ b/src/components/listPage/ListPage.propTypes.js
@@ -11,7 +11,7 @@ export default {
     message: propTypes.string
   }),
   filterBox: propTypes.object, // TODO: reference FilterBox propTypes
-  formatRow: propTypes.func.isRequired,
+  renderRow: propTypes.func.isRequired,
   items: propTypes.arrayOf(propTypes.object),
   loading: propTypes.bool,
   loadItems: propTypes.func.isRequired,

--- a/src/components/listPage/ListPage.propTypes.js
+++ b/src/components/listPage/ListPage.propTypes.js
@@ -1,0 +1,23 @@
+import propTypes from 'prop-types';
+import { Page } from '@sparkpost/matchbox';
+
+export default {
+  banner: propTypes.element,
+  columns: propTypes.arrayOf(propTypes.object).isRequired,
+  defaultSortColumn: propTypes.string,
+  deleteWarning: propTypes.oneOfType([propTypes.element, propTypes.func]),
+  empty: Page.propTypes.empty,
+  error: propTypes.shape({
+    message: propTypes.string
+  }),
+  filterBox: propTypes.object, // TODO: reference FilterBox propTypes
+  formatRow: propTypes.func.isRequired,
+  items: propTypes.arrayOf(propTypes.object),
+  loading: propTypes.bool,
+  loadItems: propTypes.func.isRequired,
+  noun: propTypes.string.isRequired,
+  onCreate: propTypes.func,
+  onDelete: propTypes.func,
+  primaryActionTitle: propTypes.string,
+  additionalActions: propTypes.arrayOf(propTypes.object)
+};

--- a/src/components/listPage/ListPage.propTypes.js
+++ b/src/components/listPage/ListPage.propTypes.js
@@ -5,7 +5,7 @@ export default {
   banner: propTypes.element,
   columns: propTypes.arrayOf(propTypes.object).isRequired,
   defaultSortColumn: propTypes.string,
-  deleteWarning: propTypes.oneOfType([propTypes.element, propTypes.func]),
+  renderDeleteWarning: propTypes.func,
   empty: Page.propTypes.empty,
   error: propTypes.shape({
     message: propTypes.string

--- a/src/components/listPage/tests/Actions.test.js
+++ b/src/components/listPage/tests/Actions.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Actions from '../Actions';
+
+describe('Actions', () => {
+  let baseProps;
+  const editRoute = '/thang/101';
+
+  beforeEach(() => {
+    baseProps = {
+      item: { id: 101 }
+    };
+  });
+
+  const subject = (props) => shallow(<Actions {...baseProps} {...props} />);
+  const subjectActions = (props) => subject(props).find('ActionPopover').prop('actions');
+
+  it('should render edit action', () => {
+    expect(subjectActions({ editRoute })).toMatchObject([
+      { content: 'Edit', to: editRoute }
+    ]);
+  });
+
+  it('should render delete action', () => {
+    expect(subjectActions({ deletable: true, onDelete: jest.fn() })).toMatchObject([
+      { content: 'Delete' }
+    ]);
+  });
+
+  it('should call onDelete with item', () => {
+    const props = {
+      deletable: true,
+      onDelete: jest.fn()
+    };
+    subjectActions(props)[0].onClick();
+    expect(props.onDelete).toHaveBeenCalledWith(baseProps.item);
+  });
+
+  it('should render custom actions', () => {
+    const props = {
+      editRoute,
+      deletable: true,
+      onDelete: jest.fn(),
+      customActions: [
+        { content: 'Twiddle', to: '/thang/101/twiddle' },
+        { content: 'Frobnicate', onClick: jest.fn() }
+      ]
+    };
+    expect(subjectActions(props)).toEqual(expect.arrayContaining(props.customActions));
+  });
+});

--- a/src/components/listPage/tests/ListPage.test.js
+++ b/src/components/listPage/tests/ListPage.test.js
@@ -14,8 +14,8 @@ describe('ListPage', () => {
 
   const subject = (props) => shallow(<ListPage {...baseProps} {...props} />);
 
-  const formatRowWithActions = (row) => ({
-    fields: baseProps.formatRow(row),
+  const renderRowWithActions = (row) => ({
+    fields: baseProps.renderRow(row),
     actions: {
       editRoute: '/sprocket/1',
       deletable: true,
@@ -26,7 +26,7 @@ describe('ListPage', () => {
   beforeEach(() => {
     baseProps = {
       columns: fixtures.columns,
-      formatRow: ({ name, diam, scale }) => [name, diam, scale],
+      renderRow: ({ name, diam, scale }) => [name, diam, scale],
       loadItems: jest.fn(),
       noun: fixtures.noun,
       primaryAction: { to: '/sprocket/new' }
@@ -65,12 +65,12 @@ describe('ListPage', () => {
       items,
       onEdit,
       onDelete,
-      formatRow: formatRowWithActions
+      renderRow: renderRowWithActions
     });
-    const formatRowFn = wrapper.find('TableCollection').prop('getRowData');
-    const formattedRow = formatRowFn(items[0]);
-    expect(formattedRow).toHaveLength(Object.keys(items[0]).length + 1);
-    expect(formattedRow).toMatchSnapshot();
+    const renderRowFn = wrapper.find('TableCollection').prop('getRowData');
+    const row = renderRowFn(items[0]);
+    expect(row).toHaveLength(Object.keys(items[0]).length + 1);
+    expect(row).toMatchSnapshot();
   });
 
   it('should show the delete modal on request', () => {

--- a/src/components/listPage/tests/ListPage.test.js
+++ b/src/components/listPage/tests/ListPage.test.js
@@ -29,7 +29,7 @@ describe('ListPage', () => {
       formatRow: ({ name, diam, scale }) => [name, diam, scale],
       loadItems: jest.fn(),
       noun: fixtures.noun,
-      onCreate: jest.fn()
+      primaryAction: { to: '/sprocket/new' }
     };
     onEdit = jest.fn();
     onDelete = jest.fn();
@@ -102,5 +102,10 @@ describe('ListPage', () => {
     wrapper.find('DeleteModal').prop('onCancel')();
     expect(onDelete).not.toHaveBeenCalled();
     expect(wrapper.find('DeleteModal').prop('open')).toBeFalsy();
+  });
+
+  it('should render custom primary action content', () => {
+    const content = 'Make a thang';
+    expect(subject({ primaryAction: { content, ...baseProps.primaryAction }}).find('Page').prop('primaryAction').content).toEqual(content);
   });
 });

--- a/src/components/listPage/tests/ListPage.test.js
+++ b/src/components/listPage/tests/ListPage.test.js
@@ -32,21 +32,21 @@ describe('ListPage', () => {
       primaryAction: { to: '/sprocket/new' }
     };
     onEdit = jest.fn();
-    onDelete = jest.fn();
+    onDelete = jest.fn().mockResolvedValue({});
     items = [...fixtures.items];
     error = { ...fixtures.error };
   });
 
   it('should render while loading', () => {
-    expect(subject({ loading: true }).find('Loading')).toHaveLength(1);
+    expect(subject({ loading: true }).find('Loading')).toExist();
   });
 
   it('should render an error', () => {
-    expect(subject({ error }).find('ApiErrorBanner')).toHaveLength(1);
+    expect(subject({ error }).find('ApiErrorBanner')).toExist();
   });
 
   it('should render items', () => {
-    expect(subject({ items }).find('TableCollection')).toHaveLength(1);
+    expect(subject({ items }).find('TableCollection')).toExist();
   });
 
   it('should render a filter box', () => {

--- a/src/components/listPage/tests/ListPage.test.js
+++ b/src/components/listPage/tests/ListPage.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ListPage from '../ListPage';
+
+import * as fixtures from './fixtures';
+
+describe('ListPage', () => {
+  let baseProps;
+  let onDelete;
+  let onEdit;
+  let items;
+  let error;
+
+  const subject = (props) => shallow(<ListPage {...baseProps} {...props} />);
+
+  const formatRowWithActions = (row) => ({
+    fields: baseProps.formatRow(row),
+    actions: {
+      editRoute: '/sprocket/1',
+      deletable: true,
+      customActions: [{ content: 'Flocculate', to: '/sprocket/1/flocculate' }]
+    }
+  });
+
+  beforeEach(() => {
+    baseProps = {
+      columns: fixtures.columns,
+      formatRow: ({ name, diam, scale }) => [name, diam, scale],
+      loadItems: jest.fn(),
+      noun: fixtures.noun,
+      onCreate: jest.fn()
+    };
+    onEdit = jest.fn();
+    onDelete = jest.fn();
+    items = [...fixtures.items];
+    error = { ...fixtures.error };
+  });
+
+  it('should render while loading', () => {
+    expect(subject({ loading: true }).find('Loading')).toHaveLength(1);
+  });
+
+  it('should render an error', () => {
+    expect(subject({ error }).find('ApiErrorBanner')).toHaveLength(1);
+  });
+
+  it('should render items', () => {
+    expect(subject({ items }).find('TableCollection')).toHaveLength(1);
+  });
+
+  it('should render a filter box', () => {
+    expect(
+      subject({ items, filterBox: fixtures.filterBox })
+        .find('TableCollection')
+        .prop('filterBox')
+    ).toMatchObject({
+      show: true,
+      ...fixtures.filterBox
+    });
+  });
+
+  it('should append item actions', () => {
+    const wrapper = subject({
+      items,
+      onEdit,
+      onDelete,
+      formatRow: formatRowWithActions
+    });
+    const formatRowFn = wrapper.find('TableCollection').prop('getRowData');
+    const formattedRow = formatRowFn(items[0]);
+    expect(formattedRow).toHaveLength(Object.keys(items[0]).length + 1);
+    expect(formattedRow).toMatchSnapshot();
+  });
+
+  it('should show the delete modal on request', () => {
+    const wrapper = subject({ items, onEdit, onDelete });
+    wrapper.instance().showDeleteModal(items[0]);
+    expect(wrapper.find('DeleteModal').prop('open')).toBeTruthy();
+  });
+
+  it('should format a fixed custom delete message', () => {
+    const deleteWarning = <p>Item will no longer be able to sing!</p>;
+    const wrapper = subject({ items, onDelete, deleteWarning });
+    wrapper.instance().showDeleteModal(items[0]);
+    expect(wrapper.find('DeleteModal').prop('content')).toEqual(deleteWarning);
+  });
+
+  it('should format a data-dependant custom delete message', () => {
+    const deleteWarning = (item) => (
+      <p>{`${item.name} will no longer be able to sing!`}</p>
+    );
+    const wrapper = subject({ items, onDelete, deleteWarning });
+    wrapper.instance().showDeleteModal(items[0]);
+    expect(wrapper.find('DeleteModal').prop('content')).toEqual(
+      deleteWarning(items[0])
+    );
+  });
+
+  it('should call onDelete on confirm', () => {
+    const wrapper = subject({ items, onEdit, onDelete });
+    wrapper.find('DeleteModal').prop('onDelete')();
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dismiss the delete modal on cancel', () => {
+    const wrapper = subject({ items, onEdit, onDelete });
+    wrapper.instance().showDeleteModal(items[0]);
+    wrapper.find('DeleteModal').prop('onCancel')();
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(wrapper.find('DeleteModal').prop('open')).toBeFalsy();
+  });
+});

--- a/src/components/listPage/tests/ListPage.test.js
+++ b/src/components/listPage/tests/ListPage.test.js
@@ -79,21 +79,14 @@ describe('ListPage', () => {
     expect(wrapper.find('DeleteModal').prop('open')).toBeTruthy();
   });
 
-  it('should format a fixed custom delete message', () => {
-    const deleteWarning = <p>Item will no longer be able to sing!</p>;
-    const wrapper = subject({ items, onDelete, deleteWarning });
-    wrapper.instance().showDeleteModal(items[0]);
-    expect(wrapper.find('DeleteModal').prop('content')).toEqual(deleteWarning);
-  });
-
   it('should format a data-dependant custom delete message', () => {
-    const deleteWarning = (item) => (
+    const renderDeleteWarning = (item) => (
       <p>{`${item.name} will no longer be able to sing!`}</p>
     );
-    const wrapper = subject({ items, onDelete, deleteWarning });
+    const wrapper = subject({ items, onDelete, renderDeleteWarning });
     wrapper.instance().showDeleteModal(items[0]);
     expect(wrapper.find('DeleteModal').prop('content')).toEqual(
-      deleteWarning(items[0])
+      renderDeleteWarning(items[0])
     );
   });
 

--- a/src/components/listPage/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/components/listPage/tests/__snapshots__/ListPage.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListPage should append item actions 1`] = `
+Array [
+  "m3 bolt",
+  3,
+  "metric",
+  <Actions
+    customActions={
+      Array [
+        Object {
+          "content": "Flocculate",
+          "to": "/sprocket/1/flocculate",
+        },
+      ]
+    }
+    deletable={true}
+    editRoute="/sprocket/1"
+    item={
+      Object {
+        "diam": 3,
+        "name": "m3 bolt",
+        "scale": "metric",
+      }
+    }
+    onDelete={[Function]}
+  />,
+]
+`;

--- a/src/components/listPage/tests/fixtures.js
+++ b/src/components/listPage/tests/fixtures.js
@@ -1,0 +1,27 @@
+const noun = 'sprocket';
+
+const columns = [ { label: 'Name', sortKey: 'name' }, { label: 'Diameter', sortKey: 'diam' }];
+
+const items = [
+  { name: 'm3 bolt', diam: 3, scale: 'metric' },
+  { name: 'm3 nut', diam: 3, scale: 'metric' },
+  { name: '16mm wingnut', diam: 16, scale: 'metric' },
+  { name: '22mm wingnut', diam: 22, scale: 'metric' },
+  { name: '1/8" wingnut', diam: 3, scale: 'imperial' },
+  { name: '3/8" wingnut', diam: 9, scale: 'imperial' },
+  { name: '5/8" wingnut', diam: 15, scale: 'imperial' },
+  { name: '7/8" wingnut', diam: 18, scale: 'imperial' },
+  { name: '1 1/8" wingnut', diam: 21, scale: 'imperial' },
+  { name: '1 3/8" wingnut', diam: 30, scale: 'imperial' },
+  { name: '1 5/8" wingnut', diam: 36, scale: 'imperial' }
+];
+
+const error = { message: 'Workshop closed' };
+
+const filterBox = {
+  keyMap: { role: 'access' },
+  exampleModifiers: ['name', 'diam'],
+  itemToStringKeys: ['diam']
+};
+
+export { noun, columns, items, error, filterBox };

--- a/src/helpers/string.js
+++ b/src/helpers/string.js
@@ -104,3 +104,5 @@ export const tagAsCopy = (str) => {
 };
 
 export const pluralString = (count, singularLabel, pluralLabel) => `${count} ${count === 1 ? singularLabel : pluralLabel || `${singularLabel}s`}`;
+
+export const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();

--- a/src/helpers/string.js
+++ b/src/helpers/string.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { newlineStrRegex, spacesRegex } from './regex';
+import capsLib from 'capitalize';
 
 export function snakeToFriendly(string = '') {
   return string
@@ -105,4 +106,4 @@ export const tagAsCopy = (str) => {
 
 export const pluralString = (count, singularLabel, pluralLabel) => `${count} ${count === 1 ? singularLabel : pluralLabel || `${singularLabel}s`}`;
 
-export const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+export const capitalize = (s) => capsLib.words(s);

--- a/src/pages/users/ListPage2.js
+++ b/src/pages/users/ListPage2.js
@@ -38,7 +38,7 @@ const renderDeleteWarning = ({ name }) => (
   </p>
 );
 
-const formatRow = (user) => ({
+const renderRow = (user) => ({
   fields: [
     <User name={user.name} email={user.email} username={user.username} />,
     user.access,
@@ -94,7 +94,7 @@ export class ListPage2 extends React.Component {
         columns={COLUMNS}
         defaultSortColumn={DEFAULT_SORT_COLUMN}
         empty={empty}
-        formatRow={formatRow}
+        renderRow={renderRow}
         onCreate={this.inviteUser}
         onDelete={this.deleteUser}
         deleteWarning={renderDeleteWarning}

--- a/src/pages/users/ListPage2.js
+++ b/src/pages/users/ListPage2.js
@@ -60,11 +60,6 @@ const formatRow = (user) => ({
 });
 
 export class ListPage2 extends React.Component {
-  inviteUser = () => {
-    const { history } = this.props;
-    history.push('/account/users/create');
-  };
-
   emptyState = () => {
     const { currentUser, users } = this.props;
 
@@ -91,7 +86,7 @@ export class ListPage2 extends React.Component {
     return (
       <ListPage
         noun='user'
-        primaryActionTitle='Invite User'
+        primaryAction={{ content: 'Invite User', to: '/account/users/create' }}
         error={error}
         loadItems={listUsers}
         loading={loading}

--- a/src/pages/users/ListPage2.js
+++ b/src/pages/users/ListPage2.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import TimeAgo from 'react-timeago';
+import { withRouter } from 'react-router-dom';
+import { Tag } from '@sparkpost/matchbox';
+
+import ListPage from 'src/components/listPage/ListPage';
+import { Users } from 'src/components/images';
+import PageLink from 'src/components/pageLink/PageLink';
+import User from './components/User';
+
+import { listUsers, deleteUser } from 'src/actions/users';
+import { selectUsers } from 'src/selectors/users';
+
+const COLUMNS = [
+  { label: 'User', sortKey: 'name' },
+  { label: 'Role', sortKey: 'access' },
+  { label: 'Two Factor Auth', sortKey: 'tfa_enabled' },
+  { label: 'Last Login', sortKey: 'last_login' },
+  null
+];
+
+const DEFAULT_SORT_COLUMN = 'name';
+
+const FILTER_BOX = {
+  keyMap: { role: 'access' },
+  exampleModifiers: ['name', 'email', 'role'],
+  itemToStringKeys: ['username', 'name', 'email']
+};
+
+const renderDeleteWarning = ({ name }) => (
+  <p>
+    <span>User "</span>
+    <span>{name}</span>
+    <span>
+      " will no longer be able to log in or access this SparkPost account.
+      All API keys associated with this user will be transferred to you.
+    </span>
+  </p>
+);
+
+const formatRow = (user) => ({
+  fields: [
+    <User name={user.name} email={user.email} username={user.username} />,
+    user.access,
+    user.tfa_enabled ? (
+      <Tag color={'blue'}>Enabled</Tag>
+    ) : (
+      <Tag>Disabled</Tag>
+    ),
+    user.last_login ? (
+      <TimeAgo date={user.last_login} live={false} />
+    ) : (
+      'Never'
+    )
+  ],
+  actions: {
+    editRoute: `/account/users/edit/${user.username}`,
+    deletable: !user.isCurrentUser
+  }
+});
+
+export class ListPage2 extends React.Component {
+  inviteUser = () => {
+    const { history } = this.props;
+    history.push('/account/users/create');
+  };
+
+  emptyState = () => {
+    const { currentUser, users } = this.props;
+
+    return {
+      show: users.length === 1,
+      title: 'Invite Your Team to SparkPost',
+      image: Users,
+      content: <p>Manage your team's accounts and roles.</p>,
+      secondaryAction: {
+        Component: PageLink,
+        content: 'Edit your user account',
+        to: `/account/users/edit/${currentUser.username}`
+      }
+    };
+  }
+
+  deleteUser = (user) => this.props.deleteUser(user.username);
+
+  render() {
+    const { error, listUsers, loading, users } = this.props;
+
+    const empty = this.emptyState();
+
+    return (
+      <ListPage
+        noun='user'
+        primaryActionTitle='Invite User'
+        error={error}
+        loadItems={listUsers}
+        loading={loading}
+        items={users}
+        columns={COLUMNS}
+        defaultSortColumn={DEFAULT_SORT_COLUMN}
+        empty={empty}
+        formatRow={formatRow}
+        onCreate={this.inviteUser}
+        onDelete={this.deleteUser}
+        deleteWarning={renderDeleteWarning}
+        filterBox={FILTER_BOX}
+      />
+    );
+  }
+}
+
+export default withRouter(
+  connect(
+    (state) => ({
+      currentUser: state.currentUser,
+      error: state.users.error,
+      loading: state.users.loading,
+      users: selectUsers(state)
+    }),
+    {
+      listUsers,
+      deleteUser
+    }
+  )(ListPage2)
+);

--- a/src/pages/users/ListPage2.js
+++ b/src/pages/users/ListPage2.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import TimeAgo from 'react-timeago';
-import { withRouter } from 'react-router-dom';
 import { Tag } from '@sparkpost/matchbox';
 
 import ListPage from 'src/components/listPage/ListPage';
@@ -110,17 +109,15 @@ export class ListPage2 extends React.Component {
   }
 }
 
-export default withRouter(
-  connect(
-    (state) => ({
-      currentUser: state.currentUser,
-      error: state.users.error,
-      loading: state.users.loading,
-      users: selectUsers(state)
-    }),
-    {
-      listUsers,
-      deleteUser
-    }
-  )(ListPage2)
-);
+export default connect(
+  (state) => ({
+    currentUser: state.currentUser,
+    error: state.users.error,
+    loading: state.users.loading,
+    users: selectUsers(state)
+  }),
+  {
+    listUsers,
+    deleteUser
+  }
+)(ListPage2);

--- a/src/pages/users/index.js
+++ b/src/pages/users/index.js
@@ -1,5 +1,6 @@
 import ListPage from './ListPage';
+import ListPage2 from './ListPage2';
 import CreatePage from './CreatePage';
 import EditPage from './EditPage.container';
 
-export default { ListPage, CreatePage, EditPage };
+export default { ListPage, ListPage2, CreatePage, EditPage };

--- a/src/pages/users/tests/ListPage2.test.js
+++ b/src/pages/users/tests/ListPage2.test.js
@@ -14,45 +14,50 @@ describe('Page: ListPage2', () => {
       loading: false,
       users,
       listUsers: jest.fn(),
-      deleteUser: jest.fn()
+      deleteUser: jest.fn(),
+      hasSubaccounts: false,
+      isSubAccountReportingLive: true
     };
   });
 
   const subject = (props) => shallow(<ListPage2 {...baseProps} {...props} />);
-  const subjectFormatRowFn = (props) => subject(props).find('ListPage').prop('formatRow');
+  const subjectRenderRowFn = (props) => subject(props).find('ListPage').prop('renderRow');
 
   it('renders a list page', () => {
     expect(subject()).toMatchSnapshot();
   });
 
   it('formats users for the table collection', () => {
-    const formatRow = subjectFormatRowFn();
-    const row = formatRow({ ...users[0], isCurrentUser: false });
+    const renderRow = subjectRenderRowFn();
+    const row = renderRow({ ...users[0], isCurrentUser: false });
     expect(row).toMatchSnapshot();
   });
 
   it('displays TFA enabled status', () => {
-    const formatRow = subjectFormatRowFn();
-    expect(formatRow({ ...users[0], tfa_enabled: true })).toMatchSnapshot();
+    const renderRow = subjectRenderRowFn();
+    expect(renderRow({ ...users[0], tfa_enabled: true })).toMatchSnapshot();
   });
 
   it('displays last login', () => {
-    const formatRow = subjectFormatRowFn();
-    expect(formatRow({ ...users[0], last_login: new Date('2018-04-01T16:15:00.000Z') })).toMatchSnapshot();
+    const renderRow = subjectRenderRowFn();
+    expect(renderRow({ ...users[0], last_login: new Date('2018-04-01T16:15:00.000Z') })).toMatchSnapshot();
+  });
+
+  it('displays subaccount info when the account uses them', () => {
+    expect(subject({ hasSubaccounts: true }).find('ListPage').prop('columns')).toContainEqual(expect.objectContaining({
+      label: 'Subaccount'
+    }));
+  });
+
+  it('should not render subaccount info when the feature is disabled', () => {
+    expect(subject({ hasSubaccounts: true, isSubAccountReportingLive: false }).find('ListPage').prop('columns')).not.toContainEqual(expect.objectContaining({
+      label: 'Subaccount'
+    }));
   });
 
   it('does not allow deletion of the current user', () => {
-    const formatRow = subjectFormatRowFn();
-    expect(formatRow({ ...users[0], isCurrentUser: true }).actions.deletable).toBeFalsy();
-  });
-
-  it('invites users', () => {
-    const props = {
-      history: { push: jest.fn() }
-    };
-    const createFn = subject(props).find('ListPage').prop('onCreate');
-    createFn();
-    expect(props.history.push).toHaveBeenCalledWith('/account/users/create');
+    const renderRow = subjectRenderRowFn();
+    expect(renderRow({ ...users[0], isCurrentUser: true }).actions.deletable).toBeFalsy();
   });
 
   it('deletes users', () => {

--- a/src/pages/users/tests/ListPage2.test.js
+++ b/src/pages/users/tests/ListPage2.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ListPage2 } from '../ListPage2';
+
+import { currentUser, users } from './fixtures';
+
+describe('Page: ListPage2', () => {
+  let baseProps;
+  beforeEach(() => {
+    baseProps = {
+      currentUser,
+      error: null,
+      loading: false,
+      users,
+      listUsers: jest.fn(),
+      deleteUser: jest.fn()
+    };
+  });
+
+  const subject = (props) => shallow(<ListPage2 {...baseProps} {...props} />);
+  const subjectFormatRowFn = (props) => subject(props).find('ListPage').prop('formatRow');
+
+  it('renders a list page', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('formats users for the table collection', () => {
+    const formatRow = subjectFormatRowFn();
+    const row = formatRow({ ...users[0], isCurrentUser: false });
+    expect(row).toMatchSnapshot();
+  });
+
+  it('displays TFA enabled status', () => {
+    const formatRow = subjectFormatRowFn();
+    expect(formatRow({ ...users[0], tfa_enabled: true })).toMatchSnapshot();
+  });
+
+  it('displays last login', () => {
+    const formatRow = subjectFormatRowFn();
+    expect(formatRow({ ...users[0], last_login: new Date('2018-04-01T16:15:00.000Z') })).toMatchSnapshot();
+  });
+
+  it('does not allow deletion of the current user', () => {
+    const formatRow = subjectFormatRowFn();
+    expect(formatRow({ ...users[0], isCurrentUser: true }).actions.deletable).toBeFalsy();
+  });
+
+  it('invites users', () => {
+    const props = {
+      history: { push: jest.fn() }
+    };
+    const createFn = subject(props).find('ListPage').prop('onCreate');
+    createFn();
+    expect(props.history.push).toHaveBeenCalledWith('/account/users/create');
+  });
+
+  it('deletes users', () => {
+    const deleteFn = subject().find('ListPage').prop('onDelete');
+    deleteFn(users[0]);
+    expect(baseProps.deleteUser).toHaveBeenCalledWith(users[0].username);
+  });
+});

--- a/src/pages/users/tests/__snapshots__/ListPage2.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage2.test.js.snap
@@ -131,7 +131,6 @@ exports[`Page: ListPage2 renders a list page 1`] = `
       },
     }
   }
-  formatRow={[Function]}
   items={
     Array [
       Object {
@@ -148,13 +147,26 @@ exports[`Page: ListPage2 renders a list page 1`] = `
         "tfa_enabled": true,
         "username": "test-user-2",
       },
+      Object {
+        "access": "admin",
+        "email": "user3@test.com",
+        "name": "Test User 3",
+        "subaccount_id": 125,
+        "tfa_enabled": true,
+        "username": "test-user-3",
+      },
     ]
   }
   loadItems={[MockFunction]}
   loading={false}
   noun="user"
-  onCreate={[Function]}
   onDelete={[Function]}
-  primaryActionTitle="Invite User"
+  primaryAction={
+    Object {
+      "content": "Invite User",
+      "to": "/account/users/create",
+    }
+  }
+  renderRow={[Function]}
 />
 `;

--- a/src/pages/users/tests/__snapshots__/ListPage2.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage2.test.js.snap
@@ -1,0 +1,160 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page: ListPage2 displays TFA enabled status 1`] = `
+Object {
+  "actions": Object {
+    "deletable": true,
+    "editRoute": "/account/users/edit/test-user-1",
+  },
+  "fields": Array [
+    <User
+      email="user1@test.com"
+      name="Test User 1"
+      username="test-user-1"
+    />,
+    "admin",
+    <Tag
+      color="blue"
+    >
+      Enabled
+    </Tag>,
+    "Never",
+  ],
+}
+`;
+
+exports[`Page: ListPage2 displays last login 1`] = `
+Object {
+  "actions": Object {
+    "deletable": true,
+    "editRoute": "/account/users/edit/test-user-1",
+  },
+  "fields": Array [
+    <User
+      email="user1@test.com"
+      name="Test User 1"
+      username="test-user-1"
+    />,
+    "admin",
+    <Tag>
+      Disabled
+    </Tag>,
+    <TimeAgo
+      component="time"
+      date={2018-04-01T16:15:00.000Z}
+      formatter={[Function]}
+      live={false}
+      maxPeriod={Infinity}
+      minPeriod={0}
+      now={[Function]}
+    />,
+  ],
+}
+`;
+
+exports[`Page: ListPage2 formats users for the table collection 1`] = `
+Object {
+  "actions": Object {
+    "deletable": true,
+    "editRoute": "/account/users/edit/test-user-1",
+  },
+  "fields": Array [
+    <User
+      email="user1@test.com"
+      name="Test User 1"
+      username="test-user-1"
+    />,
+    "admin",
+    <Tag>
+      Disabled
+    </Tag>,
+    "Never",
+  ],
+}
+`;
+
+exports[`Page: ListPage2 renders a list page 1`] = `
+<ListPage
+  columns={
+    Array [
+      Object {
+        "label": "User",
+        "sortKey": "name",
+      },
+      Object {
+        "label": "Role",
+        "sortKey": "access",
+      },
+      Object {
+        "label": "Two Factor Auth",
+        "sortKey": "tfa_enabled",
+      },
+      Object {
+        "label": "Last Login",
+        "sortKey": "last_login",
+      },
+      null,
+    ]
+  }
+  defaultSortColumn="name"
+  deleteWarning={[Function]}
+  empty={
+    Object {
+      "content": <p>
+        Manage your team's accounts and roles.
+      </p>,
+      "image": [Function],
+      "secondaryAction": Object {
+        "Component": [Function],
+        "content": "Edit your user account",
+        "to": "/account/users/edit/test-user-1",
+      },
+      "show": false,
+      "title": "Invite Your Team to SparkPost",
+    }
+  }
+  error={null}
+  filterBox={
+    Object {
+      "exampleModifiers": Array [
+        "name",
+        "email",
+        "role",
+      ],
+      "itemToStringKeys": Array [
+        "username",
+        "name",
+        "email",
+      ],
+      "keyMap": Object {
+        "role": "access",
+      },
+    }
+  }
+  formatRow={[Function]}
+  items={
+    Array [
+      Object {
+        "access": "admin",
+        "email": "user1@test.com",
+        "name": "Test User 1",
+        "tfa_enabled": false,
+        "username": "test-user-1",
+      },
+      Object {
+        "access": "admin",
+        "email": "user2@test.com",
+        "name": "Test User 2",
+        "tfa_enabled": true,
+        "username": "test-user-2",
+      },
+    ]
+  }
+  loadItems={[MockFunction]}
+  loading={false}
+  noun="user"
+  onCreate={[Function]}
+  onDelete={[Function]}
+  primaryActionTitle="Invite User"
+/>
+`;

--- a/src/pages/users/tests/fixtures.js
+++ b/src/pages/users/tests/fixtures.js
@@ -1,0 +1,22 @@
+const currentUser = {
+  username: 'test-user-1'
+};
+
+const users = [
+  {
+    name: 'Test User 1',
+    username: 'test-user-1',
+    access: 'admin',
+    email: 'user1@test.com',
+    tfa_enabled: false
+  },
+  {
+    name: 'Test User 2',
+    username: 'test-user-2',
+    access: 'admin',
+    email: 'user2@test.com',
+    tfa_enabled: true
+  }
+];
+
+export { currentUser, users };

--- a/src/pages/users/tests/fixtures.js
+++ b/src/pages/users/tests/fixtures.js
@@ -16,6 +16,14 @@ const users = [
     access: 'admin',
     email: 'user2@test.com',
     tfa_enabled: true
+  },
+  {
+    name: 'Test User 3',
+    username: 'test-user-3',
+    access: 'admin',
+    email: 'user3@test.com',
+    tfa_enabled: true,
+    subaccount_id: 125
   }
 ];
 

--- a/stories/ListPage.stories.js
+++ b/stories/ListPage.stories.js
@@ -32,9 +32,9 @@ const deleteWarning = ({ name }) => <p>This lovely {name} will no longer be usab
 
 const baseProps = {
   noun,
+  primaryAction: { to: '/sprocket/new' },
   loadItems: action('loadItems'),
   columns,
-  onCreate: action('onCreate'),
   filterBox,
   formatRow,
   additionalActions: [

--- a/stories/ListPage.stories.js
+++ b/stories/ListPage.stories.js
@@ -19,8 +19,8 @@ import { slugify } from 'src/helpers/string';
 
 import StoryContainer from './StoryContainer';
 
-const formatRow = (item) => [item.name, item.diam];
-const formatRowWithActions = (item) => ({
+const renderRow = (item) => [item.name, item.diam];
+const renderRowWithActions = (item) => ({
   fields: [item.name, item.diam],
   actions: {
     editRoute: `/account/sprocket/${slugify(item.name)}`,
@@ -28,7 +28,7 @@ const formatRowWithActions = (item) => ({
   }
 });
 
-const deleteWarning = ({ name }) => <p>This lovely {name} will no longer be usable.</p>;
+const renderDeleteWarning = ({ name }) => <p>This lovely {name} will no longer be usable.</p>;
 
 const baseProps = {
   noun,
@@ -36,7 +36,7 @@ const baseProps = {
   loadItems: action('loadItems'),
   columns,
   filterBox,
-  formatRow,
+  renderRow,
   additionalActions: [
     { Component: PageLink, content: 'Do a less obvious thing here', to: '' },
     { Component: PageLink, content: 'Straighten cheese', to: '' }
@@ -61,6 +61,13 @@ const emptyProps = {
   )
 };
 
+const onDelete = () => new Promise((resolve) => {
+  setTimeout(() => {
+    action('onDelete');
+    resolve();
+  }, 500);
+});
+
 storiesOf('ListPage', module)
   .addDecorator((getStory) => <StoryContainer>{getStory()}</StoryContainer>)
   .add('Loading', () => <ListPage {...baseProps} loading />)
@@ -70,10 +77,10 @@ storiesOf('ListPage', module)
     <ListPage
       {...baseProps}
       onEdit={action('onEdit')}
-      onDelete={action('onDelete')}
+      onDelete={onDelete}
       items={items}
-      deleteWarning={deleteWarning}
-      formatRow={formatRowWithActions}
+      renderDeleteWarning={renderDeleteWarning}
+      renderRow={renderRowWithActions}
     />
   ))
   .add('Without items', () => <ListPage {...baseProps} empty={emptyProps} />)

--- a/stories/ListPage.stories.js
+++ b/stories/ListPage.stories.js
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { Page, Banner } from '@sparkpost/matchbox';
 import { Loading, ApiErrorBanner, TableCollection, PageLink } from 'src/components';
 import { Users } from 'src/components/images';
+import { capitalize } from 'src/helpers/string';
 
 import StoryContainer from './StoryContainer';
 
@@ -19,34 +20,30 @@ class ListPage extends React.Component {
     const { loadItems, error, noun } = this.props;
     return <ApiErrorBanner
       errorDetails={error.message}
-      message={`Sorry, we seem to have had some trouble loading your ${noun}s .`}
+      message={`Sorry, we seem to have had some trouble loading your ${noun.toLowerCase()}s .`}
       reload={loadItems}
     />;
   }
 
   renderItems() {
-    const { columns, items, formatRow } = this.props;
+    const { columns, items, formatRow, filterBox, defaultSortColumn } = this.props;
     return <TableCollection
       columns={columns}
       getRowData={formatRow}
       pagination={true}
       rows={items}
-      // filterBox={{
-      //   show: true,
-      //   keyMap: { role: 'access' },
-      //   exampleModifiers: ['name', 'email', 'role'],
-      //   itemToStringKeys: ['username', 'name', 'email']
-      // }}
-      // defaultSortColumn='name'
+      filterBox={filterBox}
+      defaultSortColumn={defaultSortColumn || columns[0]}
     />;
   }
 
   render() {
-    const { noun, loading, error, banner, empty, otherActions } = this.props;
+    const { noun, slug, loading, error, banner, empty, otherActions } = this.props;
+    const capsNoun = capitalize(noun);
     const primaryAction = {
-      content: `Create ${noun}`,
+      content: `Create ${capsNoun}`,
       Component: Link,
-      to: '/account/${noun}/create'
+      to: `/account/${slug}/create`
     };
 
     if (loading) {
@@ -58,7 +55,7 @@ class ListPage extends React.Component {
       : {};
 
     return <Page
-      title={`${noun}s`}
+      title={capsNoun}
       primaryAction={primaryAction}
       secondaryActions={otherActions}
       empty={emptyProps}
@@ -71,14 +68,28 @@ class ListPage extends React.Component {
 
 ListPage.propTypes = {
   noun: propTypes.string.isRequired,
+  slug: propTypes.string.isRequired,
   loadItems: propTypes.func.isRequired,
   loading: propTypes.bool,
-  error: propTypes.object,
+  error: propTypes.shape({
+    message: propTypes.string
+  }),
   items: propTypes.arrayOf(propTypes.object),
   columns: propTypes.arrayOf(propTypes.object).isRequired,
+  defaultSortColumn: propTypes.string,
   formatRow: propTypes.func,
-  banner: propTypes.object,
-  empty: propTypes.object,
+  filterBox: propTypes.object, // TODO: reference FilterBox propTypes
+  banner: propTypes.element,
+  empty: propTypes.shape({
+    title: propTypes.string,
+    image: propTypes.shape(),
+    content: propTypes.element,
+    secondaryAction: propTypes.shape({
+      Component: propTypes.element,
+      content: propTypes.string,
+      to: propTypes.string
+    })
+  }),
   otherActions: propTypes.arrayOf(propTypes.object)
 };
 
@@ -86,8 +97,15 @@ ListPage.propTypes = {
 
 const baseProps = {
   noun: 'sprocket',
+  slug: 'sprocket',
   loadItems: action('loadItems'),
   columns: [ { label: 'Name', sortKey: 'name' }, { label: 'Diameter', sortKey: 'diam' }],
+  filterBox: {
+    show: true,
+    keyMap: { role: 'access' },
+    exampleModifiers: ['name', 'diam'],
+    itemToStringKeys: ['diam']
+  },
   formatRow: (item) => [item.name, item.diam],
   otherActions: [
     { Component: PageLink, content: 'Do a less obvious thing here', to: '' },

--- a/stories/ListPage.stories.js
+++ b/stories/ListPage.stories.js
@@ -1,148 +1,82 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { Banner } from '@sparkpost/matchbox';
 
-import propTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { Page, Banner } from '@sparkpost/matchbox';
-import { Loading, ApiErrorBanner, TableCollection, PageLink } from 'src/components';
+import PageLink from 'src/components/pageLink/PageLink';
 import { Users } from 'src/components/images';
-import { capitalize } from 'src/helpers/string';
+
+import ListPage from 'src/components/listPage/ListPage';
+import {
+  noun,
+  columns,
+  items,
+  error,
+  filterBox
+} from 'src/components/listPage/tests/fixtures';
+
+import { slugify } from 'src/helpers/string';
 
 import StoryContainer from './StoryContainer';
 
-class ListPage extends React.Component {
-  componentDidMount() {
-    this.props.loadItems();
+const formatRow = (item) => [item.name, item.diam];
+const formatRowWithActions = (item) => ({
+  fields: [item.name, item.diam],
+  actions: {
+    editRoute: `/account/sprocket/${slugify(item.name)}`,
+    deletable: item.name !== 'm3 bolt'
   }
+});
 
-  renderError() {
-    const { loadItems, error, noun } = this.props;
-    return <ApiErrorBanner
-      errorDetails={error.message}
-      message={`Sorry, we seem to have had some trouble loading your ${noun.toLowerCase()}s .`}
-      reload={loadItems}
-    />;
-  }
-
-  renderItems() {
-    const { columns, items, formatRow, filterBox, defaultSortColumn } = this.props;
-    return <TableCollection
-      columns={columns}
-      getRowData={formatRow}
-      pagination={true}
-      rows={items}
-      filterBox={filterBox}
-      defaultSortColumn={defaultSortColumn || columns[0]}
-    />;
-  }
-
-  render() {
-    const { noun, slug, loading, error, banner, empty, otherActions } = this.props;
-    const capsNoun = capitalize(noun);
-    const primaryAction = {
-      content: `Create ${capsNoun}`,
-      Component: Link,
-      to: `/account/${slug}/create`
-    };
-
-    if (loading) {
-      return <Loading />;
-    }
-
-    const emptyProps = empty
-      ? { show: true, ...empty }
-      : {};
-
-    return <Page
-      title={capsNoun}
-      primaryAction={primaryAction}
-      secondaryActions={otherActions}
-      empty={emptyProps}
-    >
-      {banner}
-      {error ? this.renderError() : this.renderItems()}
-    </Page>;
-  }
-}
-
-ListPage.propTypes = {
-  noun: propTypes.string.isRequired,
-  slug: propTypes.string.isRequired,
-  loadItems: propTypes.func.isRequired,
-  loading: propTypes.bool,
-  error: propTypes.shape({
-    message: propTypes.string
-  }),
-  items: propTypes.arrayOf(propTypes.object),
-  columns: propTypes.arrayOf(propTypes.object).isRequired,
-  defaultSortColumn: propTypes.string,
-  formatRow: propTypes.func,
-  filterBox: propTypes.object, // TODO: reference FilterBox propTypes
-  banner: propTypes.element,
-  empty: propTypes.shape({
-    title: propTypes.string,
-    image: propTypes.shape(),
-    content: propTypes.element,
-    secondaryAction: propTypes.shape({
-      Component: propTypes.element,
-      content: propTypes.string,
-      to: propTypes.string
-    })
-  }),
-  otherActions: propTypes.arrayOf(propTypes.object)
-};
-
-// --------------
+const deleteWarning = ({ name }) => <p>This lovely {name} will no longer be usable.</p>;
 
 const baseProps = {
-  noun: 'sprocket',
-  slug: 'sprocket',
+  noun,
   loadItems: action('loadItems'),
-  columns: [ { label: 'Name', sortKey: 'name' }, { label: 'Diameter', sortKey: 'diam' }],
-  filterBox: {
-    show: true,
-    keyMap: { role: 'access' },
-    exampleModifiers: ['name', 'diam'],
-    itemToStringKeys: ['diam']
-  },
-  formatRow: (item) => [item.name, item.diam],
-  otherActions: [
+  columns,
+  onCreate: action('onCreate'),
+  filterBox,
+  formatRow,
+  additionalActions: [
     { Component: PageLink, content: 'Do a less obvious thing here', to: '' },
     { Component: PageLink, content: 'Straighten cheese', to: '' }
   ]
 };
 
-const items = [
-  { name: 'm3 bolt', diam: 3, scale: 'metric' },
-  { name: 'm3 nut', diam: 3, scale: 'metric' },
-  { name: '16mm wingnut', diam: 16, scale: 'metric' },
-  { name: '22mm wingnut', diam: 22, scale: 'metric' },
-  { name: '1/8" wingnut', diam: 3, scale: 'imperial' },
-  { name: '3/8" wingnut', diam: 9, scale: 'imperial' },
-  { name: '5/8" wingnut', diam: 15, scale: 'imperial' },
-  { name: '7/8" wingnut', diam: 18, scale: 'imperial' },
-  { name: '1 1/8" wingnut', diam: 21, scale: 'imperial' },
-  { name: '1 3/8" wingnut', diam: 30, scale: 'imperial' },
-  { name: '1 5/8" wingnut', diam: 36, scale: 'imperial' }
-];
-
-const error = { message: 'Workshop closed' };
-
-const banner = <Banner title='Happiness' status='success'>Wheeeee! Wonder bubble!</Banner>;
+const banner = (
+  <Banner title="Happiness" status="success">
+    Wheeeee! Wonder bubble!
+  </Banner>
+);
 
 const emptyProps = {
+  show: true,
   image: Users,
   title: 'No sprockets here',
-  content: <p>Please consider making a new sprocket. They taste great and they're full of solid vitamins.</p>
+  content: (
+    <p>
+      Please consider making a new sprocket. They taste great and they're full
+      of solid vitamins.
+    </p>
+  )
 };
 
 storiesOf('ListPage', module)
-  .addDecorator((getStory) => (
-    <StoryContainer>{getStory()}</StoryContainer>
+  .addDecorator((getStory) => <StoryContainer>{getStory()}</StoryContainer>)
+  .add('Loading', () => <ListPage {...baseProps} loading />)
+  .add('Load failed', () => <ListPage {...baseProps} error={error} />)
+  .add('With loaded items', () => <ListPage {...baseProps} items={items} />)
+  .add('With Edit/Delete', () => (
+    <ListPage
+      {...baseProps}
+      onEdit={action('onEdit')}
+      onDelete={action('onDelete')}
+      items={items}
+      deleteWarning={deleteWarning}
+      formatRow={formatRowWithActions}
+    />
   ))
-  .add('Loading', () => <ListPage loading {...baseProps} />)
-  .add('Load failed', () => <ListPage error={error} {...baseProps} />)
-  .add('With loaded items', () => <ListPage items={items} {...baseProps} />)
-  .add('Without items', () => <ListPage empty={emptyProps} {...baseProps} />)
-  .add('With banner', () => <ListPage banner={banner} items={items} {...baseProps} />);
+  .add('Without items', () => <ListPage {...baseProps} empty={emptyProps} />)
+  .add('With banner', () => (
+    <ListPage {...baseProps} banner={banner} items={items} />
+  ));

--- a/stories/StoryContainer.js
+++ b/stories/StoryContainer.js
@@ -2,11 +2,6 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 const StoryContainer = ({ bg, children }) => {
-  // Modals need this portal element in place _before_ they render.
-  const modalPortal = document.createElement('div');
-  modalPortal.id = 'modal-portal';
-  document.body.appendChild(modalPortal);
-
   return <Router>
     <div>
       <div

--- a/stories/StoryContainer.js
+++ b/stories/StoryContainer.js
@@ -1,15 +1,25 @@
 import React from 'react';
-import {
-  BrowserRouter as Router
-} from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
+const StoryContainer = ({ bg, children }) => {
+  // Modals need this portal element in place _before_ they render.
+  const modalPortal = document.createElement('div');
+  modalPortal.id = 'modal-portal';
+  document.body.appendChild(modalPortal);
 
-const StoryContainer = ({ bg, children }) => (
-  <Router>
-    <div style={{ padding: '30px', minHeight: '100vh', background: bg || '#f2f2f5' }}>
-      {children}
+  return <Router>
+    <div>
+      <div
+        style={{
+          padding: '30px',
+          minHeight: '100vh',
+          background: bg || '#f2f2f5'
+        }}
+      >
+        {children}
+      </div>
     </div>
-  </Router>
-);
+  </Router>;
+};
 
 export default StoryContainer;


### PR DESCRIPTION
# What I Did
I built a reusable `ListPage` component to satisfy to main use cases of our list pages. I created a 2nd user list page to demo the new component.

The goal is to abstract and simplify common patterns to make them easier to reuse and maintain, and also to reduce overall codebase size. We have 12 basic list pages, each with their own basic layout and state management, and matching test suites.

# Testing
 - Check out the `ListPage` stories: `npm run storybook`
 - Try the re-implemented users list page by editing `routes.js` to point `/account/users` to `users.ListPage2`.

# To Do
 - [x] Test `pages/users/ListPage2.js`
 - [ ] Hide item actions list when not available
 - [ ] Disable delete dialog during delete
 - [x] Change PR base to master once FE-615 is merged down
