### PR TITLE
TR-1118: Some recipient list upload errors handled incorrectly

### DIFF
--- a/src/pages/recipientLists/helpers/csv.js
+++ b/src/pages/recipientLists/helpers/csv.js
@@ -62,8 +62,8 @@ const parseRecipientListCsv = (file) => new Promise((resolve, reject) => {
     header: true,
     skipEmptyLines: true,
     complete: (result) => parseRawRecords(result, resolve, reject),
-    error: (err) => reject(err)
+    error: () => reject(['Unable to read your file'])
   });
 });
-export default parseRecipientListCsv;
 
+export default parseRecipientListCsv;

--- a/src/pages/recipientLists/helpers/tests/csv.test.js
+++ b/src/pages/recipientLists/helpers/tests/csv.test.js
@@ -1,12 +1,11 @@
 import cases from 'jest-in-case';
-
+import papaparse from 'papaparse';
 import parseRecipientListCsv from '../csv';
 
 // Note: these tests pass CSV strings into the function under test.
 // The production version passes a DOM File object.
 
 describe('Recipient list CSV parser', () => {
-
   it('accepts minimal CSV and produces JSON', () => {
     const csv = 'email\nscratch@example.com\n';
     return expect(parseRecipientListCsv(csv)).resolves.toMatchSnapshot();
@@ -42,5 +41,12 @@ describe('Recipient list CSV parser', () => {
     const csv = 'email,substitution_data,metadata,tags\nscratch@example.com\n,{"badjson:101}\nscratch2@example.com,,"{morebadjson"":""fre""}\n';
     return expect(parseRecipientListCsv(csv)).rejects.toMatchSnapshot();
   });
-});
 
+  it('rejects with error message when unable to read file', () => {
+    // force call error callback
+    jest.spyOn(papaparse, 'parse')
+      .mockImplementation((file, config) => config.error(new Error('Oh no!')));
+
+    return expect(parseRecipientListCsv('test')).rejects.toEqual(['Unable to read your file']);
+  });
+});


### PR DESCRIPTION
### What Changed
When creating or updating a recipient list, fixed the handling if Papaparse is unable able to read the file provided.  Specifically, `RecipientListForm` expects an array of errors from `parseRecipientListCsv`, but `error` callback was rejecting with an `Error`.  Changed it to return an array with a static message.

<img width="1386" alt="screen shot 2019-03-07 at 11 04 17 pm" src="https://user-images.githubusercontent.com/1335605/54006922-65dfa480-412d-11e9-91db-eb15f685c8e9.png">

### How To Test

1. Navigate to /lists/recipient-lists/create
2. Download the example recipient list
3. Fill out the form, provide a label, identifier, and select example recipient list from your downloads directory
4. Rename the example recipient list file in your downloads directory
5. Click "Create Recipient List" button

You should expect to get a "Unable to read your file" error.