### PR TITLE
EO-591 - Add Alerts enable/disable action to List Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1615,9 +1615,9 @@
       "integrity": "sha512-8AHuXD3j0uv2CmZFvRb20C+lN1UDxsc3ZPeZFJFbZ2MCXv+kgR6DtA2QbQ6waaMAh+onZB+kAD9gJpFuwnxEtw=="
     },
     "@sparkpost/matchbox": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-3.3.4.tgz",
-      "integrity": "sha512-m6HCT+pvKonKEyhZCGpzkHXCxef2BueP+LrJwGuHBNI47YBL9bpZjNtulZyAuYGA1AwAf0CoZZHm4uVHLLOB2A==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-3.3.6.tgz",
+      "integrity": "sha512-Xx1QpX5c71ZSpiactGuFhFagbPib0SHP3IZ/ev78aADYDT/a7/ivEPDdTf7biaiIP0a0iUteFi3Ukk5SczJNJA==",
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5107,7 +5107,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -5491,7 +5491,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -11163,7 +11163,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -12911,7 +12911,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -16260,7 +16260,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -16504,7 +16504,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16577,7 +16577,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -19870,7 +19870,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -24002,7 +24002,7 @@
     },
     "react-redux": {
       "version": "5.0.7",
-      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
       "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
       "requires": {
         "hoist-non-react-statics": "^2.5.0",
@@ -24027,7 +24027,7 @@
     },
     "react-resize-detector": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
       "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
       "requires": {
         "lodash.debounce": "^4.0.8",
@@ -26960,7 +26960,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -29574,7 +29574,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1615,11 +1615,10 @@
       "integrity": "sha512-8AHuXD3j0uv2CmZFvRb20C+lN1UDxsc3ZPeZFJFbZ2MCXv+kgR6DtA2QbQ6waaMAh+onZB+kAD9gJpFuwnxEtw=="
     },
     "@sparkpost/matchbox": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-3.3.3.tgz",
-      "integrity": "sha512-5fnR0KEW6kesZbEIHPYbAVMvIwMFdhUtwr7Xf41+mNpetGj66DOAjBQklUY7PzZVBAkg8z9P0nYkmCA/Q90UHg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-3.3.4.tgz",
+      "integrity": "sha512-m6HCT+pvKonKEyhZCGpzkHXCxef2BueP+LrJwGuHBNI47YBL9bpZjNtulZyAuYGA1AwAf0CoZZHm4uVHLLOB2A==",
       "requires": {
-        "@sparkpost/matchbox-icons": "^1.1.4",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.1",
         "react": "^16.3.2",
@@ -1627,14 +1626,28 @@
         "react-transition-group": "^2.3.0"
       },
       "dependencies": {
-        "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
+            "js-tokens": "^3.0.0 || ^4.0.0"
           }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.3",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
+          "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA=="
         }
       }
     },
@@ -5094,7 +5107,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -5478,7 +5491,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -11150,7 +11163,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -12898,7 +12911,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -16247,7 +16260,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -16491,7 +16504,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16564,7 +16577,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -19857,7 +19870,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -26947,7 +26960,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -29561,7 +29574,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@sparkpost/boomerang": "^1.0.6",
-    "@sparkpost/matchbox": "^3.3.3",
+    "@sparkpost/matchbox": "^3.3.4",
     "@sparkpost/matchbox-icons": "^1.1.5",
     "axios": "^0.17.1",
     "bowser": "2.0.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@sparkpost/boomerang": "^1.0.6",
-    "@sparkpost/matchbox": "^3.3.4",
+    "@sparkpost/matchbox": "^3.3.6",
     "@sparkpost/matchbox-icons": "^1.1.5",
     "axios": "^0.17.1",
     "bowser": "2.0.0-alpha.4",

