### PR TITLE
AC-652: Dashboard Role Changes

### DIFF
--- a/src/components/usageReport/UsageReport.js
+++ b/src/components/usageReport/UsageReport.js
@@ -41,15 +41,12 @@ export class UsageReport extends Component {
   }
 
   render() {
-    const { subscription, usage, accountAgeInWeeks } = this.props;
+    const { subscription, usage } = this.props;
 
     if (!subscription || !usage) {
       return <PanelLoading />;
     }
 
-    if (usage.month.used === 0 && accountAgeInWeeks < 4) {
-      return null;
-    }
 
     const remaining = subscription.plan_volume - usage.month.used;
     const overage = remaining < 0 ? Math.abs(remaining) : 0;

--- a/src/components/usageReport/tests/UsageReport.test.js
+++ b/src/components/usageReport/tests/UsageReport.test.js
@@ -56,11 +56,4 @@ describe('UsageReport Component', () => {
 
     expect(wrapper).toMatchSnapshot();
   });
-
-  it('should not render with no usage on a new account', () => {
-    props.usage.month.used = 0;
-    props.accountAgeInWeeks = 1;
-    const wrapper = shallow(<UsageReport {...props} />);
-    expect(wrapper.html()).toBe(null);
-  });
 });

--- a/src/components/usageReport/tests/UsageReport.test.js
+++ b/src/components/usageReport/tests/UsageReport.test.js
@@ -27,8 +27,7 @@ describe('UsageReport Component', () => {
           start: '2017-08-30T00:00:00.000Z'
         }
       },
-      getAccount,
-      accountAgeInWeeks: 4
+      getAccount
     };
   });
 

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -49,7 +49,7 @@ import {
   isSelfServeBilling,
   hasUiOption
 } from 'src/helpers/conditions/account';
-import { isHeroku, isAzure } from 'src/helpers/conditions/user';
+import { isHeroku, isAzure, isSubaccountUser } from 'src/helpers/conditions/user';
 import { configFlag, configEquals } from 'src/helpers/conditions/config';
 
 import App from 'src/components/layout/App';
