### PR TITLE
AC-590: Changed billingInfo to utilize billing endpoint 

### DIFF
--- a/src/__integration__/__snapshots__/billing.test.js.snap
+++ b/src/__integration__/__snapshots__/billing.test.js.snap
@@ -172,10 +172,22 @@ Array [
       },
       "method": "get",
       "params": Object {
-        "include": "usage,billing",
+        "include": "usage",
       },
       "responseType": "json",
       "url": "/v1/account",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "very-real-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/account/billing",
     },
   ],
 ]
@@ -206,10 +218,22 @@ Array [
       },
       "method": "get",
       "params": Object {
-        "include": "usage,billing",
+        "include": "usage",
       },
       "responseType": "json",
       "url": "/v1/account",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "very-real-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/account/billing",
     },
   ],
 ]
@@ -315,10 +339,22 @@ Array [
       },
       "method": "get",
       "params": Object {
-        "include": "usage,billing",
+        "include": "usage",
       },
       "responseType": "json",
       "url": "/v1/account",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "very-real-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/account/billing",
     },
   ],
 ]
@@ -353,10 +389,22 @@ Array [
       },
       "method": "get",
       "params": Object {
-        "include": "usage,billing",
+        "include": "usage",
       },
       "responseType": "json",
       "url": "/v1/account",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "very-real-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/account/billing",
     },
   ],
 ]
@@ -440,10 +488,22 @@ Array [
       },
       "method": "get",
       "params": Object {
-        "include": "usage,billing",
+        "include": "usage",
       },
       "responseType": "json",
       "url": "/v1/account",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "very-real-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/account/billing",
     },
   ],
 ]

--- a/src/__integration__/http-responses/v1/account/billing/get.js
+++ b/src/__integration__/http-responses/v1/account/billing/get.js
@@ -1,0 +1,20 @@
+export default ({ params }) => ({
+  results: {
+    first_name: null,
+    last_name: null,
+    address1: null,
+    address2: null,
+    city: null,
+    state: 'MD',
+    country_code: 'US',
+    zip_code: '12345',
+    email: 'test-email@sparkpost.test',
+    credit_card: {
+      id: '2c92c0fb63ed6e0a0163f1c7bec25b52',
+      type: 'Visa',
+      number: '************1111',
+      expiration_month: 4,
+      expiration_year: 2022
+    }
+  }
+});

--- a/src/__integration__/http-responses/v1/account/get.js
+++ b/src/__integration__/http-responses/v1/account/get.js
@@ -27,25 +27,5 @@ export default ({ params }) => {
       online: true
     }
   };
-  if (typeof params.include === 'string' && params.include.includes('billing')) {
-    account.billing = {
-      first_name: null,
-      last_name: null,
-      address1: null,
-      address2: null,
-      city: null,
-      state: 'MD',
-      country_code: 'US',
-      zip_code: '12345',
-      email: 'test-email@sparkpost.test',
-      credit_card: {
-        id: '2c92c0fb63ed6e0a0163f1c7bec25b52',
-        type: 'Visa',
-        number: '************1111',
-        expiration_month: 4,
-        expiration_year: 2022
-      }
-    };
-  }
   return { results: account };
 };

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -23,6 +23,17 @@ export function getPlans({ meta = {}} = {}) {
   });
 }
 