--- a/src/actions/alerts.js
+++ b/src/actions/alerts.js
@@ -1,5 +1,5 @@
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
-import setSubaccountHeader from './helpers/setSubaccountHeader';
+// import setSubaccountHeader from './helpers/setSubaccountHeader';
 
 export function listAlerts() {
   return sparkpostApiRequest({
@@ -34,13 +34,27 @@ export function updateAlert({ id, data }) {
   });
 }
 
+export function setEnabledStatus({ id, enabled, subaccountId }) {
+  return sparkpostApiRequest({
+    type: 'SET_ALERT_ENABLED_STATUS',
+    meta: {
+      method: 'PUT',
+      url: `/labs/alerts/${id}`,
+      data: { enabled }
+      // Enable when EO-604 has been addressed
+      // headers: setSubaccountHeader(subaccountId)
+    }
+  });
+}
+
 export function deleteAlert({ id, subaccountId }) {
   return sparkpostApiRequest({
     type: 'DELETE_ALERT',
     meta: {
       method: 'DELETE',
-      url: `/labs/alerts/${id}`,
-      headers: setSubaccountHeader(subaccountId)
+      url: `/labs/alerts/${id}`
+      // Enable when EO-604 has been addressed
+      // headers: setSubaccountHeader(subaccountId)
     }
   });
 }

--- a/src/actions/alerts.js
+++ b/src/actions/alerts.js
@@ -23,28 +23,21 @@ export function createAlert({ data }) {
   });
 }
 
