### PR TITLE
EO-646 Fix Health score component tooltip labels

### DIFF
--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -126,7 +126,10 @@ export class HealthScorePage extends Component {
                       selected={selectedDate}
                       timeSeries={dataForSelectedWeight}
                       tooltipContent={({ payload = {}}) => (
-                        <TooltipMetric label={selectedComponent} value={`${roundToPlaces(payload.weight_value * 100, 4)}%`} />
+                        <TooltipMetric
+                          label={HEALTH_SCORE_COMPONENTS[selectedComponent].label}
+                          value={`${roundToPlaces(payload.weight_value * 100, 4)}%`}
+                        />
                       )}
                       yKey='weight_value'
                       yAxisProps={{

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -10,7 +10,7 @@ describe('Signals Health Score Page', () => {
       date: '2017-01-01',
       weights: [
         { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
-        { weight_type: 'Complaints', weight: -0.5, weight_value: 0.25 }
+        { weight_type: 'eng cohorts: new, 14-day', weight: -0.5, weight_value: 0.25 }
       ]
     },
     {
@@ -64,8 +64,8 @@ describe('Signals Health Score Page', () => {
 
   describe('local state', () => {
     it('handles component select', () => {
-      wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'Complaints' }});
-      expect(wrapper.find('DivergingBar').at(0).prop('selected')).toEqual('Complaints');
+      wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'eng cohorts: new, 14-day' }});
+      expect(wrapper.find('DivergingBar').at(0).prop('selected')).toEqual('eng cohorts: new, 14-day');
     });
 
     it('uses first component weight with an existing date and new data', () => {
@@ -90,7 +90,7 @@ describe('Signals Health Score Page', () => {
     });
 
     it('renders tooltip content for selected component', () => {
-      wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'Complaints' }});
+      wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'eng cohorts: new, 14-day' }});
       const Tooltip = wrapper.find('BarChart').at(2).prop('tooltipContent');
       expect(shallow(<Tooltip payload={{ weight_value: 0.0012345 }} />)).toMatchSnapshot();
     });

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -30,7 +30,7 @@ exports[`Signals Health Score Page bar chart props renders tooltip content for i
 
 exports[`Signals Health Score Page bar chart props renders tooltip content for selected component 1`] = `
 <TooltipMetric
-  label="Complaints"
+  label="Engaged Recipients"
   value="0.1235%"
 />
 `;
@@ -93,7 +93,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
                   },
                   Object {
                     "weight": -0.5,
-                    "weight_type": "Complaints",
+                    "weight_type": "eng cohorts: new, 14-day",
                     "weight_value": 0.25,
                   },
                 ],
@@ -169,7 +169,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
                   },
                   Object {
                     "weight": -0.5,
-                    "weight_type": "Complaints",
+                    "weight_type": "eng cohorts: new, 14-day",
                     "weight_value": 0.25,
                   },
                 ],
@@ -296,7 +296,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
               },
               Object {
                 "weight": -0.5,
-                "weight_type": "Complaints",
+                "weight_type": "eng cohorts: new, 14-day",
                 "weight_value": 0.25,
               },
             ]
@@ -328,7 +328,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
               },
               Object {
                 "weight": -0.5,
-                "weight_type": "Complaints",
+                "weight_type": "eng cohorts: new, 14-day",
                 "weight_value": 0.25,
               },
             ]


### PR DESCRIPTION
### What Changed
- Tooltip label for the third bar chart in the health score details page now references its friendly label.

### How To Test
- [Point your local upstreams to staging](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams).
- Go to a health score details page
- Select one of the engagement weights on the right
- Hover over the third bar chart

### To Do
- [x] Address feedback
