### PR TITLE
EO-619 Create signals v2 dashboard pages and routes

### DIFF
--- a/src/config/navItems.js
+++ b/src/config/navItems.js
@@ -43,10 +43,32 @@ export default [
     ]
   },
   {
+    // TODO Remove when signals v2 is released
     label: 'Signals',
     to: '/signals',
     icon: Signal,
     tag: 'new'
+  },
+  {
+    // Duplicated, but will not render without feature_signals_v2 UI option
+    label: 'Signals',
+    to: '/signals',
+    icon: Signal,
+    tag: 'new',
+    children: [
+      {
+        label: 'Health Score',
+        to: '/signals/health-score'
+      },
+      {
+        label: 'Spam Traps',
+        to: '/signals/spam-traps'
+      },
+      {
+        label: 'Engagement Recency',
+        to: '/signals/engagement'
+      }
+    ]
   },
   {
     label: 'Templates',

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -235,6 +235,32 @@ const routes = [
     title: 'Signals',
     supportDocSearch: 'signals'
   },
+  // Signals V2 Dashboards
+  {
+    path: '/signals/health-score',
+    component: signals.HealthScoreDashboard,
+    condition: all(hasGrants('signals/manage'), hasUiOption('feature_signals_v2')),
+    layout: App,
+    title: 'Signals',
+    supportDocSearch: 'signals'
+  },
+  {
+    path: '/signals/spam-traps',
+    component: signals.SpamTrapDashboard,
+    condition: all(hasGrants('signals/manage'), hasUiOption('feature_signals_v2')),
+    layout: App,
+    title: 'Signals',
+    supportDocSearch: 'signals'
+  },
+  {
+    path: '/signals/engagement',
+    component: signals.EngagementRecencyDashboard,
+    condition: all(hasGrants('signals/manage'), hasUiOption('feature_signals_v2')),
+    layout: App,
+    title: 'Signals',
+    supportDocSearch: 'signals'
+  },
+  // Details Pages
   {
     path: '/signals/health-score/:facet/:facetId',
     component: signals.HealthScorePage,

--- a/src/pages/signals/dashboards/EngagementRecencyDashboard.js
+++ b/src/pages/signals/dashboards/EngagementRecencyDashboard.js
@@ -1,0 +1,43 @@
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { list as getSubaccounts } from 'src/actions/subaccounts';
+import Page from '../components/SignalsPage';
+import EngagementRecencyOverview from '../containers/EngagementRecencyOverviewContainer';
+import FacetFilter from '../components/filters/FacetFilter';
+import DateFilter from '../components/filters/DateFilter';
+import SubaccountFilter from '../components/filters/SubaccountFilter';
+
+export class EngagementRecencyDashboard extends Component {
+  componentDidMount() {
+    this.props.getSubaccounts();
+  }
+
+  render() {
+    const { subaccounts } = this.props;
+
+    return (
+      <Page
+        title='Engagement Recency'
+        primaryArea={
+          <Fragment>
+            <SubaccountFilter />
+            <DateFilter />
+            <FacetFilter />
+          </Fragment>
+        }
+      >
+        <EngagementRecencyOverview subaccounts={subaccounts} />
+      </Page>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => ({
+  subaccounts: state.subaccounts.list
+});
+
+const mapDispatchToProps = {
+  getSubaccounts
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(EngagementRecencyDashboard);

--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -1,0 +1,43 @@
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { list as getSubaccounts } from 'src/actions/subaccounts';
+import Page from '../components/SignalsPage';
+import HealthScoreOverview from '../containers/HealthScoreOverviewContainer';
+import FacetFilter from '../components/filters/FacetFilter';
+import DateFilter from '../components/filters/DateFilter';
+import SubaccountFilter from '../components/filters/SubaccountFilter';
+
+export class HealthScoreDashboard extends Component {
+  componentDidMount() {
+    this.props.getSubaccounts();
+  }
+
+  render() {
+    const { subaccounts } = this.props;
+
+    return (
+      <Page
+        title='Health Score'
+        primaryArea={
+          <Fragment>
+            <SubaccountFilter />
+            <DateFilter />
+            <FacetFilter />
+          </Fragment>
+        }
+      >
+        <HealthScoreOverview subaccounts={subaccounts} />
+      </Page>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => ({
+  subaccounts: state.subaccounts.list
+});
+
+const mapDispatchToProps = {
+  getSubaccounts
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(HealthScoreDashboard);

--- a/src/pages/signals/dashboards/SpamTrapDashboard.js
+++ b/src/pages/signals/dashboards/SpamTrapDashboard.js
@@ -1,0 +1,43 @@
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { list as getSubaccounts } from 'src/actions/subaccounts';
+import Page from '../components/SignalsPage';
+import SpamTrapOverview from '../containers/SpamTrapOverviewContainer';
+import FacetFilter from '../components/filters/FacetFilter';
+import DateFilter from '../components/filters/DateFilter';
+import SubaccountFilter from '../components/filters/SubaccountFilter';
+
+export class SpamTrapDashboard extends Component {
+  componentDidMount() {
+    this.props.getSubaccounts();
+  }
+
+  render() {
+    const { subaccounts } = this.props;
+
+    return (
+      <Page
+        title='Spam Trap Monitoring'
+        primaryArea={
+          <Fragment>
+            <SubaccountFilter />
+            <DateFilter />
+            <FacetFilter />
+          </Fragment>
+        }
+      >
+        <SpamTrapOverview subaccounts={subaccounts} />
+      </Page>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => ({
+  subaccounts: state.subaccounts.list
+});
+
+const mapDispatchToProps = {
+  getSubaccounts
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(SpamTrapDashboard);

--- a/src/pages/signals/dashboards/index.js
+++ b/src/pages/signals/dashboards/index.js
@@ -1,0 +1,3 @@
+export { default as EngagementRecencyDashboard } from './EngagementRecencyDashboard';
+export { default as HealthScoreDashboard } from './HealthScoreDashboard';
+export { default as SpamTrapDashboard } from './SpamTrapDashboard';

--- a/src/pages/signals/dashboards/tests/EngagementRecencyDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/EngagementRecencyDashboard.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { EngagementRecencyDashboard } from '../EngagementRecencyDashboard';
+
+describe('Signals Engagement Recency Dashboard', () => {
+  const subject = (props = {}) => shallow(
+    <EngagementRecencyDashboard getSubaccounts={() => {}} {...props} />
+  );
+
+  it('renders page', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('calls getSubaccounts on mount', () => {
+    const getSubaccounts = jest.fn();
+    subject({ getSubaccounts });
+    expect(getSubaccounts).toHaveBeenCalled();
+  });
+});

--- a/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { HealthScoreDashboard } from '../HealthScoreDashboard';
+
+describe('Signals Health Score Dashboard', () => {
+  const subject = (props = {}) => shallow(
+    <HealthScoreDashboard getSubaccounts={() => {}} {...props} />
+  );
+
+  it('renders page', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('calls getSubaccounts on mount', () => {
+    const getSubaccounts = jest.fn();
+    subject({ getSubaccounts });
+    expect(getSubaccounts).toHaveBeenCalled();
+  });
+});

--- a/src/pages/signals/dashboards/tests/SpamTrapDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/SpamTrapDashboard.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { SpamTrapDashboard } from '../SpamTrapDashboard';
+
+describe('Signals Spam Trap Dashboard Dashboard', () => {
+  const subject = (props = {}) => shallow(
+    <SpamTrapDashboard getSubaccounts={() => {}} {...props} />
+  );
+
+  it('renders page', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('calls getSubaccounts on mount', () => {
+    const getSubaccounts = jest.fn();
+    subject({ getSubaccounts });
+    expect(getSubaccounts).toHaveBeenCalled();
+  });
+});

--- a/src/pages/signals/dashboards/tests/__snapshots__/EngagementRecencyDashboard.test.js.snap
+++ b/src/pages/signals/dashboards/tests/__snapshots__/EngagementRecencyDashboard.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals Engagement Recency Dashboard renders page 1`] = `
+<SignalsPage
+  primaryArea={
+    <React.Fragment>
+      <Connect(Connect(SubaccountFilter)) />
+      <Connect(DateFilter) />
+      <Connect(FacetFilter) />
+    </React.Fragment>
+  }
+  title="Engagement Recency"
+>
+  <Connect(withRouter(Connect(EngagementRecencyOverview))) />
+</SignalsPage>
+`;

--- a/src/pages/signals/dashboards/tests/__snapshots__/HealthScoreDashboard.test.js.snap
+++ b/src/pages/signals/dashboards/tests/__snapshots__/HealthScoreDashboard.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals Health Score Dashboard renders page 1`] = `
+<SignalsPage
+  primaryArea={
+    <React.Fragment>
+      <Connect(Connect(SubaccountFilter)) />
+      <Connect(DateFilter) />
+      <Connect(FacetFilter) />
+    </React.Fragment>
+  }
+  title="Health Score"
+>
+  <Connect(withRouter(Connect(HealthScoreOverview))) />
+</SignalsPage>
+`;

--- a/src/pages/signals/dashboards/tests/__snapshots__/SpamTrapDashboard.test.js.snap
+++ b/src/pages/signals/dashboards/tests/__snapshots__/SpamTrapDashboard.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals Spam Trap Dashboard Dashboard renders page 1`] = `
+<SignalsPage
+  primaryArea={
+    <React.Fragment>
+      <Connect(Connect(SubaccountFilter)) />
+      <Connect(DateFilter) />
+      <Connect(FacetFilter) />
+    </React.Fragment>
+  }
+  title="Spam Trap Monitoring"
+>
+  <Connect(withRouter(Connect(SpamTrapOverview))) />
+</SignalsPage>
+`;

--- a/src/pages/signals/index.js
+++ b/src/pages/signals/index.js
@@ -2,10 +2,12 @@ import EngagementRecencyPage from './EngagementRecencyPage';
 import HealthScorePage from './HealthScorePage';
 import OverviewPage from './OverviewPage';
 import SpamTrapPage from './SpamTrapPage';
+import * as dashboards from './dashboards';
 
 export default {
   EngagementRecencyPage,
   HealthScorePage,
   OverviewPage,
-  SpamTrapPage
+  SpamTrapPage,
+  ...dashboards
 };


### PR DESCRIPTION
### What Changed
- Creates three new pages, one for each leaderboard
- Nests all new page routes under a new signals nav item

### How To Test
- Verify new routes
  - Log into appteam, or add the `feature_signals_v2` UI option to your account
  - Verify new nav item renders and each page renders its leaderboard
- Verify current experience is not affected
  - Log into an account without the UI option
  - Verify the current signals nav item works, and the new nav item does not render
  - Verify new routes 404

### To Do
- [ ] Address feedback
