### PR TITLE
load pools data on creation on refresh

### DIFF
--- a/src/pages/ipPools/CreatePage.js
+++ b/src/pages/ipPools/CreatePage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { Page } from '@sparkpost/matchbox';
-import { Loading } from 'src/components';
+import { ApiErrorBanner, Loading } from 'src/components';
 import PoolForm from './components/PoolForm';
 
 import { showAlert } from 'src/actions/globalAlert';
@@ -37,9 +37,24 @@ export class CreatePage extends Component {
     });
   };
 
+  renderError() {
+    const { listError } = this.props;
+    return <ApiErrorBanner
+      errorDetails={listError.message}
+      message="Sorry, we seem to have had some trouble loading your IP pool."
+      reload={this.loadDependentData}
+    />;
+  }
+
   render() {
-    if (this.props.loading) {
+    const { loading, listError } = this.props;
+
+    if (loading) {
       return <Loading />;
+    }
+
+    if (listError) {
+      return this.renderError();
     }
 
     return (
@@ -50,7 +65,10 @@ export class CreatePage extends Component {
   }
 }
 
-const mapStateToProps = (state, props) => ({});
+const mapStateToProps = (state, props) => ({
+  listError: state.ipPools.listError,
+  loading: state.ipPools.listLoading
+});
 
 export default connect(mapStateToProps, {
   createPool,

--- a/src/pages/ipPools/CreatePage.js
+++ b/src/pages/ipPools/CreatePage.js
@@ -7,7 +7,7 @@ import { Loading } from 'src/components';
 import PoolForm from './components/PoolForm';
 
 import { showAlert } from 'src/actions/globalAlert';
-import { createPool } from 'src/actions/ipPools';
+import { createPool, listPools } from 'src/actions/ipPools';
 
 
 const breadcrumbAction = {
@@ -17,6 +17,14 @@ const breadcrumbAction = {
 };
 
 export class CreatePage extends Component {
+  loadDependentData = () => {
+    this.props.listPools();
+  };
+
+  componentDidMount() {
+    this.loadDependentData();
+  }
+
   createPool = (values) => {
     const { createPool, showAlert, history } = this.props;
 
@@ -46,5 +54,6 @@ const mapStateToProps = (state, props) => ({});
 
 export default connect(mapStateToProps, {
   createPool,
+  listPools,
   showAlert
 })(CreatePage);

--- a/src/pages/ipPools/tests/CreatePage.test.js
+++ b/src/pages/ipPools/tests/CreatePage.test.js
@@ -26,7 +26,7 @@ describe('IP Pools Create Page', () => {
 
   it('should show loading component when data is loading', () => {
     wrapper.setProps({ loading: true });
-    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Loading')).toExist();
   });
 
   it('should show an alert on successful pool creation', async () => {
@@ -38,7 +38,21 @@ describe('IP Pools Create Page', () => {
     expect(wrapper.instance().props.history.push).toHaveBeenCalled();
   });
 
-  it('should list pools and get pool on mount', () => {
+  it('lists pools and get pool on mount', () => {
+    expect(props.listPools).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders error on listError', () => {
+    const error = new Error('network error');
+    wrapper.setProps({ listError: error });
+    expect(wrapper.find('ApiErrorBanner')).toMatchSnapshot();
+  });
+
+  it('loads list data upon clicking reload button on ApiErrorBanner', () => {
+    const error = new Error('network error');
+    wrapper.setProps({ listError: error });
+    props.listPools.mockClear();
+    wrapper.find('ApiErrorBanner').prop('reload')();
     expect(props.listPools).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/ipPools/tests/CreatePage.test.js
+++ b/src/pages/ipPools/tests/CreatePage.test.js
@@ -9,6 +9,7 @@ describe('IP Pools Create Page', () => {
   beforeEach(() => {
     props = {
       createPool: jest.fn(() => Promise.resolve()),
+      listPools: jest.fn(() => Promise.resolve()),
       showAlert: jest.fn(),
       history: {
         push: jest.fn()
@@ -35,6 +36,9 @@ describe('IP Pools Create Page', () => {
       message: 'Created IP pool my-pool.'
     });
     expect(wrapper.instance().props.history.push).toHaveBeenCalled();
+  });
 
+  it('should list pools and get pool on mount', () => {
+    expect(props.listPools).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/ipPools/tests/EditIpPage.test.js
+++ b/src/pages/ipPools/tests/EditIpPage.test.js
@@ -69,8 +69,9 @@ describe('IP Edit Page', () => {
   it('reloads data on upon clicking on reload button on error banner', () => {
     const err = new Error('API Failed');
     wrapper.setProps({ error: err });
+    props.listPools.mockClear();
     wrapper.find('ApiErrorBanner').prop('reload')();
-    expect(props.listPools).toHaveBeenCalled();
+    expect(props.listPools).toHaveBeenCalledTimes(1);
   });
 
   describe('onUpdateIp', () => {

--- a/src/pages/ipPools/tests/__snapshots__/CreatePage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/CreatePage.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`IP Pools Create Page renders error on listError 1`] = `
+<ApiErrorBanner
+  errorDetails="network error"
+  message="Sorry, we seem to have had some trouble loading your IP pool."
+  reload={[Function]}
+/>
+`;
+
 exports[`IP Pools Create Page should render the list page correctly 1`] = `
 <Page
   breadcrumbAction={
@@ -18,5 +26,3 @@ exports[`IP Pools Create Page should render the list page correctly 1`] = `
   />
 </Page>
 `;
-
-exports[`IP Pools Create Page should show loading component when data is loading 1`] = `<Loading />`;


### PR DESCRIPTION
Fix following issue:
If you directly visit create pool page, it doesn't populate overflow pools

Solutions:
Because it doesn't list pools on create page upon refresh. 

**How to test**
- Go to create pool page
- Refresh page
- Overflow pools list is populate