### PR TITLE
Update bowser to the latest version 🚀

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7059,9 +7059,9 @@
       "dev": true
     },
     "bowser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.1.0.tgz",
-      "integrity": "sha512-tP90ci4QY8PRBQjU0+iTsoO3DMNYtXCM0aVxeKhjxXF8IH9xTXUmjcTECPN+y5v0BGeRDfMcSLeohPiUZuz37g=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.1.2.tgz",
+      "integrity": "sha512-K64ZigDayqlptyKVEiCDPPKQ2/SyPT/jsgJPwZOcpR3WA2bYojlHLeTHN+IRc/vbMz3F6CV62nnAo01+0zYrsQ=="
     },
     "boxen": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@sparkpost/matchbox": "^3.3.10",
     "@sparkpost/matchbox-icons": "^1.1.6",
     "axios": "^0.18.0",
-    "bowser": "2.1.0",
+    "bowser": "2.1.2",
     "classnames": "^2.2.5",
     "color": "^3.0.0",
     "copy-to-clipboard": "^3.0.8",

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -108,6 +108,12 @@ export function getEnricherOrDieTryin(store, currentWindow) {
 
     return {
       ...data,
+      extra: { // extra data that doesn't need to be searchable
+        ...data.extra,
+        isApiError: apiError,
+        isChunkFailure: chunkFailure,
+        isSupportedBrowser
+      },
       request,
       level: !fromOurBundle || apiError || chunkFailure || !isSupportedBrowser ? 'warning' : 'error',
       tags: { // all tags can be easily searched and sent in Slack notifications

--- a/src/helpers/tests/__snapshots__/errorTracker.test.js.snap
+++ b/src/helpers/tests/__snapshots__/errorTracker.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`.getEnricherOrDieTryin by default 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": undefined,
@@ -19,6 +24,11 @@ exports[`.getEnricherOrDieTryin with api error 1`] = `
 Object {
   "exception": Object {
     "type": "SparkpostApiError",
+  },
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
   },
   "level": "warning",
   "logger": "test",
@@ -42,6 +52,11 @@ Object {
       },
     ],
   },
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": true,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": undefined,
@@ -57,6 +72,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with current user 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": undefined,
@@ -76,6 +96,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with document language 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": undefined,
@@ -91,6 +116,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with email verification token 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": Object {
@@ -123,6 +153,11 @@ Object {
       },
     ],
   },
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "error",
   "logger": "test",
   "request": undefined,
@@ -138,6 +173,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with navigator language 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": undefined,
@@ -153,6 +193,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with other request fields 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": Object {
@@ -174,6 +219,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with password reset token 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": Object {
@@ -192,6 +242,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with referer header 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": Object {
@@ -213,6 +268,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin with tags 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": undefined,
@@ -229,6 +289,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin without headers 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "request": Object {
@@ -247,6 +312,11 @@ Object {
 
 exports[`.getEnricherOrDieTryin without request object 1`] = `
 Object {
+  "extra": Object {
+    "isApiError": false,
+    "isChunkFailure": false,
+    "isSupportedBrowser": true,
+  },
   "level": "warning",
   "logger": "test",
   "otherField": "blue",

--- a/src/helpers/tests/__snapshots__/errorTracker.test.js.snap
+++ b/src/helpers/tests/__snapshots__/errorTracker.test.js.snap
@@ -23,10 +23,14 @@ Object {
 exports[`.getEnricherOrDieTryin with api error 1`] = `
 Object {
   "exception": Object {
-    "type": "SparkpostApiError",
+    "values": Array [
+      Object {
+        "type": "SparkpostApiError",
+      },
+    ],
   },
   "extra": Object {
-    "isApiError": false,
+    "isApiError": true,
     "isChunkFailure": false,
     "isSupportedBrowser": true,
   },

--- a/src/helpers/tests/errorTracker.test.js
+++ b/src/helpers/tests/errorTracker.test.js
@@ -72,16 +72,18 @@ cases('.getEnricherOrDieTryin', ({ currentWindow = {}, data = {}, state = {}}) =
   'with api error': {
     data: {
       exception: {
-        type: 'SparkpostApiError'
+        values: [
+          { type: 'SparkpostApiError' }
+        ]
       }
     }
   },
   'with chunk loading error': {
     data: {
       exception: {
-        values: [{
-          value: 'Loading chunk 4 failed.'
-        }]
+        values: [
+          { value: 'Loading chunk 4 failed.' }
+        ]
       }
     }
   },


### PR DESCRIPTION
## What Changed

To make testing easier, added extra data with each error reported to Sentry.  Bowser was upgraded -- here is the [diff](https://github.com/lancedikson/bowser/compare/943adfb..28bff84) and change log (primarily fixes and documentation).

```
### 2.1.2 (March 6, 2019)
- [FIX] Fix buggy `getFirstMatch` reference

### 2.1.1 (March 6, 2019)
- [ADD] Add detection of PlayStation 4 (#291)
- [ADD] Deploy docs on GH Pages (#293)
- [FIX] Fix files extensions for importing (#294)
- [FIX] Fix docs (#295)
```

## How To Test?

Bowser is only used in our `errorTracker`.  It is used to parse the UserAgent, check if browser is on list of supported browsers, and if not supported, may mark errors reported to Sentry as warnings.  To test:

- Login
- Visit http://app.sparkpost.test/webhooks/details/0
- Find error in Sentry and confirm error has correct `isSupportedBrowser` value

Then repeat for with an unsupported browser using Sauce Labs.