### PR TITLE
EO-577 Create engagement rate by cohort page

### DIFF
--- a/src/actions/signals.fake.js
+++ b/src/actions/signals.fake.js
@@ -181,11 +181,11 @@ export function getHealthScore({ facet, filter }) {
 }
 
 const engagementRateDetails = (count) => _.range(count).map((n) => {
-  const c_new_engagement = randInt(90, 10);
-  const c_14d_engagement = randInt(90, 10);
-  const c_90d_engagement = randInt(90, 10);
-  const c_365d_engagement = randInt(90, 10);
-  const c_uneng_engagement = randInt(90, 10);
+  const c_new_engagement = randInt(80, 68);
+  const c_14d_engagement = randInt(50, 30);
+  const c_90d_engagement = randInt(30, 15);
+  const c_365d_engagement = randInt(15, 9);
+  const c_uneng_engagement = randInt(5, 1);
   const c_total_engagement = [c_new_engagement, c_14d_engagement, c_90d_engagement, c_365d_engagement, c_uneng_engagement].reduce((a, b) => a + b, 0);
 
   return {
@@ -198,7 +198,7 @@ export function getEngagementRateByCohort({ facet, filter }) {
   return (dispatch, getState) => {
     const { relativeRange } = getState().signalOptions;
     const count = Number(relativeRange.replace('days', ''));
-    const data = engagementRateDetails(count);
+    const data = engagementRateDetails(count + 1);
 
     dispatch({
       type: 'GET_ENGAGEMENT_RATE_BY_COHORT_PENDING'

--- a/src/actions/signals.fake.js
+++ b/src/actions/signals.fake.js
@@ -179,3 +179,47 @@ export function getHealthScore({ facet, filter }) {
     }), 500);
   };
 }
+
+const engagementRateDetails = (count) => _.range(count).map((n) => {
+  const c_new_engagement = randInt(90, 10);
+  const c_14d_engagement = randInt(90, 10);
+  const c_90d_engagement = randInt(90, 10);
+  const c_365d_engagement = randInt(90, 10);
+  const c_uneng_engagement = randInt(90, 10);
+  const c_total_engagement = [c_new_engagement, c_14d_engagement, c_90d_engagement, c_365d_engagement, c_uneng_engagement].reduce((a, b) => a + b, 0);
+
+  return {
+    c_new_engagement, c_14d_engagement, c_90d_engagement, c_365d_engagement, c_uneng_engagement, c_total_engagement,
+    dt: moment().subtract(count - n, 'day').format('YYYY-MM-DD')
+  };
+});
+
+export function getEngagementRateByCohort({ facet, filter }) {
+  return (dispatch, getState) => {
+    const { relativeRange } = getState().signalOptions;
+    const count = Number(relativeRange.replace('days', ''));
+    const data = engagementRateDetails(count);
+
+    dispatch({
+      type: 'GET_ENGAGEMENT_RATE_BY_COHORT_PENDING'
+    });
+
+    setTimeout(() => dispatch({
+      type: 'GET_ENGAGEMENT_RATE_BY_COHORT_SUCCESS',
+      payload: {
+        data: [
+          {
+            [facet]: filter,
+            history: data
+          },
+          {
+            // simulating multiple results to for facetid matching
+            [facet]: 'notthisone',
+            history: data
+          }
+        ],
+        total_count: 2
+      }
+    }), 500);
+  };
+}

--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -61,6 +61,11 @@ export const getEngagementRecency = signalsActionCreator({
   type: 'GET_ENGAGEMENT_RECENCY'
 });
 
+export const getEngagementRateByCohort = signalsActionCreator({
+  dimension: 'engagement_by_cohort', // TODO update when api is ready
+  type: 'GET_ENGAGEMENT_RATE_BY_COHORT'
+});
+
 export const getHealthScore = signalsActionCreator({
   dimension: 'health-score',
   type: 'GET_HEALTH_SCORE'

--- a/src/actions/tests/__snapshots__/signals.test.js.snap
+++ b/src/actions/tests/__snapshots__/signals.test.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Signals Actions .getEngagementRateByCohort by default 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "headers": Object {},
+      "method": "GET",
+      "params": Object {
+        "filter": undefined,
+        "from": "2018-01-12",
+        "limit": undefined,
+        "offset": undefined,
+        "order": undefined,
+        "order_by": undefined,
+        "to": "2018-01-13",
+      },
+      "showErrorAlert": false,
+      "url": "/v1/signals/engagement_by_cohort/",
+    },
+    "type": "GET_ENGAGEMENT_RATE_BY_COHORT",
+  },
+]
+`;
+
 exports[`Signals Actions .getEngagementRecency by default 1`] = `
 Array [
   Object {

--- a/src/actions/tests/signals.test.js
+++ b/src/actions/tests/signals.test.js
@@ -1,5 +1,5 @@
 import { snapshotActionCases } from 'src/__testHelpers__/snapshotActionHelpers';
-import { getEngagementRecency, getHealthScore, getSpamHits } from '../signals';
+import { getEngagementRecency, getEngagementRateByCohort, getHealthScore, getSpamHits } from '../signals';
 
 jest.mock('src/actions/helpers/sparkpostApiRequest');
 jest.mock('src/helpers/date', () => ({
@@ -51,6 +51,12 @@ describe('Signals Actions', () => {
   snapshotActionCases('.getEngagementRecency', {
     'by default': {
       action: () => getEngagementRecency({ ...requiredOptions })
+    }
+  });
+
+  snapshotActionCases('.getEngagementRateByCohort', {
+    'by default': {
+      action: () => getEngagementRateByCohort({ ...requiredOptions })
     }
   });
 

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -263,7 +263,7 @@ const routes = [
   },
   {
     path: '/signals/engagement/engagement-rate/:facet/:facetId',
-    component: signals.EngagementRecencyPage,
+    component: signals.EngagementRateByCohortPage,
     condition: all(hasGrants('signals/manage'), hasUiOption('feature_signals_v2')),
     layout: App,
     title: 'Signals',

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -259,6 +259,39 @@ const routes = [
     title: 'Signals',
     supportDocSearch: 'signals'
   },
+  // Signals
+  {
+    path: '/signals/engagement/cohorts/:facet/:facetId',
+    component: signals.EngagementRecencyPage,
+    condition: hasGrants('signals/manage'),
+    layout: App,
+    title: 'Signals',
+    supportDocSearch: 'signals'
+  },
+  {
+    path: '/signals/engagement/engagement-rate/:facet/:facetId',
+    component: signals.EngagementRecencyPage,
+    condition: hasGrants('signals/manage'),
+    layout: App,
+    title: 'Signals',
+    supportDocSearch: 'signals'
+  },
+  {
+    path: '/signals/engagement/unsubscribes/:facet/:facetId',
+    component: signals.EngagementRecencyPage,
+    condition: hasGrants('signals/manage'),
+    layout: App,
+    title: 'Signals',
+    supportDocSearch: 'signals'
+  },
+  {
+    path: '/signals/engagement/complaints/:facet/:facetId',
+    component: signals.EngagementRecencyPage,
+    condition: hasGrants('signals/manage'),
+    layout: App,
+    title: 'Signals',
+    supportDocSearch: 'signals'
+  },
   {
     path: '/account/security',
     redirect: '/account/profile'

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -251,15 +251,8 @@ const routes = [
     title: 'Signals',
     supportDocSearch: 'signals'
   },
-  {
-    path: '/signals/engagement-recency/:facet/:facetId',
-    component: signals.EngagementRecencyPage,
-    condition: hasGrants('signals/manage'),
-    layout: App,
-    title: 'Signals',
-    supportDocSearch: 'signals'
-  },
-  // Signals
+  // Signals routes for 'feature_signals_v2'
+  // TODO: replace the above route with this one below
   {
     path: '/signals/engagement/cohorts/:facet/:facetId',
     component: signals.EngagementRecencyPage,
@@ -271,7 +264,7 @@ const routes = [
   {
     path: '/signals/engagement/engagement-rate/:facet/:facetId',
     component: signals.EngagementRecencyPage,
-    condition: hasGrants('signals/manage'),
+    condition: all(hasGrants('signals/manage'), hasUiOption('feature_signals_v2')),
     layout: App,
     title: 'Signals',
     supportDocSearch: 'signals'
@@ -279,7 +272,7 @@ const routes = [
   {
     path: '/signals/engagement/unsubscribes/:facet/:facetId',
     component: signals.EngagementRecencyPage,
-    condition: hasGrants('signals/manage'),
+    condition: all(hasGrants('signals/manage'), hasUiOption('feature_signals_v2')),
     layout: App,
     title: 'Signals',
     supportDocSearch: 'signals'
@@ -287,7 +280,7 @@ const routes = [
   {
     path: '/signals/engagement/complaints/:facet/:facetId',
     component: signals.EngagementRecencyPage,
-    condition: hasGrants('signals/manage'),
+    condition: all(hasGrants('signals/manage'), hasUiOption('feature_signals_v2')),
     layout: App,
     title: 'Signals',
     supportDocSearch: 'signals'

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -252,7 +252,6 @@ const routes = [
     supportDocSearch: 'signals'
   },
   // Signals routes for 'feature_signals_v2'
-  // TODO: replace the above route with this one below
   {
     path: '/signals/engagement/cohorts/:facet/:facetId',
     component: signals.EngagementRecencyPage,

--- a/src/helpers/hoc.js
+++ b/src/helpers/hoc.js
@@ -1,0 +1,3 @@
+export function getDisplayName(Component, wrapper = 'container') {
+  return `${wrapper}(${Component.displayName || Component.name || 'Component'})`;
+}

--- a/src/helpers/tests/hoc.test.js
+++ b/src/helpers/tests/hoc.test.js
@@ -1,0 +1,18 @@
+import * as hoc from '../hoc';
+
+describe('getDisplayName', () => {
+  it('should return displayName without a wrapper name', () => {
+    const component = { displayName: 'MockClassComponent' };
+    expect(hoc.getDisplayName(component)).toEqual('container(MockClassComponent)');
+  });
+
+  it('should return function name with a wrapper name', () => {
+    const MockFunctionComponent = () => null;
+    expect(hoc.getDisplayName(MockFunctionComponent, 'withTest')).toEqual('withTest(MockFunctionComponent)');
+  });
+
+  it('should return default component name with a wrapper name', () => {
+    const MockFunctionComponent = {};
+    expect(hoc.getDisplayName(MockFunctionComponent, 'withTest')).toEqual('withTest(Component)');
+  });
+});

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -2,6 +2,8 @@
 import React, { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { Panel, Grid } from '@sparkpost/matchbox';
+import LineChart from './components/charts/linechart/LineChart';
+import Legend from './components/charts/legend/Legend';
 import Callout from 'src/components/callout';
 import DateFilter from './components/filters/DateFilter';
 import EngagementRecencyActions from './components/actionContent/EngagementRecencyActions';
@@ -11,7 +13,7 @@ import Page from './components/SignalsPage';
 import Tabs from './components/engagement/Tabs';
 import TooltipMetric from './components/charts/tooltip/TooltipMetric';
 import withEngagementRateByCohortDetails from './containers/EngagementRateByCohortDetailsContainer';
-// import { ENGAGEMENT_RECENCY_COHORTS, ENGAGEMENT_RECENCY_INFO } from './constants/info';
+import { ENGAGEMENT_RECENCY_COHORTS } from './constants/info';
 import { Loading } from 'src/components';
 import { roundToPlaces } from 'src/helpers/units';
 import moment from 'moment';
@@ -54,9 +56,7 @@ export class EngagementRateByCohortPage extends Component {
   }
 
   getYAxisProps = () => ({
-    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`,
-    domain: [0, 1],
-    ticks: [0, 0.25, 0.5, 0.75, 1.0]
+    tickFormatter: (tick) => `${roundToPlaces(tick, 0)}%`
   })
 
   getXAxisProps = () => {
@@ -75,7 +75,7 @@ export class EngagementRateByCohortPage extends Component {
           color={cohorts[key].fill}
           label={cohorts[key].label}
           description={cohorts[key].description}
-          value={`${roundToPlaces(payload[key] * 100, 1)}%`}
+          value={`${roundToPlaces(payload[key], 1)}%`}
         />
       ))}
     </Fragment>
@@ -110,13 +110,14 @@ export class EngagementRateByCohortPage extends Component {
           <Panel sectioned>
             {chartPanel || (
               <div className='LiftTooltip'>
-                {/* <BarChart
-                  gap={gap}
+                <LineChart
+                  height={300}
                   onClick={this.handleDateSelect}
                   selected={selectedDate}
-                  timeSeries={data}
-                  tooltipContent={this.getTooltipContent}
+                  lines={data}
+                  lineType='natural'
                   tooltipWidth='250px'
+                  tooltipContent={this.getTooltipContent}
                   yKeys={_.keys(cohorts).map((key) => ({ key, ...cohorts[key] })).reverse()}
                   yAxisProps={this.getYAxisProps()}
                   xAxisProps={this.getXAxisProps()}
@@ -124,7 +125,7 @@ export class EngagementRateByCohortPage extends Component {
                 <Legend
                   items={_.values(cohorts)}
                   tooltipContent={(label) => ENGAGEMENT_RECENCY_COHORTS[label]}
-                /> */}
+                />
               </div>
             )}
           </Panel>

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -7,7 +7,6 @@ import Legend from './components/charts/legend/Legend';
 import Callout from 'src/components/callout';
 import DateFilter from './components/filters/DateFilter';
 import EngagementRecencyActions from './components/actionContent/EngagementRecencyActions';
-// import Legend from './components/charts/legend/Legend';
 import OtherChartsHeader from './components/OtherChartsHeader';
 import Page from './components/SignalsPage';
 import Tabs from './components/engagement/Tabs';

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -1,0 +1,180 @@
+/* eslint-disable max-lines */
+import React, { Component, Fragment } from 'react';
+import { Link } from 'react-router-dom';
+import { Panel, Grid } from '@sparkpost/matchbox';
+import BarChart from './components/charts/barchart/BarChart';
+import Callout from 'src/components/callout';
+import ChartHeader from './components/ChartHeader';
+import DateFilter from './components/filters/DateFilter';
+import EngagementRecencyActions from './components/actionContent/EngagementRecencyActions';
+import Legend from './components/charts/legend/Legend';
+import OtherChartsHeader from './components/OtherChartsHeader';
+import Page from './components/SignalsPage';
+import Tabs from './components/engagement/Tabs';
+import TooltipMetric from './components/charts/tooltip/TooltipMetric';
+import withEngagementRecencyDetails from './containers/EngagementRecencyDetailsContainer';
+import { ENGAGEMENT_RECENCY_COHORTS, ENGAGEMENT_RECENCY_INFO } from './constants/info';
+import { AccessControl } from 'src/components/auth';
+import { Loading } from 'src/components';
+import { hasUiOption } from 'src/helpers/conditions/account';
+import { not } from 'src/helpers/conditions';
+import { roundToPlaces } from 'src/helpers/units';
+import moment from 'moment';
+import _ from 'lodash';
+
+import SpamTrapsPreview from './components/previews/SpamTrapsPreview';
+import HealthScorePreview from './components/previews/HealthScorePreview';
+import cohorts from './constants/cohorts';
+import styles from './DetailsPages.module.scss';
+
+export class EngagementRateByCohortPage extends Component {
+  state = {
+    selectedDate: null
+  }
+
+  componentDidMount() {
+    const { selected } = this.props;
+
+    if (selected) {
+      this.setState({ selectedDate: selected });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { data } = this.props;
+    const { selectedDate } = this.state;
+
+    const dataSetChanged = prevProps.data !== data;
+    let selectedDataByDay = _.find(data, ['date', selectedDate]);
+
+    // Select last date in time series
+    if (dataSetChanged && !selectedDataByDay) {
+      selectedDataByDay = _.last(data);
+      this.setState({ selectedDate: selectedDataByDay.date });
+    }
+  }
+
+  handleDateSelect = (node) => {
+    this.setState({ selectedDate: _.get(node, 'payload.date') });
+  }
+
+  getYAxisProps = () => ({
+    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`,
+    domain: [0, 1],
+    ticks: [0, 0.25, 0.5, 0.75, 1.0]
+  })
+
+  getXAxisProps = () => {
+    const { xTicks } = this.props;
+    return {
+      ticks: xTicks,
+      tickFormatter: (tick) => moment(tick).format('M/D')
+    };
+  }
+
+  getTooltipContent = ({ payload = {}}) => (
+    <Fragment>
+      {_.keys(cohorts).map((key) => (
+        <TooltipMetric
+          key={key}
+          color={cohorts[key].fill}
+          label={cohorts[key].label}
+          description={cohorts[key].description}
+          value={`${roundToPlaces(payload[key] * 100, 1)}%`}
+        />
+      ))}
+    </Fragment>
+  )
+
+  renderContent = () => {
+    const { data = [], facet, facetId, loading, gap, empty, error } = this.props;
+    const { selectedDate } = this.state;
+    const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
+    let chartPanel;
+
+    if (empty) {
+      chartPanel = <Callout title='No Data Available'>Insufficient data to populate this chart</Callout>;
+    }
+
+    if (error) {
+      chartPanel = <Callout title='Unable to Load Data'>{error.message}</Callout>;
+    }
+
+    if (loading) {
+      chartPanel = (
+        <div style={{ height: '220px', position: 'relative' }}>
+          <Loading />
+        </div>
+      );
+    }
+
+    return (
+      <Grid>
+        <Grid.Column sm={12} md={7}>
+          <AccessControl condition={hasUiOption('feature_signals_v2')}>
+            <Tabs facet={facet} facetId={facetId}/>
+          </AccessControl>
+          <Panel sectioned>
+            <AccessControl condition={not(hasUiOption('feature_signals_v2'))}>
+              <ChartHeader
+                title='Engagement Recency'
+                tooltipContent={ENGAGEMENT_RECENCY_INFO}
+              />
+            </AccessControl>
+            {chartPanel || (
+              <div className='LiftTooltip'>
+                <BarChart
+                  gap={gap}
+                  onClick={this.handleDateSelect}
+                  selected={selectedDate}
+                  timeSeries={data}
+                  tooltipContent={this.getTooltipContent}
+                  tooltipWidth='250px'
+                  yKeys={_.keys(cohorts).map((key) => ({ key, ...cohorts[key] })).reverse()}
+                  yAxisProps={this.getYAxisProps()}
+                  xAxisProps={this.getXAxisProps()}
+                />
+                <Legend
+                  items={_.values(cohorts)}
+                  tooltipContent={(label) => ENGAGEMENT_RECENCY_COHORTS[label]}
+                />
+              </div>
+            )}
+          </Panel>
+        </Grid.Column>
+        <Grid.Column sm={12} md={5} mdOffset={0}>
+          <div className={styles.OffsetCol}>
+            {!chartPanel && <EngagementRecencyActions cohorts={selectedCohorts} date={selectedDate} />}
+          </div>
+        </Grid.Column>
+      </Grid>
+    );
+  }
+
+  render() {
+    const { facet, facetId, subaccountId } = this.props;
+
+    return (
+      <Page
+        breadcrumbAction={{ content: 'Back to Overview', to: '/signals', component: Link }}
+        dimensionPrefix='Engagement Rate by Cohort for'
+        facet={facet}
+        facetId={facetId}
+        subaccountId={subaccountId}
+        primaryArea={<DateFilter />}>
+        {this.renderContent()}
+        <OtherChartsHeader facet={facet} facetId={facetId} subaccountId={subaccountId} />
+        <Grid>
+          <Grid.Column xs={12} sm={6}>
+            <SpamTrapsPreview />
+          </Grid.Column>
+          <Grid.Column xs={12} sm={6}>
+            <HealthScorePreview />
+          </Grid.Column>
+        </Grid>
+      </Page>
+    );
+  }
+}
+
+export default withEngagementRecencyDetails(EngagementRateByCohortPage);

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -2,22 +2,17 @@
 import React, { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { Panel, Grid } from '@sparkpost/matchbox';
-import BarChart from './components/charts/barchart/BarChart';
 import Callout from 'src/components/callout';
-import ChartHeader from './components/ChartHeader';
 import DateFilter from './components/filters/DateFilter';
 import EngagementRecencyActions from './components/actionContent/EngagementRecencyActions';
-import Legend from './components/charts/legend/Legend';
+// import Legend from './components/charts/legend/Legend';
 import OtherChartsHeader from './components/OtherChartsHeader';
 import Page from './components/SignalsPage';
 import Tabs from './components/engagement/Tabs';
 import TooltipMetric from './components/charts/tooltip/TooltipMetric';
-import withEngagementRecencyDetails from './containers/EngagementRecencyDetailsContainer';
-import { ENGAGEMENT_RECENCY_COHORTS, ENGAGEMENT_RECENCY_INFO } from './constants/info';
-import { AccessControl } from 'src/components/auth';
+import withEngagementRateByCohortDetails from './containers/EngagementRateByCohortDetailsContainer';
+// import { ENGAGEMENT_RECENCY_COHORTS, ENGAGEMENT_RECENCY_INFO } from './constants/info';
 import { Loading } from 'src/components';
-import { hasUiOption } from 'src/helpers/conditions/account';
-import { not } from 'src/helpers/conditions';
 import { roundToPlaces } from 'src/helpers/units';
 import moment from 'moment';
 import _ from 'lodash';
@@ -87,7 +82,7 @@ export class EngagementRateByCohortPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], facet, facetId, loading, gap, empty, error } = this.props;
+    const { data = [], facet, facetId, loading, empty, error } = this.props;
     const { selectedDate } = this.state;
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
@@ -111,19 +106,11 @@ export class EngagementRateByCohortPage extends Component {
     return (
       <Grid>
         <Grid.Column sm={12} md={7}>
-          <AccessControl condition={hasUiOption('feature_signals_v2')}>
-            <Tabs facet={facet} facetId={facetId}/>
-          </AccessControl>
+          <Tabs facet={facet} facetId={facetId}/>
           <Panel sectioned>
-            <AccessControl condition={not(hasUiOption('feature_signals_v2'))}>
-              <ChartHeader
-                title='Engagement Recency'
-                tooltipContent={ENGAGEMENT_RECENCY_INFO}
-              />
-            </AccessControl>
             {chartPanel || (
               <div className='LiftTooltip'>
-                <BarChart
+                {/* <BarChart
                   gap={gap}
                   onClick={this.handleDateSelect}
                   selected={selectedDate}
@@ -137,7 +124,7 @@ export class EngagementRateByCohortPage extends Component {
                 <Legend
                   items={_.values(cohorts)}
                   tooltipContent={(label) => ENGAGEMENT_RECENCY_COHORTS[label]}
-                />
+                /> */}
               </div>
             )}
           </Panel>
@@ -177,4 +164,4 @@ export class EngagementRateByCohortPage extends Component {
   }
 }
 
-export default withEngagementRecencyDetails(EngagementRateByCohortPage);
+export default withEngagementRateByCohortDetails(EngagementRateByCohortPage);

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -81,7 +81,7 @@ export class EngagementRateByCohortPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], facet, facetId, loading, empty, error } = this.props;
+    const { data = [], facet, facetId, loading, empty, error, subaccountId } = this.props;
     const { selectedDate } = this.state;
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
@@ -105,7 +105,7 @@ export class EngagementRateByCohortPage extends Component {
     return (
       <Grid>
         <Grid.Column sm={12} md={7}>
-          <Tabs facet={facet} facetId={facetId}/>
+          <Tabs facet={facet} facetId={facetId} subaccountId={subaccountId} />
           <Panel sectioned>
             {chartPanel || (
               <div className='LiftTooltip'>

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Panel, Grid } from '@sparkpost/matchbox';
 import LineChart from './components/charts/linechart/LineChart';
@@ -38,19 +38,26 @@ export class EngagementRateByCohortPage extends Component {
     };
   }
 
-  getTooltipContent = ({ payload = {}}) => (
-    <Fragment>
-      {_.keys(cohorts).map((key) => (
-        <TooltipMetric
-          key={key}
-          color={cohorts[key].fill}
-          label={cohorts[key].label}
-          description={cohorts[key].description}
-          value={`${roundToPlaces(payload[key], 1)}%`}
-        />
-      ))}
-    </Fragment>
-  )
+  getTooltipContent = ({ payload = {}}) => {
+    const metrics = _.keys(cohorts).reduce((acc, key) => ([ ...acc, {
+      ...cohorts[key], key,
+      value: roundToPlaces(payload[key], 1)
+    }]), []);
+
+    return (
+      <>
+        {_.orderBy(metrics, 'value', 'desc').map((metric) => (
+          <TooltipMetric
+            key={metric.key}
+            color={metric.fill}
+            label={metric.label}
+            description={metric.description}
+            value={`${roundToPlaces(metric.value, 1)}%`}
+          />
+        ))}
+      </>
+    );
+  }
 
   renderContent = () => {
     const { data = [], facet, facetId, handleDateSelect, loading, empty, error, selectedDate, subaccountId } = this.props;

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -12,6 +12,7 @@ import Page from './components/SignalsPage';
 import Tabs from './components/engagement/Tabs';
 import TooltipMetric from './components/charts/tooltip/TooltipMetric';
 import withEngagementRateByCohortDetails from './containers/EngagementRateByCohortDetailsContainer';
+import withDateSelection from './containers/withDateSelection';
 import { ENGAGEMENT_RECENCY_COHORTS } from './constants/info';
 import { Loading } from 'src/components';
 import { roundToPlaces } from 'src/helpers/units';
@@ -24,35 +25,6 @@ import cohorts from './constants/cohorts';
 import styles from './DetailsPages.module.scss';
 
 export class EngagementRateByCohortPage extends Component {
-  state = {
-    selectedDate: null
-  }
-
-  componentDidMount() {
-    const { selected } = this.props;
-
-    if (selected) {
-      this.setState({ selectedDate: selected });
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const { data } = this.props;
-    const { selectedDate } = this.state;
-
-    const dataSetChanged = prevProps.data !== data;
-    let selectedDataByDay = _.find(data, ['date', selectedDate]);
-
-    // Select last date in time series
-    if (dataSetChanged && !selectedDataByDay) {
-      selectedDataByDay = _.last(data);
-      this.setState({ selectedDate: selectedDataByDay.date });
-    }
-  }
-
-  handleDateSelect = (node) => {
-    this.setState({ selectedDate: _.get(node, 'payload.date') });
-  }
 
   getYAxisProps = () => ({
     tickFormatter: (tick) => `${roundToPlaces(tick, 0)}%`
@@ -81,8 +53,7 @@ export class EngagementRateByCohortPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], facet, facetId, loading, empty, error, subaccountId } = this.props;
-    const { selectedDate } = this.state;
+    const { data = [], facet, facetId, handleDateSelect, loading, empty, error, selectedDate, subaccountId } = this.props;
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
 
@@ -111,7 +82,7 @@ export class EngagementRateByCohortPage extends Component {
               <div className='LiftTooltip'>
                 <LineChart
                   height={300}
-                  onClick={this.handleDateSelect}
+                  onClick={handleDateSelect}
                   selected={selectedDate}
                   lines={data}
                   lineType='natural'
@@ -164,4 +135,4 @@ export class EngagementRateByCohortPage extends Component {
   }
 }
 
-export default withEngagementRateByCohortDetails(EngagementRateByCohortPage);
+export default withEngagementRateByCohortDetails(withDateSelection(EngagementRateByCohortPage));

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -1,18 +1,23 @@
+/* eslint-disable max-lines */
 import React, { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { Panel, Grid } from '@sparkpost/matchbox';
-import Page from './components/SignalsPage';
 import BarChart from './components/charts/barchart/BarChart';
-import EngagementRecencyActions from './components/actionContent/EngagementRecencyActions';
-import TooltipMetric from './components/charts/tooltip/TooltipMetric';
-import DateFilter from './components/filters/DateFilter';
-import { ENGAGEMENT_RECENCY_COHORTS, ENGAGEMENT_RECENCY_INFO } from './constants/info';
-import withEngagementRecencyDetails from './containers/EngagementRecencyDetailsContainer';
-import { Loading } from 'src/components';
 import Callout from 'src/components/callout';
-import OtherChartsHeader from './components/OtherChartsHeader';
 import ChartHeader from './components/ChartHeader';
+import DateFilter from './components/filters/DateFilter';
+import EngagementRecencyActions from './components/actionContent/EngagementRecencyActions';
 import Legend from './components/charts/legend/Legend';
+import OtherChartsHeader from './components/OtherChartsHeader';
+import Page from './components/SignalsPage';
+import Tabs from './components/engagement/Tabs';
+import TooltipMetric from './components/charts/tooltip/TooltipMetric';
+import withEngagementRecencyDetails from './containers/EngagementRecencyDetailsContainer';
+import { ENGAGEMENT_RECENCY_COHORTS, ENGAGEMENT_RECENCY_INFO } from './constants/info';
+import { AccessControl } from 'src/components/auth';
+import { Loading } from 'src/components';
+import { hasUiOption } from 'src/helpers/conditions/account';
+import { not } from 'src/helpers/conditions';
 import { roundToPlaces } from 'src/helpers/units';
 import moment from 'moment';
 import _ from 'lodash';
@@ -106,11 +111,16 @@ export class EngagementRecencyPage extends Component {
     return (
       <Grid>
         <Grid.Column sm={12} md={7}>
+          <AccessControl condition={hasUiOption('feature_signals_v2')}>
+            <Tabs />
+          </AccessControl>
           <Panel sectioned>
-            <ChartHeader
-              title='Engagement Recency'
-              tooltipContent={ENGAGEMENT_RECENCY_INFO}
-            />
+            <AccessControl condition={not(hasUiOption('feature_signals_v2'))}>
+              <ChartHeader
+                title='Engagement Recency'
+                tooltipContent={ENGAGEMENT_RECENCY_INFO}
+              />
+            </AccessControl>
             {chartPanel || (
               <div className='LiftTooltip'>
                 <BarChart

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -87,7 +87,7 @@ export class EngagementRecencyPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], loading, gap, empty, error } = this.props;
+    const { data = [], facet, facetId, loading, gap, empty, error } = this.props;
     const { selectedDate } = this.state;
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
@@ -112,7 +112,7 @@ export class EngagementRecencyPage extends Component {
       <Grid>
         <Grid.Column sm={12} md={7}>
           <AccessControl condition={hasUiOption('feature_signals_v2')}>
-            <Tabs />
+            <Tabs facet={facet} facetId={facetId}/>
           </AccessControl>
           <Panel sectioned>
             <AccessControl condition={not(hasUiOption('feature_signals_v2'))}>

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -13,6 +13,7 @@ import Page from './components/SignalsPage';
 import Tabs from './components/engagement/Tabs';
 import TooltipMetric from './components/charts/tooltip/TooltipMetric';
 import withEngagementRecencyDetails from './containers/EngagementRecencyDetailsContainer';
+import withDateSelection from './containers/withDateSelection';
 import { ENGAGEMENT_RECENCY_COHORTS, ENGAGEMENT_RECENCY_INFO } from './constants/info';
 import { AccessControl } from 'src/components/auth';
 import { Loading } from 'src/components';
@@ -28,35 +29,6 @@ import cohorts from './constants/cohorts';
 import styles from './DetailsPages.module.scss';
 
 export class EngagementRecencyPage extends Component {
-  state = {
-    selectedDate: null
-  }
-
-  componentDidMount() {
-    const { selected } = this.props;
-
-    if (selected) {
-      this.setState({ selectedDate: selected });
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const { data } = this.props;
-    const { selectedDate } = this.state;
-
-    const dataSetChanged = prevProps.data !== data;
-    let selectedDataByDay = _.find(data, ['date', selectedDate]);
-
-    // Select last date in time series
-    if (dataSetChanged && !selectedDataByDay) {
-      selectedDataByDay = _.last(data);
-      this.setState({ selectedDate: selectedDataByDay.date });
-    }
-  }
-
-  handleDateSelect = (node) => {
-    this.setState({ selectedDate: _.get(node, 'payload.date') });
-  }
 
   getYAxisProps = () => ({
     tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`,
@@ -87,8 +59,7 @@ export class EngagementRecencyPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], facet, facetId, loading, gap, empty, error, subaccountId } = this.props;
-    const { selectedDate } = this.state;
+    const { data = [], empty, error, facet, facetId, gap, handleDateSelect, loading, selectedDate, subaccountId } = this.props;
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
 
@@ -125,7 +96,7 @@ export class EngagementRecencyPage extends Component {
               <div className='LiftTooltip'>
                 <BarChart
                   gap={gap}
-                  onClick={this.handleDateSelect}
+                  onClick={handleDateSelect}
                   selected={selectedDate}
                   timeSeries={data}
                   tooltipContent={this.getTooltipContent}
@@ -177,4 +148,4 @@ export class EngagementRecencyPage extends Component {
   }
 }
 
-export default withEngagementRecencyDetails(EngagementRecencyPage);
+export default withEngagementRecencyDetails(withDateSelection(EngagementRecencyPage));

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -87,7 +87,7 @@ export class EngagementRecencyPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], facet, facetId, loading, gap, empty, error } = this.props;
+    const { data = [], facet, facetId, loading, gap, empty, error, subaccountId } = this.props;
     const { selectedDate } = this.state;
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
@@ -112,7 +112,7 @@ export class EngagementRecencyPage extends Component {
       <Grid>
         <Grid.Column sm={12} md={7}>
           <AccessControl condition={hasUiOption('feature_signals_v2')}>
-            <Tabs facet={facet} facetId={facetId}/>
+            <Tabs facet={facet} facetId={facetId} subaccountId={subaccountId} />
           </AccessControl>
           <Panel sectioned>
             <AccessControl condition={not(hasUiOption('feature_signals_v2'))}>

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -10,6 +10,7 @@ import TooltipMetric from './components/charts/tooltip/TooltipMetric';
 import DateFilter from './components/filters/DateFilter';
 import { HEALTH_SCORE_INFO, HEALTH_SCORE_COMPONENT_INFO, INJECTIONS_INFO, HEALTH_SCORE_COMPONENTS } from './constants/info';
 import withHealthScoreDetails from './containers/HealthScoreDetailsContainer';
+import withDateSelection from './containers/withDateSelection';
 import { Loading } from 'src/components';
 import Callout from 'src/components/callout';
 import OtherChartsHeader from './components/OtherChartsHeader';
@@ -24,40 +25,20 @@ import styles from './DetailsPages.module.scss';
 
 export class HealthScorePage extends Component {
   state = {
-    selectedDate: null,
     selectedComponent: null
   }
 
-  componentDidMount() {
-    const { selected } = this.props;
-
-    if (selected) {
-      this.setState({ selectedDate: selected });
-    }
-  }
-
   componentDidUpdate(prevProps) {
-    const { data } = this.props;
-    const { selectedDate } = this.state;
+    const { data, selectedDate } = this.props;
 
     const dataSetChanged = prevProps.data !== data;
-    let selectedDataByDay = _.find(data, ['date', selectedDate]);
-
-    // Select last date in time series
-    if (dataSetChanged && !selectedDataByDay) {
-      selectedDataByDay = _.last(data);
-      this.setState({ selectedDate: selectedDataByDay.date });
-    }
+    const selectedDataByDay = _.find(data, ['date', selectedDate]);
 
     // Select first component weight type
     if (dataSetChanged) {
       const firstComponentType = _.get(selectedDataByDay, 'weights[0].weight_type');
       this.setState({ selectedComponent: firstComponentType });
     }
-  }
-
-  handleDateSelect = (node) => {
-    this.setState({ selectedDate: _.get(node, 'payload.date') });
   }
 
   handleComponentSelect = (node) => {
@@ -73,8 +54,8 @@ export class HealthScorePage extends Component {
   }
 
   renderContent = () => {
-    const { data = [], loading, gap, empty, error } = this.props;
-    const { selectedDate, selectedComponent } = this.state;
+    const { data = [], handleDateSelect, loading, gap, empty, error, selectedDate } = this.props;
+    const { selectedComponent } = this.state;
 
     const selectedWeights = _.get(_.find(data, ['date', selectedDate]), 'weights', []);
     const selectedWeightsAreEmpty = selectedWeights.every(({ weight }) => weight === null);
@@ -107,7 +88,7 @@ export class HealthScorePage extends Component {
               <Fragment>
                 <BarChart
                   gap={gap}
-                  onClick={this.handleDateSelect}
+                  onClick={handleDateSelect}
                   selected={selectedDate}
                   timeSeries={data}
                   tooltipContent={({ payload = {}}) => (
@@ -123,7 +104,7 @@ export class HealthScorePage extends Component {
                 <BarChart
                   gap={gap}
                   height={190}
-                  onClick={this.handleDateSelect}
+                  onClick={handleDateSelect}
                   selected={selectedDate}
                   timeSeries={data}
                   tooltipContent={({ payload = {}}) => (
@@ -141,7 +122,7 @@ export class HealthScorePage extends Component {
                     <BarChart
                       gap={gap}
                       height={190}
-                      onClick={this.handleDateSelect}
+                      onClick={handleDateSelect}
                       selected={selectedDate}
                       timeSeries={dataForSelectedWeight}
                       tooltipContent={({ payload = {}}) => (
@@ -215,4 +196,4 @@ export class HealthScorePage extends Component {
   }
 }
 
-export default withHealthScoreDetails(HealthScorePage);
+export default withHealthScoreDetails(withDateSelection(HealthScorePage));

--- a/src/pages/signals/SpamTrapPage.js
+++ b/src/pages/signals/SpamTrapPage.js
@@ -8,6 +8,7 @@ import TooltipMetric from './components/charts/tooltip/TooltipMetric';
 import DateFilter from './components/filters/DateFilter';
 import { SPAM_TRAP_INFO } from './constants/info';
 import withSpamTrapDetails from './containers/SpamTrapDetailsContainer';
+import withDateSelection from './containers/withDateSelection';
 import { Loading } from 'src/components';
 import Callout from 'src/components/callout';
 import OtherChartsHeader from './components/OtherChartsHeader';
@@ -23,38 +24,11 @@ import styles from './DetailsPages.module.scss';
 
 export class SpamTrapPage extends Component {
   state = {
-    selectedDate: null,
     calculation: 'relative'
-  }
-
-  componentDidMount() {
-    const { selected } = this.props;
-
-    if (selected) {
-      this.setState({ selectedDate: selected });
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const { data } = this.props;
-    const { selectedDate } = this.state;
-
-    const dataSetChanged = prevProps.data !== data;
-    let selectedDataByDay = _.find(data, ['date', selectedDate]);
-
-    // Select last date in time series
-    if (dataSetChanged && !selectedDataByDay) {
-      selectedDataByDay = _.last(data);
-      this.setState({ selectedDate: selectedDataByDay.date });
-    }
   }
 
   handleCalculationToggle = (value) => {
     this.setState({ calculation: value });
-  }
-
-  handleDateSelect = (node) => {
-    this.setState({ selectedDate: _.get(node, 'payload.date') });
   }
 
   getYAxisProps = () => {
@@ -85,8 +59,8 @@ export class SpamTrapPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], loading, gap, empty, error } = this.props;
-    const { calculation, selectedDate } = this.state;
+    const { data = [], handleDateSelect, loading, gap, empty, error, selectedDate } = this.props;
+    const { calculation } = this.state;
     const selectedSpamTrapHits = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
 
@@ -123,7 +97,7 @@ export class SpamTrapPage extends Component {
             {chartPanel || (
               <BarChart
                 gap={gap}
-                onClick={this.handleDateSelect}
+                onClick={handleDateSelect}
                 selected={selectedDate}
                 timeSeries={data}
                 tooltipContent={this.getTooltipContent}
@@ -169,4 +143,4 @@ export class SpamTrapPage extends Component {
   }
 }
 
-export default withSpamTrapDetails(SpamTrapPage);
+export default withSpamTrapDetails(withDateSelection(SpamTrapPage));

--- a/src/pages/signals/components/EngagementRecencyOverview.js
+++ b/src/pages/signals/components/EngagementRecencyOverview.js
@@ -97,7 +97,7 @@ class EngagementRecencyOverview extends React.Component {
     }
 
     history.push({
-      pathname: `/signals/engagement-recency/${facet.key}/${facetId}`,
+      pathname: `/signals/engagement/cohorts/${facet.key}/${facetId}`,
       search,
       state: {
         date
@@ -147,7 +147,7 @@ class EngagementRecencyOverview extends React.Component {
 
               return (
                 <FacetDataCell
-                  dimension="engagement-recency"
+                  dimension="engagement/cohorts"
                   facet={facet.key}
                   id={id}
                   name={_.get(_.find(subaccounts, { id }), 'name')}

--- a/src/pages/signals/components/charts/legend/Legend.module.scss
+++ b/src/pages/signals/components/charts/legend/Legend.module.scss
@@ -8,8 +8,8 @@
 .Fill {
   display: inline-block;
   margin: 0 spacing(small) 0 rem(14);
-  width: rem(16);
-  height: rem(16);
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   vertical-align: middle;
 }

--- a/src/pages/signals/components/charts/linechart/LineChart.js
+++ b/src/pages/signals/components/charts/linechart/LineChart.js
@@ -1,0 +1,128 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { ResponsiveContainer, ComposedChart, Bar, Dot, Line, Tooltip, XAxis, YAxis, CartesianGrid, Rectangle } from 'recharts';
+import TooltipWrapper from '../tooltip/Tooltip';
+
+class LineChart extends Component {
+  renderDot = (fill) => ({ payload, ...dot }) => {
+    const { xKey, selected } = this.props;
+
+    if (payload[xKey] !== selected) {
+      return null;
+    }
+
+    return <Dot {...dot} fill={fill} style={{ pointerEvents: 'none' }} />;
+  }
+
+  renderActiveDot = (dot) => <Dot {...dot} style={{ pointerEvents: 'none' }} />
+
+  renderLine = ({ key, stroke }) => {
+    const { lineType } = this.props;
+    return (
+      <Line
+        style={{ pointerEvents: 'none' }}
+        dataKey={key}
+        dot={this.renderDot(stroke)}
+        activeDot={this.renderActiveDot}
+        isAnimationActive={false}
+        key={key}
+        onClick={this.props.onClick}
+        stroke={stroke}
+        strokeWidth={1.5}
+        type={lineType}
+      />
+    );
+  }
+
+  renderLines = () => {
+    const { yKeys, yKey, stroke } = this.props;
+
+    if (yKeys) {
+      return yKeys.map(this.renderLine);
+    }
+
+    return this.renderLine({ key: yKey, stroke });
+  }
+
+  renderBackgrounds = () => {
+    const { xKey, selected, onClick } = this.props;
+
+    return (
+      <Bar
+        cursor='pointer'
+        dataKey='noKey'
+        fill='#5DCFF5'
+        isAnimationActive={false}
+        onClick={onClick}
+        shape={
+          ({ payload, background, ...rest }) => (
+            <Rectangle {...rest} {...background} opacity={payload[xKey] === selected ? 0.4 : 0} />
+          )
+        }
+      />
+    );
+  }
+
+  render() {
+    const { height, margin, lines, tooltipContent, tooltipWidth, width, xKey, xAxisProps, yDomain, yAxisProps } = this.props;
+
+    return (
+      <ResponsiveContainer height={height} width={width} className='SignalsBarChart'>
+        <ComposedChart barCategoryGap={0} data={lines} margin={margin}>
+          {this.renderBackgrounds()}
+          <CartesianGrid
+            vertical={false}
+            stroke='#e1e1e6'
+            shapeRendering='crispEdges'
+          />
+          <YAxis
+            axisLine={false}
+            tickLine={false}
+            width={30}
+            minTickGap={2}
+            domain={yDomain}
+            {...yAxisProps}
+          />
+          <XAxis
+            axisLine={false}
+            tickLine={false}
+            dataKey={xKey}
+            type='category'
+            padding={{ left: 6, right: 6 }}
+            shapeRendering='crispEdges'
+            {...xAxisProps}
+          />
+          <Tooltip
+            offset={25}
+            cursor={false}
+            isAnimationActive={false}
+            content={<TooltipWrapper children={tooltipContent} />}
+            width={tooltipWidth}
+          />
+          {this.renderLines()}
+        </ComposedChart>
+      </ResponsiveContainer>
+    );
+  }
+}
+
+LineChart.propTypes = {
+  lineType: PropTypes.string,
+  onClick: PropTypes.func,
+  tooltipContent: PropTypes.func,
+  tooltipWidth: PropTypes.string,
+  yKeys: PropTypes.arrayOf(PropTypes.object)
+};
+
+LineChart.defaultProps = {
+  stroke: '#000',
+  height: 250,
+  width: '99%',
+  lineType: 'linear',
+  margin: { top: 12, left: 18, right: 0, bottom: 5 },
+  xKey: 'date',
+  yKey: 'value',
+  yRange: ['auto', 'auto']
+};
+
+export default LineChart;

--- a/src/pages/signals/components/charts/linechart/tests/LineChart.test.js
+++ b/src/pages/signals/components/charts/linechart/tests/LineChart.test.js
@@ -1,0 +1,79 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import LineChart from '../LineChart';
+
+describe('LineChart Component', () => {
+  let wrapper;
+  let props;
+  const single = [{ value: 2, date: '2011-01-01' }];
+  const multiple = [
+    { ab: 2, cd: 3, date: '2011-01-01' },
+    { ab: 5, cd: 8, date: '2011-01-02' }
+  ];
+  const yKeys = [
+    { key: 'ab', stroke: 'blue' },
+    { key: 'cd', stroke: 'red' }
+  ];
+
+  beforeEach(() => {
+    props = {
+      lines: single,
+      xKey: 'date',
+      yRange: [0,5],
+      height: 50,
+      width: 100,
+      onClick: jest.fn(),
+      tooltipContent: jest.fn(),
+      stroke: '#stroke'
+    };
+    wrapper = shallow(<LineChart {...props}/>);
+  });
+
+  it('renders a line chart with a single line correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders a multiple lines correctly', () => {
+    wrapper.setProps({ lines: multiple, yKeys });
+    expect(wrapper.find('Line')).toMatchSnapshot();
+  });
+
+  it('renders background bars with no opacity if unselected', () => {
+    const payload = { payload: { date: '2011-01-01' }, test: 'test' };
+    expect(wrapper.find('Bar').at(0).props().shape(payload)).toMatchSnapshot();
+  });
+
+  it('renders background bars with opacity if selected', () => {
+    wrapper.setProps({ selected: '2011-01-01' });
+    const payload = { payload: { date: '2011-01-01' }, test: 'test' };
+    expect(wrapper.find('Bar').at(0).props().shape(payload)).toMatchSnapshot();
+  });
+
+  it('renders a dot if selected', () => {
+    wrapper.setProps({ selected: '2011-01-01' });
+    const payload = { payload: { date: '2011-01-01' }, test: 'test' };
+    expect(wrapper.find('Line').props().dot(payload)).toMatchSnapshot();
+  });
+
+  it('does not renders a dot if not selected', () => {
+    const payload = { payload: { date: '2011-01-01' }, test: 'test' };
+    expect(wrapper.find('Line').props().dot(payload)).toBe(null);
+  });
+
+  it('renders active dot', () => {
+    const payload = { payload: { date: '2011-01-01' }, test: 'test' };
+    expect(wrapper.find('Line').props().activeDot(payload)).toMatchSnapshot();
+  });
+
+  it('should handle click on background bar', () => {
+    wrapper.setProps({ timeSeries: multiple, yKeys });
+    wrapper.find('Bar').simulate('click');
+    expect(props.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle click on all lines', () => {
+    wrapper.setProps({ timeSeries: multiple, yKeys });
+    wrapper.find('Line').forEach((n) => n.simulate('click'));
+    expect(props.onClick).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/pages/signals/components/charts/linechart/tests/__snapshots__/LineChart.test.js.snap
+++ b/src/pages/signals/components/charts/linechart/tests/__snapshots__/LineChart.test.js.snap
@@ -1,0 +1,319 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LineChart Component renders a dot if selected 1`] = `
+<Dot
+  fill="#stroke"
+  style={
+    Object {
+      "pointerEvents": "none",
+    }
+  }
+  test="test"
+/>
+`;
+
+exports[`LineChart Component renders a line chart with a single line correctly 1`] = `
+<ResponsiveContainer
+  className="SignalsBarChart"
+  debounce={0}
+  height={50}
+  width={100}
+>
+  <ComposedChart
+    barCategoryGap={0}
+    barGap={4}
+    data={
+      Array [
+        Object {
+          "date": "2011-01-01",
+          "value": 2,
+        },
+      ]
+    }
+    layout="horizontal"
+    margin={
+      Object {
+        "bottom": 5,
+        "left": 18,
+        "right": 0,
+        "top": 12,
+      }
+    }
+    reverseStackOrder={false}
+    stackOffset="none"
+  >
+    <Bar
+      animationBegin={0}
+      animationDuration={400}
+      animationEasing="ease"
+      cursor="pointer"
+      data={Array []}
+      dataKey="noKey"
+      fill="#5DCFF5"
+      hide={false}
+      isAnimationActive={false}
+      layout="vertical"
+      legendType="rect"
+      minPointSize={0}
+      onAnimationEnd={[Function]}
+      onAnimationStart={[Function]}
+      onClick={[MockFunction]}
+      shape={[Function]}
+      xAxisId={0}
+      yAxisId={0}
+    />
+    <CartesianGrid
+      fill="none"
+      horizontal={true}
+      horizontalFill={Array []}
+      horizontalPoints={Array []}
+      shapeRendering="crispEdges"
+      stroke="#e1e1e6"
+      vertical={false}
+      verticalFill={Array []}
+      verticalPoints={Array []}
+    />
+    <YAxis
+      allowDataOverflow={false}
+      allowDecimals={true}
+      allowDuplicatedCategory={true}
+      axisLine={false}
+      domain={
+        Array [
+          0,
+          "auto",
+        ]
+      }
+      height={0}
+      hide={false}
+      minTickGap={2}
+      mirror={false}
+      orientation="left"
+      padding={
+        Object {
+          "bottom": 0,
+          "top": 0,
+        }
+      }
+      reversed={false}
+      scale="auto"
+      tickCount={5}
+      tickLine={false}
+      type="number"
+      width={30}
+      yAxisId={0}
+    />
+    <XAxis
+      allowDataOverflow={false}
+      allowDecimals={true}
+      allowDuplicatedCategory={true}
+      axisLine={false}
+      dataKey="date"
+      domain={
+        Array [
+          0,
+          "auto",
+        ]
+      }
+      height={30}
+      hide={false}
+      mirror={false}
+      orientation="bottom"
+      padding={
+        Object {
+          "left": 6,
+          "right": 6,
+        }
+      }
+      reversed={false}
+      scale="auto"
+      shapeRendering="crispEdges"
+      tickCount={5}
+      tickLine={false}
+      type="category"
+      width={0}
+      xAxisId={0}
+    />
+    <Tooltip
+      active={false}
+      animationDuration={400}
+      animationEasing="ease"
+      content={
+        <Tooltip
+          width="200px"
+        >
+          [MockFunction]
+        </Tooltip>
+      }
+      contentStyle={Object {}}
+      coordinate={
+        Object {
+          "x": 0,
+          "y": 0,
+        }
+      }
+      cursor={false}
+      cursorStyle={Object {}}
+      filterNull={true}
+      isAnimationActive={false}
+      itemSorter={[Function]}
+      itemStyle={Object {}}
+      labelStyle={Object {}}
+      offset={25}
+      separator=" : "
+      useTranslate3d={false}
+      viewBox={
+        Object {
+          "x1": 0,
+          "x2": 0,
+          "y1": 0,
+          "y2": 0,
+        }
+      }
+      wrapperStyle={Object {}}
+    />
+    <Line
+      activeDot={[Function]}
+      animateNewValues={true}
+      animationBegin={0}
+      animationDuration={1500}
+      animationEasing="ease"
+      connectNulls={false}
+      dataKey="value"
+      dot={[Function]}
+      fill="#fff"
+      hide={false}
+      isAnimationActive={false}
+      key="value"
+      legendType="line"
+      onAnimationEnd={[Function]}
+      onAnimationStart={[Function]}
+      onClick={[MockFunction]}
+      points={Array []}
+      stroke="#stroke"
+      strokeWidth={1.5}
+      style={
+        Object {
+          "pointerEvents": "none",
+        }
+      }
+      type="linear"
+      xAxisId={0}
+      yAxisId={0}
+    />
+  </ComposedChart>
+</ResponsiveContainer>
+`;
+
+exports[`LineChart Component renders a multiple lines correctly 1`] = `
+Array [
+  <Line
+    activeDot={[Function]}
+    animateNewValues={true}
+    animationBegin={0}
+    animationDuration={1500}
+    animationEasing="ease"
+    connectNulls={false}
+    dataKey="ab"
+    dot={[Function]}
+    fill="#fff"
+    hide={false}
+    isAnimationActive={false}
+    key="ab"
+    legendType="line"
+    onAnimationEnd={[Function]}
+    onAnimationStart={[Function]}
+    onClick={[MockFunction]}
+    points={Array []}
+    stroke="blue"
+    strokeWidth={1.5}
+    style={
+      Object {
+        "pointerEvents": "none",
+      }
+    }
+    type="linear"
+    xAxisId={0}
+    yAxisId={0}
+  />,
+  <Line
+    activeDot={[Function]}
+    animateNewValues={true}
+    animationBegin={0}
+    animationDuration={1500}
+    animationEasing="ease"
+    connectNulls={false}
+    dataKey="cd"
+    dot={[Function]}
+    fill="#fff"
+    hide={false}
+    isAnimationActive={false}
+    key="cd"
+    legendType="line"
+    onAnimationEnd={[Function]}
+    onAnimationStart={[Function]}
+    onClick={[MockFunction]}
+    points={Array []}
+    stroke="red"
+    strokeWidth={1.5}
+    style={
+      Object {
+        "pointerEvents": "none",
+      }
+    }
+    type="linear"
+    xAxisId={0}
+    yAxisId={0}
+  />,
+]
+`;
+
+exports[`LineChart Component renders active dot 1`] = `
+<Dot
+  payload={
+    Object {
+      "date": "2011-01-01",
+    }
+  }
+  style={
+    Object {
+      "pointerEvents": "none",
+    }
+  }
+  test="test"
+/>
+`;
+
+exports[`LineChart Component renders background bars with no opacity if unselected 1`] = `
+<Rectangle
+  animationBegin={0}
+  animationDuration={1500}
+  animationEasing="ease"
+  height={0}
+  isAnimationActive={false}
+  isUpdateAnimationActive={false}
+  opacity={0}
+  radius={0}
+  test="test"
+  width={0}
+  x={0}
+  y={0}
+/>
+`;
+
+exports[`LineChart Component renders background bars with opacity if selected 1`] = `
+<Rectangle
+  animationBegin={0}
+  animationDuration={1500}
+  animationEasing="ease"
+  height={0}
+  isAnimationActive={false}
+  isUpdateAnimationActive={false}
+  opacity={0.4}
+  radius={0}
+  test="test"
+  width={0}
+  x={0}
+  y={0}
+/>
+`;

--- a/src/pages/signals/components/engagement/Tabs.js
+++ b/src/pages/signals/components/engagement/Tabs.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+import { Tabs as MbTabs } from '@sparkpost/matchbox';
+import _ from 'lodash';
+
+const tabs = [
+  { content: 'Cohorts', path: '/signals/engagement/cohorts' },
+  { content: 'Engagement Rate', path: '/signals/engagement/engagement-rate' },
+  { content: 'Unsubscribe Rate', path: '/signals/engagement/unsubscribes' },
+  { content: 'Complaint Rate', path: '/signals/engagement/complaints' }
+];
+
+export function Tabs({ history, facet, facetId, location }) {
+  const renderTabs = tabs.map(({ content }) => ({ content }));
+  const handleSelect = (i) => history.push(`${tabs[i].path}/${facet}/${facetId}`);
+  const selected = _.findIndex(tabs, ({ path }) => location.pathname.includes(path));
+
+  return (
+    <MbTabs
+      tabs={renderTabs}
+      onSelect={handleSelect}
+      connectBelow
+      selected={selected}
+      fitted
+    />
+  );
+}
+
+export default withRouter(Tabs);

--- a/src/pages/signals/components/engagement/Tabs.js
+++ b/src/pages/signals/components/engagement/Tabs.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
 import { Tabs as MbTabs } from '@sparkpost/matchbox';
+import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import _ from 'lodash';
 
 const tabs = [
@@ -10,9 +11,9 @@ const tabs = [
   { content: 'Complaint Rate', path: '/signals/engagement/complaints' }
 ];
 
-export function Tabs({ history, facet, facetId, location }) {
+export function Tabs({ facet, facetId, history, location, subaccountId }) {
   const renderTabs = tabs.map(({ content }) => ({ content }));
-  const handleSelect = (i) => history.push(`${tabs[i].path}/${facet}/${facetId}`);
+  const handleSelect = (i) => history.push(`${tabs[i].path}/${facet}/${facetId}${setSubaccountQuery(subaccountId)}`);
   const selected = _.findIndex(tabs, ({ path }) => location.pathname.includes(path));
 
   return (

--- a/src/pages/signals/components/engagement/tests/Tabs.test.js
+++ b/src/pages/signals/components/engagement/tests/Tabs.test.js
@@ -1,0 +1,30 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { Tabs } from '../Tabs';
+
+describe('Engagement Tabs Component', () => {
+  let push;
+
+  beforeEach(() => {
+    push = jest.fn();
+  });
+
+  const subject = (props) => shallow(<Tabs {...props} />);
+
+  it('renders correctly', () => {
+    const wrapper = subject({ location: { pathname: '/signals/engagement/complaints/1/2' }});
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should handle select', () => {
+    const wrapper = subject({
+      facet: 'mockFacet',
+      facetId: 'mockId',
+      location: { pathname: '/signals/engagement/complaints/1/2' },
+      history: { push }
+    });
+
+    wrapper.find('Tabs').prop('onSelect')(1);
+    expect(push).toHaveBeenCalledWith('/signals/engagement/engagement-rate/mockFacet/mockId');
+  });
+});

--- a/src/pages/signals/components/engagement/tests/__snapshots__/Tabs.test.js.snap
+++ b/src/pages/signals/components/engagement/tests/__snapshots__/Tabs.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Engagement Tabs Component renders correctly 1`] = `
+<Tabs
+  color="orange"
+  connectBelow={true}
+  fitted={true}
+  onSelect={[Function]}
+  selected={3}
+  tabs={
+    Array [
+      Object {
+        "content": "Cohorts",
+      },
+      Object {
+        "content": "Engagement Rate",
+      },
+      Object {
+        "content": "Unsubscribe Rate",
+      },
+      Object {
+        "content": "Complaint Rate",
+      },
+    ]
+  }
+/>
+`;

--- a/src/pages/signals/components/previews/EngagementRecencyPreview.js
+++ b/src/pages/signals/components/previews/EngagementRecencyPreview.js
@@ -51,7 +51,7 @@ export class EngagementRecencyPreview extends Component {
     }
 
     return (
-      <PageLink to={`/signals/engagement-recency/${facet}/${facetId}${setSubaccountQuery(subaccountId)}`}>
+      <PageLink to={`/signals/engagement/cohorts/${facet}/${facetId}${setSubaccountQuery(subaccountId)}`}>
         <Panel>
           <Panel.Section>
             <ChartHeader

--- a/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
@@ -64,33 +64,38 @@ exports[`Signals EngagementRecencyPreview Component renders correctly 1`] = `
           Array [
             Object {
               "description": "0-14 days since last engagement",
-              "fill": "#3F8B93",
+              "fill": "#1A838B",
               "key": "c_14d",
               "label": "Recently Engaged",
+              "stroke": "#1A838B",
             },
             Object {
               "description": "14-90 days since last engagement",
-              "fill": "#44A8AD",
+              "fill": "#219EA8",
               "key": "c_90d",
               "label": "Semi Recently Engaged",
+              "stroke": "#219EA8",
             },
             Object {
               "description": "90-365 days since last engagement",
-              "fill": "#9AD8E3",
+              "fill": "#29B9C7",
               "key": "c_365d",
               "label": "Not Recently Engaged",
+              "stroke": "#29B9C7",
             },
             Object {
               "description": "365+ days since last engagement",
-              "fill": "#B9E2E9",
+              "fill": "#50CFDA",
               "key": "c_uneng",
               "label": "Never Engaged",
+              "stroke": "#50CFDA",
             },
             Object {
               "description": "Never engaged, first email in last 7 days",
-              "fill": "#E4EEF0",
+              "fill": "#88E2E7",
               "key": "c_new",
               "label": "New",
+              "stroke": "#88E2E7",
             },
           ]
         }

--- a/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Signals EngagementRecencyPreview Component renders correctly 1`] = `
 <PageLink
-  to="/signals/engagement-recency/ip-pool/best-pool?subaccount=101"
+  to="/signals/engagement/cohorts/ip-pool/best-pool?subaccount=101"
 >
   <Panel>
     <Panel.Section>
@@ -108,7 +108,7 @@ exports[`Signals EngagementRecencyPreview Component renders correctly 1`] = `
 
 exports[`Signals EngagementRecencyPreview Component renders empty correctly 1`] = `
 <PageLink
-  to="/signals/engagement-recency/ip-pool/best-pool?subaccount=101"
+  to="/signals/engagement/cohorts/ip-pool/best-pool?subaccount=101"
 >
   <Panel>
     <Panel.Section>
@@ -135,7 +135,7 @@ exports[`Signals EngagementRecencyPreview Component renders empty correctly 1`] 
 
 exports[`Signals EngagementRecencyPreview Component renders error correctly 1`] = `
 <PageLink
-  to="/signals/engagement-recency/ip-pool/best-pool?subaccount=101"
+  to="/signals/engagement/cohorts/ip-pool/best-pool?subaccount=101"
 >
   <Panel>
     <Panel.Section>

--- a/src/pages/signals/components/tests/EngagementRecencyOverview.test.js
+++ b/src/pages/signals/components/tests/EngagementRecencyOverview.test.js
@@ -211,7 +211,7 @@ describe('EngagementRecencyOverview', () => {
       wrapper.simulate('click', { date: '2018-01-13' });
 
       expect(historyPush).toHaveBeenCalledWith({
-        pathname: '/signals/engagement-recency/domain/example.com',
+        pathname: '/signals/engagement/cohorts/domain/example.com',
         search: '?subaccount=123',
         state: { date: '2018-01-13' }
       });
@@ -223,7 +223,7 @@ describe('EngagementRecencyOverview', () => {
       wrapper.simulate('click', { date: '2018-01-13' });
 
       expect(historyPush).toHaveBeenCalledWith({
-        pathname: '/signals/engagement-recency/domain/example.com',
+        pathname: '/signals/engagement/cohorts/domain/example.com',
         search: '?subaccount=123',
         state: { date: '2018-01-13' }
       });

--- a/src/pages/signals/constants/cohorts.js
+++ b/src/pages/signals/constants/cohorts.js
@@ -1,26 +1,31 @@
 export default {
   c_new: {
-    fill: '#E4EEF0',
+    fill: '#88E2E7',
+    stroke: '#88E2E7',
     label: 'New',
     description: 'Never engaged, first email in last 7 days'
   },
   c_uneng: {
-    fill: '#B9E2E9',
+    fill: '#50CFDA',
+    stroke: '#50CFDA',
     label: 'Never Engaged',
     description: '365+ days since last engagement'
   },
   c_365d: {
-    fill: '#9AD8E3',
+    fill: '#29B9C7',
+    stroke: '#29B9C7',
     label: 'Not Recently Engaged',
     description: '90-365 days since last engagement'
   },
   c_90d: {
-    fill: '#44A8AD',
+    fill: '#219EA8',
+    stroke: '#219EA8',
     label: 'Semi Recently Engaged',
     description: '14-90 days since last engagement'
   },
   c_14d: {
-    fill: '#3F8B93',
+    fill: '#1A838B',
+    stroke: '#1A838B',
     label: 'Recently Engaged',
     description: '0-14 days since last engagement'
   }

--- a/src/pages/signals/containers/EngagementRateByCohortDetailsContainer.js
+++ b/src/pages/signals/containers/EngagementRateByCohortDetailsContainer.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { getEngagementRateByCohort } from 'src/actions/signals.fake';
+import { selectEngagementRateByCohortDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
+import { getDateTicks } from 'src/helpers/date';
+
+export class WithEngagementRateByCohortDetails extends Component {
+  componentDidMount() {
+    const { getEngagementRateByCohort, facet, facetId, filters, subaccountId } = this.props;
+    getEngagementRateByCohort({
+      facet,
+      filter: facetId,
+      relativeRange: filters.relativeRange,
+      subaccount: subaccountId
+    });
+  }
+
+  componentDidUpdate(prevProps) {
+    const { getEngagementRateByCohort, facet, facetId, filters, subaccountId } = this.props;
+    const prevRange = prevProps.filters.relativeRange;
+    const nextRange = filters.relativeRange;
+
+    // Refresh when date range changes
+    if (prevRange !== nextRange) {
+      getEngagementRateByCohort({
+        facet,
+        filter: facetId,
+        relativeRange: nextRange,
+        subaccount: subaccountId
+      });
+    }
+  }
+
+  render() {
+    const {
+      component: WrappedComponent,
+      details,
+      facet,
+      facetId,
+      filters,
+      selected,
+      subaccountId
+    } = this.props;
+
+    return (
+      <WrappedComponent {...details} facet={facet} facetId={facetId} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
+    );
+  }
+}
+
+/**
+ * Provides engagement rate by engagement cohort details to the provided component
+ * @example
+ *   export default withEngagementRateByCohortDetails(MyComponent);
+ */
+function withEngagementRateByCohortDetails(WrappedComponent) {
+  const Wrapper = (props) => (
+    <WithEngagementRateByCohortDetails {...props} component={WrappedComponent} />
+  );
+
+  Wrapper.displayName = `withEngagementRateByCohortDetails(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+
+  const mapStateToProps = (state, props) => ({
+    ...selectEngagementRateByCohortDetails(state, props),
+    filters: state.signalOptions,
+    selected: getSelectedDateFromRouter(state, props)
+  });
+
+  return withRouter(connect(mapStateToProps, { getEngagementRateByCohort })(Wrapper));
+}
+
+export default withEngagementRateByCohortDetails;

--- a/src/pages/signals/containers/EngagementRateByCohortDetailsContainer.js
+++ b/src/pages/signals/containers/EngagementRateByCohortDetailsContainer.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { getEngagementRateByCohort } from 'src/actions/signals.fake';
 import { selectEngagementRateByCohortDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
+import { getDisplayName } from 'src/helpers/hoc';
 
 export class WithEngagementRateByCohortDetails extends Component {
   componentDidMount() {
@@ -59,7 +60,7 @@ function withEngagementRateByCohortDetails(WrappedComponent) {
     <WithEngagementRateByCohortDetails {...props} component={WrappedComponent} />
   );
 
-  Wrapper.displayName = `withEngagementRateByCohortDetails(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+  Wrapper.displayName = getDisplayName(WrappedComponent, 'withEngagementRateByCohortDetails');
 
   const mapStateToProps = (state, props) => ({
     ...selectEngagementRateByCohortDetails(state, props),

--- a/src/pages/signals/containers/EngagementRecencyDetailsContainer.js
+++ b/src/pages/signals/containers/EngagementRecencyDetailsContainer.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { getEngagementRecency } from 'src/actions/signals';
 import { selectEngagementRecencyDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
+import { getDisplayName } from 'src/helpers/hoc';
 
 export class WithEngagementRecencyDetails extends Component {
   componentDidMount() {
@@ -62,7 +63,7 @@ function withEngagementRecencyDetails(WrappedComponent) {
     <WithEngagementRecencyDetails {...props} component={WrappedComponent} />
   );
 
-  Wrapper.displayName = `withEngagementRecencyDetails(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+  Wrapper.displayName = getDisplayName(WrappedComponent, 'withEngagementRecencyDetails');
 
   const mapStateToProps = (state, props) => ({
     ...selectEngagementRecencyDetails(state, props),

--- a/src/pages/signals/containers/HealthScoreDetailsContainer.js
+++ b/src/pages/signals/containers/HealthScoreDetailsContainer.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { getHealthScore, getSpamHits } from 'src/actions/signals';
 import { selectHealthScoreDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
+import { getDisplayName } from 'src/helpers/hoc';
 
 export class WithHealthScoreDetails extends Component {
   componentDidMount() {
@@ -63,7 +64,7 @@ function withHealthScoreDetails(WrappedComponent) {
     <WithHealthScoreDetails {...props} component={WrappedComponent} />
   );
 
-  Wrapper.displayName = `WithHealthScoreDetails(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+  Wrapper.displayName = getDisplayName(WrappedComponent, 'WithHealthScoreDetails');
 
   const mapStateToProps = (state, props) => ({
     ...selectHealthScoreDetails(state, props),

--- a/src/pages/signals/containers/tests/EngagementRateByCohortDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/EngagementRateByCohortDetailsContainer.test.js
@@ -51,8 +51,7 @@ describe('Signals Engagement Rate by Cohort Details Container', () => {
   });
 
   it('should not get engagement recency when range isnt updated', () => {
-    jest.clearAllMocks();
     wrapper.setProps({ another: 'prop' });
-    expect(props.getEngagementRateByCohort,).toHaveBeenCalledTimes(0);
+    expect(props.getEngagementRateByCohort).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/signals/containers/tests/EngagementRateByCohortDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/EngagementRateByCohortDetailsContainer.test.js
@@ -1,0 +1,58 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { WithEngagementRateByCohortDetails } from '../EngagementRateByCohortDetailsContainer';
+import * as dateMock from 'src/helpers/date';
+
+jest.mock('src/helpers/date');
+
+describe('Signals Engagement Rate by Cohort Details Container', () => {
+  let wrapper;
+  let props;
+  const Component = () => <div>test</div>;
+
+  beforeEach(() => {
+    props = {
+      component: Component,
+      details: {
+        data: []
+      },
+      facet: 'sending_domain',
+      facetId: 'test.com',
+      filters: {
+        relativeRange: '14days'
+      },
+      getEngagementRateByCohort: jest.fn(),
+      selected: '2015-01-01',
+      subaccountId: '101'
+    };
+
+    dateMock.getDateTicks.mockImplementation(() => [1,2]);
+    wrapper = shallow(<WithEngagementRateByCohortDetails {...props} />);
+  });
+
+  it('gets engagement rate by cohort on mount correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+    expect(props.getEngagementRateByCohort,).toHaveBeenCalledWith({
+      facet: 'sending_domain',
+      filter: 'test.com',
+      relativeRange: '14days',
+      subaccount: '101'
+    });
+  });
+
+  it('gets engagement rate by cohort when range is updated', () => {
+    wrapper.setProps({ filters: { relativeRange: '30days' }});
+    expect(props.getEngagementRateByCohort,).toHaveBeenCalledWith({
+      facet: 'sending_domain',
+      filter: 'test.com',
+      relativeRange: '30days',
+      subaccount: '101'
+    });
+  });
+
+  it('should not get engagement recency when range isnt updated', () => {
+    jest.clearAllMocks();
+    wrapper.setProps({ another: 'prop' });
+    expect(props.getEngagementRateByCohort,).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/pages/signals/containers/tests/EngagementRecencyDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/EngagementRecencyDetailsContainer.test.js
@@ -52,9 +52,8 @@ describe('Signals Engagement Recency Details Container', () => {
   });
 
   it('should not get engagement recency when range isnt updated', () => {
-    jest.clearAllMocks();
     wrapper.setProps({ another: 'prop' });
-    expect(props.getEngagementRecency).toHaveBeenCalledTimes(0);
+    expect(props.getEngagementRecency).toHaveBeenCalledTimes(1);
   });
 
   it('should shorten chart gap if data is long', () => {

--- a/src/pages/signals/containers/tests/__snapshots__/EngagementRateByCohortDetailsContainer.test.js.snap
+++ b/src/pages/signals/containers/tests/__snapshots__/EngagementRateByCohortDetailsContainer.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals Engagement Rate by Cohort Details Container gets engagement rate by cohort on mount correctly 1`] = `
+<Component
+  data={Array []}
+  facet="sending_domain"
+  facetId="test.com"
+  selected="2015-01-01"
+  subaccountId="101"
+  xTicks={
+    Array [
+      1,
+      2,
+    ]
+  }
+/>
+`;

--- a/src/pages/signals/containers/tests/__snapshots__/withDateSelection.test.js.snap
+++ b/src/pages/signals/containers/tests/__snapshots__/withDateSelection.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals Spam Trap Details Container should set date if provided one 1`] = `
+<Component
+  data={Array []}
+  handleDateSelect={[Function]}
+  selectedDate="2015-01-01"
+/>
+`;

--- a/src/pages/signals/containers/tests/withDateSelection.test.js
+++ b/src/pages/signals/containers/tests/withDateSelection.test.js
@@ -1,0 +1,48 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { WithDateSelection } from '../withDateSelection';
+// import _ from 'lodash';
+
+describe('Signals Spam Trap Details Container', () => {
+  const Component = () => <div>test</div>;
+  const props = {
+    component: Component,
+    data: []
+  };
+
+  const subject = (options) => shallow(<WithDateSelection {...props} {...options} />);
+
+  beforeEach(() => {
+
+
+  });
+
+  it('should set date if provided one', () => {
+    const wrapper = subject({ selected: '2015-01-01' });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should use the last date when not given a date', () => {
+    const wrapper = subject();
+    wrapper.setProps({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
+    expect(wrapper).toHaveState({ selectedDate: '2999-99-99' });
+  });
+
+  it('should use the last date if date does not exist in data', () => {
+    const wrapper = subject({ selected: 'not-in-data' });
+    wrapper.setProps({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
+    expect(wrapper).toHaveState({ selectedDate: '2999-99-99' });
+  });
+
+  it('should not use last date if provided date is in data', () => {
+    const wrapper = subject({ selected: '2015-01-01' });
+    wrapper.setProps({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
+    expect(wrapper).toHaveState({ selectedDate: '2015-01-01' });
+  });
+
+  it('handles date select', () => {
+    const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
+    wrapper.find('Component').prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
+    expect(wrapper).toHaveState({ selectedDate: '2015-01-01' });
+  });
+});

--- a/src/pages/signals/containers/tests/withDateSelection.test.js
+++ b/src/pages/signals/containers/tests/withDateSelection.test.js
@@ -12,11 +12,6 @@ describe('Signals Spam Trap Details Container', () => {
 
   const subject = (options) => shallow(<WithDateSelection {...props} {...options} />);
 
-  beforeEach(() => {
-
-
-  });
-
   it('should set date if provided one', () => {
     const wrapper = subject({ selected: '2015-01-01' });
     expect(wrapper).toMatchSnapshot();
@@ -25,24 +20,24 @@ describe('Signals Spam Trap Details Container', () => {
   it('should use the last date when not given a date', () => {
     const wrapper = subject();
     wrapper.setProps({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
-    expect(wrapper).toHaveState({ selectedDate: '2999-99-99' });
+    expect(wrapper).toHaveProp('selectedDate', '2999-99-99');
   });
 
   it('should use the last date if date does not exist in data', () => {
     const wrapper = subject({ selected: 'not-in-data' });
     wrapper.setProps({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
-    expect(wrapper).toHaveState({ selectedDate: '2999-99-99' });
+    expect(wrapper).toHaveProp('selectedDate', '2999-99-99');
   });
 
   it('should not use last date if provided date is in data', () => {
     const wrapper = subject({ selected: '2015-01-01' });
     wrapper.setProps({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
-    expect(wrapper).toHaveState({ selectedDate: '2015-01-01' });
+    expect(wrapper).toHaveProp('selectedDate', '2015-01-01');
   });
 
   it('handles date select', () => {
     const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
-    wrapper.find('Component').prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
-    expect(wrapper).toHaveState({ selectedDate: '2015-01-01' });
+    wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
+    expect(wrapper).toHaveProp('selectedDate', '2015-01-01');
   });
 });

--- a/src/pages/signals/containers/withDateSelection.js
+++ b/src/pages/signals/containers/withDateSelection.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import { getDisplayName } from 'src/helpers/hoc';
+import _ from 'lodash';
+
+export class WithDateSelection extends Component {
+  state = {
+    selectedDate: null
+  }
+
+  componentDidMount() {
+    const { selected } = this.props;
+
+    if (selected) {
+      this.setState({ selectedDate: selected });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { data } = this.props;
+    const { selectedDate } = this.state;
+
+    const dataSetChanged = prevProps.data !== data;
+    let selectedDataByDay = _.find(data, ['date', selectedDate]);
+
+    // Select last date in time series
+    if (dataSetChanged && !selectedDataByDay) {
+      selectedDataByDay = _.last(data);
+      this.setState({ selectedDate: selectedDataByDay.date });
+    }
+  }
+
+  handleDateSelect = (node) => {
+    this.setState({ selectedDate: _.get(node, 'payload.date') });
+  }
+
+  render() {
+    const { component: WrappedComponent, selected, ...rest } = this.props;
+    const { selectedDate } = this.state;
+
+    return (
+      <WrappedComponent {...rest} selectedDate={selectedDate} handleDateSelect={this.handleDateSelect} />
+    );
+  }
+}
+
+/**
+ * Provides date selection handlers for signals details pages
+ * @example
+ *   export default withDateSelection(MyComponent);
+ */
+function withDateSelection(WrappedComponent) {
+  const Wrapper = (props) => (
+    <WithDateSelection {...props} component={WrappedComponent} />
+  );
+
+  Wrapper.displayName = getDisplayName(WrappedComponent, 'withDateSelection');
+
+  return Wrapper;
+}
+
+export default withDateSelection;

--- a/src/pages/signals/index.js
+++ b/src/pages/signals/index.js
@@ -1,9 +1,11 @@
+import EngagementRateByCohortPage from './EngagementRateByCohortPage';
 import EngagementRecencyPage from './EngagementRecencyPage';
 import HealthScorePage from './HealthScorePage';
 import OverviewPage from './OverviewPage';
 import SpamTrapPage from './SpamTrapPage';
 
 export default {
+  EngagementRateByCohortPage,
   EngagementRecencyPage,
   HealthScorePage,
   OverviewPage,

--- a/src/pages/signals/tests/EngagementRateByCohortPage.test.js
+++ b/src/pages/signals/tests/EngagementRateByCohortPage.test.js
@@ -21,10 +21,12 @@ describe('Signals Engagement Recency Page', () => {
       facetId: 'test.com',
       facet: 'sending-domain',
       data: [{ c_total: 10 }],
+      handleDateSelect: jest.fn(),
       gap: 0.25,
       loading: false,
       empty: false,
-      xTicks: [1,2]
+      xTicks: [1,2],
+      selectedDate: '2017-01-02'
     };
     wrapper = shallow(<EngagementRateByCohortPage {...props}/>);
     wrapper.setProps({ data });
@@ -47,34 +49,6 @@ describe('Signals Engagement Recency Page', () => {
   it('renders error correctly', () => {
     wrapper.setProps({ error: { message: 'error message' }});
     expect(wrapper).toMatchSnapshot();
-  });
-
-  describe('local state', () => {
-    it('handles date select', () => {
-      wrapper.find('LineChart').simulate('click', { payload: { date: '2017-01-02' }});
-      expect(wrapper.find('LineChart').prop('selected')).toEqual('2017-01-02');
-      expect(wrapper.find('EngagementRecencyActions')).toMatchSnapshot();
-    });
-
-    it('sets selected date on mount if provided one', () => {
-      wrapper = shallow(<EngagementRateByCohortPage {...props} selected='initial-selected'/>);
-      expect(wrapper.find('LineChart').prop('selected')).toEqual('initial-selected');
-      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('initial-selected');
-    });
-
-    it('uses last selected date if selected date is not in data', () => {
-      wrapper = shallow(<EngagementRateByCohortPage {...props} loading={true} selected='initial-selected'/>);
-      wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
-      expect(wrapper.find('LineChart').prop('selected')).toEqual('last-date');
-      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('last-date');
-    });
-
-    it('does not use last selected date if selected date is in data', () => {
-      wrapper = shallow(<EngagementRateByCohortPage {...props} selected='first-date'/>);
-      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
-      expect(wrapper.find('LineChart').prop('selected')).toEqual('first-date');
-      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('first-date');
-    });
   });
 
   describe('bar chart props', () => {

--- a/src/pages/signals/tests/EngagementRateByCohortPage.test.js
+++ b/src/pages/signals/tests/EngagementRateByCohortPage.test.js
@@ -1,0 +1,105 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { EngagementRateByCohortPage } from '../EngagementRateByCohortPage';
+
+describe('Signals Engagement Recency Page', () => {
+  let wrapper;
+  let props;
+  const data = [
+    {
+      date: '2017-01-01',
+      c_total: 1
+    },
+    {
+      date: '2017-01-02',
+      c_total: 10
+    }
+  ];
+
+  beforeEach(() => {
+    props = {
+      facetId: 'test.com',
+      facet: 'sending-domain',
+      data: [{ c_total: 10 }],
+      gap: 0.25,
+      loading: false,
+      empty: false,
+      xTicks: [1,2]
+    };
+    wrapper = shallow(<EngagementRateByCohortPage {...props}/>);
+    wrapper.setProps({ data });
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders loading correctly', () => {
+    wrapper.setProps({ loading: true });
+    expect(wrapper.find('Panel')).toMatchSnapshot();
+  });
+
+  it('renders empty correctly', () => {
+    wrapper.setProps({ empty: true });
+    expect(wrapper.find('Panel')).toMatchSnapshot();
+  });
+
+  it('renders error correctly', () => {
+    wrapper.setProps({ error: { message: 'error message' }});
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('local state', () => {
+    it('handles date select', () => {
+      wrapper.find('LineChart').simulate('click', { payload: { date: '2017-01-02' }});
+      expect(wrapper.find('LineChart').prop('selected')).toEqual('2017-01-02');
+      expect(wrapper.find('EngagementRecencyActions')).toMatchSnapshot();
+    });
+
+    it('sets selected date on mount if provided one', () => {
+      wrapper = shallow(<EngagementRateByCohortPage {...props} selected='initial-selected'/>);
+      expect(wrapper.find('LineChart').prop('selected')).toEqual('initial-selected');
+      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('initial-selected');
+    });
+
+    it('uses last selected date if selected date is not in data', () => {
+      wrapper = shallow(<EngagementRateByCohortPage {...props} loading={true} selected='initial-selected'/>);
+      wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
+      expect(wrapper.find('LineChart').prop('selected')).toEqual('last-date');
+      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('last-date');
+    });
+
+    it('does not use last selected date if selected date is in data', () => {
+      wrapper = shallow(<EngagementRateByCohortPage {...props} selected='first-date'/>);
+      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
+      expect(wrapper.find('LineChart').prop('selected')).toEqual('first-date');
+      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('first-date');
+    });
+  });
+
+  describe('bar chart props', () => {
+    it('renders tooltip content', () => {
+      const Tooltip = wrapper.find('LineChart').prop('tooltipContent');
+      expect(shallow(<Tooltip payload={{
+        c_uneng: 0.1,
+        c_365d: 0.2,
+        c_90d: 0.3,
+        c_14d: 0.4,
+        c_new: 0.5,
+        date: '2018-01-01',
+        c_total: 10
+      }} />)).toMatchSnapshot();
+    });
+
+    it('gets x axis props', () => {
+      const axisProps = wrapper.find('LineChart').prop('xAxisProps');
+      expect(axisProps).toMatchSnapshot();
+      expect(axisProps.tickFormatter('2018-12-05')).toEqual('12/5');
+    });
+
+    it('gets y axis props', () => {
+      const axisProps = wrapper.find('LineChart').prop('yAxisProps');
+      expect(axisProps.tickFormatter(25.123)).toEqual('25%');
+    });
+  });
+});

--- a/src/pages/signals/tests/EngagementRecencyPage.test.js
+++ b/src/pages/signals/tests/EngagementRecencyPage.test.js
@@ -22,9 +22,11 @@ describe('Signals Engagement Recency Page', () => {
       facet: 'sending-domain',
       data: [{ c_total: 10 }],
       gap: 0.25,
+      handleDateSelect: jest.fn(),
       loading: false,
       empty: false,
-      xTicks: [1,2]
+      xTicks: [1,2],
+      selectedDate: '2017-01-02'
     };
     wrapper = shallow(<EngagementRecencyPage {...props}/>);
     wrapper.setProps({ data });
@@ -47,34 +49,6 @@ describe('Signals Engagement Recency Page', () => {
   it('renders error correctly', () => {
     wrapper.setProps({ error: { message: 'error message' }});
     expect(wrapper).toMatchSnapshot();
-  });
-
-  describe('local state', () => {
-    it('handles date select', () => {
-      wrapper.find('BarChart').simulate('click', { payload: { date: '2017-01-02' }});
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('2017-01-02');
-      expect(wrapper.find('EngagementRecencyActions')).toMatchSnapshot();
-    });
-
-    it('sets selected date on mount if provided one', () => {
-      wrapper = shallow(<EngagementRecencyPage {...props} selected='initial-selected'/>);
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('initial-selected');
-      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('initial-selected');
-    });
-
-    it('uses last selected date if selected date is not in data', () => {
-      wrapper = shallow(<EngagementRecencyPage {...props} loading={true} selected='initial-selected'/>);
-      wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('last-date');
-      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('last-date');
-    });
-
-    it('does not use last selected date if selected date is in data', () => {
-      wrapper = shallow(<EngagementRecencyPage {...props} selected='first-date'/>);
-      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('first-date');
-      expect(wrapper.find('EngagementRecencyActions').prop('date')).toEqual('first-date');
-    });
   });
 
   describe('bar chart props', () => {

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -27,7 +27,8 @@ describe('Signals Health Score Page', () => {
       facetId: 'test.com',
       facet: 'sending-domain',
       data: [],
-      selected: '2017-01-01',
+      handleDateSelect: jest.fn(),
+      selectedDate: '2017-01-01',
       gap: 0.25,
       loading: false,
       empty: false,
@@ -62,54 +63,17 @@ describe('Signals Health Score Page', () => {
   });
 
   describe('local state', () => {
-    it('handles date select', () => {
-      wrapper.find('BarChart').at(0).simulate('click', { payload: { date: '2017-01-02' }});
-      expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('2017-01-02');
-      expect(wrapper.find('BarChart').at(1).prop('selected')).toEqual('2017-01-02');
-      expect(wrapper.find('ChartHeader').at(3).prop('date')).toEqual('2017-01-02');
-      expect(wrapper.find('HealthScoreActions')).toMatchSnapshot();
-    });
-
-    it('sets selected date on mount if provided one', () => {
-      wrapper = shallow(<HealthScorePage {...props} selected='initial-selected'/>);
-      expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('initial-selected');
-      expect(wrapper.find('HealthScoreActions').prop('date')).toEqual('initial-selected');
-    });
-
-    it('uses last selected date if selected date is not in data', () => {
-      wrapper = shallow(<HealthScorePage {...props} loading={true} selected='initial-selected'/>);
-      wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
-      expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('last-date');
-      expect(wrapper.find('HealthScoreActions').prop('date')).toEqual('last-date');
-    });
-
-    it('does not use last selected date if selected date is in data', () => {
-      wrapper = shallow(<HealthScorePage {...props} selected='first-date'/>);
-      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
-      expect(wrapper.find('BarChart').at(0).prop('selected')).toEqual('first-date');
-      expect(wrapper.find('HealthScoreActions').prop('date')).toEqual('first-date');
-    });
-
     it('handles component select', () => {
       wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'Complaints' }});
       expect(wrapper.find('DivergingBar').at(0).prop('selected')).toEqual('Complaints');
     });
 
     it('uses first component weight with an existing date and new data', () => {
-      wrapper = shallow(<HealthScorePage {...props} selected='first-date'/>);
+      wrapper = shallow(<HealthScorePage {...props} selectedDate='first-date'/>);
       wrapper.setProps({ data: [{ date: 'first-date', weights: [
         { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
         { weight_type: 'Complaints', weight: 0.5, weight_value: 0.25 }
       ]}, { date: 'last-date' }]});
-      expect(wrapper.find('DivergingBar').at(0).prop('selected')).toEqual('Hard Bounces');
-    });
-
-    it('uses first component weight of last date without an existing date and new data', () => {
-      wrapper = shallow(<HealthScorePage {...props} selected='initial-date'/>);
-      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date', weights: [
-        { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
-        { weight_type: 'Complaints', weight: 0.5, weight_value: 0.25 }
-      ]}]});
       expect(wrapper.find('DivergingBar').at(0).prop('selected')).toEqual('Hard Bounces');
     });
   });

--- a/src/pages/signals/tests/SpamTrapPage.test.js
+++ b/src/pages/signals/tests/SpamTrapPage.test.js
@@ -22,9 +22,10 @@ describe('Signals Spam Trap Page', () => {
       facet: 'sending-domain',
       data: [{ relative_trap_hits: 0.1 }],
       gap: 0.25,
+      handleDateSelect: jest.fn(),
       loading: false,
       empty: false,
-      selected: '2017-01-01',
+      selectedDate: '2017-01-01',
       xTicks: []
     };
     wrapper = shallow(<SpamTrapPage {...props}/>);
@@ -55,32 +56,6 @@ describe('Signals Spam Trap Page', () => {
       const calculation = shallow(wrapper.find('ChartHeader').props().primaryArea);
       calculation.simulate('change', 'relative');
       expect(wrapper.find('BarChart').prop('yKey')).toEqual('relative_trap_hits');
-    });
-
-    it('handles date select', () => {
-      wrapper.find('BarChart').simulate('click', { payload: { date: '2017-01-02' }});
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('2017-01-02');
-      expect(wrapper.find('SpamTrapActions')).toMatchSnapshot();
-    });
-
-    it('sets selected date on mount if provided one', () => {
-      wrapper = shallow(<SpamTrapPage {...props} selected='initial-selected'/>);
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('initial-selected');
-      expect(wrapper.find('SpamTrapActions').prop('date')).toEqual('initial-selected');
-    });
-
-    it('uses last selected date if selected date is not in data', () => {
-      wrapper = shallow(<SpamTrapPage {...props} loading={true} selected='initial-selected'/>);
-      wrapper.setProps({ data: [1, { date: 'last-date' }], loading: false });
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('last-date');
-      expect(wrapper.find('SpamTrapActions').prop('date')).toEqual('last-date');
-    });
-
-    it('does not use last selected date if selected date is in data', () => {
-      wrapper = shallow(<SpamTrapPage {...props} selected='first-date'/>);
-      wrapper.setProps({ data: [{ date: 'first-date' }, { date: 'last-date' }]});
-      expect(wrapper.find('BarChart').prop('selected')).toEqual('first-date');
-      expect(wrapper.find('SpamTrapActions').prop('date')).toEqual('first-date');
     });
   });
 

--- a/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
@@ -50,18 +50,6 @@ exports[`Signals Engagement Recency Page bar chart props renders tooltip content
 </Fragment>
 `;
 
-exports[`Signals Engagement Recency Page local state handles date select 1`] = `
-<EngagementRecencyActions
-  cohorts={
-    Object {
-      "c_total": 10,
-      "date": "2017-01-02",
-    }
-  }
-  date="2017-01-02"
-/>
-`;
-
 exports[`Signals Engagement Recency Page renders correctly 1`] = `
 <SignalsPage
   breadcrumbAction={
@@ -114,7 +102,7 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
                 "top": 12,
               }
             }
-            onClick={[Function]}
+            onClick={[MockFunction]}
             selected="2017-01-02"
             stroke="#000"
             tooltipContent={[Function]}

--- a/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
@@ -1,0 +1,357 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals Engagement Recency Page bar chart props gets x axis props 1`] = `
+Object {
+  "tickFormatter": [Function],
+  "ticks": Array [
+    1,
+    2,
+  ],
+}
+`;
+
+exports[`Signals Engagement Recency Page bar chart props renders tooltip content 1`] = `
+<Fragment>
+  <TooltipMetric
+    color="#88E2E7"
+    description="Never engaged, first email in last 7 days"
+    key="c_new"
+    label="New"
+    value="0.5%"
+  />
+  <TooltipMetric
+    color="#50CFDA"
+    description="365+ days since last engagement"
+    key="c_uneng"
+    label="Never Engaged"
+    value="0.1%"
+  />
+  <TooltipMetric
+    color="#29B9C7"
+    description="90-365 days since last engagement"
+    key="c_365d"
+    label="Not Recently Engaged"
+    value="0.2%"
+  />
+  <TooltipMetric
+    color="#219EA8"
+    description="14-90 days since last engagement"
+    key="c_90d"
+    label="Semi Recently Engaged"
+    value="0.3%"
+  />
+  <TooltipMetric
+    color="#1A838B"
+    description="0-14 days since last engagement"
+    key="c_14d"
+    label="Recently Engaged"
+    value="0.4%"
+  />
+</Fragment>
+`;
+
+exports[`Signals Engagement Recency Page local state handles date select 1`] = `
+<EngagementRecencyActions
+  cohorts={
+    Object {
+      "c_total": 10,
+      "date": "2017-01-02",
+    }
+  }
+  date="2017-01-02"
+/>
+`;
+
+exports[`Signals Engagement Recency Page renders correctly 1`] = `
+<SignalsPage
+  breadcrumbAction={
+    Object {
+      "component": [Function],
+      "content": "Back to Overview",
+      "to": "/signals",
+    }
+  }
+  dimensionPrefix="Engagement Rate by Cohort for"
+  facet="sending-domain"
+  facetId="test.com"
+  primaryArea={<Connect(DateFilter) />}
+>
+  <Grid>
+    <Grid.Column
+      md={7}
+      sm={12}
+    >
+      <withRouter(Tabs)
+        facet="sending-domain"
+        facetId="test.com"
+      />
+      <Panel
+        sectioned={true}
+      >
+        <div
+          className="LiftTooltip"
+        >
+          <LineChart
+            height={300}
+            lineType="natural"
+            lines={
+              Array [
+                Object {
+                  "c_total": 1,
+                  "date": "2017-01-01",
+                },
+                Object {
+                  "c_total": 10,
+                  "date": "2017-01-02",
+                },
+              ]
+            }
+            margin={
+              Object {
+                "bottom": 5,
+                "left": 18,
+                "right": 0,
+                "top": 12,
+              }
+            }
+            onClick={[Function]}
+            selected="2017-01-02"
+            stroke="#000"
+            tooltipContent={[Function]}
+            tooltipWidth="250px"
+            width="99%"
+            xAxisProps={
+              Object {
+                "tickFormatter": [Function],
+                "ticks": Array [
+                  1,
+                  2,
+                ],
+              }
+            }
+            xKey="date"
+            yAxisProps={
+              Object {
+                "tickFormatter": [Function],
+              }
+            }
+            yKey="value"
+            yKeys={
+              Array [
+                Object {
+                  "description": "0-14 days since last engagement",
+                  "fill": "#1A838B",
+                  "key": "c_14d",
+                  "label": "Recently Engaged",
+                  "stroke": "#1A838B",
+                },
+                Object {
+                  "description": "14-90 days since last engagement",
+                  "fill": "#219EA8",
+                  "key": "c_90d",
+                  "label": "Semi Recently Engaged",
+                  "stroke": "#219EA8",
+                },
+                Object {
+                  "description": "90-365 days since last engagement",
+                  "fill": "#29B9C7",
+                  "key": "c_365d",
+                  "label": "Not Recently Engaged",
+                  "stroke": "#29B9C7",
+                },
+                Object {
+                  "description": "365+ days since last engagement",
+                  "fill": "#50CFDA",
+                  "key": "c_uneng",
+                  "label": "Never Engaged",
+                  "stroke": "#50CFDA",
+                },
+                Object {
+                  "description": "Never engaged, first email in last 7 days",
+                  "fill": "#88E2E7",
+                  "key": "c_new",
+                  "label": "New",
+                  "stroke": "#88E2E7",
+                },
+              ]
+            }
+            yRange={
+              Array [
+                "auto",
+                "auto",
+              ]
+            }
+          />
+          <Legend
+            items={
+              Array [
+                Object {
+                  "description": "Never engaged, first email in last 7 days",
+                  "fill": "#88E2E7",
+                  "label": "New",
+                  "stroke": "#88E2E7",
+                },
+                Object {
+                  "description": "365+ days since last engagement",
+                  "fill": "#50CFDA",
+                  "label": "Never Engaged",
+                  "stroke": "#50CFDA",
+                },
+                Object {
+                  "description": "90-365 days since last engagement",
+                  "fill": "#29B9C7",
+                  "label": "Not Recently Engaged",
+                  "stroke": "#29B9C7",
+                },
+                Object {
+                  "description": "14-90 days since last engagement",
+                  "fill": "#219EA8",
+                  "label": "Semi Recently Engaged",
+                  "stroke": "#219EA8",
+                },
+                Object {
+                  "description": "0-14 days since last engagement",
+                  "fill": "#1A838B",
+                  "label": "Recently Engaged",
+                  "stroke": "#1A838B",
+                },
+              ]
+            }
+            tooltipContent={[Function]}
+          />
+        </div>
+      </Panel>
+    </Grid.Column>
+    <Grid.Column
+      md={5}
+      mdOffset={0}
+      sm={12}
+    >
+      <div
+        className="OffsetCol"
+      >
+        <EngagementRecencyActions
+          cohorts={
+            Object {
+              "c_total": 10,
+              "date": "2017-01-02",
+            }
+          }
+          date="2017-01-02"
+        />
+      </div>
+    </Grid.Column>
+  </Grid>
+  <OtherChartsHeader
+    facet="sending-domain"
+    facetId="test.com"
+  />
+  <Grid>
+    <Grid.Column
+      sm={6}
+      xs={12}
+    >
+      <withRouter(Connect(WithSpamTrapDetails(SpamTrapsPreview))) />
+    </Grid.Column>
+    <Grid.Column
+      sm={6}
+      xs={12}
+    >
+      <withRouter(Connect(WithHealthScoreDetails(HealthScorePreview))) />
+    </Grid.Column>
+  </Grid>
+</SignalsPage>
+`;
+
+exports[`Signals Engagement Recency Page renders empty correctly 1`] = `
+<Panel
+  sectioned={true}
+>
+  <Callout
+    title="No Data Available"
+  >
+    Insufficient data to populate this chart
+  </Callout>
+</Panel>
+`;
+
+exports[`Signals Engagement Recency Page renders error correctly 1`] = `
+<SignalsPage
+  breadcrumbAction={
+    Object {
+      "component": [Function],
+      "content": "Back to Overview",
+      "to": "/signals",
+    }
+  }
+  dimensionPrefix="Engagement Rate by Cohort for"
+  facet="sending-domain"
+  facetId="test.com"
+  primaryArea={<Connect(DateFilter) />}
+>
+  <Grid>
+    <Grid.Column
+      md={7}
+      sm={12}
+    >
+      <withRouter(Tabs)
+        facet="sending-domain"
+        facetId="test.com"
+      />
+      <Panel
+        sectioned={true}
+      >
+        <Callout
+          title="Unable to Load Data"
+        >
+          error message
+        </Callout>
+      </Panel>
+    </Grid.Column>
+    <Grid.Column
+      md={5}
+      mdOffset={0}
+      sm={12}
+    >
+      <div
+        className="OffsetCol"
+      />
+    </Grid.Column>
+  </Grid>
+  <OtherChartsHeader
+    facet="sending-domain"
+    facetId="test.com"
+  />
+  <Grid>
+    <Grid.Column
+      sm={6}
+      xs={12}
+    >
+      <withRouter(Connect(WithSpamTrapDetails(SpamTrapsPreview))) />
+    </Grid.Column>
+    <Grid.Column
+      sm={6}
+      xs={12}
+    >
+      <withRouter(Connect(WithHealthScoreDetails(HealthScorePreview))) />
+    </Grid.Column>
+  </Grid>
+</SignalsPage>
+`;
+
+exports[`Signals Engagement Recency Page renders loading correctly 1`] = `
+<Panel
+  sectioned={true}
+>
+  <div
+    style={
+      Object {
+        "height": "220px",
+        "position": "relative",
+      }
+    }
+  >
+    <Loading />
+  </div>
+</Panel>
+`;

--- a/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
@@ -20,18 +20,11 @@ exports[`Signals Engagement Recency Page bar chart props renders tooltip content
     value="0.5%"
   />
   <TooltipMetric
-    color="#50CFDA"
-    description="365+ days since last engagement"
-    key="c_uneng"
-    label="Never Engaged"
-    value="0.1%"
-  />
-  <TooltipMetric
-    color="#29B9C7"
-    description="90-365 days since last engagement"
-    key="c_365d"
-    label="Not Recently Engaged"
-    value="0.2%"
+    color="#1A838B"
+    description="0-14 days since last engagement"
+    key="c_14d"
+    label="Recently Engaged"
+    value="0.4%"
   />
   <TooltipMetric
     color="#219EA8"
@@ -41,11 +34,18 @@ exports[`Signals Engagement Recency Page bar chart props renders tooltip content
     value="0.3%"
   />
   <TooltipMetric
-    color="#1A838B"
-    description="0-14 days since last engagement"
-    key="c_14d"
-    label="Recently Engaged"
-    value="0.4%"
+    color="#29B9C7"
+    description="90-365 days since last engagement"
+    key="c_365d"
+    label="Not Recently Engaged"
+    value="0.2%"
+  />
+  <TooltipMetric
+    color="#50CFDA"
+    description="365+ days since last engagement"
+    key="c_uneng"
+    label="Never Engaged"
+    value="0.1%"
   />
 </Fragment>
 `;

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -50,18 +50,6 @@ exports[`Signals Engagement Recency Page bar chart props renders tooltip content
 </Fragment>
 `;
 
-exports[`Signals Engagement Recency Page local state handles date select 1`] = `
-<EngagementRecencyActions
-  cohorts={
-    Object {
-      "c_total": 10,
-      "date": "2017-01-02",
-    }
-  }
-  date="2017-01-02"
-/>
-`;
-
 exports[`Signals Engagement Recency Page renders correctly 1`] = `
 <SignalsPage
   breadcrumbAction={
@@ -118,7 +106,7 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
                 "top": 12,
               }
             }
-            onClick={[Function]}
+            onClick={[MockFunction]}
             selected="2017-01-02"
             timeSeries={
               Array [

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -13,35 +13,35 @@ Object {
 exports[`Signals Engagement Recency Page bar chart props renders tooltip content 1`] = `
 <Fragment>
   <TooltipMetric
-    color="#E4EEF0"
+    color="#88E2E7"
     description="Never engaged, first email in last 7 days"
     key="c_new"
     label="New"
     value="50%"
   />
   <TooltipMetric
-    color="#B9E2E9"
+    color="#50CFDA"
     description="365+ days since last engagement"
     key="c_uneng"
     label="Never Engaged"
     value="10%"
   />
   <TooltipMetric
-    color="#9AD8E3"
+    color="#29B9C7"
     description="90-365 days since last engagement"
     key="c_365d"
     label="Not Recently Engaged"
     value="20%"
   />
   <TooltipMetric
-    color="#44A8AD"
+    color="#219EA8"
     description="14-90 days since last engagement"
     key="c_90d"
     label="Semi Recently Engaged"
     value="30%"
   />
   <TooltipMetric
-    color="#3F8B93"
+    color="#1A838B"
     description="0-14 days since last engagement"
     key="c_14d"
     label="Recently Engaged"
@@ -166,33 +166,38 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
               Array [
                 Object {
                   "description": "0-14 days since last engagement",
-                  "fill": "#3F8B93",
+                  "fill": "#1A838B",
                   "key": "c_14d",
                   "label": "Recently Engaged",
+                  "stroke": "#1A838B",
                 },
                 Object {
                   "description": "14-90 days since last engagement",
-                  "fill": "#44A8AD",
+                  "fill": "#219EA8",
                   "key": "c_90d",
                   "label": "Semi Recently Engaged",
+                  "stroke": "#219EA8",
                 },
                 Object {
                   "description": "90-365 days since last engagement",
-                  "fill": "#9AD8E3",
+                  "fill": "#29B9C7",
                   "key": "c_365d",
                   "label": "Not Recently Engaged",
+                  "stroke": "#29B9C7",
                 },
                 Object {
                   "description": "365+ days since last engagement",
-                  "fill": "#B9E2E9",
+                  "fill": "#50CFDA",
                   "key": "c_uneng",
                   "label": "Never Engaged",
+                  "stroke": "#50CFDA",
                 },
                 Object {
                   "description": "Never engaged, first email in last 7 days",
-                  "fill": "#E4EEF0",
+                  "fill": "#88E2E7",
                   "key": "c_new",
                   "label": "New",
+                  "stroke": "#88E2E7",
                 },
               ]
             }
@@ -208,28 +213,33 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
               Array [
                 Object {
                   "description": "Never engaged, first email in last 7 days",
-                  "fill": "#E4EEF0",
+                  "fill": "#88E2E7",
                   "label": "New",
+                  "stroke": "#88E2E7",
                 },
                 Object {
                   "description": "365+ days since last engagement",
-                  "fill": "#B9E2E9",
+                  "fill": "#50CFDA",
                   "label": "Never Engaged",
+                  "stroke": "#50CFDA",
                 },
                 Object {
                   "description": "90-365 days since last engagement",
-                  "fill": "#9AD8E3",
+                  "fill": "#29B9C7",
                   "label": "Not Recently Engaged",
+                  "stroke": "#29B9C7",
                 },
                 Object {
                   "description": "14-90 days since last engagement",
-                  "fill": "#44A8AD",
+                  "fill": "#219EA8",
                   "label": "Semi Recently Engaged",
+                  "stroke": "#219EA8",
                 },
                 Object {
                   "description": "0-14 days since last engagement",
-                  "fill": "#3F8B93",
+                  "fill": "#1A838B",
                   "label": "Recently Engaged",
+                  "stroke": "#1A838B",
                 },
               ]
             }

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -81,16 +81,25 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
       md={7}
       sm={12}
     >
+      <Connect(AccessControl)
+        condition={[Function]}
+      >
+        <withRouter(Tabs) />
+      </Connect(AccessControl)>
       <Panel
         sectioned={true}
       >
-        <ChartHeader
-          title="Engagement Recency"
-          tooltipContent="
+        <Connect(AccessControl)
+          condition={[Function]}
+        >
+          <ChartHeader
+            title="Engagement Recency"
+            tooltipContent="
   The share over time of your email that has been sent to recipients who most recently
   opened messages or clicked links during several defined time periods.
 "
-        />
+          />
+        </Connect(AccessControl)>
         <div
           className="LiftTooltip"
         >
@@ -271,13 +280,17 @@ exports[`Signals Engagement Recency Page renders empty correctly 1`] = `
 <Panel
   sectioned={true}
 >
-  <ChartHeader
-    title="Engagement Recency"
-    tooltipContent="
+  <Connect(AccessControl)
+    condition={[Function]}
+  >
+    <ChartHeader
+      title="Engagement Recency"
+      tooltipContent="
   The share over time of your email that has been sent to recipients who most recently
   opened messages or clicked links during several defined time periods.
 "
-  />
+    />
+  </Connect(AccessControl)>
   <Callout
     title="No Data Available"
   >
@@ -305,16 +318,25 @@ exports[`Signals Engagement Recency Page renders error correctly 1`] = `
       md={7}
       sm={12}
     >
+      <Connect(AccessControl)
+        condition={[Function]}
+      >
+        <withRouter(Tabs) />
+      </Connect(AccessControl)>
       <Panel
         sectioned={true}
       >
-        <ChartHeader
-          title="Engagement Recency"
-          tooltipContent="
+        <Connect(AccessControl)
+          condition={[Function]}
+        >
+          <ChartHeader
+            title="Engagement Recency"
+            tooltipContent="
   The share over time of your email that has been sent to recipients who most recently
   opened messages or clicked links during several defined time periods.
 "
-        />
+          />
+        </Connect(AccessControl)>
         <Callout
           title="Unable to Load Data"
         >
@@ -357,13 +379,17 @@ exports[`Signals Engagement Recency Page renders loading correctly 1`] = `
 <Panel
   sectioned={true}
 >
-  <ChartHeader
-    title="Engagement Recency"
-    tooltipContent="
+  <Connect(AccessControl)
+    condition={[Function]}
+  >
+    <ChartHeader
+      title="Engagement Recency"
+      tooltipContent="
   The share over time of your email that has been sent to recipients who most recently
   opened messages or clicked links during several defined time periods.
 "
-  />
+    />
+  </Connect(AccessControl)>
   <div
     style={
       Object {

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -84,7 +84,10 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
       <Connect(AccessControl)
         condition={[Function]}
       >
-        <withRouter(Tabs) />
+        <withRouter(Tabs)
+          facet="sending-domain"
+          facetId="test.com"
+        />
       </Connect(AccessControl)>
       <Panel
         sectioned={true}
@@ -321,7 +324,10 @@ exports[`Signals Engagement Recency Page renders error correctly 1`] = `
       <Connect(AccessControl)
         condition={[Function]}
       >
-        <withRouter(Tabs) />
+        <withRouter(Tabs)
+          facet="sending-domain"
+          facetId="test.com"
+        />
       </Connect(AccessControl)>
       <Panel
         sectioned={true}

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -37,26 +37,6 @@ exports[`Signals Health Score Page bar chart props renders tooltip content for s
 
 exports[`Signals Health Score Page bar chart props renders y label content for component weights 1`] = `"Engaged Recipients"`;
 
-exports[`Signals Health Score Page local state handles date select 1`] = `
-<HealthScoreActions
-  date="2017-01-02"
-  weights={
-    Array [
-      Object {
-        "weight": 0.8,
-        "weight_type": "List Quality",
-        "weight_value": 0.25,
-      },
-      Object {
-        "weight": -0.8,
-        "weight_type": "Other bounces",
-        "weight_value": 0.25,
-      },
-    ]
-  }
-/>
-`;
-
 exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
 <SignalsPage
   breadcrumbAction={
@@ -99,7 +79,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
               "top": 12,
             }
           }
-          onClick={[Function]}
+          onClick={[MockFunction]}
           selected="2017-01-01"
           timeSeries={
             Array [
@@ -175,7 +155,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
               "top": 12,
             }
           }
-          onClick={[Function]}
+          onClick={[MockFunction]}
           selected="2017-01-01"
           timeSeries={
             Array [
@@ -248,7 +228,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
               "top": 12,
             }
           }
-          onClick={[Function]}
+          onClick={[MockFunction]}
           selected="2017-01-01"
           timeSeries={
             Array [
@@ -440,7 +420,7 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
               "top": 12,
             }
           }
-          onClick={[Function]}
+          onClick={[MockFunction]}
           selected="2017-01-01"
           timeSeries={
             Array [
@@ -489,7 +469,7 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
               "top": 12,
             }
           }
-          onClick={[Function]}
+          onClick={[MockFunction]}
           selected="2017-01-01"
           timeSeries={
             Array [

--- a/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
@@ -24,13 +24,6 @@ exports[`Signals Spam Trap Page bar chart props renders tooltip content 1`] = `
 </Fragment>
 `;
 
-exports[`Signals Spam Trap Page local state handles date select 1`] = `
-<SpamTrapActions
-  date="2017-01-02"
-  percent={0.5}
-/>
-`;
-
 exports[`Signals Spam Trap Page renders correctly 1`] = `
 <SignalsPage
   breadcrumbAction={
@@ -78,7 +71,7 @@ exports[`Signals Spam Trap Page renders correctly 1`] = `
               "top": 12,
             }
           }
-          onClick={[Function]}
+          onClick={[MockFunction]}
           selected="2017-01-01"
           timeSeries={
             Array [

--- a/src/reducers/signals.js
+++ b/src/reducers/signals.js
@@ -8,7 +8,8 @@ const initialDimensionState = {
 const initialState = {
   spamHits: initialDimensionState,
   healthScore: initialDimensionState,
-  engagementRecency: initialDimensionState
+  engagementRecency: initialDimensionState,
+  engagementRateByCohort: initialDimensionState
 };
 
 const signalsReducer = (state = initialState, { type, payload, meta }) => {
@@ -33,6 +34,17 @@ const signalsReducer = (state = initialState, { type, payload, meta }) => {
     case 'GET_ENGAGEMENT_RECENCY_SUCCESS': {
       const { data, total_count: totalCount } = payload;
       return { ...state, engagementRecency: { ...initialDimensionState, data, loading: false, totalCount }};
+    }
+
+    case 'GET_ENGAGEMENT_RATE_BY_COHORT_FAIL':
+      return { ...state, engagementRateByCohort: { ...initialDimensionState, error: payload.error, loading: false }};
+
+    case 'GET_ENGAGEMENT_RATE_BY_COHORT_PENDING':
+      return { ...state, engagementRateByCohort: { ...initialDimensionState, loading: true }};
+
+    case 'GET_ENGAGEMENT_RATE_BY_COHORT_SUCCESS': {
+      const { data, total_count: totalCount } = payload;
+      return { ...state, engagementRateByCohort: { ...initialDimensionState, data, loading: false, totalCount }};
     }
 
     case 'GET_HEALTH_SCORE_FAIL':

--- a/src/reducers/tests/__snapshots__/signals.test.js.snap
+++ b/src/reducers/tests/__snapshots__/signals.test.js.snap
@@ -1,7 +1,104 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Signals Reducer engagment rate by cohort fail 1`] = `
+Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": [Error: Oh no!],
+    "loading": false,
+    "totalCount": 0,
+  },
+  "engagementRecency": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+  "healthScore": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+  "spamHits": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+}
+`;
+
+exports[`Signals Reducer engagment rate by cohort pending 1`] = `
+Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": true,
+    "totalCount": 0,
+  },
+  "engagementRecency": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+  "healthScore": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+  "spamHits": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+}
+`;
+
+exports[`Signals Reducer engagment rate by cohort success 1`] = `
+Object {
+  "engagementRateByCohort": Object {
+    "data": Array [
+      Object {
+        "sending-domain": "example.com",
+      },
+    ],
+    "error": null,
+    "loading": false,
+    "totalCount": 3,
+  },
+  "engagementRecency": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+  "healthScore": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+  "spamHits": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
+}
+`;
+
 exports[`Signals Reducer engagment recency fail 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": [Error: Oh no!],
@@ -25,6 +122,12 @@ Object {
 
 exports[`Signals Reducer engagment recency pending 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,
@@ -48,6 +151,12 @@ Object {
 
 exports[`Signals Reducer engagment recency success 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [
       Object {
@@ -75,6 +184,12 @@ Object {
 
 exports[`Signals Reducer health score fail 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,
@@ -98,6 +213,12 @@ Object {
 
 exports[`Signals Reducer health score pending 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,
@@ -121,6 +242,12 @@ Object {
 
 exports[`Signals Reducer health score success 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,
@@ -148,6 +275,12 @@ Object {
 
 exports[`Signals Reducer init 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,
@@ -171,6 +304,12 @@ Object {
 
 exports[`Signals Reducer spam hits fail 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,
@@ -194,6 +333,12 @@ Object {
 
 exports[`Signals Reducer spam hits pending 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,
@@ -217,6 +362,12 @@ Object {
 
 exports[`Signals Reducer spam hits success 1`] = `
 Object {
+  "engagementRateByCohort": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRecency": Object {
     "data": Array [],
     "error": null,

--- a/src/reducers/tests/signals.test.js
+++ b/src/reducers/tests/signals.test.js
@@ -44,6 +44,24 @@ cases('Signals Reducer', ({ name, ...action }) => {
       total_count: 3
     }
   },
+  'engagment rate by cohort fail': {
+    type: 'GET_ENGAGEMENT_RATE_BY_COHORT_FAIL',
+    payload: {
+      error: new Error('Oh no!')
+    }
+  },
+  'engagment rate by cohort pending': {
+    type: 'GET_ENGAGEMENT_RATE_BY_COHORT_PENDING'
+  },
+  'engagment rate by cohort success': {
+    type: 'GET_ENGAGEMENT_RATE_BY_COHORT_SUCCESS',
+    payload: {
+      data: [
+        { 'sending-domain': 'example.com' }
+      ],
+      total_count: 3
+    }
+  },
   'health score fail': {
     type: 'GET_HEALTH_SCORE_FAIL',
     payload: {

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -109,17 +109,24 @@ export const selectEngagementRateByCohortDetails = createSelector(
   [getEngagementRateByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
   ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange }) => {
     const match = data.find((item) => String(item[facet]) === facetId) || {};
-    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
+
+    // Rename keys to reference correct cohort constants within components
+    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => {
+      const reKeyed = _.keys(values).reduce((acc, key) => ({
+        ...acc, [key.replace(/_engagement$/, '')]: values[key]
+      }), {});
+      return { date, ...reKeyed }
+    });
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
       fill: {
-        c_new_engagment: null,
-        c_14d_engagment: null,
-        c_90d_engagment: null,
-        c_365d_engagment: null,
-        c_uneng_engagment: null,
-        c_total_engagment: null
+        c_new: null,
+        c_14d: null,
+        c_90d: null,
+        c_365d: null,
+        c_uneng: null,
+        c_total: null
       },
       now,
       relativeRange

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -19,6 +19,7 @@ export const getOptions = (state, { now = moment().subtract(1, 'day'), ...option
 // Redux store
 export const getSpamHitsData = (state, props) => _.get(state, 'signals.spamHits', {});
 export const getEngagementRecencyData = (state, props) => _.get(state, 'signals.engagementRecency', {});
+export const getEngagementRateByCohortData = (state, props) => _.get(state, 'signals.engagementRateByCohort', {});
 export const getHealthScoreData = (state, props) => _.get(state, 'signals.healthScore', {});
 
 // Details
@@ -89,6 +90,42 @@ export const selectEngagementRecencyDetails = createSelector(
     });
 
     const isEmpty = filledHistory.every((values) => values.c_total === null);
+
+    return {
+      details: {
+        data: filledHistory,
+        empty: isEmpty && !loading,
+        error,
+        loading
+      },
+      facet,
+      facetId,
+      subaccountId
+    };
+  }
+);
+
+export const selectEngagementRateByCohortDetails = createSelector(
+  [getEngagementRateByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
+  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange }) => {
+    const match = data.find((item) => String(item[facet]) === facetId) || {};
+    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
+
+    const filledHistory = fillByDate({
+      dataSet: normalizedHistory,
+      fill: {
+        c_new_engagment: null,
+        c_14d_engagment: null,
+        c_90d_engagment: null,
+        c_365d_engagment: null,
+        c_uneng_engagment: null,
+        c_total_engagment: null
+      },
+      now,
+      relativeRange
+    });
+
+    const isEmpty = filledHistory.every((values) => values.c_total_engagment === null);
 
     return {
       details: {

--- a/src/selectors/tests/__snapshots__/signals.test.js.snap
+++ b/src/selectors/tests/__snapshots__/signals.test.js.snap
@@ -1,5 +1,177 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Selectors: signals engagement rate by cohort details should be empty with only fill data when not loading 1`] = `
+Object {
+  "details": Object {
+    "data": Array [
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-27",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-28",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-29",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-30",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-31",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2018-01-01",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2018-01-02",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2018-01-03",
+      },
+    ],
+    "empty": false,
+    "error": undefined,
+    "loading": false,
+  },
+  "facet": "sending_domain",
+  "facetId": "test.com",
+  "subaccountId": "101",
+}
+`;
+
+exports[`Selectors: signals engagement rate by cohort details should select details 1`] = `
+Object {
+  "details": Object {
+    "data": Array [
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-27",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-28",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-29",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-30",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2017-12-31",
+      },
+      Object {
+        "c_14d": 5,
+        "c_365d": 5,
+        "c_new": 5,
+        "c_total": 25,
+        "c_uneng": 5,
+        "date": "2018-01-01",
+      },
+      Object {
+        "c_14d": null,
+        "c_365d": null,
+        "c_90d": null,
+        "c_new": null,
+        "c_total": null,
+        "c_uneng": null,
+        "date": "2018-01-02",
+      },
+      Object {
+        "c_14d": 10,
+        "c_365d": 10,
+        "c_new": 10,
+        "c_total": 50,
+        "c_uneng": 10,
+        "date": "2018-01-03",
+      },
+    ],
+    "empty": false,
+    "error": null,
+    "loading": false,
+  },
+  "facet": "sending_domain",
+  "facetId": "test.com",
+  "subaccountId": "101",
+}
+`;
+
 exports[`Selectors: signals engagement recency details should be empty with only fill data when not loading 1`] = `
 Object {
   "details": Object {

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -103,6 +103,34 @@ describe('Selectors: signals', () => {
           loading: false,
           error: null
         },
+        engagementRateByCohort: {
+          total_count: 10,
+          data: [
+            {
+              sending_domain: 'test.com',
+              history: [
+                {
+                  c_total_engagement: 25,
+                  c_new_engagement: 5,
+                  c_uneng_engagement: 5,
+                  c_14d_engagement: 5,
+                  c_365d_engagement: 5,
+                  dt: '2018-01-01'
+                },
+                {
+                  c_total_engagement: 50,
+                  c_new_engagement: 10,
+                  c_uneng_engagement: 10,
+                  c_14d_engagement: 10,
+                  c_365d_engagement: 10,
+                  dt: '2018-01-03'
+                }
+              ]
+            }
+          ],
+          loading: false,
+          error: null
+        },
         healthScore: {
           total_count: 10,
           data: [
@@ -176,6 +204,22 @@ describe('Selectors: signals', () => {
     it('should not be empty when loading', () => {
       const stateWhenLoading = { ...state, signals: { engagementRecency: { data: [], loading: true }}};
       expect(selectors.selectEngagementRecencyDetails(stateWhenLoading, props).details.empty).toBe(false);
+    });
+  });
+
+  describe('engagement rate by cohort details', () => {
+    it('should select details', () => {
+      expect(selectors.selectEngagementRateByCohortDetails(state, props)).toMatchSnapshot();
+    });
+
+    it('should be empty with only fill data when not loading', () => {
+      const stateWhenEmpty = { ...state, signals: { engagementRateByCohort: { data: [], loading: false }}};
+      expect(selectors.selectEngagementRateByCohortDetails(stateWhenEmpty, props)).toMatchSnapshot();
+    });
+
+    it('should not be empty when loading', () => {
+      const stateWhenLoading = { ...state, signals: { engagementRateByCohort: { data: [], loading: true }}};
+      expect(selectors.selectEngagementRateByCohortDetails(stateWhenLoading, props).details.empty).toBe(false);
     });
   });
 


### PR DESCRIPTION
Note: Give your PR a short title. Something like "_TICKET NUMBER: feature description_" is good.

### What Changed
- Renamed `/signals/engagement-recency` to `/signals/engagement/cohorts`
  - Three new routes gated with the UI option `feature_signals_v2`:
    - `/signals/engagement/engagement-rate`
    - `/signals/engagement/complaints`
    - `/signals/engagement/unsubscribes`
- New `/signals/engagement/engagement-rate` page
- New fake endpoint (API endpoint does not exist)
- Abstracted out date selection into a higher order component (hooks pls)


### How To Test
- Point your local openresty upstreams to staging
- Verify UI does not change without the `feature_signals_v2` UI option
  - Visit `/signals/engagement/cohorts`
  - Verify the Tabs do not render
  - Verify the the gated routes 404
- Verify the new page
  - Log into `appteam` or add the `feature_signals_v2` UI option to your account
  - Verify the Tabs render on `/signals/engagement/cohorts`
  - Click on Engagement Rate tab

### To Do
- [ ] Address feedback

### Maybe To Do
- [ ] Add recommended actions
- [ ] Hook up to real API
- [x] Abstract out selected date logic, and maybe some selector reshaping to reduce copy pasted code