### PR TITLE
EO-650 Remove sending domain typeahead

### DIFF
--- a/src/pages/alerts-new/components/AlertForm.js
+++ b/src/pages/alerts-new/components/AlertForm.js
@@ -8,18 +8,17 @@ import { Panel, Grid, Button } from '@sparkpost/matchbox';
 import { withRouter } from 'react-router-dom';
 import ToggleBlock from 'src/components/toggleBlock/ToggleBlock';
 import { TextFieldWrapper, SelectWrapper, RadioGroup, SubaccountTypeaheadWrapper } from 'src/components';
-import { formatEditValues, selectDomainsBySubaccount, selectIpPools } from 'src/selectors/alerts';
+import { formatEditValues, selectIpPools } from 'src/selectors/alerts';
 import getOptions from '../helpers/getOptions';
 import { METRICS } from '../constants/metrics';
 import { FACETS } from '../constants/facets';
 import { COMPARATOR } from '../constants/comparator';
 import { defaultFormValues } from '../constants/defaultFormValues';
-import { list as listDomains } from 'src/actions/sendingDomains';
 import { listPools } from 'src/actions/ipPools';
 import MultiFacetWrapper from './MultiFacetWrapper';
 
 // Helpers & Validation
-import { required, integer, minNumber, maxLength, numberBetween } from 'src/helpers/validation';
+import { domain, required, integer, minNumber, maxLength, numberBetween } from 'src/helpers/validation';
 import validateEmailList from '../helpers/validateEmailList';
 
 const formName = 'alertForm';