@@ -159,6 +159,7 @@ const routes = [
     layout: App,
     title: 'Dashboard',
     condition: all(
+      not(isSubaccountUser),
       configEquals('splashPage', '/dashboard') // want to hide if not a splash page https://jira.int.messagesystems.com/browse/FAD-6046
     ),
     // TODO: implement some kind of blockedRoutes check that runs on every route so we can

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -159,7 +159,6 @@ const routes = [
     layout: App,
     title: 'Dashboard',
     condition: all(
-      hasGrants('api_keys/manage', 'templates/modify', 'sending_domains/manage'),
       configEquals('splashPage', '/dashboard') // want to hide if not a splash page https://jira.int.messagesystems.com/browse/FAD-6046
     ),
     // TODO: implement some kind of blockedRoutes check that runs on every route so we can

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -114,8 +114,6 @@ export const ALL_EVENTS_FILTERS = {
 
 export const DEFAULT_PER_PAGE_BUTTONS = [10, 25, 50, 100];
 
-export const SUBACCOUNT_REPORTING_ROLE = 'subaccount_reporting';
-
 export const ANALYTICS_CREATE_ACCOUNT = 'create account';
 export const ANALYTICS_ADDON_IP = 'dedicated_ips';
 export const ANALYTICS_PREMIUM_SUPPORT = 'premium-support';
@@ -138,3 +136,5 @@ export const ROLES = {
   SUBACCOUNT_REPORTING: 'subaccount_reporting',
   SUPERUSER: 'superuser'
 };
+
+export const SUBACCOUNT_ROLES = [ROLES.SUBACCOUNT_REPORTING];

--- a/src/helpers/conditions/tests/user.test.js
+++ b/src/helpers/conditions/tests/user.test.js
@@ -1,61 +1,87 @@
-import { isAdmin, isHeroku, isAzure, isSso, hasRole, isUserUiOptionSet } from '../user';
+import { isAdmin, isHeroku, isAzure, isSso, hasRole, isUserUiOptionSet, isSubaccountUser } from '../user';
+import { ROLES } from 'src/constants';
 
 import cases from 'jest-in-case';
 
 describe('User Condition Tests', () => {
-  it('should return true if user is heroku', () => {
-    const currentUser = { access_level: 'heroku' };
-    expect(isHeroku({ currentUser })).toEqual(true);
+
+  describe('Heroku User', () => {
+    it('should return true if user is heroku', () => {
+      const currentUser = { access_level: 'heroku' };
+      expect(isHeroku({ currentUser })).toEqual(true);
+    });
+
+    it('should return false if user is not heroku', () => {
+      const currentUser = { access_level: 'klurgen' };
+      expect(isHeroku({ currentUser })).toEqual(false);
+    });
   });
 
-  it('should return false if user is not heroku', () => {
-    const currentUser = { access_level: 'klurgen' };
-    expect(isHeroku({ currentUser })).toEqual(false);
+  describe('Azure User', () => {
+    it('should return true if user is azure', () => {
+      const currentUser = { access_level: 'azure' };
+      expect(isAzure({ currentUser })).toEqual(true);
+    });
+
+    it('should return false if user is not azure', () => {
+      const currentUser = { access_level: 'blargh' };
+      expect(isAzure({ currentUser })).toEqual(false);
+    });
   });
 
-  it('should return true if user is azure', () => {
-    const currentUser = { access_level: 'azure' };
-    expect(isAzure({ currentUser })).toEqual(true);
+  describe('Admin User', () => {
+    it('should return true if user is an admin', () => {
+      const currentUser = { access_level: 'admin' };
+      expect(isAdmin({ currentUser })).toEqual(true);
+    });
+
+    it('should return true if user is a superuser', () => {
+      const currentUser = { access_level: 'superuser' };
+      expect(isAdmin({ currentUser })).toEqual(true);
+    });
+
+    it('should return false if user is not an admin', () => {
+      const currentUser = { access_level: 'reporting' };
+      expect(isAdmin({ currentUser })).toEqual(false);
+    });
   });
 
-  it('should return false if user is not azure', () => {
-    const currentUser = { access_level: 'blargh' };
-    expect(isAzure({ currentUser })).toEqual(false);
+
+  describe('SSO User', () => {
+    it('should return true if user is sso', () => {
+      const currentUser = { is_sso: true };
+      expect(isSso({ currentUser })).toEqual(true);
+    });
+
+    it('should return false if user is sso', () => {
+      const currentUser = { is_sso: false };
+      expect(isSso({ currentUser })).toEqual(false);
+    });
   });
 
-  it('should return true if user is an admin', () => {
-    const currentUser = { access_level: 'admin' };
-    expect(isAdmin({ currentUser })).toEqual(true);
+
+  describe('Access Level', () => {
+    it('should return true if access level matches', () => {
+      const currentUser = { access_level: 'admin' };
+      expect(hasRole('admin')({ currentUser })).toEqual(true);
+    });
+
+    it('should return true if access level does not match', () => {
+      const currentUser = { access_level: 'reporting' };
+      expect(hasRole('admin')({ currentUser })).toEqual(false);
+    });
   });
 
-  it('should return true if user is a superuser', () => {
-    const currentUser = { access_level: 'superuser' };
-    expect(isAdmin({ currentUser })).toEqual(true);
-  });
+  describe('Subaccount User', () => {
+    it('should return true if user is subaccount user', () => {
+      const currentUser = { access_level: ROLES.SUBACCOUNT_REPORTING };
+      expect(isSubaccountUser({ currentUser })).toEqual(true);
+    });
 
-  it('should return false if user is not an admin', () => {
-    const currentUser = { access_level: 'reporting' };
-    expect(isAdmin({ currentUser })).toEqual(false);
-  });
-
-  it('should return true if user is sso', () => {
-    const currentUser = { is_sso: true };
-    expect(isSso({ currentUser })).toEqual(true);
-  });
-
-  it('should return false if user is sso', () => {
-    const currentUser = { is_sso: false };
-    expect(isSso({ currentUser })).toEqual(false);
-  });
-
-  it('should return true if access level matches', () => {
-    const currentUser = { access_level: 'admin' };
-    expect(hasRole('admin')({ currentUser })).toEqual(true);
-  });
-
-  it('should return true if access level does not match', () => {
-    const currentUser = { access_level: 'reporting' };
-    expect(hasRole('admin')({ currentUser })).toEqual(false);
+    it('should return false if user is not suabaccount user', () => {
+      const currentUser = { access_level: 'owijeoi' };
+      expect(isSubaccountUser({ currentUser })).toEqual(false);
+    });
   });
 
   describe('Condition: isUiOptionSet', () => {

--- a/src/helpers/conditions/user.js
+++ b/src/helpers/conditions/user.js
@@ -1,9 +1,12 @@
 import { any } from 'src/helpers/conditions';
 import _ from 'lodash';
+import { SUBACCOUNT_ROLES } from 'src/constants';
 
 export const isHeroku = ({ currentUser }) => currentUser.access_level === 'heroku';
 
 export const isAzure = ({ currentUser }) => currentUser.access_level === 'azure';
+
+export const isSubaccountUser = ({ currentUser }) => SUBACCOUNT_ROLES.includes(currentUser.access_level);
 
 export const hasRole = (role) => ({ currentUser }) => currentUser.access_level === role;
 

--- a/src/pages/dashboard/DashboardPage.container.js
+++ b/src/pages/dashboard/DashboardPage.container.js
@@ -10,7 +10,6 @@ import { listApiKeys } from 'src/actions/api-keys';
 import { selectAccountAgeInWeeks , selectAccountAgeInDays } from 'src/selectors/accountAge';
 import { selectVerifiedDomains, selectNotBlockedDomains } from 'src/selectors/sendingDomains';
 import { selectApiKeysForSending } from 'src/selectors/api-keys';
-import { hasGrants } from 'src/helpers/conditions';
 
 function mapStateToProps(state) {
   const acctAgeWeeks = selectAccountAgeInWeeks(state);
@@ -28,8 +27,7 @@ function mapStateToProps(state) {
     hasSendingDomains: notBlockedDomains.length > 0,
     hasVerifiedDomains: verifiedDomains.length > 0,
     hasApiKeysForSending: apiKeysForSending.length > 0,
-    hasSentThisMonth: _.get(state, 'account.usage.month.used', 0) > 0,
-    canViewTutorialAndSuppressions: hasGrants('api_keys/manage', 'templates/modify', 'sending_domains/manage')(state)
+    hasSentThisMonth: _.get(state, 'account.usage.month.used', 0) > 0
   };
 }
 

--- a/src/pages/dashboard/DashboardPage.container.js
+++ b/src/pages/dashboard/DashboardPage.container.js
@@ -1,0 +1,37 @@
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import DashboardPage from './DashboardPage';
+import _ from 'lodash';
+
+import { fetch as fetchAccount } from 'src/actions/account';
+import { checkSuppression } from 'src/actions/suppressions';
+import { list as listSendingDomains } from 'src/actions/sendingDomains';
+import { listApiKeys } from 'src/actions/api-keys';
+
+import { selectAccountAgeInWeeks , selectAccountAgeInDays } from 'src/selectors/accountAge';
+import { selectVerifiedDomains, selectNotBlockedDomains } from 'src/selectors/sendingDomains';
+import { selectApiKeysForSending } from 'src/selectors/api-keys';
+import { hasGrants } from 'src/helpers/conditions';
+
+function mapStateToProps(state) {
+  const acctAgeWeeks = selectAccountAgeInWeeks(state);
+  const acctAgeDays = selectAccountAgeInDays(state);
+  const notBlockedDomains = selectNotBlockedDomains(state);
+  const verifiedDomains = selectVerifiedDomains(state);
+  const apiKeysForSending = selectApiKeysForSending(state);
+
+  return {
+    account: state.account,
+    currentUser: state.currentUser,
+    accountAgeInWeeks: acctAgeWeeks,
+    accountAgeInDays: acctAgeDays,
+    hasSuppressions: state.suppressions.hasSuppression,
+    hasSendingDomains: notBlockedDomains.length > 0,
+    hasVerifiedDomains: verifiedDomains.length > 0,
+    hasApiKeysForSending: apiKeysForSending.length > 0,
+    hasSentThisMonth: _.get(state, 'account.usage.month.used', 0) > 0,
+    canViewTutorialAndSuppressions: hasGrants('api_keys/manage', 'templates/modify', 'sending_domains/manage')(state)
+  };
+}
+
+export default withRouter(connect(mapStateToProps, { fetchAccount, checkSuppression, listSendingDomains, listApiKeys })(DashboardPage));

--- a/src/pages/dashboard/DashboardPage.container.js
+++ b/src/pages/dashboard/DashboardPage.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import DashboardPage from './DashboardPage';
 import _ from 'lodash';
 
@@ -34,4 +33,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default withRouter(connect(mapStateToProps, { fetchAccount, checkSuppression, listSendingDomains, listApiKeys })(DashboardPage));
+export default connect(mapStateToProps, { fetchAccount, checkSuppression, listSendingDomains, listApiKeys })(DashboardPage);

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -26,7 +26,7 @@ export class DashboardPage extends Component {
           <VerifyEmailBanner verifying={currentUser.verifyingEmail} />
         )}
         <FreePlanWarningBanner account={account} accountAgeInDays={accountAgeInDays} ageRangeStart={16}/>
-        <UsageReport accountAgeInWeeks={accountAgeInWeeks} />
+        <UsageReport/>
         {canViewTutorialAndSuppressions && (
           <>
             <SuppressionBanner accountAgeInWeeks={accountAgeInWeeks} hasSuppressions={hasSuppressions} />

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -8,13 +8,6 @@ import { FreePlanWarningBanner } from 'src/pages/billing/components/Banners';
 import { hasGrants } from 'src/helpers/conditions';
 import { AccessControl } from 'src/components/auth';
 export class DashboardPage extends Component {
-  componentDidMount() {
-    if (this.props.canViewTutorialAndSuppressions) {
-      this.props.checkSuppression();
-      this.props.listSendingDomains();
-      this.props.listApiKeys({ id: 0 });
-    }
-  }
 
   render() {
     const { accountAgeInDays, currentUser, account } = this.props;

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -1,7 +1,4 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
-import _ from 'lodash';
 
 import { Page } from '@sparkpost/matchbox';
 import { UsageReport } from 'src/components';
@@ -9,26 +6,17 @@ import Tutorial from './components/Tutorial';
 import VerifyEmailBanner from 'src/components/verifyEmailBanner/VerifyEmailBanner';
 import SuppressionBanner from './components/SuppressionBanner';
 import { FreePlanWarningBanner } from 'src/pages/billing/components/Banners';
-
-import { fetch as fetchAccount } from 'src/actions/account';
-import { checkSuppression } from 'src/actions/suppressions';
-import { list as listSendingDomains } from 'src/actions/sendingDomains';
-import { listApiKeys } from 'src/actions/api-keys';
-
-import { selectAccountAgeInWeeks , selectAccountAgeInDays } from 'src/selectors/accountAge';
-import { selectVerifiedDomains, selectNotBlockedDomains } from 'src/selectors/sendingDomains';
-import { selectApiKeysForSending } from 'src/selectors/api-keys';
-import { hasGrants } from 'src/helpers/conditions';
-
 export class DashboardPage extends Component {
   componentDidMount() {
-    this.props.checkSuppression();
-    this.props.listSendingDomains();
-    this.props.listApiKeys({ id: 0 });
+    if (this.props.canViewTutorialAndSuppressions) {
+      this.props.checkSuppression();
+      this.props.listSendingDomains();
+      this.props.listApiKeys({ id: 0 });
+    }
   }
 
   render() {
-    const { accountAgeInWeeks, accountAgeInDays, currentUser, hasSuppressions, account } = this.props;
+    const { accountAgeInWeeks, accountAgeInDays, currentUser, hasSuppressions, account, canViewTutorialAndSuppressions } = this.props;
 
     //Shows banner if within 14 days of plan to downgrade
 
@@ -39,32 +27,15 @@ export class DashboardPage extends Component {
         )}
         <FreePlanWarningBanner account={account} accountAgeInDays={accountAgeInDays} ageRangeStart={16}/>
         <UsageReport accountAgeInWeeks={accountAgeInWeeks} />
-        <SuppressionBanner accountAgeInWeeks={accountAgeInWeeks} hasSuppressions={hasSuppressions} />
-        <Tutorial {...this.props} />
+        {canViewTutorialAndSuppressions && (
+          <>
+            <SuppressionBanner accountAgeInWeeks={accountAgeInWeeks} hasSuppressions={hasSuppressions} />
+            <Tutorial {...this.props} />
+          </>
+        )}
       </Page>
     );
   }
 }
 
-function mapStateToProps(state) {
-  const acctAgeWeeks = selectAccountAgeInWeeks(state);
-  const acctAgeDays = selectAccountAgeInDays(state);
-  const notBlockedDomains = selectNotBlockedDomains(state);
-  const verifiedDomains = selectVerifiedDomains(state);
-  const apiKeysForSending = selectApiKeysForSending(state);
-
-  return {
-    account: state.account,
-    currentUser: state.currentUser,
-    accountAgeInWeeks: acctAgeWeeks,
-    accountAgeInDays: acctAgeDays,
-    hasSuppressions: state.suppressions.hasSuppression,
-    hasSendingDomains: notBlockedDomains.length > 0,
-    hasVerifiedDomains: verifiedDomains.length > 0,
-    hasApiKeysForSending: apiKeysForSending.length > 0,
-    hasSentThisMonth: _.get(state, 'account.usage.month.used', 0) > 0,
-    canViewTutorial: hasGrants('api_keys/manage', 'templates/modify', 'sending_domains/manage')
-  };
-}
-
-export default withRouter(connect(mapStateToProps, { fetchAccount, checkSuppression, listSendingDomains, listApiKeys })(DashboardPage));
+export default DashboardPage;

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -18,6 +18,8 @@ import { listApiKeys } from 'src/actions/api-keys';
 import { selectAccountAgeInWeeks , selectAccountAgeInDays } from 'src/selectors/accountAge';
 import { selectVerifiedDomains, selectNotBlockedDomains } from 'src/selectors/sendingDomains';
 import { selectApiKeysForSending } from 'src/selectors/api-keys';
+import { hasGrants } from 'src/helpers/conditions';
+
 export class DashboardPage extends Component {
   componentDidMount() {
     this.props.checkSuppression();
@@ -60,7 +62,8 @@ function mapStateToProps(state) {
     hasSendingDomains: notBlockedDomains.length > 0,
     hasVerifiedDomains: verifiedDomains.length > 0,
     hasApiKeysForSending: apiKeysForSending.length > 0,
-    hasSentThisMonth: _.get(state, 'account.usage.month.used', 0) > 0
+    hasSentThisMonth: _.get(state, 'account.usage.month.used', 0) > 0,
+    canViewTutorial: hasGrants('api_keys/manage', 'templates/modify', 'sending_domains/manage')
   };
 }
 

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -4,8 +4,9 @@ import { Page } from '@sparkpost/matchbox';
 import { UsageReport } from 'src/components';
 import Tutorial from './components/Tutorial';
 import VerifyEmailBanner from 'src/components/verifyEmailBanner/VerifyEmailBanner';
-import SuppressionBanner from './components/SuppressionBanner';
 import { FreePlanWarningBanner } from 'src/pages/billing/components/Banners';
+import { hasGrants } from 'src/helpers/conditions';
+import { AccessControl } from 'src/components/auth';
 export class DashboardPage extends Component {
   componentDidMount() {
     if (this.props.canViewTutorialAndSuppressions) {
@@ -16,7 +17,7 @@ export class DashboardPage extends Component {
   }
 
   render() {
-    const { accountAgeInWeeks, accountAgeInDays, currentUser, hasSuppressions, account, canViewTutorialAndSuppressions } = this.props;
+    const { accountAgeInDays, currentUser, account } = this.props;
 
     //Shows banner if within 14 days of plan to downgrade
 
@@ -27,12 +28,9 @@ export class DashboardPage extends Component {
         )}
         <FreePlanWarningBanner account={account} accountAgeInDays={accountAgeInDays} ageRangeStart={16}/>
         <UsageReport/>
-        {canViewTutorialAndSuppressions && (
-          <>
-            <SuppressionBanner accountAgeInWeeks={accountAgeInWeeks} hasSuppressions={hasSuppressions} />
-            <Tutorial {...this.props} />
-          </>
-        )}
+        <AccessControl condition={hasGrants('api_keys/manage', 'templates/modify', 'sending_domains/manage')}>
+          <Tutorial {...this.props} />
+        </AccessControl>
       </Page>
     );
   }

--- a/src/pages/dashboard/components/Tutorial.js
+++ b/src/pages/dashboard/components/Tutorial.js
@@ -4,7 +4,7 @@ import { Panel } from '@sparkpost/matchbox';
 import { OpenInNew } from '@sparkpost/matchbox-icons';
 import TutorialItem from './TutorialItem';
 import { LINKS } from 'src/constants';
-import { AccessControl } from 'src/components/auth';
+import SuppressionBanner from './SuppressionBanner';
 
 export class Tutorial extends Component {
   render() {
@@ -14,11 +14,13 @@ export class Tutorial extends Component {
       hasVerifiedDomains,
       hasApiKeysForSending,
       hasSentThisMonth,
-      canViewTutorial
+      accountAgeInWeeks,
+      hasSuppressions
     } = this.props;
 
     return (
-      <AccessControl condition={canViewTutorial}>
+      <>
+        <SuppressionBanner accountAgeInWeeks={accountAgeInWeeks} hasSuppressions={hasSuppressions} />
         <Panel title='Getting Started Checklist' actions={[{
           content: <span>Need help? Check out our Getting Started guide <OpenInNew size={13}/></span>,
           color: 'orange',
@@ -59,7 +61,7 @@ export class Tutorial extends Component {
             <p>Get sending!</p>
           </TutorialItem>
         </Panel>
-      </AccessControl>
+      </>
     );
   }
 }

--- a/src/pages/dashboard/components/Tutorial.js
+++ b/src/pages/dashboard/components/Tutorial.js
@@ -7,6 +7,13 @@ import { LINKS } from 'src/constants';
 import SuppressionBanner from './SuppressionBanner';
 
 export class Tutorial extends Component {
+
+  componentDidMount() {
+    this.props.checkSuppression();
+    this.props.listSendingDomains();
+    this.props.listApiKeys({ id: 0 });
+  }
+
   render() {
     const {
       currentUser,

--- a/src/pages/dashboard/components/Tutorial.js
+++ b/src/pages/dashboard/components/Tutorial.js
@@ -4,6 +4,7 @@ import { Panel } from '@sparkpost/matchbox';
 import { OpenInNew } from '@sparkpost/matchbox-icons';
 import TutorialItem from './TutorialItem';
 import { LINKS } from 'src/constants';
+import { AccessControl } from 'src/components/auth';
 
 export class Tutorial extends Component {
   render() {
@@ -12,50 +13,53 @@ export class Tutorial extends Component {
       hasSendingDomains,
       hasVerifiedDomains,
       hasApiKeysForSending,
-      hasSentThisMonth
+      hasSentThisMonth,
+      canViewTutorial
     } = this.props;
 
     return (
-      <Panel title='Getting Started Checklist' actions={[{
-        content: <span>Need help? Check out our Getting Started guide <OpenInNew size={13}/></span>,
-        color: 'orange',
-        external: true,
-        to: LINKS.GETTING_STARTED_GUIDE }]}>
+      <AccessControl condition={canViewTutorial}>
+        <Panel title='Getting Started Checklist' actions={[{
+          content: <span>Need help? Check out our Getting Started guide <OpenInNew size={13}/></span>,
+          color: 'orange',
+          external: true,
+          to: LINKS.GETTING_STARTED_GUIDE }]}>
 
-        <TutorialItem
-          label='Verify your email address'
-          completed={currentUser.email_verified}>
-          <p>So we know you're legitimate, check your email to verify your email address. This also unlocks higher daily sending limits.</p>
-        </TutorialItem>
+          <TutorialItem
+            label='Verify your email address'
+            completed={currentUser.email_verified}>
+            <p>So we know you're legitimate, check your email to verify your email address.</p>
+          </TutorialItem>
 
-        <TutorialItem
-          label='Add a sending domain'
-          actions={[{ content: 'Add Sending Domain', color: 'orange', component: Link, to: '/account/sending-domains/create' }]}
-          completed={hasSendingDomains}>
-          <p>Adding a sending domain will allow you to send email from your own domain.</p>
-        </TutorialItem>
+          <TutorialItem
+            label='Add a sending domain'
+            actions={[{ content: 'Add Sending Domain', color: 'orange', component: Link, to: '/account/sending-domains/create' }]}
+            completed={hasSendingDomains}>
+            <p>Adding a sending domain will allow you to send email from your own domain.</p>
+          </TutorialItem>
 
-        <TutorialItem
-          label='Verify your sending domain'
-          actions={[{ content: 'View Sending Domains', color: 'orange', component: Link, to: '/account/sending-domains' }]}
-          completed={hasVerifiedDomains}>
-          <p>You'll need to verify your domain before you can use it.</p>
-        </TutorialItem>
+          <TutorialItem
+            label='Verify your sending domain'
+            actions={[{ content: 'View Sending Domains', color: 'orange', component: Link, to: '/account/sending-domains' }]}
+            completed={hasVerifiedDomains}>
+            <p>You'll need to verify your domain before you can use it.</p>
+          </TutorialItem>
 
-        <TutorialItem
-          label='Get an API key for sending email'
-          labelLink='account/api-keys'
-          actions={[{ content: 'Create an API Key', color: 'orange', component: Link, to: '/account/api-keys/create' }]}
-          completed={hasApiKeysForSending}>
-          <p>You'll need to create an API key with the correct permissions to send email.</p>
-        </TutorialItem>
+          <TutorialItem
+            label='Get an API key for sending email'
+            labelLink='account/api-keys'
+            actions={[{ content: 'Create an API Key', color: 'orange', component: Link, to: '/account/api-keys/create' }]}
+            completed={hasApiKeysForSending}>
+            <p>You'll need to create an API key with the correct permissions to send email.</p>
+          </TutorialItem>
 
-        <TutorialItem
-          label='Send an email'
-          completed={hasSentThisMonth}>
-          <p>Get sending!</p>
-        </TutorialItem>
-      </Panel>
+          <TutorialItem
+            label='Send an email'
+            completed={hasSentThisMonth}>
+            <p>Get sending!</p>
+          </TutorialItem>
+        </Panel>
+      </AccessControl>
     );
   }
 }

--- a/src/pages/dashboard/components/tests/Tutorial.test.js
+++ b/src/pages/dashboard/components/tests/Tutorial.test.js
@@ -8,6 +8,9 @@ describe('Component: Tutorial', () => {
     currentUser: {
       email_verified: true
     },
+    checkSuppression: jest.fn(() => []),
+    listSendingDomains: jest.fn(() => []),
+    listApiKeys: jest.fn(() => []),
     hasSendingDomains: false,
     hasVerifiedDomains: true,
     hasApiKeysForSending: false,
@@ -26,4 +29,9 @@ describe('Component: Tutorial', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should call the correct functions on mount', () => {
+    expect(props.checkSuppression).toHaveBeenCalled();
+    expect(props.listSendingDomains).toHaveBeenCalled();
+    expect(props.listApiKeys).toHaveBeenCalledWith({ id: 0 });
+  });
 });

--- a/src/pages/dashboard/components/tests/Tutorial.test.js
+++ b/src/pages/dashboard/components/tests/Tutorial.test.js
@@ -11,7 +11,9 @@ describe('Component: Tutorial', () => {
     hasSendingDomains: false,
     hasVerifiedDomains: true,
     hasApiKeysForSending: false,
-    hasBounceDomains: true
+    hasBounceDomains: true,
+    accountAgeInWeeks: 4,
+    hasSuppressions: false
   };
 
   let wrapper;

--- a/src/pages/dashboard/components/tests/__snapshots__/Tutorial.test.js.snap
+++ b/src/pages/dashboard/components/tests/__snapshots__/Tutorial.test.js.snap
@@ -1,93 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component: Tutorial should render correctly by default 1`] = `
-<Panel
-  actions={
-    Array [
-      Object {
-        "color": "orange",
-        "content": <span>
-          Need help? Check out our Getting Started guide 
-          <OpenInNew
-            size={13}
-          />
-        </span>,
-        "external": true,
-        "to": "https://www.sparkpost.com/docs/getting-started/getting-started-sparkpost",
-      },
-    ]
-  }
-  title="Getting Started Checklist"
->
-  <TutorialItem
-    completed={true}
-    label="Verify your email address"
-  >
-    <p>
-      So we know you're legitimate, check your email to verify your email address. This also unlocks higher daily sending limits.
-    </p>
-  </TutorialItem>
-  <TutorialItem
+<Connect(AccessControl)>
+  <Panel
     actions={
       Array [
         Object {
           "color": "orange",
-          "component": [Function],
-          "content": "Add Sending Domain",
-          "to": "/account/sending-domains/create",
+          "content": <span>
+            Need help? Check out our Getting Started guide 
+            <OpenInNew
+              size={13}
+            />
+          </span>,
+          "external": true,
+          "to": "https://www.sparkpost.com/docs/getting-started/getting-started-sparkpost",
         },
       ]
     }
-    completed={false}
-    label="Add a sending domain"
+    title="Getting Started Checklist"
   >
-    <p>
-      Adding a sending domain will allow you to send email from your own domain.
-    </p>
-  </TutorialItem>
-  <TutorialItem
-    actions={
-      Array [
-        Object {
-          "color": "orange",
-          "component": [Function],
-          "content": "View Sending Domains",
-          "to": "/account/sending-domains",
-        },
-      ]
-    }
-    completed={true}
-    label="Verify your sending domain"
-  >
-    <p>
-      You'll need to verify your domain before you can use it.
-    </p>
-  </TutorialItem>
-  <TutorialItem
-    actions={
-      Array [
-        Object {
-          "color": "orange",
-          "component": [Function],
-          "content": "Create an API Key",
-          "to": "/account/api-keys/create",
-        },
-      ]
-    }
-    completed={false}
-    label="Get an API key for sending email"
-    labelLink="account/api-keys"
-  >
-    <p>
-      You'll need to create an API key with the correct permissions to send email.
-    </p>
-  </TutorialItem>
-  <TutorialItem
-    label="Send an email"
-  >
-    <p>
-      Get sending!
-    </p>
-  </TutorialItem>
-</Panel>
+    <TutorialItem
+      completed={true}
+      label="Verify your email address"
+    >
+      <p>
+        So we know you're legitimate, check your email to verify your email address.
+      </p>
+    </TutorialItem>
+    <TutorialItem
+      actions={
+        Array [
+          Object {
+            "color": "orange",
+            "component": [Function],
+            "content": "Add Sending Domain",
+            "to": "/account/sending-domains/create",
+          },
+        ]
+      }
+      completed={false}
+      label="Add a sending domain"
+    >
+      <p>
+        Adding a sending domain will allow you to send email from your own domain.
+      </p>
+    </TutorialItem>
+    <TutorialItem
+      actions={
+        Array [
+          Object {
+            "color": "orange",
+            "component": [Function],
+            "content": "View Sending Domains",
+            "to": "/account/sending-domains",
+          },
+        ]
+      }
+      completed={true}
+      label="Verify your sending domain"
+    >
+      <p>
+        You'll need to verify your domain before you can use it.
+      </p>
+    </TutorialItem>
+    <TutorialItem
+      actions={
+        Array [
+          Object {
+            "color": "orange",
+            "component": [Function],
+            "content": "Create an API Key",
+            "to": "/account/api-keys/create",
+          },
+        ]
+      }
+      completed={false}
+      label="Get an API key for sending email"
+      labelLink="account/api-keys"
+    >
+      <p>
+        You'll need to create an API key with the correct permissions to send email.
+      </p>
+    </TutorialItem>
+    <TutorialItem
+      label="Send an email"
+    >
+      <p>
+        Get sending!
+      </p>
+    </TutorialItem>
+  </Panel>
+</Connect(AccessControl)>
 `;

--- a/src/pages/dashboard/components/tests/__snapshots__/Tutorial.test.js.snap
+++ b/src/pages/dashboard/components/tests/__snapshots__/Tutorial.test.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component: Tutorial should render correctly by default 1`] = `
-<Connect(AccessControl)>
+<Fragment>
+  <SuppressionBanner
+    accountAgeInWeeks={4}
+    hasSuppressions={false}
+  />
   <Panel
     actions={
       Array [
@@ -91,5 +95,5 @@ exports[`Component: Tutorial should render correctly by default 1`] = `
       </p>
     </TutorialItem>
   </Panel>
-</Connect(AccessControl)>
+</Fragment>
 `;

--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -1,0 +1,3 @@
+import DashboardPage from './DashboardPage.container';
+
+export default DashboardPage;

--- a/src/pages/dashboard/tests/DashboardPage.test.js
+++ b/src/pages/dashboard/tests/DashboardPage.test.js
@@ -23,8 +23,7 @@ describe('Page: Dashboard tests', () => {
     hasSuppressions: true,
     accountAgeInWeeks: 0,
     verifyingEmail: false,
-    accountAgeInDays: 15,
-    canViewTutorialAndSuppressions: true
+    accountAgeInDays: 15
   };
 
   let wrapper;

--- a/src/pages/dashboard/tests/DashboardPage.test.js
+++ b/src/pages/dashboard/tests/DashboardPage.test.js
@@ -23,7 +23,8 @@ describe('Page: Dashboard tests', () => {
     hasSuppressions: true,
     accountAgeInWeeks: 0,
     verifyingEmail: false,
-    accountAgeInDays: 15
+    accountAgeInDays: 15,
+    canViewTutorialAndSuppressions: true
   };
 
   let wrapper;
@@ -34,6 +35,11 @@ describe('Page: Dashboard tests', () => {
   });
 
   it('should render page correctly with defaults', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render if cannot view Tutorial and supressions', () => {
+    wrapper.setProps({ canViewTutorialAndSuppressions: false });
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/dashboard/tests/DashboardPage.test.js
+++ b/src/pages/dashboard/tests/DashboardPage.test.js
@@ -38,11 +38,6 @@ describe('Page: Dashboard tests', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render if cannot view Tutorial and supressions', () => {
-    wrapper.setProps({ canViewTutorialAndSuppressions: false });
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('should correctly render page when user is not verified', () => {
     wrapper.setProps({ currentUser: { email_verfied: false }});
     expect(wrapper).toMatchSnapshot();

--- a/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
+++ b/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
@@ -18,9 +18,7 @@ exports[`Page: Dashboard tests should correctly render page when user is not ver
     accountAgeInDays={15}
     ageRangeStart={16}
   />
-  <Connect(UsageReport)
-    accountAgeInWeeks={0}
-  />
+  <Connect(UsageReport) />
   <SuppressionBanner
     accountAgeInWeeks={0}
     hasSuppressions={true}
@@ -94,9 +92,7 @@ exports[`Page: Dashboard tests should display upgrade CTA when account is free a
     accountAgeInDays={15}
     ageRangeStart={16}
   />
-  <Connect(UsageReport)
-    accountAgeInWeeks={0}
-  />
+  <Connect(UsageReport) />
   <SuppressionBanner
     accountAgeInWeeks={0}
     hasSuppressions={true}
@@ -170,9 +166,7 @@ exports[`Page: Dashboard tests should render if cannot view Tutorial and supress
     accountAgeInDays={15}
     ageRangeStart={16}
   />
-  <Connect(UsageReport)
-    accountAgeInWeeks={0}
-  />
+  <Connect(UsageReport) />
 </Page>
 `;
 
@@ -194,9 +188,7 @@ exports[`Page: Dashboard tests should render import suppression list when 0 supp
     accountAgeInDays={15}
     ageRangeStart={16}
   />
-  <Connect(UsageReport)
-    accountAgeInWeeks={40}
-  />
+  <Connect(UsageReport) />
   <SuppressionBanner
     accountAgeInWeeks={40}
     hasSuppressions={false}
@@ -271,9 +263,7 @@ exports[`Page: Dashboard tests should render page correctly with defaults 1`] = 
     accountAgeInDays={15}
     ageRangeStart={16}
   />
-  <Connect(UsageReport)
-    accountAgeInWeeks={0}
-  />
+  <Connect(UsageReport) />
   <SuppressionBanner
     accountAgeInWeeks={0}
     hasSuppressions={true}

--- a/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
+++ b/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
@@ -19,59 +19,59 @@ exports[`Page: Dashboard tests should correctly render page when user is not ver
     ageRangeStart={16}
   />
   <Connect(UsageReport) />
-  <SuppressionBanner
-    accountAgeInWeeks={0}
-    hasSuppressions={true}
-  />
-  <Tutorial
-    account={
-      Object {
-        "created": 2018-05-15T12:00:00.000Z,
-        "status": "active",
-        "subscription": Object {
-          "code": "paid",
-        },
+  <Connect(AccessControl)
+    condition={[Function]}
+  >
+    <Tutorial
+      account={
+        Object {
+          "created": 2018-05-15T12:00:00.000Z,
+          "status": "active",
+          "subscription": Object {
+            "code": "paid",
+          },
+        }
       }
-    }
-    accountAgeInDays={15}
-    accountAgeInWeeks={0}
-    canViewTutorialAndSuppressions={true}
-    checkSuppression={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
-      }
-    }
-    currentUser={
-      Object {
-        "email_verfied": false,
-      }
-    }
-    hasSuppressions={true}
-    listApiKeys={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "id": 0,
-            },
+      accountAgeInDays={15}
+      accountAgeInWeeks={0}
+      canViewTutorialAndSuppressions={true}
+      checkSuppression={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
           ],
-        ],
-        "results": undefined,
+          "results": undefined,
+        }
       }
-    }
-    listSendingDomains={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
+      currentUser={
+        Object {
+          "email_verfied": false,
+        }
       }
-    }
-    verifyingEmail={false}
-  />
+      hasSuppressions={true}
+      listApiKeys={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "id": 0,
+              },
+            ],
+          ],
+          "results": undefined,
+        }
+      }
+      listSendingDomains={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": undefined,
+        }
+      }
+      verifyingEmail={false}
+    />
+  </Connect(AccessControl)>
 </Page>
 `;
 
@@ -93,80 +93,58 @@ exports[`Page: Dashboard tests should display upgrade CTA when account is free a
     ageRangeStart={16}
   />
   <Connect(UsageReport) />
-  <SuppressionBanner
-    accountAgeInWeeks={0}
-    hasSuppressions={true}
-  />
-  <Tutorial
-    account={
-      Object {
-        "status": "active",
-        "subscription": Object {
-          "code": "free",
-        },
+  <Connect(AccessControl)
+    condition={[Function]}
+  >
+    <Tutorial
+      account={
+        Object {
+          "status": "active",
+          "subscription": Object {
+            "code": "free",
+          },
+        }
       }
-    }
-    accountAgeInDays={15}
-    accountAgeInWeeks={0}
-    canViewTutorialAndSuppressions={true}
-    checkSuppression={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
-      }
-    }
-    currentUser={
-      Object {
-        "email_verified": true,
-      }
-    }
-    hasSuppressions={true}
-    listApiKeys={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "id": 0,
-            },
+      accountAgeInDays={15}
+      accountAgeInWeeks={0}
+      canViewTutorialAndSuppressions={true}
+      checkSuppression={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
           ],
-        ],
-        "results": undefined,
+          "results": undefined,
+        }
       }
-    }
-    listSendingDomains={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
+      currentUser={
+        Object {
+          "email_verified": true,
+        }
       }
-    }
-    verifyingEmail={false}
-  />
-</Page>
-`;
-
-exports[`Page: Dashboard tests should render if cannot view Tutorial and supressions 1`] = `
-<Page
-  empty={Object {}}
-  title="Dashboard"
->
-  <FreePlanWarningBanner
-    account={
-      Object {
-        "created": 2018-05-15T12:00:00.000Z,
-        "status": "active",
-        "subscription": Object {
-          "code": "paid",
-        },
+      hasSuppressions={true}
+      listApiKeys={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "id": 0,
+              },
+            ],
+          ],
+          "results": undefined,
+        }
       }
-    }
-    accountAgeInDays={15}
-    ageRangeStart={16}
-  />
-  <Connect(UsageReport) />
+      listSendingDomains={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": undefined,
+        }
+      }
+      verifyingEmail={false}
+    />
+  </Connect(AccessControl)>
 </Page>
 `;
 
@@ -189,59 +167,59 @@ exports[`Page: Dashboard tests should render import suppression list when 0 supp
     ageRangeStart={16}
   />
   <Connect(UsageReport) />
-  <SuppressionBanner
-    accountAgeInWeeks={40}
-    hasSuppressions={false}
-  />
-  <Tutorial
-    account={
-      Object {
-        "created": 2018-05-15T12:00:00.000Z,
-        "status": "active",
-        "subscription": Object {
-          "code": "paid",
-        },
+  <Connect(AccessControl)
+    condition={[Function]}
+  >
+    <Tutorial
+      account={
+        Object {
+          "created": 2018-05-15T12:00:00.000Z,
+          "status": "active",
+          "subscription": Object {
+            "code": "paid",
+          },
+        }
       }
-    }
-    accountAgeInDays={15}
-    accountAgeInWeeks={40}
-    canViewTutorialAndSuppressions={true}
-    checkSuppression={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
-      }
-    }
-    currentUser={
-      Object {
-        "email_verified": true,
-      }
-    }
-    hasSuppressions={false}
-    listApiKeys={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "id": 0,
-            },
+      accountAgeInDays={15}
+      accountAgeInWeeks={40}
+      canViewTutorialAndSuppressions={true}
+      checkSuppression={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
           ],
-        ],
-        "results": undefined,
+          "results": undefined,
+        }
       }
-    }
-    listSendingDomains={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
+      currentUser={
+        Object {
+          "email_verified": true,
+        }
       }
-    }
-    verifyingEmail={false}
-  />
+      hasSuppressions={false}
+      listApiKeys={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "id": 0,
+              },
+            ],
+          ],
+          "results": undefined,
+        }
+      }
+      listSendingDomains={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": undefined,
+        }
+      }
+      verifyingEmail={false}
+    />
+  </Connect(AccessControl)>
 </Page>
 `;
 
@@ -264,58 +242,58 @@ exports[`Page: Dashboard tests should render page correctly with defaults 1`] = 
     ageRangeStart={16}
   />
   <Connect(UsageReport) />
-  <SuppressionBanner
-    accountAgeInWeeks={0}
-    hasSuppressions={true}
-  />
-  <Tutorial
-    account={
-      Object {
-        "created": 2018-05-15T12:00:00.000Z,
-        "status": "active",
-        "subscription": Object {
-          "code": "paid",
-        },
+  <Connect(AccessControl)
+    condition={[Function]}
+  >
+    <Tutorial
+      account={
+        Object {
+          "created": 2018-05-15T12:00:00.000Z,
+          "status": "active",
+          "subscription": Object {
+            "code": "paid",
+          },
+        }
       }
-    }
-    accountAgeInDays={15}
-    accountAgeInWeeks={0}
-    canViewTutorialAndSuppressions={true}
-    checkSuppression={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
-      }
-    }
-    currentUser={
-      Object {
-        "email_verified": true,
-      }
-    }
-    hasSuppressions={true}
-    listApiKeys={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "id": 0,
-            },
+      accountAgeInDays={15}
+      accountAgeInWeeks={0}
+      canViewTutorialAndSuppressions={true}
+      checkSuppression={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
           ],
-        ],
-        "results": undefined,
+          "results": undefined,
+        }
       }
-    }
-    listSendingDomains={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
+      currentUser={
+        Object {
+          "email_verified": true,
+        }
       }
-    }
-    verifyingEmail={false}
-  />
+      hasSuppressions={true}
+      listApiKeys={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Object {
+                "id": 0,
+              },
+            ],
+          ],
+          "results": undefined,
+        }
+      }
+      listSendingDomains={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": undefined,
+        }
+      }
+      verifyingEmail={false}
+    />
+  </Connect(AccessControl)>
 </Page>
 `;

--- a/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
+++ b/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
@@ -37,6 +37,7 @@ exports[`Page: Dashboard tests should correctly render page when user is not ver
     }
     accountAgeInDays={15}
     accountAgeInWeeks={0}
+    canViewTutorialAndSuppressions={true}
     checkSuppression={
       [MockFunction] {
         "calls": Array [
@@ -111,6 +112,7 @@ exports[`Page: Dashboard tests should display upgrade CTA when account is free a
     }
     accountAgeInDays={15}
     accountAgeInWeeks={0}
+    canViewTutorialAndSuppressions={true}
     checkSuppression={
       [MockFunction] {
         "calls": Array [
@@ -146,6 +148,30 @@ exports[`Page: Dashboard tests should display upgrade CTA when account is free a
       }
     }
     verifyingEmail={false}
+  />
+</Page>
+`;
+
+exports[`Page: Dashboard tests should render if cannot view Tutorial and supressions 1`] = `
+<Page
+  empty={Object {}}
+  title="Dashboard"
+>
+  <FreePlanWarningBanner
+    account={
+      Object {
+        "created": 2018-05-15T12:00:00.000Z,
+        "status": "active",
+        "subscription": Object {
+          "code": "paid",
+        },
+      }
+    }
+    accountAgeInDays={15}
+    ageRangeStart={16}
+  />
+  <Connect(UsageReport)
+    accountAgeInWeeks={0}
   />
 </Page>
 `;
@@ -187,6 +213,7 @@ exports[`Page: Dashboard tests should render import suppression list when 0 supp
     }
     accountAgeInDays={15}
     accountAgeInWeeks={40}
+    canViewTutorialAndSuppressions={true}
     checkSuppression={
       [MockFunction] {
         "calls": Array [
@@ -263,6 +290,7 @@ exports[`Page: Dashboard tests should render page correctly with defaults 1`] = 
     }
     accountAgeInDays={15}
     accountAgeInWeeks={0}
+    canViewTutorialAndSuppressions={true}
     checkSuppression={
       [MockFunction] {
         "calls": Array [

--- a/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
+++ b/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
@@ -34,7 +34,6 @@ exports[`Page: Dashboard tests should correctly render page when user is not ver
       }
       accountAgeInDays={15}
       accountAgeInWeeks={0}
-      canViewTutorialAndSuppressions={true}
       checkSuppression={[MockFunction]}
       currentUser={
         Object {
@@ -82,7 +81,6 @@ exports[`Page: Dashboard tests should display upgrade CTA when account is free a
       }
       accountAgeInDays={15}
       accountAgeInWeeks={0}
-      canViewTutorialAndSuppressions={true}
       checkSuppression={[MockFunction]}
       currentUser={
         Object {
@@ -132,7 +130,6 @@ exports[`Page: Dashboard tests should render import suppression list when 0 supp
       }
       accountAgeInDays={15}
       accountAgeInWeeks={40}
-      canViewTutorialAndSuppressions={true}
       checkSuppression={[MockFunction]}
       currentUser={
         Object {
@@ -182,7 +179,6 @@ exports[`Page: Dashboard tests should render page correctly with defaults 1`] = 
       }
       accountAgeInDays={15}
       accountAgeInWeeks={0}
-      canViewTutorialAndSuppressions={true}
       checkSuppression={[MockFunction]}
       currentUser={
         Object {

--- a/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
+++ b/src/pages/dashboard/tests/__snapshots__/DashboardPage.test.js.snap
@@ -35,40 +35,15 @@ exports[`Page: Dashboard tests should correctly render page when user is not ver
       accountAgeInDays={15}
       accountAgeInWeeks={0}
       canViewTutorialAndSuppressions={true}
-      checkSuppression={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      checkSuppression={[MockFunction]}
       currentUser={
         Object {
           "email_verfied": false,
         }
       }
       hasSuppressions={true}
-      listApiKeys={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Object {
-                "id": 0,
-              },
-            ],
-          ],
-          "results": undefined,
-        }
-      }
-      listSendingDomains={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      listApiKeys={[MockFunction]}
+      listSendingDomains={[MockFunction]}
       verifyingEmail={false}
     />
   </Connect(AccessControl)>
@@ -108,40 +83,15 @@ exports[`Page: Dashboard tests should display upgrade CTA when account is free a
       accountAgeInDays={15}
       accountAgeInWeeks={0}
       canViewTutorialAndSuppressions={true}
-      checkSuppression={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      checkSuppression={[MockFunction]}
       currentUser={
         Object {
           "email_verified": true,
         }
       }
       hasSuppressions={true}
-      listApiKeys={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Object {
-                "id": 0,
-              },
-            ],
-          ],
-          "results": undefined,
-        }
-      }
-      listSendingDomains={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      listApiKeys={[MockFunction]}
+      listSendingDomains={[MockFunction]}
       verifyingEmail={false}
     />
   </Connect(AccessControl)>
@@ -183,40 +133,15 @@ exports[`Page: Dashboard tests should render import suppression list when 0 supp
       accountAgeInDays={15}
       accountAgeInWeeks={40}
       canViewTutorialAndSuppressions={true}
-      checkSuppression={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      checkSuppression={[MockFunction]}
       currentUser={
         Object {
           "email_verified": true,
         }
       }
       hasSuppressions={false}
-      listApiKeys={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Object {
-                "id": 0,
-              },
-            ],
-          ],
-          "results": undefined,
-        }
-      }
-      listSendingDomains={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      listApiKeys={[MockFunction]}
+      listSendingDomains={[MockFunction]}
       verifyingEmail={false}
     />
   </Connect(AccessControl)>
@@ -258,40 +183,15 @@ exports[`Page: Dashboard tests should render page correctly with defaults 1`] = 
       accountAgeInDays={15}
       accountAgeInWeeks={0}
       canViewTutorialAndSuppressions={true}
-      checkSuppression={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      checkSuppression={[MockFunction]}
       currentUser={
         Object {
           "email_verified": true,
         }
       }
       hasSuppressions={true}
-      listApiKeys={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Object {
-                "id": 0,
-              },
-            ],
-          ],
-          "results": undefined,
-        }
-      }
-      listSendingDomains={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-          "results": undefined,
-        }
-      }
+      listApiKeys={[MockFunction]}
+      listSendingDomains={[MockFunction]}
       verifyingEmail={false}
     />
   </Connect(AccessControl)>

--- a/src/pages/defaultRedirect/DefaultRedirect.js
+++ b/src/pages/defaultRedirect/DefaultRedirect.js
@@ -19,7 +19,7 @@ export class DefaultRedirect extends Component {
   handleRedirect() {
     const { location, history, currentUser, ready } = this.props;
     const { state: routerState = {}, ...locationWithoutState } = location;
-    const allowedAccessLevels = ['subaccount_reporting', 'reporting', 'heroku', 'azure', 'email'];
+    const allowedAccessLevels = ['subaccount_reporting', 'reporting', 'heroku', 'azure'];
 
     // if there is a redirect route set on state, we can
     // redirect there before access condition state is ready

--- a/src/pages/defaultRedirect/tests/DefaultRedirect.test.js
+++ b/src/pages/defaultRedirect/tests/DefaultRedirect.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import cases from 'jest-in-case';
 
 import { DefaultRedirect } from '../DefaultRedirect';
+import { ROLES } from 'src/constants';
 
 jest.mock('src/config', () => ({
   splashPage: '/config/splash'
@@ -77,9 +78,8 @@ describe('Component: DefaultRedirect', () => {
       state: {}
     });
   }, {
-    reporting: { accessLevel: 'reporting' },
-    'subaccount reporting': { accessLevel: 'subaccount_reporting' },
-    email: { accessLevel: 'email' }
+    reporting: { accessLevel: ROLES.REPORTING },
+    'subaccount reporting': { accessLevel: ROLES.SUBACCOUNT_REPORTING }
   });
 
   it('should redirect based on config', () => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,7 +6,7 @@ export { default as TfaPage } from './auth/TfaPage';
 export { default as EnableTfaPage } from './auth/EnableTfaPage';
 export { default as SsoAuthPage } from './auth/SsoAuthPage';
 export { default as billing } from './billing';
-export { default as DashboardPage } from './dashboard/DashboardPage';
+export { default as DashboardPage } from './dashboard';
 export { default as ProfilePage } from './profile/ProfilePage';
 export { default as abTesting } from './abTesting';
 export { default as apiKeys } from './api-keys';

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -7,7 +7,7 @@ import { Page, Tag } from '@sparkpost/matchbox';
 import TimeAgo from 'react-timeago';
 import { Users } from 'src/components/images';
 import PageLink from 'src/components/pageLink/PageLink';
-import { SUBACCOUNT_REPORTING_ROLE } from 'src/constants';
+import { ROLES } from 'src/constants';
 import { hasUiOption } from 'src/helpers/conditions/account';
 
 import * as usersActions from 'src/actions/users';
@@ -62,7 +62,7 @@ export class ListPage extends Component {
   }
 
   formatRole(role) {
-    if (role === SUBACCOUNT_REPORTING_ROLE) {
+    if (role === ROLES.SUBACCOUNT_REPORTING) {
       return 'reporting';
     }
     return role;


### PR DESCRIPTION
### What Changed
 - Dashboard available to other roles (except subaccount roles)
    - Checklist hidden from those missing grants instead of whole dashboard
    - Route prevents subaccount roles
    - Email users directed to dashboard, reporting still directed to summary report
 - Dashboard now shows usage from the start

### How To Test
 - Login to check where you are directed depending on Role
    - Admin, Developer, Email directed to dashboard
    - Reporting directed to summary w/ link to dashboard in navbar
    - Subaccount reporting directed to summary w/ no link to dashboard
 - Admin and developer should have access to checklist on dashboard

### To Do
- [ ] Double check the routes access 
- [ ] Address any UX concerns with new landing page
- [ ] Address any feedback
