### PR TITLE
AC-647: Removed subaccount columns for subaccount users

### DIFF
--- a/src/components/actionPopover/ActionPopover.js
+++ b/src/components/actionPopover/ActionPopover.js
@@ -3,9 +3,11 @@ import { Popover, Button, ActionList } from '@sparkpost/matchbox';
 import { MoreHoriz } from '@sparkpost/matchbox-icons';
 
 const ActionPopover = ({ actions }) => (
-  <Popover left trigger={<Button flat><MoreHoriz size={20}/></Button>}>
-    <ActionList actions={actions}/>
-  </Popover>
+  <div style={{ textAlign: 'right' }}>
+    <Popover left trigger={<Button flat><MoreHoriz size={20}/></Button>}>
+      <ActionList actions={actions}/>
+    </Popover>
+  </div>
 );
 
 export default ActionPopover;

--- a/src/components/actionPopover/tests/__snapshots__/ActionPopover.test.js.snap
+++ b/src/components/actionPopover/tests/__snapshots__/ActionPopover.test.js.snap
@@ -1,57 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActionPopover Component should render with actions 1`] = `
-<Popover
-  bottom={true}
-  left={true}
-  right={true}
-  trigger={
-    <Button
-      flat={true}
-      size="default"
-    >
-      <MoreHoriz
-        size={20}
-      />
-    </Button>
+<div
+  style={
+    Object {
+      "textAlign": "right",
+    }
   }
 >
-  <ActionList
-    actions={
-      Array [
-        Object {
-          "content": "Edit",
-          "to": "/some/link",
-        },
-        Object {
-          "content": "Delete",
-          "onClick": [MockFunction],
-        },
-      ]
+  <Popover
+    bottom={true}
+    left={true}
+    right={true}
+    trigger={
+      <Button
+        flat={true}
+        size="default"
+      >
+        <MoreHoriz
+          size={20}
+        />
+      </Button>
     }
-    groupByKey="section"
-  />
-</Popover>
+  >
+    <ActionList
+      actions={
+        Array [
+          Object {
+            "content": "Edit",
+            "to": "/some/link",
+          },
+          Object {
+            "content": "Delete",
+            "onClick": [MockFunction],
+          },
+        ]
+      }
+      groupByKey="section"
+    />
+  </Popover>
+</div>
 `;
 
 exports[`ActionPopover Component should render with no props 1`] = `
-<Popover
-  bottom={true}
-  left={true}
-  right={true}
-  trigger={
-    <Button
-      flat={true}
-      size="default"
-    >
-      <MoreHoriz
-        size={20}
-      />
-    </Button>
+<div
+  style={
+    Object {
+      "textAlign": "right",
+    }
   }
 >
-  <ActionList
-    groupByKey="section"
-  />
-</Popover>
+  <Popover
+    bottom={true}
+    left={true}
+    right={true}
+    trigger={
+      <Button
+        flat={true}
+        size="default"
+      >
+        <MoreHoriz
+          size={20}
+        />
+      </Button>
+    }
+  >
+    <ActionList
+      groupByKey="section"
+    />
+  </Popover>
+</div>
 `;

--- a/src/pages/snippets/ListPage.container.js
+++ b/src/pages/snippets/ListPage.container.js
@@ -6,6 +6,7 @@ import ListPage from './ListPage';
 
 const mapStateToProps = (state, props) => ({
   canCreate: hasGrants('templates/modify')(state), // snippet grants are inherited from templates
+  userAccessLevel: state.currentUser.access_level,
   error: state.snippets.error,
   hasSubaccounts: hasSubaccounts(state),
   loading: state.snippets.loading,

--- a/src/pages/snippets/ListPage.js
+++ b/src/pages/snippets/ListPage.js
@@ -5,7 +5,7 @@ import { Templates } from 'src/components/images';
 import Loading from 'src/components/loading';
 import PageLink from 'src/components/pageLink';
 import SnippetCollection from './components/SnippetCollection';
-
+import { ROLES } from 'src/constants';
 export default class ListPage extends React.Component {
   componentDidMount() {
     this.props.getSnippets();
@@ -23,11 +23,12 @@ export default class ListPage extends React.Component {
   }
 
   renderCollection() {
-    const { snippets, hasSubaccounts, canCreate } = this.props;
+    const { snippets, hasSubaccounts, canCreate, userAccessLevel } = this.props;
     return (
       <SnippetCollection
         canCreate={canCreate}
         hasSubaccounts={hasSubaccounts}
+        canViewSubaccounts={userAccessLevel !== ROLES.SUBACCOUNT_REPORTING}
         snippets={snippets}
       />
     );

--- a/src/pages/snippets/components/SnippetCollection.js
+++ b/src/pages/snippets/components/SnippetCollection.js
@@ -29,7 +29,7 @@ export default class SnippetCollection extends Component {
           subaccount_id || shared_with_subaccounts
         )
       },
-      visible: () => this.props.hasSubaccounts
+      visible: () => this.props.hasSubaccounts && this.props.canViewSubaccounts
     },
     {
       component: UpdatedAtTableData,

--- a/src/pages/snippets/components/tests/SnippetCollection.test.js
+++ b/src/pages/snippets/components/tests/SnippetCollection.test.js
@@ -6,7 +6,7 @@ describe('SnippetCollection', () => {
   // pass-through to test the render prop
   const subject = ({ open, ...props } = {}) => {
     const wrapper = shallow(
-      <SnippetCollection snippets={[{ id: 'test-snippet' }]} {...props} />
+      <SnippetCollection canViewSubaccounts={true} snippets={[{ id: 'test-snippet' }]} {...props} />
     );
     const RenderProp = wrapper.prop('children');
 
@@ -20,6 +20,11 @@ describe('SnippetCollection', () => {
   it('renders table collection with subaccount column', () => {
     const wrapper = subject({ hasSubaccounts: true });
     expect(wrapper.prop('columns')).toContainEqual(expect.objectContaining({ label: 'Subaccount' }));
+  });
+
+  it('renders without subaccount column if not allowed', () => {
+    const wrapper = subject({ hasSubaccounts: true, canViewSubaccounts: false });
+    expect(wrapper.prop('columns')).not.toContain(expect.objectContaining({ label: 'Subaccount' }));
   });
 
   it('renders table collection with actions column', () => {

--- a/src/pages/snippets/tests/ListPage.test.js
+++ b/src/pages/snippets/tests/ListPage.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ListPage from '../ListPage';
+import { ROLES } from 'src/constants';
 
 describe('ListPage', () => {
   const subject = (props = {}) => shallow(
@@ -37,6 +38,10 @@ describe('ListPage', () => {
 
   it('renders page without subaccount column', () => {
     expect(subject({ hasSubaccounts: false })).toMatchSnapshot();
+  });
+
+  it('renders page without subaccount column if a subaccount reporting user', () => {
+    expect(subject({ userAccessLevel: ROLES.SUBACCOUNT_REPORTING })).toMatchSnapshot();
   });
 
   it('shows empty state', () => {

--- a/src/pages/snippets/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/snippets/tests/__snapshots__/ListPage.test.js.snap
@@ -54,6 +54,7 @@ exports[`ListPage renders page with snippet collection 1`] = `
 >
   <SnippetCollection
     canCreate={true}
+    canViewSubaccounts={true}
     hasSubaccounts={true}
     snippets={
       Array [
@@ -83,6 +84,7 @@ exports[`ListPage renders page without primary action button 1`] = `
 >
   <SnippetCollection
     canCreate={false}
+    canViewSubaccounts={true}
     hasSubaccounts={true}
     snippets={
       Array [
@@ -119,7 +121,45 @@ exports[`ListPage renders page without subaccount column 1`] = `
 >
   <SnippetCollection
     canCreate={true}
+    canViewSubaccounts={true}
     hasSubaccounts={false}
+    snippets={
+      Array [
+        Object {
+          "id": "example-id",
+          "name": "Example Snippet",
+        },
+      ]
+    }
+  />
+</Page>
+`;
+
+exports[`ListPage renders page without subaccount column if a subaccount reporting user 1`] = `
+<Page
+  empty={
+    Object {
+      "content": <p>
+        Build, import, edit, and reuse snippets.
+      </p>,
+      "image": [Function],
+      "show": false,
+      "title": "Manage your template snippets",
+    }
+  }
+  primaryAction={
+    Object {
+      "Component": [Function],
+      "content": "Create Snippet",
+      "to": "/snippets/create",
+    }
+  }
+  title="Snippets"
+>
+  <SnippetCollection
+    canCreate={true}
+    canViewSubaccounts={false}
+    hasSubaccounts={true}
     snippets={
       Array [
         Object {

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -5,6 +5,7 @@ import { Templates } from 'src/components/images';
 import { Page } from '@sparkpost/matchbox';
 import { Name, Status, Actions, LastUpdated } from './components/ListComponents';
 import { resolveTemplateStatus } from 'src/helpers/templates';
+import { ROLES } from 'src/constants';
 
 const primaryAction = {
   content: 'Create Template',
@@ -29,8 +30,9 @@ export default class ListPage extends Component {
   }
 
   getRowData = ({ shared_with_subaccounts, ...rowData }) => {
-    const { hasSubaccounts } = this.props;
+    const { hasSubaccounts, userAccessLevel } = this.props;
     const { subaccount_id } = rowData;
+    const canViewSubaccounts = userAccessLevel !== ROLES.SUBACCOUNT_REPORTING;
 
     const subaccountCell = subaccount_id || shared_with_subaccounts
       ? <SubaccountTag all={shared_with_subaccounts} id={subaccount_id} />
@@ -39,19 +41,19 @@ export default class ListPage extends Component {
     return [
       <Name {...rowData} />,
       <Status {...rowData} />,
-      ...(hasSubaccounts ? [subaccountCell] : []),
+      ...(hasSubaccounts && canViewSubaccounts ? [subaccountCell] : []),
       <LastUpdated {...rowData}/>,
       <Actions {...rowData} />
     ];
   }
 
   getColumns() {
-    const { hasSubaccounts } = this.props;
-
+    const { hasSubaccounts, userAccessLevel } = this.props;
+    const canViewSubaccounts = userAccessLevel !== ROLES.SUBACCOUNT_REPORTING;
     return [
       { label: 'Name', width: '28%', sortKey: 'name' },
       { label: 'Status', width: '18%', sortKey: (template) => [resolveTemplateStatus(template).publishedWithChanges, template.published]},
-      ...(hasSubaccounts ? [{
+      ...(hasSubaccounts && canViewSubaccounts ? [{
         label: 'Subaccount', width: '18%', sortKey: (template) => [template.subaccount_id, template.shared_with_subaccounts]
       }] : []),
       { label: 'Last Updated', sortKey: 'last_update_time' },

--- a/src/pages/templates/containers/ListPage.container.js
+++ b/src/pages/templates/containers/ListPage.container.js
@@ -15,6 +15,7 @@ function mapStateToProps(state) {
     count: templates.length,
     templates,
     hasSubaccounts: hasSubaccounts(state),
+    userAccessLevel: state.currentUser.access_level,
     loading: state.templates.listLoading,
     error: state.templates.listError,
     canModify

--- a/src/pages/templates/tests/ListPage.test.js
+++ b/src/pages/templates/tests/ListPage.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import dateMock from 'date-fns';
 import ListPage from '../ListPage';
+import { ROLES } from 'src/constants';
 
 jest.mock('date-fns');
 
@@ -45,6 +46,11 @@ it('renders without primary action for read-only users', () => {
 
 it('renders columns correctly with subaccounts', () => {
   wrapper.setProps({ hasSubaccounts: true });
+  expect(wrapper.find('TableCollection').props().columns).toMatchSnapshot();
+});
+
+it('renders columns correctly for subaccount reporting users', () => {
+  wrapper.setProps({ hasSubaccounts: true, userAccessLevel: ROLES.SUBACCOUNT_REPORTING });
   expect(wrapper.find('TableCollection').props().columns).toMatchSnapshot();
 });
 

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders columns correctly for subaccount reporting users 1`] = `
+Array [
+  Object {
+    "label": "Name",
+    "sortKey": "name",
+    "width": "28%",
+  },
+  Object {
+    "label": "Status",
+    "sortKey": [Function],
+    "width": "18%",
+  },
+  Object {
+    "label": "Last Updated",
+    "sortKey": "last_update_time",
+  },
+  null,
+]
+`;
+
 exports[`renders columns correctly with subaccounts 1`] = `
 Array [
   Object {


### PR DESCRIPTION
### What Changed
 - Hid subaccount columns for any with subaccount_reporting access level
   - Hid in templates list page
   -  Hid in snippets list page
 - Right aligned icon in ActionPopover to be consistent with other lists
    - ActionPopover used in users list and snippets list

### How To Test
 - Check that subaccounts columns show up in list for non subaccount users
- Check that the column gone if user is a subaccount reporting user

### To Do
- [ ] Address feedback