-export function updateAlert({ id, data }) {
+export function updateAlert({ data, id, subaccountId, type = 'UPDATE_ALERT' }) {
   return sparkpostApiRequest({
-    type: 'UPDATE_ALERT',
+    type,
     meta: {
       method: 'PUT',
       url: `/labs/alerts/${id}`,
       data
-    }
-  });
-}
-
-export function setEnabledStatus({ id, enabled, subaccountId }) {
-  return sparkpostApiRequest({
-    type: 'SET_ALERT_ENABLED_STATUS',
-    meta: {
-      method: 'PUT',
-      url: `/labs/alerts/${id}`,
-      data: { enabled }
       // Enable when EO-604 has been addressed
       // headers: setSubaccountHeader(subaccountId)
     }
   });
+}
+
+export function setEnabledStatus({ enabled, ...rest }) {
+  return updateAlert({ type: 'SET_ALERT_ENABLED_STATUS', data: { enabled }, ...rest });
 }
 
 export function deleteAlert({ id, subaccountId }) {
@@ -52,7 +45,8 @@ export function deleteAlert({ id, subaccountId }) {
     type: 'DELETE_ALERT',
     meta: {
       method: 'DELETE',
-      url: `/labs/alerts/${id}`
+      url: `/labs/alerts/${id}`,
+      id
       // Enable when EO-604 has been addressed
       // headers: setSubaccountHeader(subaccountId)
     }

--- a/src/actions/alerts.js
+++ b/src/actions/alerts.js
@@ -23,9 +23,9 @@ export function createAlert({ data }) {
   });
 }
 
-export function updateAlert({ data, id, subaccountId, type = 'UPDATE_ALERT' }) {
+export function updateAlert({ data, id, subaccountId }) {
   return sparkpostApiRequest({
-    type,
+    type: 'UPDATE_ALERT',
     meta: {
       method: 'PUT',
       url: `/labs/alerts/${id}`,
@@ -36,8 +36,17 @@ export function updateAlert({ data, id, subaccountId, type = 'UPDATE_ALERT' }) {
   });
 }
 
-export function setEnabledStatus({ enabled, ...rest }) {
-  return updateAlert({ type: 'SET_ALERT_ENABLED_STATUS', data: { enabled }, ...rest });
+export function setEnabledStatus({ enabled, id, subaccountId }) {
+  return sparkpostApiRequest({
+    type: 'SET_ALERT_ENABLED_STATUS',
+    meta: {
+      method: 'PUT',
+      url: `/labs/alerts/${id}`,
+      data: { enabled }
+      // Enable when EO-604 has been addressed
+      // headers: setSubaccountHeader(subaccountId)
+    }
+  });
 }
 
 export function deleteAlert({ id, subaccountId }) {

--- a/src/actions/alerts.js
+++ b/src/actions/alerts.js
@@ -1,5 +1,4 @@
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
-// import setSubaccountHeader from './helpers/setSubaccountHeader';
 
 export function listAlerts() {
   return sparkpostApiRequest({
@@ -23,41 +22,35 @@ export function createAlert({ data }) {
   });
 }
 
-export function updateAlert({ data, id, subaccountId }) {
+export function updateAlert({ data, id }) {
   return sparkpostApiRequest({
     type: 'UPDATE_ALERT',
     meta: {
       method: 'PUT',
       url: `/labs/alerts/${id}`,
       data
-      // Enable when EO-604 has been addressed
-      // headers: setSubaccountHeader(subaccountId)
     }
   });
 }
 
-export function setEnabledStatus({ enabled, id, subaccountId }) {
+export function setEnabledStatus({ enabled, id }) {
   return sparkpostApiRequest({
     type: 'SET_ALERT_ENABLED_STATUS',
     meta: {
       method: 'PUT',
       url: `/labs/alerts/${id}`,
       data: { enabled }
-      // Enable when EO-604 has been addressed
-      // headers: setSubaccountHeader(subaccountId)
     }
   });
 }
 
-export function deleteAlert({ id, subaccountId }) {
+export function deleteAlert({ id }) {
   return sparkpostApiRequest({
     type: 'DELETE_ALERT',
     meta: {
       method: 'DELETE',
       url: `/labs/alerts/${id}`,
       id
-      // Enable when EO-604 has been addressed
-      // headers: setSubaccountHeader(subaccountId)
     }
   });
 }

--- a/src/actions/tests/__snapshots__/alerts.test.js.snap
+++ b/src/actions/tests/__snapshots__/alerts.test.js.snap
@@ -19,7 +19,7 @@ exports[`Action Creator: Alerts should dispatch a delete action 1`] = `
 Array [
   Object {
     "meta": Object {
-      "headers": Object {},
+      "id": "alert-id",
       "method": "DELETE",
       "url": "/labs/alerts/alert-id",
     },
@@ -37,6 +37,21 @@ Array [
       "url": "/labs/alerts",
     },
     "type": "LIST_ALERTS",
+  },
+]
+`;
+
+exports[`Action Creator: Alerts should dispatch a set enabled status action 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "enabled": false,
+      },
+      "method": "PUT",
+      "url": "/labs/alerts/alert-id",
+    },
+    "type": "SET_ALERT_ENABLED_STATUS",
   },
 ]
 `;

--- a/src/actions/tests/alerts.test.js
+++ b/src/actions/tests/alerts.test.js
@@ -25,6 +25,11 @@ describe('Action Creator: Alerts', () => {
     expect(mockStore.getActions()).toMatchSnapshot();
   });
 
+  it('should dispatch a set enabled status action', () => {
+    mockStore.dispatch(alerts.setEnabledStatus({ id: 'alert-id', enabled: false }));
+    expect(mockStore.getActions()).toMatchSnapshot();
+  });
+
   it('should dispatch a delete action', () => {
     mockStore.dispatch(alerts.deleteAlert({ id: 'alert-id' }));
     expect(mockStore.getActions()).toMatchSnapshot();

--- a/src/pages/alerts-new/components/AlertCollection.js
+++ b/src/pages/alerts-new/components/AlertCollection.js
@@ -1,8 +1,9 @@
 import React, { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
-import { Button, Popover, ActionList, Tag } from '@sparkpost/matchbox';
+import { ActionList, Button, Popover, Tag } from '@sparkpost/matchbox';
 import { TableCollection, PageLink } from 'src/components';
+import AlertToggle from './AlertToggle';
 import { MoreHoriz } from '@sparkpost/matchbox-icons';
 import { METRICS } from '../constants/metrics';
 import _ from 'lodash';
@@ -11,7 +12,7 @@ const filterBoxConfig = {
   show: true,
   exampleModifiers: ['enabled', 'metric'],
   itemToStringKeys: ['name', 'id', 'enabled', 'metric'],
-  keyMap: { metric: 'alert_metric', status: 'enabled' }
+  keyMap: { metric: 'alert_metric' }
 };
 
 class AlertCollection extends Component {
@@ -21,7 +22,7 @@ class AlertCollection extends Component {
     const columns = [
       { label: 'Name', sortKey: 'name', width: '25%' },
       { label: 'Metric', sortKey: 'alert_metric' },
-      { label: 'Status', sortKey: 'enabled' },
+      { label: 'Enabled', sortKey: 'enabled' },
       null
     ];
 
@@ -48,9 +49,7 @@ class AlertCollection extends Component {
         <PageLink to={this.getDetailsLink({ id, subaccount_id })}>{name}</PageLink>
       </Fragment>,
       <Tag>{_.get(METRICS, alert_metric, alert_metric)}</Tag>,
-      <Tag color={enabled ? 'blue' : null}>
-        {enabled ? 'Enabled' : 'Disabled'}
-      </Tag>,
+      <AlertToggle enabled={enabled} id={id} subaccountId={subaccount_id} />,
       <div style={{ textAlign: 'right' }}>
         <Popover left trigger={<Button flat size='large'><MoreHoriz size={21}/></Button>}>
           <ActionList actions={actions}/>

--- a/src/pages/alerts-new/components/AlertToggle.js
+++ b/src/pages/alerts-new/components/AlertToggle.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { Toggle } from '@sparkpost/matchbox';
 import { setEnabledStatus } from 'src/actions/alerts';
 import { showAlert } from 'src/actions/globalAlert';
+import styles from './AlertToggle.module.scss';
 
 export class AlertToggle extends Component {
   state = {
@@ -31,13 +32,15 @@ export class AlertToggle extends Component {
     const { id, pending } = this.props;
 
     return (
-      <Toggle
-        id={id}
-        compact
-        checked={enabled}
-        disabled={pending}
-        onChange={this.handleToggle}
-      />
+      <div className={styles.Wrapper}>
+        <Toggle
+          id={id}
+          compact
+          checked={enabled}
+          disabled={pending}
+          onChange={this.handleToggle}
+        />
+      </div>
     );
   }
 }

--- a/src/pages/alerts-new/components/AlertToggle.js
+++ b/src/pages/alerts-new/components/AlertToggle.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Toggle } from '@sparkpost/matchbox';
+import { setEnabledStatus } from 'src/actions/alerts';
+import { showAlert } from 'src/actions/globalAlert';
+
+class AlertToggle extends Component {
+  state = {
+    enabled: false
+  }
+
+  componentDidMount() {
+    this.setState({ enabled: this.props.enabled });
+  }
+
+  componentDidUpdate({ enabled: prevEnabled }) {
+    const { enabled } = this.props;
+
+    // Update checkbox value when list updates (do i need this)
+    if (enabled !== prevEnabled) {
+      this.setState({ enabled });
+    }
+  }
+
+  handleToggle = () => {
+    const { id, subaccountId, setEnabledStatus, showAlert } = this.props;
+    const { enabled } = this.state;
+
+    this.setState({ enabled: !enabled });
+
+    return setEnabledStatus({ id, subaccountId, enabled: !enabled }).then(() => {
+      showAlert({ type: 'success', message: 'Alert updated' });
+    }).catch(() => {
+      // Revert to initial value
+      this.setState({ enabled: this.props.enabled });
+    });
+  }
+
+  render() {
+    const { enabled } = this.state;
+    const { id, pending } = this.props;
+
+    return (
+      <Toggle
+        id={id}
+        compact
+        checked={enabled}
+        disabled={pending}
+        onChange={this.handleToggle}
+      />
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  pending: state.alerts.setEnabledStatusPending
+});
+
+export default connect(mapStateToProps, { setEnabledStatus, showAlert })(AlertToggle);
+
+/* <Toggle
+  id={`alert-${id}`}
+  defaultChecked={enabled}
+  // disabled={rowUpdatePending}
+  // value={enabled ? 'checked' : null}
+  compact
+  onChange={() => handleEnabledToggle({ id, enabled, subaccountId: subaccount_id })}
+/> */

--- a/src/pages/alerts-new/components/AlertToggle.js
+++ b/src/pages/alerts-new/components/AlertToggle.js
@@ -4,22 +4,13 @@ import { Toggle } from '@sparkpost/matchbox';
 import { setEnabledStatus } from 'src/actions/alerts';
 import { showAlert } from 'src/actions/globalAlert';
 
-class AlertToggle extends Component {
+export class AlertToggle extends Component {
   state = {
     enabled: false
   }
 
   componentDidMount() {
     this.setState({ enabled: this.props.enabled });
-  }
-
-  componentDidUpdate({ enabled: prevEnabled }) {
-    const { enabled } = this.props;
-
-    // Update checkbox value when list updates (do i need this)
-    if (enabled !== prevEnabled) {
-      this.setState({ enabled });
-    }
   }
 
   handleToggle = () => {
@@ -31,8 +22,7 @@ class AlertToggle extends Component {
     return setEnabledStatus({ id, subaccountId, enabled: !enabled }).then(() => {
       showAlert({ type: 'success', message: 'Alert updated' });
     }).catch(() => {
-      // Revert to initial value
-      this.setState({ enabled: this.props.enabled });
+      this.setState({ enabled: this.props.enabled }); // Revert to initial value
     });
   }
 
@@ -57,12 +47,3 @@ const mapStateToProps = (state) => ({
 });
 
 export default connect(mapStateToProps, { setEnabledStatus, showAlert })(AlertToggle);
-
-/* <Toggle
-  id={`alert-${id}`}
-  defaultChecked={enabled}
-  // disabled={rowUpdatePending}
-  // value={enabled ? 'checked' : null}
-  compact
-  onChange={() => handleEnabledToggle({ id, enabled, subaccountId: subaccount_id })}
-/> */

--- a/src/pages/alerts-new/components/AlertToggle.module.scss
+++ b/src/pages/alerts-new/components/AlertToggle.module.scss
@@ -1,0 +1,6 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.Wrapper {
+  display: flex;
+  align-items: center;
+}

--- a/src/pages/alerts-new/components/tests/AlertToggle.test.js
+++ b/src/pages/alerts-new/components/tests/AlertToggle.test.js
@@ -1,0 +1,57 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { AlertToggle } from '../AlertToggle';
+
+describe('AlertToggle Component', () => {
+  const props = {
+    id: 'mock-id',
+    subaccountId: 101,
+    enabled: true,
+    pending: false,
+    setEnabledStatus: jest.fn(),
+    showAlert: jest.fn()
+  };
+
+  const subject = (options) => shallow(<AlertToggle {...props} {...options} />);
+
+  it('should render initial state', () => {
+    const wrapper = subject();
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Toggle')).toBeChecked();
+  });
+
+  it('should handle a successful toggle', async () => {
+    const setEnabledStatus = jest.fn(() => Promise.resolve());
+    const wrapper = subject({ setEnabledStatus });
+
+    await wrapper.find('Toggle').prop('onChange')();
+
+    expect(setEnabledStatus).toHaveBeenCalledWith({
+      enabled: false,
+      id: 'mock-id',
+      subaccountId: 101
+    });
+
+    expect(props.showAlert).toHaveBeenCalledWith({
+      message: 'Alert updated',
+      type: 'success'
+    });
+
+    expect(wrapper.find('Toggle')).not.toBeChecked();
+  });
+
+  it('should handle a failed toggle', async () => {
+    const setEnabledStatus = jest.fn(() => Promise.reject());
+    const wrapper = subject({ setEnabledStatus, enabled: false });
+
+    await wrapper.find('Toggle').prop('onChange')();
+
+    expect(setEnabledStatus).toHaveBeenCalledWith({
+      enabled: true,
+      id: 'mock-id',
+      subaccountId: 101
+    });
+
+    expect(wrapper.find('Toggle')).not.toBeChecked();
+  });
+});

--- a/src/pages/alerts-new/components/tests/AlertToggle.test.js
+++ b/src/pages/alerts-new/components/tests/AlertToggle.test.js
@@ -20,6 +20,11 @@ describe('AlertToggle Component', () => {
     expect(wrapper.find('Toggle')).toBeChecked();
   });
 
+  it('should render pending state', () => {
+    const wrapper = subject({ pending: true });
+    expect(wrapper.find('Toggle')).toBeDisabled();
+  });
+
   it('should handle a successful toggle', async () => {
     const setEnabledStatus = jest.fn(() => Promise.resolve());
     const wrapper = subject({ setEnabledStatus });

--- a/src/pages/alerts-new/components/tests/__snapshots__/AlertCollection.test.js.snap
+++ b/src/pages/alerts-new/components/tests/__snapshots__/AlertCollection.test.js.snap
@@ -14,7 +14,7 @@ exports[`TestCollection Component should render 1`] = `
         "sortKey": "alert_metric",
       },
       Object {
-        "label": "Status",
+        "label": "Enabled",
         "sortKey": "enabled",
       },
       null,
@@ -36,7 +36,6 @@ exports[`TestCollection Component should render 1`] = `
       ],
       "keyMap": Object {
         "metric": "alert_metric",
-        "status": "enabled",
       },
       "show": true,
     }
@@ -81,11 +80,11 @@ Array [
   <Tag>
     Monthly Sending Limit
   </Tag>,
-  <Tag
-    color="blue"
-  >
-    Enabled
-  </Tag>,
+  <Connect(AlertToggle)
+    enabled={true}
+    id="id-1"
+    subaccountId={101}
+  />,
   <div
     style={
       Object {
@@ -143,11 +142,10 @@ Array [
   <Tag>
     Monthly Sending Limit
   </Tag>,
-  <Tag
-    color={null}
-  >
-    Disabled
-  </Tag>,
+  <Connect(AlertToggle)
+    enabled={false}
+    id="id-2"
+  />,
   <div
     style={
       Object {
@@ -205,11 +203,10 @@ Array [
   <Tag>
     another_metric
   </Tag>,
-  <Tag
-    color="blue"
-  >
-    Enabled
-  </Tag>,
+  <Connect(AlertToggle)
+    enabled={true}
+    id="id-3"
+  />,
   <div
     style={
       Object {

--- a/src/pages/alerts-new/components/tests/__snapshots__/AlertToggle.test.js.snap
+++ b/src/pages/alerts-new/components/tests/__snapshots__/AlertToggle.test.js.snap
@@ -1,11 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AlertToggle Component should render initial state 1`] = `
-<Toggle
-  checked={true}
-  compact={true}
-  disabled={false}
-  id="mock-id"
-  onChange={[Function]}
-/>
+<div
+  className="Wrapper"
+>
+  <Toggle
+    checked={true}
+    compact={true}
+    disabled={false}
+    id="mock-id"
+    onChange={[Function]}
+  />
+</div>
 `;

--- a/src/pages/alerts-new/components/tests/__snapshots__/AlertToggle.test.js.snap
+++ b/src/pages/alerts-new/components/tests/__snapshots__/AlertToggle.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertToggle Component should render initial state 1`] = `
+<Toggle
+  checked={true}
+  compact={true}
+  disabled={false}
+  id="mock-id"
+  onChange={[Function]}
+/>
+`;

--- a/src/pages/alerts-new/containers/ListPage.container.js
+++ b/src/pages/alerts-new/containers/ListPage.container.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { deleteAlert, listAlerts, createAlert } from 'src/actions/alerts';
+import { createAlert, deleteAlert, listAlerts, setEnabledStatus, updateAlert } from 'src/actions/alerts';
 import { showAlert } from 'src/actions/globalAlert';
 
 function withAlertsList(WrappedComponent) {
-  const mapDispatchToProps = { deleteAlert, listAlerts, showAlert, createAlert };
+  const mapDispatchToProps = { deleteAlert, createAlert, listAlerts, setEnabledStatus, showAlert, updateAlert };
 
   const mapStateToProps = (state, props) => ({
     alerts: state.alerts.list,

--- a/src/pages/alerts-new/containers/ListPage.container.js
+++ b/src/pages/alerts-new/containers/ListPage.container.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { createAlert, deleteAlert, listAlerts, setEnabledStatus, updateAlert } from 'src/actions/alerts';
+import { deleteAlert, listAlerts } from 'src/actions/alerts';
 import { showAlert } from 'src/actions/globalAlert';
 
 function withAlertsList(WrappedComponent) {
-  const mapDispatchToProps = { deleteAlert, createAlert, listAlerts, setEnabledStatus, showAlert, updateAlert };
+  const mapDispatchToProps = { deleteAlert, listAlerts, showAlert };
 
   const mapStateToProps = (state, props) => ({
     alerts: state.alerts.list,

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -4,7 +4,8 @@ const initialState = {
   listError: null,
   createPending: false,
   updatePending: false,
-  deletePending: false
+  deletePending: false,
+  setEnabledStatusPending: false
 };
 
 export default (state = initialState, { type, payload, meta }) => {
@@ -52,6 +53,13 @@ export default (state = initialState, { type, payload, meta }) => {
       return { ...state, deletePending: true };
 
     case 'DELETE_ALERT_SUCCESS':
+      return {
+        ...state,
+        deletePending: false,
+        // TODO will need to match subaccount id
+        list: state.list.filter((a) => a.id !== meta.id)
+      };
+
     case 'DELETE_ALERT_FAIL':
       return { ...state, deletePending: false };
 

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -38,6 +38,14 @@ export default (state = initialState, { type, payload, meta }) => {
     case 'UPDATE_ALERT_FAIL':
       return { ...state, updatePending: false };
 
+    // UPDATE single list row enabled status
+    case 'SET_ALERT_ENABLED_STATUS_PENDING':
+      return { ...state, setEnabledStatusPending: true };
+
+    case 'SET_ALERT_ENABLED_STATUS_SUCCESS':
+    case 'SET_ALERT_ENABLED_STATUS_FAIL':
+      return { ...state, setEnabledStatusPending: false };
+
       /* DELETE */
 
     case 'DELETE_ALERT_PENDING':

--- a/src/reducers/tests/__snapshots__/alerts.test.js.snap
+++ b/src/reducers/tests/__snapshots__/alerts.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alerts reducer matches alerts correctly (excludes deleted one) 1`] = `
+Object {
+  "deletePending": false,
+  "list": Array [
+    Object {
+      "enabled": true,
+      "id": "mock-alert-1",
+    },
+  ],
+}
+`;

--- a/src/reducers/tests/alerts.test.js
+++ b/src/reducers/tests/alerts.test.js
@@ -1,0 +1,20 @@
+import cases from 'jest-in-case';
+import alertsReducer from '../alerts';
+
+const state = {
+  list: [
+    { 'id': 'mock-alert-1', enabled: true },
+    { 'id': 'mock-alert-2', enabled: false }
+  ]
+};
+
+const TEST_CASES = {
+  'matches alerts correctly (excludes deleted one)': {
+    type: 'DELETE_ALERT_SUCCESS',
+    meta: { id: 'mock-alert-2' }
+  }
+};
+
+cases('Alerts reducer', (action) => {
+  expect(alertsReducer(state, action)).toMatchSnapshot();
+}, TEST_CASES);


### PR DESCRIPTION
### What Changed
 - Bumped matchbox to 3.3.4 to include new `compact` style `<Toggle/>`
 - Adds new AlertToggle component inlined within the alerts table collection
   - Component manages `enabled` local state and handles the update request
 - A successful delete action from the list page now excludes the row

### How To Test
 - Log into `appteam` or enable the `feature-alerts` account UI options
 - Go to `/alerts-new` (hidden route)

### Notes
- Due to EO-604, certain entries may 404 on update or 500 on delete.
- API reference: https://developers.sparkpost.com/api/alerts
- Small visual bug with toggles, `border-radius` should be `50%` not `100%` (might not fix in this ticket)

### To Do
- [x] Address feedback
- [x] ~~Reinstate subaccount headers if the issue is resolved before this is ready to merge~~
