### PR TITLE
TR-1124: Launch AMP for all in UI

### DIFF
--- a/src/components/contentEditor/ContentEditor.js
+++ b/src/components/contentEditor/ContentEditor.js
@@ -27,7 +27,7 @@ const fields = [
     name: 'content.amp_html',
     mode: 'html',
     syntaxValidation: false,
-    show: ({ isAmpLive }) => isAmpLive
+    show: () => true
   },
   {
     alwaysEditable: true,
@@ -58,16 +58,8 @@ class ContentEditor extends React.Component {
   }
 
   // note, must handle null template parts
-  requiredHtmlOrText = (value, { content: { html, text } = {}}) => {
-    // return validation error if both parts are falsy or empty
-    if (!this.normalize(html) && !this.normalize(text)) {
-      return 'HTML or Text is required';
-    }
-  }
-
-  // note, must handle null template parts
   requiredHtmlTextOrAmp = (value, { content: { html, text, amp_html } = {}}) => {
-    // return validation error if both parts are falsy or empty
+    // return validation error if all parts are falsy or empty
     if (!this.normalize(html) && !this.normalize(text) && !this.normalize(amp_html)) {
       return 'HTML, AMP HTML, or Text is required';
     }
@@ -80,13 +72,10 @@ class ContentEditor extends React.Component {
   }
 
   render() {
-    const { readOnly, isAmpLive, contentOnly } = this.props;
+    const { readOnly } = this.props;
     const { selectedTab } = this.state;
     const visibleFields = fields.filter((field) => field.show(this.props));
     const tabs = visibleFields.map(({ content }, index) => ({ content, onClick: () => this.handleTab(index) }));
-
-    // Templates require HTML or Text. Snippets require HTML, AMP HTML, or Text.
-    const requiredContentValidator = isAmpLive && contentOnly ? this.requiredHtmlTextOrAmp : this.requiredHtmlOrText;
 
     return (
       <div className={styles.EditorSection}>
@@ -102,7 +91,7 @@ class ContentEditor extends React.Component {
             normalize={this.normalize}
             readOnly={readOnly && !visibleFields[selectedTab].alwaysEditable}
             syntaxValidation={visibleFields[selectedTab].syntaxValidation}
-            validate={[requiredContentValidator, this.validTestDataJson]}
+            validate={[this.requiredHtmlTextOrAmp, this.validTestDataJson]}
           />
         </Panel>
       </div>

--- a/src/components/contentEditor/ContentEditor.test.js
+++ b/src/components/contentEditor/ContentEditor.test.js
@@ -8,6 +8,14 @@ describe('ContentEditor', () => {
   let wrapper;
   let props;
 
+  const selectTabByContent = (wrapper, content) => {
+    wrapper
+      .find('Tabs')
+      .prop('tabs')
+      .find((tab) => tab.content === content)
+      .onClick();
+  };
+
   beforeEach(() => {
     wrapper = shallow(<ContentEditor {...props} />);
   });
@@ -28,69 +36,50 @@ describe('ContentEditor', () => {
   });
 
   it('should select tabs', () => {
-    wrapper.find('Tabs').props().tabs[1].onClick();
-    expect(wrapper.state().selectedTab).toBe(1);
+    selectTabByContent(wrapper, 'Text');
+    expect(wrapper.find('Tabs')).toHaveProp('selected', 1);
   });
 
   it('should set field read only correctly', () => {
     wrapper.setProps({ readOnly: true });
-    expect(wrapper.find('Field').props().readOnly).toBe(true);
+    expect(wrapper.find('Field')).toHaveProp('readOnly', true);
 
     // 'Test Data' is always editable
-    wrapper.instance().handleTab(2);
-    wrapper.update();
-    expect(wrapper.find('Field').props().readOnly).toBe(false);
+    selectTabByContent(wrapper, 'Test Data');
+    expect(wrapper.find('Field')).toHaveProp('readOnly', false);
   });
 
   it('should set HTML syntax validation correctly', () => {
-    wrapper.instance().handleTab(0);
-    wrapper.update();
-    expect(wrapper.find('Field').props().name).toBe('content.html');
-    expect(wrapper.find('Field').props().syntaxValidation).toBe(false);
+    selectTabByContent(wrapper, 'HTML');
+    expect(wrapper.find('Field')).toHaveProp('name', 'content.html');
+    expect(wrapper.find('Field')).toHaveProp('syntaxValidation', false);
   });
 
   it('should set Text syntax validation correctly', () => {
-    wrapper.instance().handleTab(1);
-    wrapper.update();
-    expect(wrapper.find('Field').props().name).toBe('content.text');
-    expect(wrapper.find('Field').props().syntaxValidation).toBe(false);
+    selectTabByContent(wrapper, 'Text');
+    expect(wrapper.find('Field')).toHaveProp('name', 'content.text');
+    expect(wrapper.find('Field')).toHaveProp('syntaxValidation', false);
   });
 
   it('should set Test Data syntax validation correctly', () => {
-    wrapper.instance().handleTab(2);
-    wrapper.update();
-    expect(wrapper.find('Field').props().name).toBe('testData');
-    expect(wrapper.find('Field').props().syntaxValidation).toBe(true);
+    selectTabByContent(wrapper, 'Test Data');
+    expect(wrapper.find('Field')).toHaveProp('name', 'testData');
+    expect(wrapper.find('Field')).toHaveProp('syntaxValidation', true);
+  });
+
+  it('should set AMP syntax validation correctly', () => {
+    selectTabByContent(wrapper, 'AMP HTML');
+    expect(wrapper.find('Field')).toHaveProp('name', 'content.amp_html');
+    expect(wrapper.find('Field')).toHaveProp('syntaxValidation', false);
   });
 
   it('should set required content validation correctly for just HTML and Text', () => {
-    expect(wrapper.find('Field').props().validate[0]).toBe(wrapper.instance().requiredHtmlOrText);
-  });
-
-  it('should set required content validation correctly for HTML, Text, and AMP', () => {
-    wrapper.setProps({ isAmpLive: true, contentOnly: true });
     expect(wrapper.find('Field').props().validate[0]).toBe(wrapper.instance().requiredHtmlTextOrAmp);
   });
 
-  describe('when AMP is live', () => {
-    beforeEach(() => {
-      wrapper.setProps({ isAmpLive: true });
-    });
-
-    it('should set syntax validation correctly', () => {
-      wrapper.instance().handleTab(2);
-      wrapper.update();
-      expect(wrapper.find('Field').props().name).toBe('content.amp_html');
-      expect(wrapper.find('Field').props().syntaxValidation).toBe(false);
-    });
-
-    it('should leave test data tab editable when other tabs are read only', () => {
-      wrapper.setProps({ readOnly: true });
-      wrapper.instance().handleTab(3);
-
-      expect(wrapper.find('Field')).toHaveProp('name', 'testData');
-      expect(wrapper.find('Field')).toHaveProp('readOnly', false);
-    });
+  it('should set required content validation correctly for HTML, Text, and AMP', () => {
+    wrapper.setProps({ contentOnly: true });
+    expect(wrapper.find('Field').props().validate[0]).toBe(wrapper.instance().requiredHtmlTextOrAmp);
   });
 
   cases('.normalize', ({ expected, value }) => {
@@ -108,36 +97,6 @@ describe('ContentEditor', () => {
       expected: ' <p>testing</p> ',
       value: ' <p>testing</p> '
     }
-  });
-
-  describe('.requiredHtmlOrText', () => {
-    const subject = (content) => (
-      wrapper.instance().requiredHtmlOrText(undefined, { content })
-    );
-
-    it('returns undefined with html content', () => {
-      expect(subject({ html: '<p>test</p>' })).toBeUndefined();
-    });
-
-    it('returns undefined with text content', () => {
-      expect(subject({ text: 'test' })).toBeUndefined();
-    });
-
-    it('returns undefined with html and text content', () => {
-      expect(subject({ html: '<p>test</p>', text: 'test' })).toBeUndefined();
-    });
-
-    it('returns required validation message', () => {
-      expect(subject({})).toMatch(/required/);
-    });
-
-    it('returns required validation message with whitespace', () => {
-      expect(subject({ html: '     ' })).toMatch(/required/);
-    });
-
-    it('returns required validation message with null', () => {
-      expect(subject({ html: null })).toMatch(/required/);
-    });
   });
 
   describe('.requiredHtmlTextOrAmp', () => {
@@ -167,6 +126,10 @@ describe('ContentEditor', () => {
 
     it('returns required validation message with whitespace', () => {
       expect(subject({ html: '     ' })).toMatch(/required/);
+    });
+
+    it('returns required validation message with null', () => {
+      expect(subject({ html: null })).toMatch(/required/);
     });
   });
 

--- a/src/components/contentEditor/__snapshots__/ContentEditor.test.js.snap
+++ b/src/components/contentEditor/__snapshots__/ContentEditor.test.js.snap
@@ -19,6 +19,10 @@ exports[`ContentEditor should render 1`] = `
           "onClick": [Function],
         },
         Object {
+          "content": "AMP HTML",
+          "onClick": [Function],
+        },
+        Object {
           "content": "Test Data",
           "onClick": [Function],
         },
@@ -61,6 +65,10 @@ exports[`ContentEditor should render without test data tab 1`] = `
         },
         Object {
           "content": "Text",
+          "onClick": [Function],
+        },
+        Object {
+          "content": "AMP HTML",
           "onClick": [Function],
         },
       ]

--- a/src/pages/snippets/CreatePage.container.js
+++ b/src/pages/snippets/CreatePage.container.js
@@ -3,7 +3,6 @@ import { reduxForm } from 'redux-form';
 import { clearSnippet, createSnippet, getSnippet } from 'src/actions/snippets';
 import assignedTo from 'src/helpers/assignedTo';
 import { duplicate } from 'src/helpers/snippets';
-import { hasUiOption } from 'src/helpers/conditions/account';
 import { hasSubaccounts, selectSubaccountFromId } from 'src/selectors/subaccounts';
 import CreatePage from './CreatePage';
 
@@ -36,8 +35,7 @@ export const mapStateToProps = (state, props) => {
       snippetToDuplicate: {
         id,
         subaccountId
-      },
-      isAmpLive: hasUiOption('amp_html')(state)
+      }
     };
   }
 
@@ -45,8 +43,7 @@ export const mapStateToProps = (state, props) => {
     hasSubaccounts: hasSubaccounts(state),
     initialValues: {
       assignTo: 'master'
-    },
-    isAmpLive: hasUiOption('amp_html')(state)
+    }
   };
 };
 

--- a/src/pages/snippets/CreatePage.js
+++ b/src/pages/snippets/CreatePage.js
@@ -37,7 +37,7 @@ export default class CreatePage extends React.Component {
   }) => {
     // must handle when subaccount is set to null by SubaccountSection
     const subaccountId = subaccount ? subaccount.id : undefined;
-    const { createSnippet, history, isAmpLive } = this.props;
+    const { createSnippet, history } = this.props;
 
     return createSnippet({
       html,
@@ -46,14 +46,14 @@ export default class CreatePage extends React.Component {
       sharedWithSubaccounts: assignTo === 'shared',
       subaccountId,
       text,
-      amp_html: isAmpLive ? amp_html : undefined
+      amp_html
     }).then(() => {
       history.push(`/snippets/edit/${id}${setSubaccountQuery(subaccountId)}`);
     });
   }
 
   render() {
-    const { snippetToDuplicate, handleSubmit, hasSubaccounts, loading, submitting, isAmpLive } = this.props;
+    const { snippetToDuplicate, handleSubmit, hasSubaccounts, loading, submitting } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -95,7 +95,7 @@ export default class CreatePage extends React.Component {
               </Panel>
             </Grid.Column>
             <Grid.Column xs={12} lg={8}>
-              <ContentEditor contentOnly={true} isAmpLive={isAmpLive} />
+              <ContentEditor contentOnly={true} />
             </Grid.Column>
           </Grid>
         </Form>

--- a/src/pages/snippets/EditPage.container.js
+++ b/src/pages/snippets/EditPage.container.js
@@ -4,7 +4,6 @@ import qs from 'query-string';
 import { showAlert } from 'src/actions/globalAlert';
 import { clearSnippet, getSnippet, updateSnippet } from 'src/actions/snippets';
 import { hasGrants } from 'src/helpers/conditions';
-import { hasUiOption } from 'src/helpers/conditions/account';
 import { hasSubaccounts, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 import EditPage from './EditPage';
 
@@ -35,8 +34,7 @@ const mapStateToProps = (state, props) => {
       ...state.snippets.item,
       subaccount_id: subaccountId, // remove once provided by state
       subaccount: selectSubaccountFromQuery(state, props) // for SubaccountSection
-    },
-    isAmpLive: hasUiOption('amp_html')(state)
+    }
   };
 };
 

--- a/src/pages/snippets/EditPage.js
+++ b/src/pages/snippets/EditPage.js
@@ -54,7 +54,7 @@ export default class EditPage extends React.Component {
   }) => {
     // must handle when subaccount is set to null by SubaccountSection
     const subaccountId = subaccount ? subaccount.id : undefined;
-    const { updateSnippet, showAlert, isAmpLive } = this.props;
+    const { updateSnippet, showAlert } = this.props;
 
     return updateSnippet({
       html,
@@ -63,7 +63,7 @@ export default class EditPage extends React.Component {
       sharedWithSubaccounts,
       subaccountId,
       text,
-      amp_html: isAmpLive ? amp_html : undefined
+      amp_html
     }).then(() => showAlert({ type: 'success', message: 'Snippet saved' }));
   }
 
@@ -75,8 +75,7 @@ export default class EditPage extends React.Component {
       hasSubaccounts,
       id,
       loading,
-      submitting,
-      isAmpLive
+      submitting
     } = this.props;
     const disabled = !canModify || submitting;
 
@@ -140,7 +139,7 @@ export default class EditPage extends React.Component {
               </Panel>
             </Grid.Column>
             <Grid.Column xs={12} lg={8}>
-              <ContentEditor contentOnly={true} readOnly={disabled} isAmpLive={isAmpLive} />
+              <ContentEditor contentOnly={true} readOnly={disabled} />
             </Grid.Column>
           </Grid>
         </Form>

--- a/src/pages/snippets/tests/CreatePage.test.js
+++ b/src/pages/snippets/tests/CreatePage.test.js
@@ -62,7 +62,7 @@ describe('CreatePage', () => {
     cases('succeeds', ({ name, ...values }) => {
       const createSnippet = jest.fn(() => Promise.resolve());
       const historyPush = jest.fn();
-      const wrapper = subject({ createSnippet, history: { push: historyPush }, isAmpLive: !!values.content.amp_html });
+      const wrapper = subject({ createSnippet, history: { push: historyPush }});
 
       wrapper.prop('primaryAction').onClick({
         ...values,

--- a/src/pages/snippets/tests/EditPage.test.js
+++ b/src/pages/snippets/tests/EditPage.test.js
@@ -18,10 +18,6 @@ describe('EditPage', () => {
     expect(subject()).toMatchSnapshot();
   });
 
-  it('renders edit form with AMP enabled', () => {
-    expect(subject({ isAmpLive: true }).find('LoadableComponent').props().isAmpLive).toEqual(true);
-  });
-
   it('redirects with alert when load request fails', () => {
     const wrapper = subject({ loadingError: new Error('Oh no!') });
     expect(wrapper).toMatchSnapshot();

--- a/src/pages/templates/CreatePage.js
+++ b/src/pages/templates/CreatePage.js
@@ -25,7 +25,7 @@ export default class CreatePage extends Component {
   }
 
   render() {
-    const { cloneId, handleSubmit, submitting, loading, formName, subaccountId, isAmpLive } = this.props;
+    const { cloneId, handleSubmit, submitting, loading, formName, subaccountId } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -54,7 +54,7 @@ export default class CreatePage extends Component {
             <Form newTemplate name={formName} subaccountId={subaccountId}/>
           </Grid.Column>
           <Grid.Column xs={12} lg={8}>
-            <ContentEditor action={<ImportSnippetLink />} isAmpLive={isAmpLive} />
+            <ContentEditor action={<ImportSnippetLink />} />
           </Grid.Column>
         </Grid>
       </Page>

--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -118,7 +118,7 @@ export default class EditPage extends Component {
   }
 
   render() {
-    const { canModify, loading, formName, subaccountId, template, isAmpLive } = this.props;
+    const { canModify, loading, formName, subaccountId, template } = this.props;
 
     if (loading || _.isEmpty(template)) {
       return <Loading />;
@@ -131,7 +131,7 @@ export default class EditPage extends Component {
             <Form name={formName} subaccountId={subaccountId} readOnly={!canModify} />
           </Grid.Column>
           <Grid.Column xs={12} lg={8}>
-            <ContentEditor readOnly={!canModify} action={canModify && <ImportSnippetLink />} isAmpLive={isAmpLive} />
+            <ContentEditor readOnly={!canModify} action={canModify && <ImportSnippetLink />} />
           </Grid.Column>
         </Grid>
         <DeleteModal

--- a/src/pages/templates/PreviewPage.js
+++ b/src/pages/templates/PreviewPage.js
@@ -72,7 +72,7 @@ export default class PreviewPage extends Component {
   }
 
   render() {
-    const { canSendEmail, mode, preview, returnPath, template, isAmpLive } = this.props;
+    const { canSendEmail, mode, preview, returnPath, template } = this.props;
     const { loading, loadingError, sending, to, validationError } = this.state;
 
     if (loading) {
@@ -117,7 +117,7 @@ export default class PreviewPage extends Component {
           }
           <TextField disabled label="From" value={name ? `${name} <${email}>` : email} />
           <TextField disabled label="Subject" value={preview.subject} />
-          <PreviewPanel html={preview.html} text={preview.text} amp_html={preview.amp_html} isAmpLive={isAmpLive} />
+          <PreviewPanel html={preview.html} text={preview.text} amp_html={preview.amp_html} />
         </Panel>
       </Page>
     );

--- a/src/pages/templates/PreviewPage.js
+++ b/src/pages/templates/PreviewPage.js
@@ -117,7 +117,7 @@ export default class PreviewPage extends Component {
           }
           <TextField disabled label="From" value={name ? `${name} <${email}>` : email} />
           <TextField disabled label="Subject" value={preview.subject} />
-          <PreviewPanel html={preview.html} text={preview.text} amp_html={preview.amp_html} />
+          <PreviewPanel html={preview.html} text={preview.text} />
         </Panel>
       </Page>
     );

--- a/src/pages/templates/PublishedPage.js
+++ b/src/pages/templates/PublishedPage.js
@@ -57,7 +57,7 @@ export default class PublishedPage extends Component {
   }
 
   render() {
-    const { loading, formName, subaccountId, isAmpLive } = this.props;
+    const { loading, formName, subaccountId } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -70,7 +70,7 @@ export default class PublishedPage extends Component {
             <Form name={formName} subaccountId={subaccountId} readOnly />
           </Grid.Column>
           <Grid.Column xs={12} lg={8}>
-            <ContentEditor readOnly isAmpLive={isAmpLive}/>
+            <ContentEditor readOnly />
           </Grid.Column>
         </Grid>
       </Page>

--- a/src/pages/templates/components/PreviewPanel.js
+++ b/src/pages/templates/components/PreviewPanel.js
@@ -28,15 +28,11 @@ export default class PreviewPanel extends Component {
   }
 
   render() {
-    const { isAmpLive } = this.props;
     const tabs = [
       { content: 'HTML', onClick: this.onChange },
-      { content: 'Text', onClick: this.onChange }
+      { content: 'Text', onClick: this.onChange },
+      { content: 'AMP HTML', onClick: this.onChange }
     ];
-
-    if (isAmpLive) {
-      tabs.push({ content: 'AMP HTML', onClick: this.onChange });
-    }
 
     const selectedTabIndex = tabs.findIndex(({ content }) => content === this.state.contentType);
     const contentType = this.state.contentType.toLowerCase().replace(' ', '_');

--- a/src/pages/templates/components/PreviewPanel.js
+++ b/src/pages/templates/components/PreviewPanel.js
@@ -9,14 +9,12 @@ import styles from './PreviewPanel.module.scss';
 export default class PreviewPanel extends Component {
   static defaultProps = {
     html: '',
-    text: '',
-    amp_html: ''
+    text: ''
   }
 
   static propTypes = {
     html: PropTypes.string,
-    text: PropTypes.string,
-    amp_html: PropTypes.string
+    text: PropTypes.string
   }
 
   state = {
@@ -30,8 +28,7 @@ export default class PreviewPanel extends Component {
   render() {
     const tabs = [
       { content: 'HTML', onClick: this.onChange },
-      { content: 'Text', onClick: this.onChange },
-      { content: 'AMP HTML', onClick: this.onChange }
+      { content: 'Text', onClick: this.onChange }
     ];
 
     const selectedTabIndex = tabs.findIndex(({ content }) => content === this.state.contentType);

--- a/src/pages/templates/components/tests/PreviewPanel.test.js
+++ b/src/pages/templates/components/tests/PreviewPanel.test.js
@@ -22,27 +22,23 @@ it('renders HTML by default', () => {
 it('renders text on tab click', () => {
   const wrapper = shallow(<PreviewPanel {...props} />);
 
-  // @todo should be able to .find() the Text tab then .simulate('click')
-  wrapper.instance().onChange({
-    currentTarget: {
-      text: 'Text'
-    }
-  });
-  wrapper.update();
+  wrapper
+    .find('Tabs')
+    .prop('tabs')
+    .find(({ content }) => content === 'Text')
+    .onClick({ currentTarget: { text: 'Text' }});
 
   expect(wrapper).toMatchSnapshot();
 });
 
 it('renders AMP HTML on tab click', () => {
-  const wrapper = shallow(<PreviewPanel {...props} isAmpLive={true} />);
+  const wrapper = shallow(<PreviewPanel {...props} />);
 
-  // @todo should be able to .find() the AMP HTML tab then .simulate('click')
-  wrapper.instance().onChange({
-    currentTarget: {
-      text: 'AMP HTML'
-    }
-  });
-  wrapper.update();
+  wrapper
+    .find('Tabs')
+    .prop('tabs')
+    .find(({ content }) => content === 'AMP HTML')
+    .onClick({ currentTarget: { text: 'AMP HTML' }});
 
   expect(wrapper).toMatchSnapshot();
 });

--- a/src/pages/templates/components/tests/PreviewPanel.test.js
+++ b/src/pages/templates/components/tests/PreviewPanel.test.js
@@ -5,8 +5,7 @@ import PreviewPanel from '../PreviewPanel';
 
 const props = {
   html: '<h1>Test Template</h1>',
-  text: 'Test Template',
-  amp_html: '<h2>Test Template</h2>'
+  text: 'Test Template'
 };
 
 it('renders blank panel', () => {
@@ -27,18 +26,6 @@ it('renders text on tab click', () => {
     .prop('tabs')
     .find(({ content }) => content === 'Text')
     .onClick({ currentTarget: { text: 'Text' }});
-
-  expect(wrapper).toMatchSnapshot();
-});
-
-it('renders AMP HTML on tab click', () => {
-  const wrapper = shallow(<PreviewPanel {...props} />);
-
-  wrapper
-    .find('Tabs')
-    .prop('tabs')
-    .find(({ content }) => content === 'AMP HTML')
-    .onClick({ currentTarget: { text: 'AMP HTML' }});
 
   expect(wrapper).toMatchSnapshot();
 });

--- a/src/pages/templates/components/tests/__snapshots__/PreviewPanel.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewPanel.test.js.snap
@@ -1,41 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders AMP HTML on tab click 1`] = `
-<div
-  className="PreviewPanel notranslate"
->
-  <Tabs
-    color="orange"
-    connectBelow={true}
-    selected={2}
-    tabs={
-      Array [
-        Object {
-          "content": "HTML",
-          "onClick": [Function],
-        },
-        Object {
-          "content": "Text",
-          "onClick": [Function],
-        },
-        Object {
-          "content": "AMP HTML",
-          "onClick": [Function],
-        },
-      ]
-    }
-  />
-  <div
-    className="PreviewPanelWrapper"
-  >
-    <PreviewFrame
-      content="<h2>Test Template</h2>"
-      key="amp_html"
-    />
-  </div>
-</div>
-`;
-
 exports[`renders HTML by default 1`] = `
 <div
   className="PreviewPanel notranslate"
@@ -52,10 +16,6 @@ exports[`renders HTML by default 1`] = `
         },
         Object {
           "content": "Text",
-          "onClick": [Function],
-        },
-        Object {
-          "content": "AMP HTML",
           "onClick": [Function],
         },
       ]
@@ -90,10 +50,6 @@ exports[`renders blank panel 1`] = `
           "content": "Text",
           "onClick": [Function],
         },
-        Object {
-          "content": "AMP HTML",
-          "onClick": [Function],
-        },
       ]
     }
   />
@@ -124,10 +80,6 @@ exports[`renders text on tab click 1`] = `
         },
         Object {
           "content": "Text",
-          "onClick": [Function],
-        },
-        Object {
-          "content": "AMP HTML",
           "onClick": [Function],
         },
       ]

--- a/src/pages/templates/components/tests/__snapshots__/PreviewPanel.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewPanel.test.js.snap
@@ -54,6 +54,10 @@ exports[`renders HTML by default 1`] = `
           "content": "Text",
           "onClick": [Function],
         },
+        Object {
+          "content": "AMP HTML",
+          "onClick": [Function],
+        },
       ]
     }
   />
@@ -86,6 +90,10 @@ exports[`renders blank panel 1`] = `
           "content": "Text",
           "onClick": [Function],
         },
+        Object {
+          "content": "AMP HTML",
+          "onClick": [Function],
+        },
       ]
     }
   />
@@ -116,6 +124,10 @@ exports[`renders text on tab click 1`] = `
         },
         Object {
           "content": "Text",
+          "onClick": [Function],
+        },
+        Object {
+          "content": "AMP HTML",
           "onClick": [Function],
         },
       ]

--- a/src/pages/templates/containers/CreatePage.container.js
+++ b/src/pages/templates/containers/CreatePage.container.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { reduxForm, formValueSelector } from 'redux-form';
-import { hasUiOption } from 'src/helpers/conditions/account';
 import _ from 'lodash';
 
 // Actions
@@ -27,8 +26,7 @@ const mapStateToProps = (state, props) => ({
     assignTo: 'master',
     testData: selectDefaultTestData(),
     ...selectClonedTemplate(state, props)
-  },
-  isAmpLive: hasUiOption('amp_html')(state)
+  }
 });
 
 const formOptions = {

--- a/src/pages/templates/containers/EditPage.container.js
+++ b/src/pages/templates/containers/EditPage.container.js
@@ -5,7 +5,6 @@ import { reduxForm } from 'redux-form';
 import { getDraft, update, deleteTemplate, publish, getTestData, setTestData } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 import { hasGrants } from 'src/helpers/conditions';
-import { hasUiOption } from 'src/helpers/conditions/account';
 import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, hasSubaccounts, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 
@@ -31,8 +30,7 @@ const mapStateToProps = (state, props) => {
       testData: selectTemplateTestData(state),
       ...template,
       subaccount: selectSubaccountFromQuery(state, props)
-    },
-    isAmpLive: hasUiOption('amp_html')(state)
+    }
   };
 };
 

--- a/src/pages/templates/containers/PreviewDraftPage.container.js
+++ b/src/pages/templates/containers/PreviewDraftPage.container.js
@@ -7,7 +7,6 @@ import { selectDraftTemplate, selectDraftTemplatePreview } from 'src/selectors/t
 import { selectSubaccountIdFromQuery } from 'src/selectors/subaccounts';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { hasGrants } from 'src/helpers/conditions';
-import { hasUiOption } from 'src/helpers/conditions/account';
 import PreviewPage from '../PreviewPage';
 
 export const mapStateToProps = (state, props) => {
@@ -19,8 +18,7 @@ export const mapStateToProps = (state, props) => {
     returnPath: `/templates/edit/${props.match.params.id}${setSubaccountQuery(subaccountId)}`,
     preview: selectDraftTemplatePreview(state, props.match.params.id),
     template: selectDraftTemplate(state, props.match.params.id),
-    subaccountId,
-    isAmpLive: hasUiOption('amp_html')(state)
+    subaccountId
   };
 };
 

--- a/src/pages/templates/containers/PreviewPublishedPage.container.js
+++ b/src/pages/templates/containers/PreviewPublishedPage.container.js
@@ -7,7 +7,6 @@ import { selectPublishedTemplate, selectPublishedTemplatePreview } from 'src/sel
 import { selectSubaccountIdFromQuery } from 'src/selectors/subaccounts';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { hasGrants } from 'src/helpers/conditions';
-import { hasUiOption } from 'src/helpers/conditions/account';
 import PreviewPage from '../PreviewPage';
 
 export const mapStateToProps = (state, props) => {
@@ -19,8 +18,7 @@ export const mapStateToProps = (state, props) => {
     returnPath: `/templates/edit/${props.match.params.id}/published${setSubaccountQuery(subaccountId)}`,
     preview: selectPublishedTemplatePreview(state, props.match.params.id),
     template: selectPublishedTemplate(state, props.match.params.id),
-    subaccountId,
-    isAmpLive: hasUiOption('amp_html')(state)
+    subaccountId
   };
 };
 

--- a/src/pages/templates/containers/PublishedPage.container.js
+++ b/src/pages/templates/containers/PublishedPage.container.js
@@ -4,7 +4,6 @@ import { reduxForm } from 'redux-form';
 
 import { getPublished, getTestData, setTestData } from 'src/actions/templates';
 import { hasGrants } from 'src/helpers/conditions';
-import { hasUiOption } from 'src/helpers/conditions/account';
 import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
@@ -29,8 +28,7 @@ const mapStateToProps = (state, props) => {
       testData: selectTemplateTestData(state),
       ...template,
       subaccount: selectSubaccountFromQuery(state, props)
-    },
-    isAmpLive: hasUiOption('amp_html')(state)
+    }
   };
 };
 

--- a/src/pages/templates/tests/PreviewPage.test.js
+++ b/src/pages/templates/tests/PreviewPage.test.js
@@ -41,11 +41,6 @@ it('renders preview page with template', async () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-it('renders preview page with template and AMP enabled', async () => {
-  const wrapper = await loadPreviewPage({ isAmpLive: true });
-  expect(wrapper).toMatchSnapshot();
-});
-
 it('renders preview page with read-only template', async () => {
   const wrapper = await loadPreviewPage({ canSendEmail: false });
   expect(wrapper).toMatchSnapshot();

--- a/src/pages/templates/tests/PreviewPage.test.js
+++ b/src/pages/templates/tests/PreviewPage.test.js
@@ -15,8 +15,7 @@ const loadPreviewPage = async (overrides = {}) => {
       from: { email: 'test@example.com' },
       subject: 'Test Template',
       html: '<h1>Test Template</h1>',
-      text: 'Test Template',
-      amp_html: '<h2>Test Template</h2>'
+      text: 'Test Template'
     },
     returnPath: '/path/to/return',
     template: {

--- a/src/pages/templates/tests/PublishedPage.test.js
+++ b/src/pages/templates/tests/PublishedPage.test.js
@@ -29,11 +29,6 @@ describe('Template PublishedPage', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render correctly with AMP enabled', () => {
-    wrapper = shallow(<PublishedPage {...props} isAmpLive={true} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('should render read-only correctly', () => {
     wrapper = shallow(<PublishedPage {...props} canModify={false} />);
     expect(wrapper).toMatchSnapshot();

--- a/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
@@ -163,61 +163,6 @@ exports[`renders preview page with template 1`] = `
 </Page>
 `;
 
-exports[`renders preview page with template and AMP enabled 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "Back To Template",
-      "to": "/path/to/return",
-    }
-  }
-  empty={Object {}}
-  primaryAction={
-    Object {
-      "content": "Send Email",
-      "disabled": false,
-      "onClick": [Function],
-    }
-  }
-  title="Test Template (Draft)"
->
-  <Panel
-    sectioned={true}
-  >
-    <TextField
-      disabled={false}
-      label="To"
-      onChange={[Function]}
-      placeholder="Send to recipient email addresses"
-      resize="both"
-      type="text"
-      value=""
-    />
-    <TextField
-      disabled={true}
-      label="From"
-      resize="both"
-      type="text"
-      value="test@example.com"
-    />
-    <TextField
-      disabled={true}
-      label="Subject"
-      resize="both"
-      type="text"
-      value="Test Template"
-    />
-    <PreviewPanel
-      amp_html="<h2>Test Template</h2>"
-      html="<h1>Test Template</h1>"
-      isAmpLive={true}
-      text="Test Template"
-    />
-  </Panel>
-</Page>
-`;
-
 exports[`resets error message when user starts typing again 1`] = `
 <Page
   breadcrumbAction={

--- a/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
@@ -61,7 +61,6 @@ exports[`renders loading error 1`] = `
       value="Test Template"
     />
     <PreviewPanel
-      amp_html="<h2>Test Template</h2>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />
@@ -101,7 +100,6 @@ exports[`renders preview page with read-only template 1`] = `
       value="Test Template"
     />
     <PreviewPanel
-      amp_html="<h2>Test Template</h2>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />
@@ -155,7 +153,6 @@ exports[`renders preview page with template 1`] = `
       value="Test Template"
     />
     <PreviewPanel
-      amp_html="<h2>Test Template</h2>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />
@@ -209,7 +206,6 @@ exports[`resets error message when user starts typing again 1`] = `
       value="Test Template"
     />
     <PreviewPanel
-      amp_html="<h2>Test Template</h2>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />

--- a/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PublishedPage.test.js.snap
@@ -47,54 +47,6 @@ exports[`Template PublishedPage should render correctly 1`] = `
 </Page>
 `;
 
-exports[`Template PublishedPage should render correctly with AMP enabled 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "component": [Function],
-      "content": "Templates",
-      "to": "/templates",
-    }
-  }
-  empty={Object {}}
-  secondaryActions={
-    Array [
-      Object {
-        "component": [Function],
-        "content": "Edit Draft",
-        "to": "/templates/edit/id",
-      },
-      Object {
-        "content": "Preview & Send",
-        "onClick": undefined,
-      },
-    ]
-  }
-  title="id (Published)"
->
-  <Grid>
-    <Grid.Column
-      lg={4}
-      xs={12}
-    >
-      <Connect(Form)
-        name="templatePublished"
-        readOnly={true}
-      />
-    </Grid.Column>
-    <Grid.Column
-      lg={8}
-      xs={12}
-    >
-      <LoadableComponent
-        isAmpLive={true}
-        readOnly={true}
-      />
-    </Grid.Column>
-  </Grid>
-</Page>
-`;
-
 exports[`Template PublishedPage should render read-only correctly 1`] = `
 <Page
   breadcrumbAction={


### PR DESCRIPTION
_Refer to [TR-1124](https://jira.int.messagesystems.com/browse/TR-1124) for more details._

### What Changed

- Removed "amp_html" feature toggles for snippets and templates
 
![Screen Shot 2019-03-25 at 11 04 10 AM](https://user-images.githubusercontent.com/1335605/54930564-dccaba80-4eed-11e9-9f36-638392694f79.png)

### How To Test
- Confirm with any account a user can perform management tasks for templates and snippets (e.g. create, edit, clone, etc.)
- Confirm content validation works for both templates and snippet
- Confirm there is no "AMP HTML" preview tab

### To Do
- [ x ] ~Confirm AMP preview works with amp specific tags, specifically scripts~ (removed tab for now, will implement with follow-up ticket)
- [ x ] Provide info above for "What Changed" and "How to Test"
