### PR TITLE
Ignore coveralls return value in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ cache:
 before_install: npm install -g greenkeeper-lockfile@1
 install: npm ci --loglevel http
 before_script: greenkeeper-lockfile-update
-script: npm run test-ci && npm run build || npm run coveralls
+script: npm run travis
 after_script: greenkeeper-lockfile-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ cache:
 before_install: npm install -g greenkeeper-lockfile@1
 install: npm ci --loglevel http
 before_script: greenkeeper-lockfile-update
-script: npm run test-ci && npm run build && npm run coveralls
+script: npm run test-ci && npm run build || npm run coveralls
 after_script: greenkeeper-lockfile-upload

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test-examples": "node scripts/test.js --env=jsdom --config=./jest.config.js --testMatch='<rootDir>/docs/testing/**/?(*.)test.js'",
     "lint": "node node_modules/eslint/bin/eslint.js src",
     "lintfix": "npm run lint -- --fix",
-    "storybook": "start-storybook -p 9001 -c .storybook"
+    "storybook": "start-storybook -p 9001 -c .storybook",
+    "travis": "npm run test-ci && npm run build && (npm run coveralls || exit 0)"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
# Background
Coveralls began failing today with [this error](https://github.com/lemurheavy/coveralls-public/issues/1264) in our Travis builds. This PR aims to leave coveralls running but ignore its return value _temporarily_ so we can keep using travis build status in our PRs.

# What I Did
I changed our travis config to make our builds succeed even if the coveralls step fails.

(I took 2 attempts as you'll see from the commit)

# How To Test
Wait for this PR's Travis build to finish :)