@@ -33,7 +32,6 @@ const accountOptions = [
 export class AlertForm extends Component {
 
   componentDidMount() {
-    this.props.listDomains();
     this.props.listPools();
   }
 
@@ -47,15 +45,14 @@ export class AlertForm extends Component {
 
   validateFacet = (value, allValues) => {
     const { facet_name } = allValues;
-    const { domains, ipPools } = this.props;
+    const { ipPools } = this.props;
 
     if (facet_name === 'ALL') {
       return undefined;
     }
 
     if (facet_name === 'sending_domain' && value && value !== '') {
-      const domainsArray = domains.map(({ domain }) => domain) || [];
-      return domainsArray.includes(value) ? undefined : 'This is not a valid sending domain for this account';
+      return domain(value);
     }
 
     if (facet_name === 'ip_pool' && value && value !== '') {
@@ -75,9 +72,6 @@ export class AlertForm extends Component {
       facet_name,
       handleSubmit,
       newAlert,
-      subaccount,
-      domains = [],
-      domainsLoading,
       ipPools = [],
       ipPoolsLoading
     } = this.props;
@@ -105,12 +99,6 @@ export class AlertForm extends Component {
     };
 
     const multiFacetWarning = () => {
-      if (facet_name === 'sending_domain' && !domainsLoading && !domains.length) {
-        return (assignTo === 'subaccount' && subaccount)
-          ? 'The selected subaccount does not have any verified sending domains.'
-          : 'You do not have any verified sending domains to use.';
-      }
-
       if (facet_name === 'ip_pool' && !ipPoolsLoading && !ipPools.length) {
         return 'You do not have any ip pools to use.';
       }
@@ -169,8 +157,8 @@ export class AlertForm extends Component {
                         validate={required}
                       />
                     }
-                    component={(facet_name === 'sending_domain' || facet_name === 'ip_pool') ? MultiFacetWrapper : TextFieldWrapper}
-                    items={(facet_name === 'sending_domain') ? domains : ipPools}
+                    component={facet_name === 'ip_pool' ? MultiFacetWrapper : TextFieldWrapper}
+                    items={(facet_name === 'ip_pool') ? ipPools : null}
                     disabled={submitting || checkFacet()}
                     placeholder={facet_name === 'ALL' ? 'No facet selected' : facet_name === 'sending_domain' ? 'mail.example.com' : ''}
                     validate={this.validateFacet}
@@ -244,8 +232,6 @@ const mapStateToProps = (state, props) => {
   const selector = formValueSelector(formName);
 
   return {
-    domains: selectDomainsBySubaccount(state, formName),
-    domainsLoading: state.sendingDomains.listLoading,
     ipPools: selectIpPools(state, formName),
     ipPoolsLoading: state.ipPools.listLoading,
     alert_metric: selector(state, 'alert_metric'),
@@ -263,4 +249,4 @@ const formOptions = {
   enableReinitialize: true
 };
 
-export default withRouter(connect(mapStateToProps, { listDomains, listPools })(reduxForm(formOptions)(AlertForm)));
+export default withRouter(connect(mapStateToProps, { listPools })(reduxForm(formOptions)(AlertForm)));

--- a/src/pages/alerts-new/components/AlertForm.js
+++ b/src/pages/alerts-new/components/AlertForm.js
@@ -238,7 +238,6 @@ const mapStateToProps = (state, props) => {
     facet_name: selector(state, 'facet_name'),
     facet_value: selector(state, 'facet_value'),
     assignTo: selector(state, 'assignTo'),
-    subaccount: selector(state, 'subaccount'),
     enabled: selector(state, 'enabled'),
     initialValues: props.newAlert ? defaultFormValues : formatEditValues(state, state.alerts.alert)
   };

--- a/src/pages/alerts-new/components/tests/AlertForm.test.js
+++ b/src/pages/alerts-new/components/tests/AlertForm.test.js
@@ -20,12 +20,10 @@ describe('Alert Form Component', () => {
           target: 50
         }
       },
-      domains: [{ domain: 'someDomain.com' }, { domain: 'someOtherDomain.com' }],
       ipPools: [{ id: 'someIpPool' }, { id: 'someOtherIpPool' }],
       alert_metric: 'signals_health_threshold',
       facet_name: 'sending_domain',
       enabled: true,
-      listDomains: jest.fn(),
       listPools: jest.fn(),
       change: (a, b) => b
     };
@@ -60,14 +58,19 @@ describe('Alert Form Component', () => {
       expect(wrapper.find({ name: 'facet_value' }).props().connectLeft.props.name).toEqual('facet_name');
     });
 
-    it('should show sending domain facets typeahead component with correct props when facet_name is set to sending_domain', () => {
+    it('should show sending domain facets textfield component with correct props when facet_name is set to sending_domain', () => {
       wrapper.setProps({ alert_metric: 'signals_health_threshold', assignTo: 'all', facet_name: 'sending_domain', facet_value: 'blah' });
-      expect(wrapper.find({ name: 'facet_value' }).props()).toMatchSnapshot();
+      const field = wrapper.find({ name: 'facet_value' });
+      expect(field.prop('component').name).toEqual('TextFieldWrapper');
+      expect(field.prop('items')).toEqual(null);
+      expect(field.prop('placeholder')).toEqual('mail.example.com');
     });
 
-    it('should show warning if no domains', () => {
-      wrapper.setProps({ alert_metric: 'signals_health_threshold', assignTo: 'all', facet_name: 'sending_domain', domains: []});
-      expect(wrapper.find({ name: 'facet_value' }).props()).toMatchSnapshot();
+    it('should validate domain', () => {
+      wrapper.setProps({ alert_metric: 'signals_health_threshold', assignTo: 'all', facet_name: 'sending_domain', facet_value: 'blah' });
+      const validate = wrapper.find({ name: 'facet_value' }).prop('validate');
+      expect(validate('foo', { facet_name: 'sending_domain' })).toEqual('Invalid Domain');
+      expect(validate('foo.co', { facet_name: 'sending_domain' })).toBe(undefined);
     });
 
     it('should show warning if no ip pools', () => {
@@ -77,6 +80,7 @@ describe('Alert Form Component', () => {
 
     it('should show ip pool facets typeahead component with correct props when facet_name is set to ip_pool', () => {
       wrapper.setProps({ alert_metric: 'signals_health_threshold', assignTo: 'all', facet_name: 'ip_pool', facet_value: 'blah' });
+      expect(wrapper.find({ name: 'facet_value' }).prop('component').name).toEqual('MultiFacetWrapper');
       expect(wrapper.find({ name: 'facet_value' }).props()).toMatchSnapshot();
     });
 

--- a/src/pages/alerts-new/components/tests/__snapshots__/AlertForm.test.js.snap
+++ b/src/pages/alerts-new/components/tests/__snapshots__/AlertForm.test.js.snap
@@ -109,16 +109,7 @@ exports[`Alert Form Component enabled prop should only show enabled toggle on ed
               }
               disabled={false}
               helpText={null}
-              items={
-                Array [
-                  Object {
-                    "domain": "someDomain.com",
-                  },
-                  Object {
-                    "domain": "someOtherDomain.com",
-                  },
-                ]
-              }
+              items={null}
               name="facet_value"
               placeholder="mail.example.com"
               validate={[Function]}
@@ -315,16 +306,7 @@ exports[`Alert Form Component enabled prop should only show enabled toggle on ed
               }
               disabled={false}
               helpText={null}
-              items={
-                Array [
-                  Object {
-                    "domain": "someDomain.com",
-                  },
-                  Object {
-                    "domain": "someOtherDomain.com",
-                  },
-                ]
-              }
+              items={null}
               name="facet_value"
               placeholder="mail.example.com"
               validate={[Function]}
@@ -544,16 +526,7 @@ exports[`Alert Form Component facet props should clear facet_value and validatio
               }
               disabled={true}
               helpText={null}
-              items={
-                Array [
-                  Object {
-                    "id": "someIpPool",
-                  },
-                  Object {
-                    "id": "someOtherIpPool",
-                  },
-                ]
-              }
+              items={null}
               name="facet_value"
               placeholder="No facet selected"
               validate={[Function]}
@@ -914,89 +887,6 @@ Object {
 }
 `;
 
-exports[`Alert Form Component facet props should show sending domain facets typeahead component with correct props when facet_name is set to sending_domain 1`] = `
-Object {
-  "component": [Function],
-  "connectLeft": <Field
-    component={[Function]}
-    disabled={false}
-    name="facet_name"
-    options={
-      Array [
-        Object {
-          "label": "None",
-          "value": "ALL",
-        },
-        Object {
-          "label": "Sending Domain",
-          "value": "sending_domain",
-        },
-        Object {
-          "label": "IP Pool",
-          "value": "ip_pool",
-        },
-        Object {
-          "label": "Campaign ID",
-          "value": "campaign_id",
-        },
-      ]
-    }
-    validate={[Function]}
-  />,
-  "disabled": false,
-  "helpText": null,
-  "items": Array [
-    Object {
-      "domain": "someDomain.com",
-    },
-    Object {
-      "domain": "someOtherDomain.com",
-    },
-  ],
-  "name": "facet_value",
-  "placeholder": "mail.example.com",
-  "validate": [Function],
-}
-`;
-
-exports[`Alert Form Component facet props should show warning if no domains 1`] = `
-Object {
-  "component": [Function],
-  "connectLeft": <Field
-    component={[Function]}
-    disabled={false}
-    name="facet_name"
-    options={
-      Array [
-        Object {
-          "label": "None",
-          "value": "ALL",
-        },
-        Object {
-          "label": "Sending Domain",
-          "value": "sending_domain",
-        },
-        Object {
-          "label": "IP Pool",
-          "value": "ip_pool",
-        },
-        Object {
-          "label": "Campaign ID",
-          "value": "campaign_id",
-        },
-      ]
-    }
-    validate={[Function]}
-  />,
-  "disabled": false,
-  "helpText": "You do not have any verified sending domains to use.",
-  "items": Array [],
-  "name": "facet_value",
-  "placeholder": "mail.example.com",
-  "validate": [Function],
-}
-`;
-
 exports[`Alert Form Component facet props should show warning if no ip pools 1`] = `
 Object {
   "component": [Function],
@@ -1151,16 +1041,7 @@ exports[`Alert Form Component should handle submit 1`] = `
               }
               disabled={false}
               helpText={null}
-              items={
-                Array [
-                  Object {
-                    "domain": "someDomain.com",
-                  },
-                  Object {
-                    "domain": "someOtherDomain.com",
-                  },
-                ]
-              }
+              items={null}
               name="facet_value"
               placeholder="mail.example.com"
               validate={[Function]}
@@ -1380,16 +1261,7 @@ exports[`Alert Form Component should render the alert form component correctly 1
               }
               disabled={false}
               helpText={null}
-              items={
-                Array [
-                  Object {
-                    "domain": "someDomain.com",
-                  },
-                  Object {
-                    "domain": "someOtherDomain.com",
-                  },
-                ]
-              }
+              items={null}
               name="facet_value"
               placeholder="mail.example.com"
               validate={[Function]}


### PR DESCRIPTION
### What Changed
- Removes the sending domain typeahead from the alerts form
- Adds a domain validator to the facet_value field

### How To Test
- Add the `feature_alerts` UI option to your account, or log into appteam
- Go to `/alerts-new/create`, or an alerts edit page
- Select a health score metric, and set facet name to 'Sending Domain'

### To Do
- [ ] Any outstanding tasks go here