+export function getBillingInfo({ meta = {}} = {}) {
+  return sparkpostApiRequest({
+    type: 'GET_BILLING',
+    meta: {
+      method: 'GET',
+      url: '/v1/account/billing',
+      ...meta
+    }
+  });
+}
+
 export function update(data) {
   return sparkpostApiRequest({
     type: 'UPDATE_ACCOUNT',

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -1,6 +1,6 @@
 /* eslint max-lines: ["error", 215] */
 import { formatContactData } from 'src/helpers/billing';
-import { fetch as fetchAccount } from './account';
+import { fetch as fetchAccount, getBillingInfo } from './account';
 import { list as getSendingIps } from './sendingIps';
 import { isAws } from 'src/helpers/conditions/account';
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
@@ -23,6 +23,8 @@ export function syncSubscription({ meta = {}} = {}) {
  * @param {string} code
  */
 export function updateSubscription({ code, promoCode, meta = {}}) {
+  const getBillingAction = () => getBillingInfo();
+  const fetchAccountAction = () => fetchAccount({ include: 'usage', meta: { onSuccess: getBillingAction }});
   return (dispatch, getState) => dispatch(
     sparkpostApiRequest({
       type: 'UPDATE_SUBSCRIPTION',
@@ -34,7 +36,7 @@ export function updateSubscription({ code, promoCode, meta = {}}) {
           code
         },
         ...meta,
-        onSuccess: meta.onSuccess ? meta.onSuccess : () => fetchAccount({ include: 'usage,billing' })
+        onSuccess: meta.onSuccess ? meta.onSuccess : fetchAccountAction
       }
     })
   );
@@ -55,7 +57,8 @@ export function updateBillingContact(data) {
   });
 
   return (dispatch) => dispatch(action)
-    .then(() => dispatch(fetchAccount({ include: 'usage,billing' })));
+    .then(() => dispatch(fetchAccount({ include: 'usage' })))
+    .then(() => dispatch(getBillingInfo()));
 }
 
 export function verifyPromoCode({ promoCode, billingId, meta = {}}) {

--- a/src/actions/billingCreate.js
+++ b/src/actions/billingCreate.js
@@ -1,6 +1,6 @@
 import { isAws, isCustomBilling } from 'src/helpers/conditions/account';
 import { formatCreateData, formatDataForCors } from 'src/helpers/billing';
-import { fetch as fetchAccount } from './account';
+import { fetch as fetchAccount, getBillingInfo } from './account';
 import chainActions from 'src/actions/helpers/chainActions';
 import { cors, createZuoraAccount, syncSubscription, updateSubscription, consumePromoCode } from './billing';
 
@@ -16,7 +16,8 @@ export default function billingCreate(values) {
 
     // action creator wrappers for chaining as callbacks
     const corsCreateBilling = ({ meta }) => cors({ meta, context: 'create-account', data: corsData });
-    const fetchUsageAndBilling = ({ meta }) => fetchAccount({ include: 'usage,billing', meta });
+    const fetchUsage = ({ meta }) => fetchAccount({ include: 'usage', meta });
+    const fetchBillingInfo = ({ meta }) => getBillingInfo({ meta });
     const constructZuoraAccount = ({ results: { signature, token, ...results }, meta }) => {
       const state = getState();
       const invoiceCollect = !isCustomBilling(state); // don't send initial invoice for custom plans
@@ -27,7 +28,7 @@ export default function billingCreate(values) {
       return createZuoraAccount({ data, token, signature, meta });
     };
 
-    const actions = [corsCreateBilling, constructZuoraAccount, syncSubscription, fetchUsageAndBilling];
+    const actions = [corsCreateBilling, constructZuoraAccount, syncSubscription, fetchUsage, fetchBillingInfo];
     if (values.promoCode) {
       const consumePromo = ({ meta }) => consumePromoCode({ meta, promoCode: values.promoCode, billingId: billingData.billingId });
       actions.push(consumePromo);

--- a/src/actions/billingUpdate.js
+++ b/src/actions/billingUpdate.js
@@ -1,4 +1,4 @@
-import { fetch as fetchAccount } from './account';
+import { fetch as fetchAccount, getBillingInfo } from './account';
 import { formatUpdateData } from 'src/helpers/billing';
 import chainActions from 'src/actions/helpers/chainActions';
 import { collectPayments, cors, syncSubscription, updateCreditCard, updateSubscription } from './billing';
@@ -21,8 +21,9 @@ export default function billingUpdate(values) {
     const updateZuoraCC = ({ meta, results: { accountKey, token, signature }}) => (
       updateCreditCard({ data: formatUpdateData({ ...values, accountKey }), signature, token, meta })
     );
-    const fetchAccountDetails = () => fetchAccount({ include: 'usage,billing' });
-    const actions = [corsUpdateBilling, updateZuoraCC, maybeUpdateSubscription, syncSubscription, collectPayments, fetchAccountDetails];
+    const fetchAccountDetails = ({ meta }) => fetchAccount({ include: 'usage', meta });
+    const fetchBillingInfo = () => getBillingInfo();
+    const actions = [corsUpdateBilling, updateZuoraCC, maybeUpdateSubscription, syncSubscription, collectPayments, fetchAccountDetails, fetchBillingInfo];
 
     return dispatch(chainActions(...actions)());
   };

--- a/src/actions/tests/__snapshots__/account.test.js.snap
+++ b/src/actions/tests/__snapshots__/account.test.js.snap
@@ -62,6 +62,16 @@ Object {
 }
 `;
 
+exports[`getBilling 1`] = `
+Object {
+  "meta": Object {
+    "method": "GET",
+    "url": "/v1/account/billing",
+  },
+  "type": "GET_BILLING",
+}
+`;
+
 exports[`getPlans 1`] = `
 Object {
   "meta": Object {

--- a/src/actions/tests/account.test.js
+++ b/src/actions/tests/account.test.js
@@ -1,4 +1,4 @@
-import { fetch, getPlans, register, emailRequest } from '../account';
+import { fetch, getPlans, register, emailRequest, getBillingInfo } from '../account';
 jest.mock('../helpers/sparkpostApiRequest', () => jest.fn((a) => a));
 
 test('fetch - no params', () => {
@@ -19,6 +19,11 @@ test('fetch with params', () => {
 test('getPlans', () => {
   const getPlansAction = getPlans();
   expect(getPlansAction).toMatchSnapshot();
+});
+
+test('getBilling', () => {
+  const getBillingInfoAction = getBillingInfo();
+  expect(getBillingInfoAction).toMatchSnapshot();
 });
 
 describe('Account action creators', () => {

--- a/src/actions/tests/billingCreate.test.js
+++ b/src/actions/tests/billingCreate.test.js
@@ -30,7 +30,8 @@ describe('Action Creator: Billing Create', () => {
     }));
 
     expect(billingActions.syncSubscription).toHaveBeenCalled();
-    expect(accountActions.fetch).toHaveBeenCalledWith(expect.objectContaining({ include: 'usage,billing' }));
+    expect(accountActions.fetch).toHaveBeenCalledWith(expect.objectContaining({ include: 'usage' }));
+    expect(accountActions.getBillingInfo).toHaveBeenCalled();
   };
 
   beforeEach(() => {
@@ -63,6 +64,7 @@ describe('Action Creator: Billing Create', () => {
       }
     }));
     accountActions.fetch = jest.fn(({ meta }) => meta.onSuccess({}));
+    accountActions.getBillingInfo = jest.fn(({ meta }) => meta.onSuccess({}));
     billingHelpers.formatCreateData = jest.fn((a) => a);
     billingHelpers.formatDataForCors = jest.fn((a) => ({ billingData, corsData }));
   });
@@ -70,7 +72,7 @@ describe('Action Creator: Billing Create', () => {
   it('update without a planpicker code', () => {
 
     const thunk = billingCreate(values);
-    accountActions.fetch = jest.fn();
+    accountActions.getBillingInfo = jest.fn();
 
     thunk(dispatch, getState);
 

--- a/src/actions/tests/billingUpdate.test.js
+++ b/src/actions/tests/billingUpdate.test.js
@@ -23,7 +23,8 @@ describe('Action Creator: Billing Update', () => {
     billingActions.updateSubscription = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.syncSubscription = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.collectPayments = jest.fn(({ meta }) => meta.onSuccess({}));
-    accountActions.fetch = jest.fn();
+    accountActions.fetch = jest.fn(({ meta }) => meta.onSuccess({}));
+    accountActions.getBillingInfo = jest.fn();
     billingHelpers.formatUpdateData = jest.fn((a) => a);
   });
 
@@ -46,7 +47,8 @@ describe('Action Creator: Billing Update', () => {
     expect(billingActions.updateSubscription).not.toHaveBeenCalled();
     expect(billingActions.syncSubscription).toHaveBeenCalled();
     expect(billingActions.collectPayments).toHaveBeenCalled();
-    expect(accountActions.fetch).toHaveBeenCalledWith({ include: 'usage,billing' });
+    expect(accountActions.fetch).toHaveBeenCalledWith(expect.objectContaining({ include: 'usage' }));
+    expect(accountActions.getBillingInfo).toHaveBeenCalled();
   });
 
   it('update with a planpicker code', () => {
@@ -75,6 +77,7 @@ describe('Action Creator: Billing Update', () => {
     }));
     expect(billingActions.syncSubscription).toHaveBeenCalled();
     expect(billingActions.collectPayments).toHaveBeenCalled();
-    expect(accountActions.fetch).toHaveBeenCalledWith({ include: 'usage,billing' });
+    expect(accountActions.fetch).toHaveBeenCalledWith(expect.objectContaining({ include: 'usage' }));
+    expect(accountActions.getBillingInfo).toHaveBeenCalled();
   });
 });

--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Page } from '@sparkpost/matchbox';
-import { fetch as fetchAccount, getPlans } from 'src/actions/account';
+import { fetch as fetchAccount, getPlans, getBillingInfo } from 'src/actions/account';
 import { list as getSendingIps } from 'src/actions/sendingIps';
 import { selectBillingInfo } from 'src/selectors/accountBillingInfo';
 import { selectAccountAgeInDays } from 'src/selectors/accountAge';
@@ -17,7 +17,8 @@ import { list as getInvoices } from 'src/actions/invoices';
 export class BillingSummaryPage extends Component {
 
   componentDidMount() {
-    this.props.fetchAccount({ include: 'billing' });
+    this.props.fetchAccount();
+    this.props.getBillingInfo();
     this.props.getPlans();
     this.props.getSendingIps();
     this.props.getInvoices();
@@ -51,4 +52,4 @@ const mapStateToProps = (state) => ({
   invoices: state.invoices.list
 });
 
-export default connect(mapStateToProps, { getInvoices, getSendingIps, getPlans, fetchAccount })(BillingSummaryPage);
+export default connect(mapStateToProps, { getInvoices, getSendingIps, getPlans, fetchAccount, getBillingInfo })(BillingSummaryPage);

--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Page } from '@sparkpost/matchbox';
 import { fetch as fetchAccount, getPlans, getBillingInfo } from 'src/actions/account';
 import { list as getSendingIps } from 'src/actions/sendingIps';
-import { selectBillingInfo } from 'src/selectors/accountBillingInfo';
+import { selectBillingInfo, selectAccountBilling } from 'src/selectors/accountBillingInfo';
 import { selectAccountAgeInDays } from 'src/selectors/accountAge';
 import ConditionSwitch, { defaultCase } from 'src/components/auth/ConditionSwitch';
 import { not } from 'src/helpers/conditions';
@@ -43,13 +43,16 @@ export class BillingSummaryPage extends Component {
   }
 }
 
-const mapStateToProps = (state) => ({
-  loading: state.account.loading || state.billing.plansLoading || !state.account.subscription,
-  account: state.account,
-  accountAgeInDays: selectAccountAgeInDays(state),
-  billingInfo: selectBillingInfo(state),
-  sendingIps: state.sendingIps.list,
-  invoices: state.invoices.list
-});
+const mapStateToProps = (state) => {
+  const { account, loading } = selectAccountBilling(state);
+  return ({
+    loading: loading || state.billing.plansLoading || !state.account.subscription,
+    account,
+    accountAgeInDays: selectAccountAgeInDays(state),
+    billingInfo: selectBillingInfo(state),
+    sendingIps: state.sendingIps.list,
+    invoices: state.invoices.list
+  });
+};
 
 export default connect(mapStateToProps, { getInvoices, getSendingIps, getPlans, fetchAccount, getBillingInfo })(BillingSummaryPage);

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -11,7 +11,7 @@ import billingUpdate from 'src/actions/billingUpdate';
 import { showAlert } from 'src/actions/globalAlert';
 import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
 import {
-  currentPlanSelector, canUpdateBillingInfoSelector, selectVisiblePlans
+  currentPlanSelector, canUpdateBillingInfoSelector, selectVisiblePlans, selectAccountBilling
 } from 'src/selectors/accountBillingInfo';
 import { Panel, Grid } from '@sparkpost/matchbox';
 import { Loading, PlanPicker } from 'src/components';
@@ -177,13 +177,13 @@ export class ChangePlanForm extends Component {
 const mapStateToProps = (state, props) => {
   const selector = formValueSelector(FORMNAME);
   const { code: planCode } = qs.parse(props.location.search);
-
   const plans = selectVisiblePlans(state);
+  const { account, loading } = selectAccountBilling(state);
 
   return {
-    loading: (!state.account.created && state.account.loading) || (plans.length === 0 && state.billing.plansLoading) || state.account.billingLoading,
+    loading: (!account.created && loading) || (plans.length === 0 && state.billing.plansLoading),
     isAws: selectCondition(isAws)(state),
-    account: state.account,
+    account,
     billing: state.billing,
     canUpdateBillingInfo: canUpdateBillingInfoSelector(state),
     isSelfServeBilling: selectCondition(isSelfServeBilling)(state),

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
-import { fetch as fetchAccount, getPlans } from 'src/actions/account';
+import { fetch as fetchAccount, getPlans, getBillingInfo } from 'src/actions/account';
 import { updateSubscription, getBillingCountries, verifyPromoCode, clearPromoCode } from 'src/actions/billing';
 import billingCreate from 'src/actions/billingCreate';
 import billingUpdate from 'src/actions/billingUpdate';
@@ -39,7 +39,8 @@ export class ChangePlanForm extends Component {
   componentDidMount() {
     this.props.getPlans();
     this.props.getBillingCountries();
-    this.props.fetchAccount({ include: 'billing' });
+    this.props.fetchAccount();
+    this.props.getBillingInfo();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -180,7 +181,7 @@ const mapStateToProps = (state, props) => {
   const plans = selectVisiblePlans(state);
 
   return {
-    loading: (!state.account.created && state.account.loading) || (plans.length === 0 && state.billing.plansLoading),
+    loading: (!state.account.created && state.account.loading) || (plans.length === 0 && state.billing.plansLoading) || state.account.billingLoading,
     isAws: selectCondition(isAws)(state),
     account: state.account,
     billing: state.billing,
@@ -193,6 +194,6 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-const mapDispatchtoProps = { billingCreate, billingUpdate, updateSubscription, showAlert, getPlans, getBillingCountries, fetchAccount, verifyPromoCode, clearPromoCode };
+const mapDispatchtoProps = { getBillingInfo, billingCreate, billingUpdate, updateSubscription, showAlert, getPlans, getBillingCountries, fetchAccount, verifyPromoCode, clearPromoCode };
 const formOptions = { form: FORMNAME, asyncValidate: promoCodeValidate(FORMNAME), asyncChangeFields: ['planpicker'], asyncBlurFields: ['promoCode']};
 export default withRouter(connect(mapStateToProps, mapDispatchtoProps)(reduxForm(formOptions)(ChangePlanForm)));

--- a/src/pages/billing/forms/tests/ChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/ChangePlanForm.test.js
@@ -40,6 +40,7 @@ describe('Form Container: Change Plan', () => {
       getPlans: jest.fn(),
       getBillingCountries: jest.fn(),
       verifyPromoCode: jest.fn(() => Promise.resolve({ discount_id: 'test-discount' })),
+      getBillingInfo: jest.fn(),
       fetchAccount: jest.fn(),
       plans,
       currentPlan: {},
@@ -70,9 +71,8 @@ describe('Form Container: Change Plan', () => {
   });
 
   it('should get plans and countries on mount', () => {
-    expect(props.fetchAccount).toHaveBeenCalledWith(expect.objectContaining({
-      include: expect.stringContaining('billing')
-    }));
+    expect(props.fetchAccount).toHaveBeenCalled();
+    expect(props.getBillingInfo).toHaveBeenCalled();
     expect(props.getPlans).toHaveBeenCalled();
     expect(props.getBillingCountries).toHaveBeenCalled();
   });

--- a/src/pages/billing/tests/SummaryPage.test.js
+++ b/src/pages/billing/tests/SummaryPage.test.js
@@ -16,6 +16,7 @@ describe('Page: BillingSummaryPage', () => {
       sendingIps: {
         list: []
       },
+      getBillingInfo: jest.fn(),
       fetchAccount: jest.fn(),
       getPlans: jest.fn(),
       getSendingIps: jest.fn(),
@@ -36,7 +37,8 @@ describe('Page: BillingSummaryPage', () => {
 
   it('should get plans, sending ips, invoices, and account on mount', () => {
     expect(props.getPlans).toHaveBeenCalledTimes(1);
-    expect(props.fetchAccount).toHaveBeenCalledWith({ include: 'billing' });
+    expect(props.fetchAccount).toHaveBeenCalledTimes(1);
+    expect(props.getBillingInfo).toHaveBeenCalledTimes(1);
     expect(props.getSendingIps).toHaveBeenCalledTimes(1);
     expect(props.getInvoices).toHaveBeenCalledTimes(1);
   });

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -48,6 +48,15 @@ export default (state = initialState, { type, meta, payload }) => {
     case 'CREATE_ACCOUNT_FAIL':
       return { ...state, createError: payload, createLoading: false };
 
+    case 'GET_BILLING_SUCCESS':
+      return { ...state, billing: payload, billingLoading: false };
+
+    case 'GET_BILLING_FAIL':
+      return { ...state, billingError: payload, billingLoading: false };
+
+    case 'GET_BILLING_PENDING':
+      return { ...state, loading: true };
+
     default:
       return state;
   }

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -57,7 +57,7 @@ export default (state = initialState, { type, meta, payload }) => {
       return { ...state, billingError: payload, billingLoading: false };
 
     case 'GET_BILLING_PENDING':
-      return { ...state, loading: true };
+      return { ...state, billingLoading: true };
 
     default:
       return state;

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export const initialState = {
   updateError: null,
   loading: false,
@@ -49,7 +51,7 @@ export default (state = initialState, { type, meta, payload }) => {
       return { ...state, createError: payload, createLoading: false };
 
     case 'GET_BILLING_SUCCESS':
-      return { ...state, billing: payload, billingLoading: false };
+      return { ...state, billing: _.isEmpty(payload) ? null : payload, billingLoading: false };
 
     case 'GET_BILLING_FAIL':
       return { ...state, billingError: payload, billingLoading: false };

--- a/src/reducers/tests/__snapshots__/account.test.js.snap
+++ b/src/reducers/tests/__snapshots__/account.test.js.snap
@@ -65,8 +65,9 @@ Object {
 
 exports[`Billing reducer get billing pending 1`] = `
 Object {
+  "billingLoading": true,
   "createLoading": false,
-  "loading": true,
+  "loading": false,
   "subscription": Object {},
   "updateError": null,
   "updateLoading": false,

--- a/src/reducers/tests/__snapshots__/account.test.js.snap
+++ b/src/reducers/tests/__snapshots__/account.test.js.snap
@@ -44,3 +44,57 @@ Object {
   "updateLoading": false,
 }
 `;
+
+exports[`Billing reducer get billing fail 1`] = `
+Object {
+  "billingError": Object {
+    "errors": Array [
+      Object {
+        "message": "Some error occurred",
+      },
+    ],
+  },
+  "billingLoading": false,
+  "createLoading": false,
+  "loading": false,
+  "subscription": Object {},
+  "updateError": null,
+  "updateLoading": false,
+}
+`;
+
+exports[`Billing reducer get billing pending 1`] = `
+Object {
+  "createLoading": false,
+  "loading": true,
+  "subscription": Object {},
+  "updateError": null,
+  "updateLoading": false,
+}
+`;
+
+exports[`Billing reducer get billing success 1`] = `
+Object {
+  "billing": Object {
+    "card": "************0001",
+  },
+  "billingLoading": false,
+  "createLoading": false,
+  "loading": false,
+  "subscription": Object {},
+  "updateError": null,
+  "updateLoading": false,
+}
+`;
+
+exports[`Billing reducer get billing success empty 1`] = `
+Object {
+  "billing": null,
+  "billingLoading": false,
+  "createLoading": false,
+  "loading": false,
+  "subscription": Object {},
+  "updateError": null,
+  "updateLoading": false,
+}
+`;

--- a/src/reducers/tests/account.test.js
+++ b/src/reducers/tests/account.test.js
@@ -21,6 +21,30 @@ const CREATE_TEST_CASES = {
   }
 };
 
+const BILLING_TEST_CASES = {
+  'get billing pending': {
+    type: 'GET_BILLING_PENDING'
+  },
+  'get billing fail': {
+    type: 'GET_BILLING_FAIL',
+    payload: { errors: [{ message: 'Some error occurred' }]}
+  },
+  'get billing success': {
+    type: 'GET_BILLING_SUCCESS',
+    payload: {
+      'card': '************0001'
+    }
+  },
+  'get billing success empty': {
+    type: 'GET_BILLING_SUCCESS',
+    payload: { }
+  }
+};
+
 cases('Account reducer', (action) => {
   expect(accountReducer(initialState, action)).toMatchSnapshot();
 }, CREATE_TEST_CASES);
+
+cases('Billing reducer', (action) => {
+  expect(accountReducer(initialState, action)).toMatchSnapshot();
+}, BILLING_TEST_CASES);

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -84,6 +84,17 @@ export const selectVisiblePlans = createSelector(
   )
 );
 
+export const selectAccount = (state) => state.account;
+
+export const selectAccountBilling = createSelector(
+  [selectAccount],
+  (account) => ({
+    account,
+    error: account.error || account.billingError,
+    loading: account.loading || account.billingLoading
+  })
+);
+
 export const selectBillingInfo = createSelector(
   [
     canUpdateBillingInfoSelector,


### PR DESCRIPTION
### What Changed
 - Removed usage of GET on /account?includes=billing
- Added usage of GET on /account/billing
- Updated tests
- Added mock request for /account/billing

### How To Test
 - Open /account/billing page
- Verify that /account request does not contain query for 'includes=billing'
- Verify that a billing request is made

### To Do
