### PR TITLE
AC-600 Onboarding copy changes to position as test account

### DIFF
--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -16,8 +16,8 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
     ? 'First dedicated IP address is free'
     : null;
 
-  const currentFreePlan = plan.code && plan.code.includes('free500-1018');
-  const planTitle = currentFreePlan ? 'Test Account' : `${plan.volume.toLocaleString()} emails`;
+  const currentFreePlan = plan.code && ['free500-1018', 'free15K-1018'].includes(plan.code);
+  const planTitle = currentFreePlan ? 'Test Account' : `${plan.volume.toLocaleString()}`;
 
   const displayCsm = showCsm && plan.includesCsm;
 
@@ -34,7 +34,7 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{planTitle}</strong>
+        <strong>{planTitle}</strong> {!currentFreePlan && 'emails'}
         {!plan.isFree && '/month'}
         {priceInfo.price > 0 && <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
       </span>

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -12,9 +12,7 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
 
   const is30DayPlan = plan.code && plan.code.includes('free15K');
 
-  const overage = plan.isFree
-    ? 'Full-featured developer account'
-    : plan.overage ? `$${plan.overage.toFixed(2)}/ thousand extra emails. ` : null;
+  const overage = !plan.isFree && plan.overage ? `$${plan.overage.toFixed(2)}/ thousand extra emails. ` : null;
 
   const ip = plan.includesIp
     ? 'First dedicated IP address is free'
@@ -32,13 +30,15 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
     discountAmount = discountAmount * ((100 - selectedPromo.discount_percentage) / 100);
   }
 
+  const planName = plan.isFree ? 'Test Account' : plan.volume.toLocaleString();
+  const planVolume = is30DayPlan ? ' for 30 days' : '/month';
+
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{plan.volume.toLocaleString()}</strong> emails
-        {is30DayPlan ? ' for 30 days' : '/month'}
+        <strong>{planName}</strong> {!plan.isFree && ' emails'}
+        {!plan.isFree && planVolume}
         {priceInfo.price > 0 && <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
-        {plan.isFree && ' for free'}
       </span>
       <span className={styles.SupportLabel}>
         {showOverage && overage}

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -10,8 +10,6 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
 
   const priceInfo = getPlanPrice(plan);
 
-  const is30DayPlan = plan.code && plan.code.includes('free15K');
-
   const overage = !plan.isFree && plan.overage ? `$${plan.overage.toFixed(2)}/ thousand extra emails. ` : null;
 
   const ip = plan.includesIp
@@ -30,14 +28,11 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
     discountAmount = discountAmount * ((100 - selectedPromo.discount_percentage) / 100);
   }
 
