### PR TITLE
Pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,14 @@
-# What Changed
- - What did you do and why? (Alignment between PR commits and this section helps your reviewers)
+Note: Give your PR a short title. Something like "_TICKET NUMBER: feature description_" is good.
 
-# How To Test
- - Include any special dev environment setup required. (Anything outside basic hamurai-managed stuff counts as "special")
+### What Changed
+ - What changes did you make to satisfy the AC?
+     > Outline changes to user flows, any surprising architectural decisions 
+     > Alignment between PR commits and this section helps your reviewers.
 
-# Todo
-- [ ] Any outstanding tasks go here (Manage reviewers' expectations re missing features, tests, bugs, late design changes, ...)
+### How To Test
+ - Describe any special dev environment setup required.
+     > Anything outside basic hamurai-managed stuff counts as "special".
+
+### To Do
+- [ ] Any outstanding tasks go here
+    > Manage reviewers' expectations on missing features, tests, bugs, late design changes, ...)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+# What Changed
+ - What did you do and why? (Alignment between PR commits and this section helps your reviewers)
+
+# How To Test
+ - Include any special dev environment setup required. (Anything outside basic hamurai-managed stuff counts as "special")
+
+# Todo
+- [ ] Any outstanding tasks go here (Manage reviewers' expectations re missing features, tests, bugs, late design changes, ...)


### PR DESCRIPTION
# THIS PR WILL BE MERGED ON 2019-02-21 12.00 EST

# What Changed
Added a PR template to give people a minimum of info when picking up a review, and lighten up the task of opening a PR.

Once merged, the contents of this template will appear pre-populated in the "Open a pull request" form in GitHub.

# How To Test
Preview the template in GitHub or a Markdown viewer.
Critique the sections, content and most importantly guidance.

# Todo
- [x] Address review feedback
