### PR TITLE
FE-628: Use qs instead of query-string to parse URI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12671,8 +12671,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12693,14 +12692,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12715,20 +12712,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12845,8 +12839,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12858,7 +12851,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12873,7 +12865,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12881,14 +12872,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12907,7 +12896,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12988,8 +12976,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -13001,7 +12988,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13087,8 +13073,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13124,7 +13109,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13144,7 +13128,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13188,14 +13171,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -27739,9 +27720,9 @@
       "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
     },
     "query-string": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "papaparse": "^4.3.6",
     "payment": "^2.3.0",
     "print-js": "^1.0.31",
+    "qs": "^6.6.0",
     "query-string": "^6.2.0",
     "raven-for-redux": "^1.1.1",
     "raven-js": "^3.26.3",

--- a/src/actions/messageEvents.js
+++ b/src/actions/messageEvents.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import config from 'src/config';
 import _ from 'lodash';
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
-import qs from 'query-string';
+import qs from 'qs';
 
 const { apiDateFormat, messageEvents: { retentionPeriodDays }} = config;
 

--- a/src/actions/tests/messageEvents.test.js
+++ b/src/actions/tests/messageEvents.test.js
@@ -55,7 +55,7 @@ describe('Action Creator: MessageEvents', () => {
     beforeEach(() => {
       testState = { messageEvents: {
         cachedResultsByPage: [[]],
-        linkByPage: ['foo=bar1', 'for=bar2']
+        linkByPage: ['foo=bar1', 'for=bar2&cursor=foo==']
       }};
       dispatchMock = jest.fn((a) => a);
       getStateMock = jest.fn(() => testState);
@@ -71,7 +71,8 @@ describe('Action Creator: MessageEvents', () => {
           currentPageIndex: currentPage - 1,
           method: 'GET',
           params: {
-            for: 'bar2'
+            for: 'bar2',
+            cursor: 'foo=='
           },
           showErrorAlert: false,
           url: '/v1/events/message'


### PR DESCRIPTION


### What Changed
 - Added `qs` as a dependency.
 - Use `qs` in events page
 - Add tests for cursor

### How To Test
 - Go to Events Search page and navigate through pages.
