### PR TITLE
List pages: open-for-extension API

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const paths = require('../config/paths');
 
 const sassRegex = /\.(scss|sass)$/;
@@ -48,5 +49,11 @@ module.exports = {
         include: path.resolve(__dirname, '../')
       },
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      SUPPORTED_BROWSERS: {},
+      TENANT_CONFIGS: {}
+    })
+  ]
 };

--- a/src/components/listPage/Actions.js
+++ b/src/components/listPage/Actions.js
@@ -4,7 +4,7 @@ import PageLink from 'src/components/pageLink';
 import { ActionPopover } from 'src/components';
 
 const Actions = ({ item, editRoute, deletable, onDelete, customActions }) => {
-  const baseActions = [
+  const actions = [
     editRoute && {
       component: PageLink,
       content: 'Edit',
@@ -13,10 +13,10 @@ const Actions = ({ item, editRoute, deletable, onDelete, customActions }) => {
     deletable && {
       content: 'Delete',
       onClick: () => onDelete(item)
-    }
+    },
+    ...customActions
   ].filter(Boolean);
 
-  const actions = [...baseActions, ...customActions];
   return <ActionPopover actions={actions} />;
 };
 

--- a/src/components/listPage/ErrorBanner.js
+++ b/src/components/listPage/ErrorBanner.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { ApiErrorBanner } from 'src/components';
+
+const ErrorBanner = ({ loadItems, error, noun }) =>
+  error ? (
+    <ApiErrorBanner
+      errorDetails={error.message}
+      message={`Sorry, we seem to have had some trouble loading your ${noun.toLowerCase()}s .`}
+      reload={loadItems}
+    />
+  ) : null;
+
+ErrorBanner.displayName = 'ListPage.ErrorBanner';
+
+ErrorBanner.propTypes = {
+  errorDetails: propTypes.string.isRequired,
+  message: propTypes.string,
+  reload: propTypes.func
+};
+
+export default ErrorBanner;

--- a/src/components/listPage/ListPage.propTypes.js
+++ b/src/components/listPage/ListPage.propTypes.js
@@ -2,16 +2,13 @@ import propTypes from 'prop-types';
 import { Page } from '@sparkpost/matchbox';
 
 export default {
-  banner: propTypes.element,
   columns: propTypes.arrayOf(propTypes.object).isRequired,
   defaultSortColumn: propTypes.string,
-  renderDeleteWarning: propTypes.func,
   empty: Page.propTypes.empty,
   error: propTypes.shape({
     message: propTypes.string
   }),
   filterBox: propTypes.object, // TODO: reference FilterBox propTypes
-  renderRow: propTypes.func.isRequired,
   items: propTypes.arrayOf(propTypes.object),
   loading: propTypes.bool,
   loadItems: propTypes.func.isRequired,
@@ -21,5 +18,6 @@ export default {
     content: propTypes.node,
     to: propTypes.string.isRequired
   }),
-  additionalActions: propTypes.arrayOf(propTypes.object)
+  additionalActions: propTypes.arrayOf(propTypes.object),
+  children: propTypes.func.isRequired
 };

--- a/src/components/listPage/Modal.js
+++ b/src/components/listPage/Modal.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { DeleteModal } from 'src/components';
+
+const Modal = ({ noun, item, children, ...rest }) => (
+  <DeleteModal
+    title={`Are you sure you want to delete this ${noun}?`}
+    content={rest.open && children ? children({ noun, item }) : null}
+    {...rest}
+  />
+);
+Modal.displayName = 'ListPage.Modal';
+Modal.propTypes = {
+  noun: propTypes.string.isRequired,
+  item: propTypes.object
+};
+
+export default Modal;

--- a/src/components/listPage/Table.js
+++ b/src/components/listPage/Table.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { TableCollection } from 'src/components';
+
+const Table = ({
+  columns,
+  items,
+  filterBox,
+  defaultSortColumn,
+  actionProps,
+  children
+}) => {
+  const filterBoxOptions = filterBox
+    ? { show: true, ...filterBox }
+    : { show: false };
+  return (
+    <TableCollection
+      columns={columns}
+      getRowData={(row) =>
+        children({ row, columns, actionProps: { item: row, ...actionProps }})
+      }
+      pagination={true}
+      rows={items}
+      filterBox={filterBoxOptions}
+      defaultSortColumn={defaultSortColumn || columns[0]}
+    />
+  );
+};
+
+Table.displayName = 'ListPage.Table';
+
+Table.propTypes = {
+  children: propTypes.func.isRequired
+};
+
+Table.defaultProps = {
+  children: ({ row, columns }) => [
+    ...columns.map(({ sortKey }) => row[sortKey])
+  ]
+};
+
+export default Table;


### PR DESCRIPTION
### What Changed
 - Opened up `ListPage` for customised rendering at the page and list levels

For example, given an item like this:
```
 {
  name: 'm3 bolt',
  diam: 3,
  scale: 'metric'
}
```
 ...we can create a ListPage with a page header, custom row rendering and actions like this:

```jsx
    <ListPage {...baseProps} items={items}>
      {({ errorProps, tableProps, modalProps }) => (
        <>
          <ListPage.ErrorBanner {...errorProps} />
          <ListPage.Table {...tableProps}>
            {({ row, actionProps }) => [
              row.name,
              row.diam,
              <ListPage.Actions
                {...actionProps}
                editRoute={mkEditRoute(name)}
                deletable={mkDeletable(name)}
              />
            ]}
          </ListPage.Table>
          <ListPage.Modal {...modalProps} />
        </>
      )}
    </ListPage>
```

### How To Test
 - Review the ListPage stories in `stories/ListPage.stories.js`
 - `npm run storybook` to review rendered results

### To Do
 - [ ] Address feedback
 - [ ] Update unit tests
 - [ ] Build a list page with `ListPage` - probably users
