### PR TITLE
AC-573: Add subaccount to users list page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1912,7 +1912,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -7403,7 +7403,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -9114,7 +9114,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,7 +5478,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -11150,7 +11150,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -12898,7 +12898,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -16247,7 +16247,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -16491,7 +16491,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16564,7 +16564,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -26947,7 +26947,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,7 +5478,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -16247,7 +16247,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -16491,7 +16491,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16564,7 +16564,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -26947,7 +26947,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -104,6 +104,8 @@ export const EVENTS_SEARCH_FILTERS = {
 };
 export const DEFAULT_PER_PAGE_BUTTONS = [10, 25, 50, 100];
 
+export const SUBACCOUNT_REPORTING_ROLE = 'subaccount_reporting';
+
 export const ANALYTICS_CREATE_ACCOUNT = 'create account';
 export const ANALYTICS_ADDON_IP = 'dedicated_ips';
 export const ANALYTICS_PREMIUM_SUPPORT = 'premium-support';

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -9,8 +9,9 @@ import PageLink from 'src/components/pageLink/PageLink';
 
 import * as usersActions from 'src/actions/users';
 import { selectUsers } from 'src/selectors/users';
+import { hasSubaccounts } from 'src/selectors/subaccounts';
 
-import { Loading, ApiErrorBanner, DeleteModal, TableCollection, ActionPopover } from 'src/components';
+import { SubaccountTag, Loading, ApiErrorBanner, DeleteModal, TableCollection, ActionPopover } from 'src/components';
 import User from './components/User';
 
 const COLUMNS = [
@@ -18,8 +19,17 @@ const COLUMNS = [
   { label: 'Role', sortKey: 'access' },
   { label: 'Two Factor Auth', sortKey: 'tfa_enabled' },
   { label: 'Last Login', sortKey: 'last_login' },
-  { label: 'Subaccount', sortKey: 'subaccount' },
   null
+];
+
+const COLUMN_SUBS = [
+  { label: 'User', sortKey: 'name' },
+  { label: 'Role', sortKey: 'access' },
+  { label: 'Two Factor Auth', sortKey: 'tfa_enabled' },
+  { label: 'Last Login', sortKey: 'last_login' },
+  { label: 'Subaccount', sortKey: 'subaccount_id' },
+  null
+
 ];
 
 export const Actions = ({ username, deletable, onDelete }) => {
@@ -55,7 +65,7 @@ export class ListPage extends Component {
     user.access,
     user.tfa_enabled ? <Tag color={'blue'}>Enabled</Tag> : <Tag>Disabled</Tag>,
     user.last_login ? <TimeAgo date={user.last_login} live={false} /> : 'Never',
-    user.subaccount_id ? <p>{user.subaccount_id}</p> : <p>null</p>,
+    user.subaccount_id ? <SubaccountTag id={user.subaccount_id} /> : <p>null</p>,
     <Actions username={user.username} deletable={!user.isCurrentUser} onDelete={this.handleDeleteRequest} />
   ];
 
@@ -107,7 +117,7 @@ export class ListPage extends Component {
     return (
       <div>
         <TableCollection
-          columns={COLUMNS}
+          columns={this.props.hasSubaccounts ? COLUMN_SUBS : COLUMNS}
           getRowData={this.getRowData}
           pagination={true}
           rows={this.props.users}
@@ -156,7 +166,8 @@ const mapStateToProps = (state) => ({
   currentUser: state.currentUser,
   error: state.users.error,
   loading: state.users.loading,
-  users: selectUsers(state)
+  users: selectUsers(state),
+  hasSubaccounts: hasSubaccounts(state)
 });
 
 export default connect(mapStateToProps, usersActions)(ListPage);

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -18,6 +18,7 @@ const COLUMNS = [
   { label: 'Role', sortKey: 'access' },
   { label: 'Two Factor Auth', sortKey: 'tfa_enabled' },
   { label: 'Last Login', sortKey: 'last_login' },
+  { label: 'Subaccount', sortKey: 'subaccount' },
   null
 ];
 
@@ -54,6 +55,7 @@ export class ListPage extends Component {
     user.access,
     user.tfa_enabled ? <Tag color={'blue'}>Enabled</Tag> : <Tag>Disabled</Tag>,
     user.last_login ? <TimeAgo date={user.last_login} live={false} /> : 'Never',
+    user.subaccount_id ? <p>{user.subaccount_id}</p> : <p>null</p>,
     <Actions username={user.username} deletable={!user.isCurrentUser} onDelete={this.handleDeleteRequest} />
   ];
 

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -16,14 +17,21 @@ import { SubaccountTag, Loading, ApiErrorBanner, DeleteModal, TableCollection, A
 import User from './components/User';
 
 const COLUMNS = [
+  { label: 'User', sortKey: 'name' },
+  { label: 'Role', sortKey: 'access' },
+  { label: 'Two Factor Auth', sortKey: 'tfa_enabled' },
+  { label: 'Last Login', sortKey: 'last_login' },
+  null
+];
+
+const SUB_COLUMN = [
   { label: 'User', sortKey: 'name', width: '40%' },
   { label: 'Role', sortKey: 'access', width: '11%' },
+  { label: 'Subaccount', sortKey: 'subaccount_id', width: '14%' },
   { label: 'Two Factor Auth', sortKey: 'tfa_enabled', width: '15%' },
   { label: 'Last Login', sortKey: 'last_login', width: '8%' },
   null
 ];
-
-const SUB_COLUMN = { label: 'Subaccount', sortKey: 'subaccount_id', width: '14%' };
 
 export const Actions = ({ username, deletable, onDelete }) => {
   const actions = [ { content: 'Edit', to: `/account/users/edit/${username}`, component: Link } ];
@@ -117,11 +125,10 @@ export class ListPage extends Component {
   }
 
   renderPage() {
-    if (this.props.hasSubaccounts) { COLUMNS.splice(2, 0, SUB_COLUMN); }
     return (
       <div>
         <TableCollection
-          columns={COLUMNS}
+          columns={this.props.hasSubaccounts ? SUB_COLUMN : COLUMNS}
           getRowData={this.getRowData}
           pagination={true}
           rows={this.props.users}

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -23,6 +23,8 @@ const COLUMNS = [
   null
 ];
 
+const SUB_COLUMN = { label: 'Subaccount', sortKey: 'subaccount_id', width: '14%' };
+
 export const Actions = ({ username, deletable, onDelete }) => {
   const actions = [ { content: 'Edit', to: `/account/users/edit/${username}`, component: Link } ];
   if (deletable) {
@@ -66,9 +68,7 @@ export class ListPage extends Component {
       user.last_login ? <TimeAgo date={user.last_login} live={false} /> : 'Never',
       <Actions username={user.username} deletable={!user.isCurrentUser} onDelete={this.handleDeleteRequest} />
     ];
-    if (this.props.hasSubaccounts) {
-      data.splice(2, 0, user.subaccount_id ? <SubaccountTag id={user.subaccount_id} /> : null);
-    }
+    if (this.props.hasSubaccounts) { data.splice(2, 0, user.subaccount_id ? <SubaccountTag id={user.subaccount_id} /> : null); }
     return data;
   };
 
@@ -117,7 +117,7 @@ export class ListPage extends Component {
   }
 
   renderPage() {
-    if (this.props.hasSubaccounts) { COLUMNS.splice(2, 0, { label: 'Subaccount', sortKey: 'subaccount_id', width: '14%' }); }
+    if (this.props.hasSubaccounts) { COLUMNS.splice(2, 0, SUB_COLUMN); }
     return (
       <div>
         <TableCollection

--- a/src/pages/users/tests/ListPage.test.js
+++ b/src/pages/users/tests/ListPage.test.js
@@ -21,7 +21,8 @@ describe('Page: Users List', () => {
         { name: 'Test User 1', username: 'test-user-1', access: 'admin', email: 'user1@test.com', tfa_enabled: false },
         { name: 'Test User 2', username: 'test-user-2', access: 'admin', email: 'user2@test.com', tfa_enabled: true },
         { name: 'Test User 3', username: 'test-user-3', access: 'admin', email: 'user3@test.com', tfa_enabled: true, subaccount_id: 125 }
-      ]
+      ],
+      isSubAccountReportingLive: true
     };
     wrapper = shallow(<ListPage {...props} />);
     instance = wrapper.instance();
@@ -77,6 +78,13 @@ describe('Page: Users List', () => {
   it('should render subaccount info when the account uses them', () => {
     wrapper.setProps({ hasSubaccounts: true });
     expect(wrapper.find('TableCollection').prop('columns')).toContainEqual(expect.objectContaining({
+      label: 'Subaccount'
+    }));
+  });
+
+  it('should not render subaccount info when the feature is disabled', () => {
+    wrapper.setProps({ hasSubaccounts: true, isSubAccountReportingLive: false });
+    expect(wrapper.find('TableCollection').prop('columns')).not.toContainEqual(expect.objectContaining({
       label: 'Subaccount'
     }));
   });

--- a/src/pages/users/tests/ListPage.test.js
+++ b/src/pages/users/tests/ListPage.test.js
@@ -18,7 +18,8 @@ describe('Page: Users List', () => {
       listUsers: jest.fn(),
       users: [
         { name: 'Test User 1', username: 'test-user-1', access: 'admin', email: 'user1@test.com', tfa_enabled: false },
-        { name: 'Test User 2', username: 'test-user-2', access: 'admin', email: 'user2@test.com', tfa_enabled: true }
+        { name: 'Test User 2', username: 'test-user-2', access: 'admin', email: 'user2@test.com', tfa_enabled: true },
+        { name: 'Test User 3', username: 'test-user-3', access: 'admin', email: 'user3@test.com', tfa_enabled: true, subaccount_id: 125 }
       ]
     };
     wrapper = shallow(<ListPage {...props} />);

--- a/src/pages/users/tests/ListPage.test.js
+++ b/src/pages/users/tests/ListPage.test.js
@@ -16,6 +16,7 @@ describe('Page: Users List', () => {
       },
       loading: false,
       listUsers: jest.fn(),
+      hasSubaccounts: true,
       users: [
         { name: 'Test User 1', username: 'test-user-1', access: 'admin', email: 'user1@test.com', tfa_enabled: false },
         { name: 'Test User 2', username: 'test-user-2', access: 'admin', email: 'user2@test.com', tfa_enabled: true },

--- a/src/pages/users/tests/ListPage.test.js
+++ b/src/pages/users/tests/ListPage.test.js
@@ -16,7 +16,7 @@ describe('Page: Users List', () => {
       },
       loading: false,
       listUsers: jest.fn(),
-      hasSubaccounts: true,
+      hasSubaccounts: false,
       users: [
         { name: 'Test User 1', username: 'test-user-1', access: 'admin', email: 'user1@test.com', tfa_enabled: false },
         { name: 'Test User 2', username: 'test-user-2', access: 'admin', email: 'user2@test.com', tfa_enabled: true },
@@ -71,6 +71,14 @@ describe('Page: Users List', () => {
     const timeAgoProps = wrapper.find(TimeAgo).props();
     expect(timeAgoProps.date).toBeInstanceOf(Date);
     expect(timeAgoProps.live).toEqual(false);
+  });
+
+  // This assumes `hasSubaccounts=false` in the wrapper as a precondition
+  it('should render subaccount info when the account uses them', () => {
+    wrapper.setProps({ hasSubaccounts: true });
+    expect(wrapper.find('TableCollection').prop('columns')).toContainEqual(expect.objectContaining({
+      label: 'Subaccount'
+    }));
   });
 
   it('should render ActionPopover', () => {

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -64,10 +64,6 @@ exports[`Page: Users List should render correctly by default 1`] = `
             "label": "Last Login",
             "sortKey": "last_login",
           },
-          Object {
-            "label": "Subaccount",
-            "sortKey": "subaccount_id",
-          },
           null,
         ]
       }
@@ -230,10 +226,6 @@ exports[`Page: Users List should show a delete modal 1`] = `
             "label": "Last Login",
             "sortKey": "last_login",
           },
-          Object {
-            "label": "Subaccount",
-            "sortKey": "subaccount_id",
-          },
           null,
         ]
       }
@@ -319,9 +311,6 @@ Array [
     Disabled
   </Tag>,
   "Never",
-  <p>
-    null
-  </p>,
   <Actions
     deletable={true}
     onDelete={[Function]}

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -51,18 +51,22 @@ exports[`Page: Users List should render correctly by default 1`] = `
           Object {
             "label": "User",
             "sortKey": "name",
+            "width": "40%",
           },
           Object {
             "label": "Role",
             "sortKey": "access",
+            "width": "11%",
           },
           Object {
             "label": "Two Factor Auth",
             "sortKey": "tfa_enabled",
+            "width": "15%",
           },
           Object {
             "label": "Last Login",
             "sortKey": "last_login",
+            "width": "8%",
           },
           null,
         ]
@@ -213,18 +217,27 @@ exports[`Page: Users List should show a delete modal 1`] = `
           Object {
             "label": "User",
             "sortKey": "name",
+            "width": "40%",
           },
           Object {
             "label": "Role",
             "sortKey": "access",
+            "width": "11%",
+          },
+          Object {
+            "label": "Subaccount",
+            "sortKey": "subaccount_id",
+            "width": "14%",
           },
           Object {
             "label": "Two Factor Auth",
             "sortKey": "tfa_enabled",
+            "width": "15%",
           },
           Object {
             "label": "Last Login",
             "sortKey": "last_login",
+            "width": "8%",
           },
           null,
         ]

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -64,6 +64,10 @@ exports[`Page: Users List should render correctly by default 1`] = `
             "label": "Last Login",
             "sortKey": "last_login",
           },
+          Object {
+            "label": "Subaccount",
+            "sortKey": "subaccount",
+          },
           null,
         ]
       }
@@ -104,6 +108,14 @@ exports[`Page: Users List should render correctly by default 1`] = `
             "name": "Test User 2",
             "tfa_enabled": true,
             "username": "test-user-2",
+          },
+          Object {
+            "access": "admin",
+            "email": "user3@test.com",
+            "name": "Test User 3",
+            "subaccount_id": 125,
+            "tfa_enabled": true,
+            "username": "test-user-3",
           },
         ]
       }
@@ -218,6 +230,10 @@ exports[`Page: Users List should show a delete modal 1`] = `
             "label": "Last Login",
             "sortKey": "last_login",
           },
+          Object {
+            "label": "Subaccount",
+            "sortKey": "subaccount",
+          },
           null,
         ]
       }
@@ -259,6 +275,14 @@ exports[`Page: Users List should show a delete modal 1`] = `
             "tfa_enabled": true,
             "username": "test-user-2",
           },
+          Object {
+            "access": "admin",
+            "email": "user3@test.com",
+            "name": "Test User 3",
+            "subaccount_id": 125,
+            "tfa_enabled": true,
+            "username": "test-user-3",
+          },
         ]
       }
     />
@@ -295,6 +319,9 @@ Array [
     Disabled
   </Tag>,
   "Never",
+  <p>
+    null
+  </p>,
   <Actions
     deletable={true}
     onDelete={[Function]}

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -66,7 +66,7 @@ exports[`Page: Users List should render correctly by default 1`] = `
           },
           Object {
             "label": "Subaccount",
-            "sortKey": "subaccount",
+            "sortKey": "subaccount_id",
           },
           null,
         ]
@@ -232,7 +232,7 @@ exports[`Page: Users List should show a delete modal 1`] = `
           },
           Object {
             "label": "Subaccount",
-            "sortKey": "subaccount",
+            "sortKey": "subaccount_id",
           },
           null,
         ]

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -51,22 +51,18 @@ exports[`Page: Users List should render correctly by default 1`] = `
           Object {
             "label": "User",
             "sortKey": "name",
-            "width": "40%",
           },
           Object {
             "label": "Role",
             "sortKey": "access",
-            "width": "11%",
           },
           Object {
             "label": "Two Factor Auth",
             "sortKey": "tfa_enabled",
-            "width": "15%",
           },
           Object {
             "label": "Last Login",
             "sortKey": "last_login",
-            "width": "8%",
           },
           null,
         ]
@@ -217,27 +213,18 @@ exports[`Page: Users List should show a delete modal 1`] = `
           Object {
             "label": "User",
             "sortKey": "name",
-            "width": "40%",
           },
           Object {
             "label": "Role",
             "sortKey": "access",
-            "width": "11%",
-          },
-          Object {
-            "label": "Subaccount",
-            "sortKey": "subaccount_id",
-            "width": "14%",
           },
           Object {
             "label": "Two Factor Auth",
             "sortKey": "tfa_enabled",
-            "width": "15%",
           },
           Object {
             "label": "Last Login",
             "sortKey": "last_login",
-            "width": "8%",
           },
           null,
         ]


### PR DESCRIPTION
**What I did**
- Added a subaccount id column to the users list page
- Added 'subaccount' to search terms

**How to test**
- Create a user with a linked subaccount in Dynamobd
- Load the users list page and verify your user has been picked up
- Verify subaccount search feature, keyword : subaccount

**Todo**
- [ ] Verify user list page includes subaccount_id data