### PR TITLE
SD-732 default allow_default_signing_domains_for_ip_pools to true

### DIFF
--- a/scripts/generateConfigs/tenants/production.js
+++ b/scripts/generateConfigs/tenants/production.js
@@ -136,6 +136,9 @@ const productionTenants = {
     alias: 'ca',
     bounceDomains: {
       allowSubaccountDefault: false
+    },
+    featureFlags: {
+      allow_default_signing_domains_for_ip_pools: false
     }
   },
   capone: {

--- a/scripts/generateConfigs/tests/__snapshots__/index.func.test.js.snap
+++ b/scripts/generateConfigs/tests/__snapshots__/index.func.test.js.snap
@@ -697,7 +697,9 @@ Object {
       "allowSubaccountDefault": false,
       "cnameValue": "ca.mail.e.sparkpost.com",
     },
-    "featureFlags": Object {},
+    "featureFlags": Object {
+      "allow_default_signing_domains_for_ip_pools": false,
+    },
     "sentry": Object {
       "projectId": 237613,
       "publicKey": "014f9707c27b4e7ea90aff051a82e561",

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -45,7 +45,7 @@ const config = {
     }
   },
   featureFlags: {
-    allow_default_signing_domains_for_ip_pools: false,
+    allow_default_signing_domains_for_ip_pools: true,
     allow_mailbox_verification: true,
     allow_anyone_at_verification: false,
     has_signup: false

--- a/src/config/env/dev-config.js
+++ b/src/config/env/dev-config.js
@@ -17,7 +17,7 @@ export default {
     }
   },
   featureFlags: {
-    allow_default_signing_domains_for_ip_pools: false,
+    allow_default_signing_domains_for_ip_pools: true,
     allow_mailbox_verification: true,
     allow_anyone_at_verification: true,
     has_signup: true


### PR DESCRIPTION
SD-732: Enable IP Pool DKIM signing domain UI by default for all tenants except amex
Amex was migrated and no longer needs to avoid this restriction, so it can be true for amex. Creditag has not yet migrated and this option must be false for them. 