### PR TITLE
Alert UI Product Feedback

### DIFF
--- a/src/pages/alerts-new/CreatePage.js
+++ b/src/pages/alerts-new/CreatePage.js
@@ -19,7 +19,7 @@ export class CreatePage extends Component {
     await createAlert({
       data: _.omit(alertBody, 'id', 'subaccount', 'assignTo')
     }).then((response) => {
-      showAlert({ type: 'success', message: 'Create Successful' });
+      showAlert({ type: 'success', message: 'Alert created' });
       this.props.history.push(`/alerts-new/edit/${response.id}`);
     });
   }

--- a/src/pages/alerts-new/EditPage.js
+++ b/src/pages/alerts-new/EditPage.js
@@ -55,7 +55,7 @@ export class EditPage extends Component {
   }
 
   render() {
-    const { loading, deletePending } = this.props;
+    const { loading, deletePending, alert } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -63,7 +63,7 @@ export class EditPage extends Component {
 
     return (
       <Page
-        title='Edit Alert'
+        title={`Edit ${_.get(alert, 'name', 'Alert')}`}
         breadcrumbAction={{ content: 'Back to Alerts', to: '/alerts', component: Link }}
         secondaryActions={[{ content: 'Delete Alert', onClick: this.toggleDelete }]}>
         <AlertForm newAlert = {false} onSubmit = {this.handleUpdate}/>

--- a/src/pages/alerts-new/components/AlertForm.js
+++ b/src/pages/alerts-new/components/AlertForm.js
@@ -183,7 +183,7 @@ export class AlertForm extends Component {
               validate={[required, validateEmailList]}
               multiline
             />
-            <Grid>
+            {!newAlert && <Grid>
               <Grid.Column xs={1} md={1}>
                 <label>Enabled</label>
               </Grid.Column>
@@ -198,7 +198,7 @@ export class AlertForm extends Component {
                   />
                 </div>
               </Grid.Column>
-            </Grid>
+            </Grid>}
             <br/>
             <Button submit primary disabled={pristine || submitting}>{submitText}</Button>
           </Panel.Section>

--- a/src/pages/alerts-new/components/tests/AlertForm.test.js
+++ b/src/pages/alerts-new/components/tests/AlertForm.test.js
@@ -16,7 +16,7 @@ describe('Alert Form Component', () => {
       assignTo: 'all',
       threshold: {
         error: {
-          comparator: 'gt',
+          comparator: 'lt',
           target: 50
         }
       },
@@ -101,6 +101,15 @@ describe('Alert Form Component', () => {
       expect(wrapper.find({ name: 'threshold.error.target' }).props().validate()).toEqual('Required');
       wrapper.setProps({ alert_metric: 'signals_health_day_over_day' });
       expect(wrapper.find({ name: 'threshold.error.target' }).props().validate()).toEqual('Required');
+    });
+  });
+
+  describe('enabled prop', () => {
+    it('should only show enabled toggle on edit page', () => {
+      wrapper.setProps({ alert_metric: 'signals_health_threshold', newAlert: true });
+      expect(wrapper).toMatchSnapshot();
+      wrapper.setProps({ newAlert: false });
+      expect(wrapper).toMatchSnapshot();
     });
   });
 

--- a/src/pages/alerts-new/components/tests/__snapshots__/AlertForm.test.js.snap
+++ b/src/pages/alerts-new/components/tests/__snapshots__/AlertForm.test.js.snap
@@ -1,5 +1,419 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Alert Form Component enabled prop should only show enabled toggle on edit page 1`] = `
+<Form
+  onSubmit={[MockFunction]}
+>
+  <Panel>
+    <Panel.Section>
+      <Field
+        component={[Function]}
+        disabled={false}
+        label="Name"
+        name="name"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
+      />
+      <Field
+        component={[Function]}
+        disabled={false}
+        helpText="This assignment is permanent."
+        label="Alert Type"
+        name="alert_metric"
+        options={
+          Array [
+            Object {
+              "label": "Monthly Sending Limit",
+              "value": "monthly_sending_limit",
+            },
+            Object {
+              "label": "Health Score",
+              "value": "signals_health_threshold",
+            },
+            Object {
+              "label": "Health Score - Day over Day",
+              "value": "signals_health_dod",
+            },
+            Object {
+              "label": "Health Score - Week over Week",
+              "value": "signals_health_wow",
+            },
+          ]
+        }
+        validate={[Function]}
+      />
+      <Field
+        component={[Function]}
+        label="Account"
+        name="assignTo"
+        options={
+          Array [
+            Object {
+              "label": "Master and all subaccounts",
+              "value": "all",
+            },
+            Object {
+              "label": "Master account only",
+              "value": "master",
+            },
+            Object {
+              "label": "Single Subaccount",
+              "value": "subaccount",
+            },
+          ]
+        }
+      />
+      <label>
+        Facet
+      </label>
+      <Grid>
+        <Grid.Column
+          lg={5}
+          md={7}
+          sm={8}
+        >
+          <div>
+            <Field
+              component={[Function]}
+              connectLeft={
+                <Field
+                  component={[Function]}
+                  disabled={false}
+                  name="facet_name"
+                  options={
+                    Array [
+                      Object {
+                        "label": "None",
+                        "value": "ALL",
+                      },
+                      Object {
+                        "label": "Sending Domain",
+                        "value": "sending_domain",
+                      },
+                      Object {
+                        "label": "IP Pool",
+                        "value": "ip_pool",
+                      },
+                      Object {
+                        "label": "Campaign ID",
+                        "value": "campaign_id",
+                      },
+                    ]
+                  }
+                  validate={[Function]}
+                />
+              }
+              disabled={false}
+              name="facet_value"
+              placeholder=""
+              validate={[Function]}
+            />
+          </div>
+        </Grid.Column>
+      </Grid>
+      <br />
+      <label>
+        Criteria
+      </label>
+      <Grid>
+        <Grid.Column
+          lg={5}
+          md={7}
+          sm={8}
+        >
+          <div>
+            <Field
+              component={[Function]}
+              connectLeft={
+                <Field
+                  component={[Function]}
+                  disabled={false}
+                  name="threshold.error.comparator"
+                  options={
+                    Array [
+                      Object {
+                        "label": "Below",
+                        "value": "lt",
+                      },
+                      Object {
+                        "label": "Above",
+                        "value": "gt",
+                      },
+                    ]
+                  }
+                  validate={[Function]}
+                />
+              }
+              disabled={false}
+              name="threshold.error.target"
+              prefix=""
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+              suffix=""
+              validate={
+                Array [
+                  [Function],
+                  [Function],
+                ]
+              }
+            />
+          </div>
+        </Grid.Column>
+      </Grid>
+      <br />
+      <Field
+        component={[Function]}
+        disabled={false}
+        label="Notify"
+        multiline={true}
+        name="email_addresses"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
+      />
+      <br />
+      <Button
+        disabled={true}
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Create Alert
+      </Button>
+    </Panel.Section>
+  </Panel>
+</Form>
+`;
+
+exports[`Alert Form Component enabled prop should only show enabled toggle on edit page 2`] = `
+<Form
+  onSubmit={[MockFunction]}
+>
+  <Panel>
+    <Panel.Section>
+      <Field
+        component={[Function]}
+        disabled={false}
+        label="Name"
+        name="name"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        helpText="This assignment is permanent."
+        label="Alert Type"
+        name="alert_metric"
+        options={
+          Array [
+            Object {
+              "label": "Monthly Sending Limit",
+              "value": "monthly_sending_limit",
+            },
+            Object {
+              "label": "Health Score",
+              "value": "signals_health_threshold",
+            },
+            Object {
+              "label": "Health Score - Day over Day",
+              "value": "signals_health_dod",
+            },
+            Object {
+              "label": "Health Score - Week over Week",
+              "value": "signals_health_wow",
+            },
+          ]
+        }
+        validate={[Function]}
+      />
+      <Field
+        component={[Function]}
+        label="Account"
+        name="assignTo"
+        options={
+          Array [
+            Object {
+              "label": "Master and all subaccounts",
+              "value": "all",
+            },
+            Object {
+              "label": "Master account only",
+              "value": "master",
+            },
+            Object {
+              "label": "Single Subaccount",
+              "value": "subaccount",
+            },
+          ]
+        }
+      />
+      <label>
+        Facet
+      </label>
+      <Grid>
+        <Grid.Column
+          lg={5}
+          md={7}
+          sm={8}
+        >
+          <div>
+            <Field
+              component={[Function]}
+              connectLeft={
+                <Field
+                  component={[Function]}
+                  disabled={false}
+                  name="facet_name"
+                  options={
+                    Array [
+                      Object {
+                        "label": "None",
+                        "value": "ALL",
+                      },
+                      Object {
+                        "label": "Sending Domain",
+                        "value": "sending_domain",
+                      },
+                      Object {
+                        "label": "IP Pool",
+                        "value": "ip_pool",
+                      },
+                      Object {
+                        "label": "Campaign ID",
+                        "value": "campaign_id",
+                      },
+                    ]
+                  }
+                  validate={[Function]}
+                />
+              }
+              disabled={false}
+              name="facet_value"
+              placeholder=""
+              validate={[Function]}
+            />
+          </div>
+        </Grid.Column>
+      </Grid>
+      <br />
+      <label>
+        Criteria
+      </label>
+      <Grid>
+        <Grid.Column
+          lg={5}
+          md={7}
+          sm={8}
+        >
+          <div>
+            <Field
+              component={[Function]}
+              connectLeft={
+                <Field
+                  component={[Function]}
+                  disabled={false}
+                  name="threshold.error.comparator"
+                  options={
+                    Array [
+                      Object {
+                        "label": "Below",
+                        "value": "lt",
+                      },
+                      Object {
+                        "label": "Above",
+                        "value": "gt",
+                      },
+                    ]
+                  }
+                  validate={[Function]}
+                />
+              }
+              disabled={false}
+              name="threshold.error.target"
+              prefix=""
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+              suffix=""
+              validate={
+                Array [
+                  [Function],
+                  [Function],
+                ]
+              }
+            />
+          </div>
+        </Grid.Column>
+      </Grid>
+      <br />
+      <Field
+        component={[Function]}
+        disabled={false}
+        label="Notify"
+        multiline={true}
+        name="email_addresses"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
+      />
+      <Grid>
+        <Grid.Column
+          md={1}
+          xs={1}
+        >
+          <label>
+            Enabled
+          </label>
+        </Grid.Column>
+        <Grid.Column
+          md={1}
+          xs={1}
+        >
+          <div>
+            <Field
+              component={[Function]}
+              disabled={false}
+              name="enabled"
+              parse={[Function]}
+              type="checkbox"
+            />
+          </div>
+        </Grid.Column>
+      </Grid>
+      <br />
+      <Button
+        disabled={true}
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Update Alert
+      </Button>
+    </Panel.Section>
+  </Panel>
+</Form>
+`;
+
 exports[`Alert Form Component facet props should clear facet_value and validation when facet_name is set to ALL and signals threshold 1`] = `
 <Form
   onSubmit={[MockFunction]}

--- a/src/pages/alerts-new/constants/defaultFormValues.js
+++ b/src/pages/alerts-new/constants/defaultFormValues.js
@@ -6,9 +6,9 @@ export const defaultFormValues = {
   facet_value: undefined,
   threshold: {
     error: {
-      comparator: 'gt',
+      comparator: 'lt',
       target: null
     }
   },
-  enabled: false
+  enabled: true
 };

--- a/src/pages/alerts-new/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/alerts-new/tests/__snapshots__/EditPage.test.js.snap
@@ -32,7 +32,7 @@ exports[`Page: Alerts Edit should render happy path 1`] = `
       },
     ]
   }
-  title="Edit Alert"
+  title="Edit shortName"
 >
   <withRouter(Connect(ReduxForm))
     newAlert={false}


### PR DESCRIPTION
EO-616: Alerts UI Product Feedback
### What Changed
 AC:
- Enable on Create Form is hidden (automatically enabled)
- Set Default Criteria Comparator to 'lt' (below)
- Show name of alert being edited in page title