-  const planName = plan.isFree ? 'Test Account' : plan.volume.toLocaleString();
-  const planVolume = is30DayPlan ? ' for 30 days' : '/month';
-
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{planName}</strong> {!plan.isFree && ' emails'}
-        {!plan.isFree && planVolume}
+        <strong>{plan.isFree ? 'Test Account' : plan.volume.toLocaleString()}</strong>
+        {!plan.isFree && ' emails/month'}
         {priceInfo.price > 0 && <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
       </span>
       <span className={styles.SupportLabel}>

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -34,8 +34,7 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{planTitle}</strong> {!currentFreePlan && 'emails'}
-        {!plan.isFree && '/month'}
+        <strong>{planTitle}</strong> {!currentFreePlan && 'emails/month'}
         {priceInfo.price > 0 && <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
       </span>
       <span className={styles.SupportLabel}>

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -3,18 +3,21 @@ import _ from 'lodash';
 import { getPlanPrice } from 'src/helpers/billing';
 import styles from './PlanPrice.module.scss';
 
-const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false, selectedPromo = {} , ...rest }) => {
+const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false, selectedPromo = {}, ...rest }) => {
   if (_.isEmpty(plan)) {
     return null;
   }
 
   const priceInfo = getPlanPrice(plan);
 
-  const overage = !plan.isFree && plan.overage ? `$${plan.overage.toFixed(2)}/ thousand extra emails. ` : null;
+  const overage = plan.isFree ? 'Full-featured developer account' : plan.overage ? `$${plan.overage.toFixed(2)}/ thousand extra emails. ` : null;
 
   const ip = plan.includesIp
     ? 'First dedicated IP address is free'
     : null;
+
+  const currentFreePlan = plan.code && plan.code.includes('free500-1018');
+  const planTitle = currentFreePlan ? 'Test Account' : `${plan.volume.toLocaleString()} emails`;
 
   const displayCsm = showCsm && plan.includesCsm;
 
@@ -31,8 +34,8 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{plan.isFree ? 'Test Account' : plan.volume.toLocaleString()}</strong>
-        {!plan.isFree && ' emails/month'}
+        <strong>{planTitle}</strong>
+        {!plan.isFree && '/month'}
         {priceInfo.price > 0 && <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
       </span>
       <span className={styles.SupportLabel}>

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -10,6 +10,7 @@ exports[`PlanPrice allows class name overriding 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -38,6 +39,7 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -72,6 +74,7 @@ exports[`PlanPrice renders correctly 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -98,11 +101,9 @@ exports[`PlanPrice renders correctly for 30 day free plan 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      Test Account
     </strong>
-     emails
-     for 30 days
-     for free
+     
   </span>
   <span
     className="SupportLabel"
@@ -120,6 +121,7 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -151,11 +153,9 @@ exports[`PlanPrice renders correctly for eternal free plan 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      Test Account
     </strong>
-     emails
-    /month
-     for free
+     
   </span>
   <span
     className="SupportLabel"
@@ -173,6 +173,7 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -201,6 +202,7 @@ exports[`PlanPrice renders flat discount 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -235,6 +237,7 @@ exports[`PlanPrice renders free ip 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -265,6 +268,7 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -298,6 +302,7 @@ exports[`PlanPrice renders percent discount 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>
@@ -332,6 +337,7 @@ exports[`PlanPrice renders with overage 1`] = `
     <strong>
       50,000
     </strong>
+     
      emails
     /month
     <span>

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -8,8 +8,10 @@ exports[`PlanPrice allows class name overriding 1`] = `
     className="abcd-class"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -35,8 +37,10 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -68,8 +72,10 @@ exports[`PlanPrice renders correctly 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -95,8 +101,10 @@ exports[`PlanPrice renders correctly for 30 day free plan 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
   </span>
   <span
     className="SupportLabel"
@@ -112,8 +120,10 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -144,8 +154,10 @@ exports[`PlanPrice renders correctly for eternal free plan 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
   </span>
   <span
     className="SupportLabel"
@@ -161,8 +173,10 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -188,8 +202,10 @@ exports[`PlanPrice renders flat discount 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -221,8 +237,10 @@ exports[`PlanPrice renders free ip 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -250,8 +268,10 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -282,8 +302,10 @@ exports[`PlanPrice renders percent discount 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 
@@ -315,8 +337,10 @@ exports[`PlanPrice renders with overage 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000 emails
+      50,000
     </strong>
+     
+    emails
     /month
     <span>
        at 

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -10,9 +10,7 @@ exports[`PlanPrice allows class name overriding 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <strong>
@@ -39,9 +37,7 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <s
@@ -74,9 +70,7 @@ exports[`PlanPrice renders correctly 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <strong>
@@ -103,7 +97,6 @@ exports[`PlanPrice renders correctly for 30 day free plan 1`] = `
     <strong>
       Test Account
     </strong>
-     
   </span>
   <span
     className="SupportLabel"
@@ -121,9 +114,7 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <strong>
@@ -155,7 +146,6 @@ exports[`PlanPrice renders correctly for eternal free plan 1`] = `
     <strong>
       Test Account
     </strong>
-     
   </span>
   <span
     className="SupportLabel"
@@ -173,9 +163,7 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <strong>
@@ -202,9 +190,7 @@ exports[`PlanPrice renders flat discount 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <s
@@ -237,9 +223,7 @@ exports[`PlanPrice renders free ip 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <strong>
@@ -268,9 +252,7 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <strong>
@@ -302,9 +284,7 @@ exports[`PlanPrice renders percent discount 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <s
@@ -337,9 +317,7 @@ exports[`PlanPrice renders with overage 1`] = `
     <strong>
       50,000
     </strong>
-     
-     emails
-    /month
+     emails/month
     <span>
        at 
       <strong>

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -11,8 +11,7 @@ exports[`PlanPrice allows class name overriding 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <strong>
@@ -40,8 +39,7 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <s
@@ -75,8 +73,7 @@ exports[`PlanPrice renders correctly 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <strong>
@@ -104,7 +101,7 @@ exports[`PlanPrice renders correctly for 30 day free plan 1`] = `
       50,000
     </strong>
      
-    emails
+    emails/month
   </span>
   <span
     className="SupportLabel"
@@ -123,8 +120,7 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <strong>
@@ -157,7 +153,7 @@ exports[`PlanPrice renders correctly for eternal free plan 1`] = `
       50,000
     </strong>
      
-    emails
+    emails/month
   </span>
   <span
     className="SupportLabel"
@@ -176,8 +172,7 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <strong>
@@ -205,8 +200,7 @@ exports[`PlanPrice renders flat discount 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <s
@@ -240,8 +234,7 @@ exports[`PlanPrice renders free ip 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <strong>
@@ -271,8 +264,7 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <strong>
@@ -305,8 +297,7 @@ exports[`PlanPrice renders percent discount 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <s
@@ -340,8 +331,7 @@ exports[`PlanPrice renders with overage 1`] = `
       50,000
     </strong>
      
-    emails
-    /month
+    emails/month
     <span>
        at 
       <strong>

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -8,9 +8,9 @@ exports[`PlanPrice allows class name overriding 1`] = `
     className="abcd-class"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <strong>
@@ -35,9 +35,9 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <s
@@ -68,9 +68,9 @@ exports[`PlanPrice renders correctly 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <strong>
@@ -95,7 +95,7 @@ exports[`PlanPrice renders correctly for 30 day free plan 1`] = `
     className="MainLabel"
   >
     <strong>
-      Test Account
+      50,000 emails
     </strong>
   </span>
   <span
@@ -112,9 +112,9 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <strong>
@@ -144,7 +144,7 @@ exports[`PlanPrice renders correctly for eternal free plan 1`] = `
     className="MainLabel"
   >
     <strong>
-      Test Account
+      50,000 emails
     </strong>
   </span>
   <span
@@ -161,9 +161,9 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <strong>
@@ -188,9 +188,9 @@ exports[`PlanPrice renders flat discount 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <s
@@ -221,9 +221,9 @@ exports[`PlanPrice renders free ip 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <strong>
@@ -250,9 +250,9 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <strong>
@@ -282,9 +282,9 @@ exports[`PlanPrice renders percent discount 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <s
@@ -315,9 +315,9 @@ exports[`PlanPrice renders with overage 1`] = `
     className="MainLabel"
   >
     <strong>
-      50,000
+      50,000 emails
     </strong>
-     emails/month
+    /month
     <span>
        at 
       <strong>

--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -73,9 +73,9 @@ export class OnboardingPlanPage extends Component {
     if (selectedPlan.isFree) {
       return (
         <Panel.Section>
-          <p>Our full-featured, free account provides you:</p>
+          <p>Full featured test account that includes:</p>
           <ul>
-            <li>Up to 15,000 free messages for first 30 days, then 500/month forever.</li>
+            <li>Limited sending volume for testing.</li>
             <li>Access to all of our powerful API features.</li>
             <li>30 days of free technical support to get you up and running.</li>
           </ul>

--- a/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
+++ b/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
@@ -129,11 +129,11 @@ exports[`ChoosePlan page tests should show free bullets when isFree is selected 
         >
           <Panel.Section>
             <p>
-              Our full-featured, free account provides you:
+              Full featured test account that includes:
             </p>
             <ul>
               <li>
-                Up to 15,000 free messages for first 30 days, then 500/month forever.
+                Limited sending volume for testing.
               </li>
               <li>
                 Access to all of our powerful API features.


### PR DESCRIPTION
Small PR to change the naming used for the free account teir in the ChoosePlan and PlanPrice components. The subtext for free accounts when selecting a plan has been removed. The 
`50,000 emails/month for free` has been replaced with `Test Account`.

