### PR TITLE
EO-661 Fix current health score dashboard

### DIFF
--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -81,6 +81,11 @@ export const getHealthScore = signalsActionCreator({
   type: 'GET_HEALTH_SCORE'
 });
 
+export const getCurrentHealthScore = signalsActionCreator({
+  dimension: 'health-score',
+  type: 'GET_CURRENT_HEALTH_SCORE'
+});
+
 export const getSpamHits = signalsActionCreator({
   dimension: 'spam-hits',
   type: 'GET_SPAM_HITS'

--- a/src/actions/tests/__snapshots__/signals.test.js.snap
+++ b/src/actions/tests/__snapshots__/signals.test.js.snap
@@ -23,6 +23,29 @@ Array [
 ]
 `;
 
+exports[`Signals Actions .getCurrentHealthScore by default 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "headers": Object {},
+      "method": "GET",
+      "params": Object {
+        "filter": undefined,
+        "from": "2018-01-12",
+        "limit": undefined,
+        "offset": undefined,
+        "order": undefined,
+        "order_by": undefined,
+        "to": "2018-01-13",
+      },
+      "showErrorAlert": false,
+      "url": "/v1/signals/health-score/",
+    },
+    "type": "GET_CURRENT_HEALTH_SCORE",
+  },
+]
+`;
+
 exports[`Signals Actions .getEngagementRateByCohort by default 1`] = `
 Array [
   Object {

--- a/src/actions/tests/signals.test.js
+++ b/src/actions/tests/signals.test.js
@@ -77,6 +77,12 @@ describe('Signals Actions', () => {
     }
   });
 
+  snapshotActionCases('.getCurrentHealthScore', {
+    'by default': {
+      action: () => actions.getCurrentHealthScore({ ...requiredOptions })
+    }
+  });
+
   snapshotActionCases('.getInjections', {
     'by default': {
       action: () => actions.getInjections({ ...requiredOptions })

--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { list as getSubaccounts } from 'src/actions/subaccounts';
-import { getInjections } from 'src/actions/signals';
+import { getCurrentHealthScore, getInjections } from 'src/actions/signals';
 import { Grid } from '@sparkpost/matchbox';
 import Page from '../components/SignalsPage';
 import HealthScoreOverview from '../containers/HealthScoreOverviewContainer';
@@ -12,46 +12,47 @@ import CurrentHealthGauge from './components/CurrentHealthGauge/CurrentHealthGau
 import HealthScoreChart from './components/HealthScoreChart/HealthScoreChart';
 import _ from 'lodash';
 
-export class HealthScoreDashboard extends Component {
-  componentDidMount() {
-    this.props.getSubaccounts();
-    this.props.getInjections({ relativeRange: this.props.filters.relativeRange });
-    // TODO Lift the GET health score request to this component
-  }
+export function HealthScoreDashboard(props) {
+  const { getCurrentHealthScore, getInjections, relativeRange } = props;
 
-  render() {
-    const { subaccounts, injections } = this.props;
+  // Gets subaccount info on mount
+  useEffect(() => {
+    props.getSubaccounts();
+  }, [props]);
 
-    return (
-      <Page
-        title='Health Score'
-        primaryArea={<DateFilter />}
-      >
-        <Grid>
-          <Grid.Column xs={12} lg={5} xl={4}>
-            <CurrentHealthGauge />
-          </Grid.Column>
-          <Grid.Column xs={12} lg={7} xl={8}>
-            <HealthScoreChart injections={injections} />
-          </Grid.Column>
-        </Grid>
-        <div style={{ marginBottom: '1rem', marginTop: '1.5rem', textAlign: 'right' }}>
-          <SubaccountFilter />
-          <FacetFilter />
-        </div>
-        <HealthScoreOverview subaccounts={subaccounts} />
-      </Page>
-    );
-  }
+  // Gets injections and current score for gauge and timeseries only when dates change
+  useEffect(() => {
+    getCurrentHealthScore({ relativeRange: relativeRange });
+    getInjections({ relativeRange: relativeRange });
+  }, [relativeRange, getCurrentHealthScore, getInjections]);
+
+  return (
+    <Page title='Health Score' primaryArea={<DateFilter />}>
+      <Grid>
+        <Grid.Column xs={12} lg={5} xl={4}>
+          <CurrentHealthGauge />
+        </Grid.Column>
+        <Grid.Column xs={12} lg={7} xl={8}>
+          <HealthScoreChart injections={props.injections} />
+        </Grid.Column>
+      </Grid>
+      <div style={{ marginBottom: '1rem', marginTop: '1.5rem', textAlign: 'right' }}>
+        <SubaccountFilter />
+        <FacetFilter />
+      </div>
+      <HealthScoreOverview subaccounts={props.subaccounts} />
+    </Page>
+  );
 }
 
 const mapStateToProps = (state) => ({
   subaccounts: state.subaccounts.list,
-  filters: state.signalOptions,
+  relativeRange: state.signalOptions.relativeRange,
   injections: _.get(state, 'signals.injections', {})
 });
 
 const mapDispatchToProps = {
+  getCurrentHealthScore,
   getSubaccounts,
   getInjections
 };

--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -23,7 +23,7 @@ export function HealthScoreDashboard(props) {
   useEffect(() => {
     getCurrentHealthScore({ relativeRange });
     getInjections({ relativeRange });
-  }, [relativeRange, getCurrentHealthScore, getInjections]);
+  }, [getCurrentHealthScore, getInjections, relativeRange]);
 
   return (
     <Page title='Health Score' primaryArea={<DateFilter />}>

--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -10,7 +10,6 @@ import DateFilter from '../components/filters/DateFilter';
 import SubaccountFilter from '../components/filters/SubaccountFilter';
 import CurrentHealthGauge from './components/CurrentHealthGauge/CurrentHealthGauge';
 import HealthScoreChart from './components/HealthScoreChart/HealthScoreChart';
-import _ from 'lodash';
 
 export function HealthScoreDashboard(props) {
   const { getCurrentHealthScore, getInjections, relativeRange } = props;
@@ -22,8 +21,8 @@ export function HealthScoreDashboard(props) {
 
   // Gets injections and current score for gauge and timeseries only when dates change
   useEffect(() => {
-    getCurrentHealthScore({ relativeRange: relativeRange });
-    getInjections({ relativeRange: relativeRange });
+    getCurrentHealthScore({ relativeRange });
+    getInjections({ relativeRange });
   }, [relativeRange, getCurrentHealthScore, getInjections]);
 
   return (
@@ -33,7 +32,7 @@ export function HealthScoreDashboard(props) {
           <CurrentHealthGauge />
         </Grid.Column>
         <Grid.Column xs={12} lg={7} xl={8}>
-          <HealthScoreChart injections={props.injections} />
+          <HealthScoreChart />
         </Grid.Column>
       </Grid>
       <div style={{ marginBottom: '1rem', marginTop: '1.5rem', textAlign: 'right' }}>
@@ -47,8 +46,7 @@ export function HealthScoreDashboard(props) {
 
 const mapStateToProps = (state) => ({
   subaccounts: state.subaccounts.list,
-  relativeRange: state.signalOptions.relativeRange,
-  injections: _.get(state, 'signals.injections', {})
+  relativeRange: state.signalOptions.relativeRange
 });
 
 const mapDispatchToProps = {

--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -12,12 +12,12 @@ import CurrentHealthGauge from './components/CurrentHealthGauge/CurrentHealthGau
 import HealthScoreChart from './components/HealthScoreChart/HealthScoreChart';
 
 export function HealthScoreDashboard(props) {
-  const { getCurrentHealthScore, getInjections, relativeRange } = props;
+  const { getCurrentHealthScore, getInjections, getSubaccounts, relativeRange } = props;
 
   // Gets subaccount info on mount
   useEffect(() => {
-    props.getSubaccounts();
-  }, [props]);
+    getSubaccounts();
+  }, [getSubaccounts]);
 
   // Gets injections and current score for gauge and timeseries only when dates change
   useEffect(() => {

--- a/src/pages/signals/dashboards/components/CurrentHealthGauge/CurrentHealthGauge.js
+++ b/src/pages/signals/dashboards/components/CurrentHealthGauge/CurrentHealthGauge.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { getCaretProps } from 'src/helpers/signals';
-import { selectHealthScoreOverview } from 'src/selectors/signals';
+import { selectCurrentHealthScoreDashboard } from 'src/selectors/signals';
 import { Panel, Tooltip } from '@sparkpost/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
 import { PanelLoading } from 'src/components';
@@ -14,20 +14,19 @@ import _ from 'lodash';
 
 import styles from './CurrentHealthGauge.module.scss';
 
-export function CurrentHealthGauge({ data, loading, error }) {
-  const accountData = _.find(data, ['sid', -1]) || {};
-  const noData = _.isNil(accountData.current_health_score);
+export function CurrentHealthGauge(props) {
+  const noData = _.isNil(props.current_health_score);
 
-  if (loading) {
+  if (props.loading) {
     return <PanelLoading minHeight='407px' />;
   }
 
-  if (error) {
+  if (props.error) {
     return (
       <Panel sectioned>
         <div className={styles.Content}>
           <div className={styles.ErrorMessage}>
-            <Callout title='Unable to Load Data' height='auto' children={error.message} />
+            <Callout title='Unable to Load Data' height='auto' children={_.get(props, 'error.message')} />
           </div>
         </div>
       </Panel>
@@ -37,7 +36,7 @@ export function CurrentHealthGauge({ data, loading, error }) {
   let threshold = {};
 
   for (const key in thresholds) {
-    if (thresholds[key].condition(accountData.current_health_score)) {
+    if (thresholds[key].condition(props.current_health_score)) {
       threshold = thresholds[key];
     }
   }
@@ -45,7 +44,7 @@ export function CurrentHealthGauge({ data, loading, error }) {
   const DescriptionIcon = threshold.icon;
 
   function getMetricProps(key) {
-    const value = accountData[key];
+    const value = props[key];
     return { value: _.isNil(value) ? 'n/a' : `${value}%`, ...getCaretProps(value) };
   }
 
@@ -66,7 +65,7 @@ export function CurrentHealthGauge({ data, loading, error }) {
         {noData && <div><Callout height='auto'>Current Health Score Not Available</Callout></div>}
         {!noData && (
           <>
-            <Gauge score={accountData.current_health_score} threshold={threshold} />
+            <Gauge score={props.current_health_score} threshold={threshold} />
             <div className={styles.Description}>
               <DescriptionIcon className={styles.DescriptionIcon} size={25} style={{ fill: threshold.color }} />
               <p className={styles.DescriptionContent}>{threshold.description}</p>
@@ -83,7 +82,7 @@ export function CurrentHealthGauge({ data, loading, error }) {
 }
 
 const mapStateToProps = (state) => ({
-  ...selectHealthScoreOverview(state)
+  ...selectCurrentHealthScoreDashboard(state)
 });
 
 export default connect(mapStateToProps, {})(CurrentHealthGauge);

--- a/src/pages/signals/dashboards/components/CurrentHealthGauge/tests/CurrentHealthGauge.test.js
+++ b/src/pages/signals/dashboards/components/CurrentHealthGauge/tests/CurrentHealthGauge.test.js
@@ -6,7 +6,7 @@ describe('Signals Health Score Gauge Container', () => {
   const props = {
     loading: false,
     error: null,
-    data: []
+    current_health_score: null
   };
 
   const subject = (options = {}) => shallow(
@@ -14,9 +14,9 @@ describe('Signals Health Score Gauge Container', () => {
   );
 
   it('renders happy path correctly', () => {
-    expect(subject({ data: [{
-      sid: -1, current_health_score: 88, WoW: -5, current_DoD: 5
-    }]})).toMatchSnapshot();
+    expect(subject({
+      current_health_score: 88, WoW: -5, current_DoD: 5
+    })).toMatchSnapshot();
   });
 
   it('renders loading correctly', () => {
@@ -30,25 +30,25 @@ describe('Signals Health Score Gauge Container', () => {
   });
 
   it('renders no current score correctly', () => {
-    const wrapper = subject({ data: [{
-      sid: -1, WoW: -5, current_DoD: 5
-    }]});
+    const wrapper = subject({
+      WoW: -5, current_DoD: 5
+    });
     expect(wrapper.find('Callout')).toMatchSnapshot();
   });
 
   it('renders no WoW, or Dod', () => {
-    const wrapper = subject({ data: [{ sid: -1 }]});
+    const wrapper = subject({ });
     expect(wrapper.find({ label: 'WoW Change' }).prop('value')).toEqual('n/a');
     expect(wrapper.find({ label: 'DoD Change' }).prop('value')).toEqual('n/a');
   });
 
   it('renders warning threshold color', () => {
-    const wrapper = subject({ data: [{ sid: -1, current_health_score: 60 }]});
+    const wrapper = subject({ current_health_score: 60 });
     expect(wrapper.find({ className: 'DescriptionIcon' }).prop('style').fill).toMatchSnapshot();
   });
 
   it('renders bad threshold color', () => {
-    const wrapper = subject({ data: [{ sid: -1, current_health_score: 40 }]});
+    const wrapper = subject({ current_health_score: 40 });
     expect(wrapper.find({ className: 'DescriptionIcon' }).prop('style').fill).toMatchSnapshot();
   });
 });

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -58,7 +58,7 @@ export function HealthScoreChart(props) {
   }
 
   function getTotalInjectionProps() {
-    const injectionEntries = _.filter(injections.data, (entry) => entry.injections);
+    const injectionEntries = _.filter(history, (entry) => entry.injections);
     const injectionTotals = _.map(injectionEntries, (entry) => entry.injections);
     const sumInjectionTotals = _.sum(injectionTotals);
     return { value: _.isNil(sumInjectionTotals) ? 'n/a' : formatNumber(sumInjectionTotals) };

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -85,12 +85,12 @@ export function HealthScoreChart(props) {
   }
 
   function getMin() {
-    const min = _.min(getHealthScores(history));
+    const min = _.min(getHealthScores());
     return { value: _.isNil(min) ? 'n/a' : min };
   }
 
   function getMax() {
-    const max = _.max(getHealthScores(history));
+    const max = _.max(getHealthScores());
     return { value: _.isNil(max) ? 'n/a' : max };
   }
 

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -24,7 +24,7 @@ export function HealthScoreChart(props) {
     setHovered(props.date);
   }
 
-  const { history = [], loading, error, filters, injections } = props;
+  const { history = [], loading, error, filters } = props;
   const noData = (history) ? !_.some(getHealthScores()) : true;
   const lastItem = _.last(history) || {};
   const selectedDate = _.get(lastItem, 'date', '');
@@ -65,7 +65,7 @@ export function HealthScoreChart(props) {
   }
 
   function getHoverInjectionProps() {
-    const currentEntry = _.find(injections.data, ['dt', hoveredDate]);
+    const currentEntry = _.find(history, ['date', hoveredDate]);
     const value = (currentEntry) ? currentEntry.injections : null;
     return { value: _.isNil(value) ? 'n/a' : formatNumber(value) };
   }
@@ -157,8 +157,7 @@ export function HealthScoreChart(props) {
 
 const mapStateToProps = (state) => ({
   filters: state.signalOptions,
-  ...selectCurrentHealthScoreDashboard(state),
-  injections: _.get(state, 'signals.injections', {})
+  ...selectCurrentHealthScoreDashboard(state)
 });
 
 export default connect(mapStateToProps, {})(HealthScoreChart);

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -157,7 +157,8 @@ export function HealthScoreChart(props) {
 
 const mapStateToProps = (state) => ({
   filters: state.signalOptions,
-  ...selectCurrentHealthScoreDashboard(state)
+  ...selectCurrentHealthScoreDashboard(state),
+  injections: _.get(state, 'signals.injections', {})
 });
 
 export default connect(mapStateToProps, {})(HealthScoreChart);

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { getCaretProps, getDoD } from 'src/helpers/signals';
-import { selectHealthScoreOverview } from 'src/selectors/signals';
+import { selectCurrentHealthScoreDashboard } from 'src/selectors/signals';
 import { Panel, Tooltip } from '@sparkpost/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
 import BarChart from '../../../components/charts/barchart/BarChart';
@@ -24,10 +24,9 @@ export function HealthScoreChart(props) {
     setHovered(props.date);
   }
 
-  const { data, loading, error, filters, injections } = props;
-  const accountData = _.find(data, ['sid', -1]) || {};
-  const noData = (accountData.history) ? !_.some(getHealthScores(accountData)) : true;
-  const lastItem = _.last(accountData.history) || {};
+  const { history = [], loading, error, filters, injections } = props;
+  const noData = (history) ? !_.some(getHealthScores()) : true;
+  const lastItem = _.last(history) || {};
   const selectedDate = _.get(lastItem, 'date', '');
 
   if (loading) {
@@ -46,9 +45,8 @@ export function HealthScoreChart(props) {
     );
   }
 
-  function getHealthScores(accountData) {
-    const accountHistory = _.get(accountData, 'history', []);
-    return _.map(accountHistory, (entry) => entry.health_score);
+  function getHealthScores() {
+    return _.map(history, (entry) => entry.health_score);
   }
 
   function getXAxisProps() {
@@ -74,8 +72,8 @@ export function HealthScoreChart(props) {
 
   function getHoverDoDProps() {
     const previousDay = moment(hoveredDate).subtract(1, 'day').format('YYYY-MM-DD');
-    const currentEntry = _.find(accountData.history, ['date', hoveredDate]);
-    const prevEntry = _.find(accountData.history, ['date', previousDay]);
+    const currentEntry = _.find(history, ['date', hoveredDate]);
+    const prevEntry = _.find(history, ['date', previousDay]);
     const currentScore = (currentEntry) ? currentEntry.health_score : null;
     const prevScore = (prevEntry) ? prevEntry.health_score : null;
     const value = getDoD(currentScore, prevScore);
@@ -83,16 +81,16 @@ export function HealthScoreChart(props) {
   }
 
   function getGap() {
-    return accountData.history.length > 15 ? 0.2 : 1;
+    return history.length > 15 ? 0.2 : 1;
   }
 
   function getMin() {
-    const min = _.min(getHealthScores(accountData));
+    const min = _.min(getHealthScores(history));
     return { value: _.isNil(min) ? 'n/a' : min };
   }
 
   function getMax() {
-    const max = _.max(getHealthScores(accountData));
+    const max = _.max(getHealthScores(history));
     return { value: _.isNil(max) ? 'n/a' : max };
   }
 
@@ -119,7 +117,7 @@ export function HealthScoreChart(props) {
               onMouseOut={() => setHovered({})}
               selected={selectedDate}
               hovered={hoveredDate}
-              timeSeries={accountData.history}
+              timeSeries={history}
               tooltipContent={({ payload = {}}) => (payload.ranking) &&
                 (<TooltipMetric
                   label='Health Score'
@@ -159,7 +157,7 @@ export function HealthScoreChart(props) {
 
 const mapStateToProps = (state) => ({
   filters: state.signalOptions,
-  ...selectHealthScoreOverview(state)
+  ...selectCurrentHealthScoreDashboard(state)
 });
 
 export default connect(mapStateToProps, {})(HealthScoreChart);

--- a/src/pages/signals/dashboards/components/HealthScoreChart/tests/HealthScoreChart.test.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/tests/HealthScoreChart.test.js
@@ -26,27 +26,24 @@ describe('Signals Health Score Chart', () => {
           spam_hits: 1
         }]
       },
-      data: [{
-        sid: -1,
-        current_health_score: 88,
-        WoW: -5, current_DoD: 5,
-        history: [{
-          date: '2019-03-24',
-          health_score: 75,
-          ranking: 'warning'
-        },{
-          date: '2019-03-25',
-          health_score: 96,
-          ranking: 'good'
-        },{
-          date: '2019-03-26',
-          health_score: 23,
-          ranking: 'danger'
-        },{
-          date: '2019-03-27',
-          health_score: null,
-          ranking: null
-        }]
+      current_health_score: 88,
+      WoW: -5, current_DoD: 5,
+      history: [{
+        date: '2019-03-24',
+        health_score: 75,
+        ranking: 'warning'
+      },{
+        date: '2019-03-25',
+        health_score: 96,
+        ranking: 'good'
+      },{
+        date: '2019-03-26',
+        health_score: 23,
+        ranking: 'danger'
+      },{
+        date: '2019-03-27',
+        health_score: null,
+        ranking: null
       }],
       filters: {
         relativeRange: '90days'
@@ -73,7 +70,7 @@ describe('Signals Health Score Chart', () => {
   });
 
   it('renders no account level data callout correctly', () => {
-    props.data = [];
+    props.history = [];
     const wrapper = subject(props);
     expect(wrapper.find('Callout')).toMatchSnapshot();
   });

--- a/src/pages/signals/dashboards/components/HealthScoreChart/tests/HealthScoreChart.test.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/tests/HealthScoreChart.test.js
@@ -11,34 +11,22 @@ describe('Signals Health Score Chart', () => {
     props = {
       loading: false,
       error: null,
-      injections: {
-        data: [{
-          dt: '2019-03-24',
-          injections: 75000000000,
-          spam_hits: 1
-        },{
-          dt: '2019-03-25',
-          injections: 75000000000,
-          spam_hits: 1
-        },{
-          dt: '2019-03-26',
-          injections: 75000000000,
-          spam_hits: 1
-        }]
-      },
       current_health_score: 88,
       WoW: -5, current_DoD: 5,
       history: [{
         date: '2019-03-24',
         health_score: 75,
+        injections: 75000000000,
         ranking: 'warning'
       },{
         date: '2019-03-25',
         health_score: 96,
+        injections: 75000000000,
         ranking: 'good'
       },{
         date: '2019-03-26',
         health_score: 23,
+        injections: 75000000000,
         ranking: 'danger'
       },{
         date: '2019-03-27',

--- a/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
@@ -69,16 +69,19 @@ exports[`Signals Health Score Chart renders happy path correctly 1`] = `
           Object {
             "date": "2019-03-24",
             "health_score": 75,
+            "injections": 75000000000,
             "ranking": "warning",
           },
           Object {
             "date": "2019-03-25",
             "health_score": 96,
+            "injections": 75000000000,
             "ranking": "good",
           },
           Object {
             "date": "2019-03-26",
             "health_score": 23,
+            "injections": 75000000000,
             "ranking": "danger",
           },
           Object {

--- a/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
@@ -1,10 +1,24 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { HealthScoreDashboard } from '../HealthScoreDashboard';
 
+// Going to great lengths to use hooks
+jest.mock('../../containers/HealthScoreOverviewContainer');
+jest.mock('../components/CurrentHealthGauge/CurrentHealthGauge');
+jest.mock('../components/HealthScoreChart/HealthScoreChart');
+jest.mock('../../components/filters/FacetFilter');
+jest.mock('../../components/filters/DateFilter');
+jest.mock('../../components/filters/SubaccountFilter');
+
 describe('Signals Health Score Dashboard', () => {
-  const subject = (props = {}) => shallow(
-    <HealthScoreDashboard getSubaccounts={() => {}} filters={{ relativeRange: '90days' }} getInjections={() => {}} {...props} />
+  const subject = (props = {}, render = shallow) => render(
+    <HealthScoreDashboard
+      getCurrentHealthScore={() => {}}
+      getSubaccounts={() => {}}
+      getInjections={() => {}}
+      filters={{ relativeRange: '90days' }}
+      {...props}
+    />
   );
 
   it('renders page', () => {
@@ -13,13 +27,15 @@ describe('Signals Health Score Dashboard', () => {
 
   it('calls getSubaccounts on mount', () => {
     const getSubaccounts = jest.fn();
-    subject({ getSubaccounts });
+    subject({ getSubaccounts }, mount);
     expect(getSubaccounts).toHaveBeenCalled();
   });
 
-  it('calls getInjections on mount', () => {
+  it('calls getCurrentHealthScore getInjections on mount', () => {
     const getInjections = jest.fn();
-    subject({ getInjections });
+    const getCurrentHealthScore = jest.fn();
+    subject({ getInjections, getCurrentHealthScore }, mount);
     expect(getInjections).toHaveBeenCalled();
+    expect(getCurrentHealthScore).toHaveBeenCalled();
   });
 });

--- a/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
@@ -2,7 +2,10 @@ import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { HealthScoreDashboard } from '../HealthScoreDashboard';
 
-// Going to great lengths to use hooks
+// Child components are mocked because
+// 1. useEffect requires enzyme mount to test
+// 2. child components are connected to redux
+// This avoids setting up a mock store
 jest.mock('../../containers/HealthScoreOverviewContainer');
 jest.mock('../components/CurrentHealthGauge/CurrentHealthGauge');
 jest.mock('../components/HealthScoreChart/HealthScoreChart');

--- a/src/reducers/signals.js
+++ b/src/reducers/signals.js
@@ -6,6 +6,7 @@ const initialDimensionState = {
 };
 
 const initialState = {
+  currentHealthScore: initialDimensionState,
   injections: initialDimensionState,
   spamHits: initialDimensionState,
   healthScore: initialDimensionState,
@@ -92,6 +93,17 @@ const signalsReducer = (state = initialState, { type, payload, meta }) => {
     case 'GET_HEALTH_SCORE_SUCCESS': {
       const { data, total_count: totalCount } = payload;
       return { ...state, healthScore: { ...initialDimensionState, data, loading: false, totalCount }};
+    }
+
+    case 'GET_CURRENT_HEALTH_SCORE_FAIL':
+      return { ...state, currentHealthScore: { ...initialDimensionState, error: payload.error, loading: false }};
+
+    case 'GET_CURRENT_HEALTH_SCORE_PENDING':
+      return { ...state, currentHealthScore: { ...initialDimensionState, loading: true }};
+
+    case 'GET_CURRENT_HEALTH_SCORE_SUCCESS': {
+      const { data, total_count: totalCount } = payload;
+      return { ...state, currentHealthScore: { ...initialDimensionState, data, loading: false, totalCount }};
     }
 
     default:

--- a/src/reducers/tests/__snapshots__/signals.test.js.snap
+++ b/src/reducers/tests/__snapshots__/signals.test.js.snap
@@ -101,6 +101,12 @@ Object {
     "loading": false,
     "totalCount": 0,
   },
+  "currentHealthScore": Object {
+    "data": Array [],
+    "error": null,
+    "loading": false,
+    "totalCount": 0,
+  },
   "engagementRateByCohort": Object {
     "data": Array [],
     "error": null,

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -25,6 +25,7 @@ export const getUnsubscribeRateByCohortData = (state, props) => _.get(state, 'si
 export const getComplaintsByCohortData = (state, props) => _.get(state, 'signals.complaintsByCohort', {});
 export const getHealthScoreData = (state, props) => _.get(state, 'signals.healthScore', {});
 export const getCurrentHealthScoreData = (state, props) => _.get(state, 'signals.currentHealthScore', {});
+export const getInjections = (state, props) => _.get(state, 'signals.injections', {});
 
 // Details
 export const selectSpamHitsDetails = createSelector(
@@ -406,19 +407,21 @@ export const selectHealthScoreOverviewData = createSelector(
 );
 
 export const selectCurrentHealthScoreDashboard = createSelector(
-  [getCurrentHealthScoreData, getOptions],
-  ({ data, loading, error }, { now, relativeRange }) => {
+  [getCurrentHealthScoreData, getOptions, getInjections],
+  ({ data, loading, error }, { now, relativeRange }, injections) => {
     const accountData = _.find(data, ['sid', -1]) || {};
     const history = accountData.history || [];
 
     const normalizedHistory = history.map(({ dt: date, health_score, ...values }) => {
       const roundedHealthScore = roundToPlaces(health_score * 100, 1);
+      const injectionData = _.find(injections.data, ['dt', date]) || {};
 
       return {
         ...values,
         date,
         health_score: roundedHealthScore,
-        ranking: rankHealthScore(roundedHealthScore)
+        ranking: rankHealthScore(roundedHealthScore),
+        injections: injectionData.injections
       };
     });
 
@@ -426,7 +429,8 @@ export const selectCurrentHealthScoreDashboard = createSelector(
       dataSet: normalizedHistory,
       fill: {
         health_score: null,
-        ranking: null
+        ranking: null,
+        injections: null
       },
       now,
       relativeRange

--- a/src/selectors/tests/__snapshots__/signals.test.js.snap
+++ b/src/selectors/tests/__snapshots__/signals.test.js.snap
@@ -1034,6 +1034,58 @@ Object {
 }
 `;
 
+exports[`Selectors: signals selectCurrentHealthScoreDashboard returns data 1`] = `
+Object {
+  "WoW": null,
+  "current_DoD": null,
+  "current_health_score": null,
+  "error": undefined,
+  "history": Array [
+    Object {
+      "date": "2017-12-27",
+      "health_score": null,
+      "ranking": null,
+    },
+    Object {
+      "date": "2017-12-28",
+      "health_score": null,
+      "ranking": null,
+    },
+    Object {
+      "date": "2017-12-29",
+      "health_score": null,
+      "ranking": null,
+    },
+    Object {
+      "date": "2017-12-30",
+      "health_score": null,
+      "ranking": null,
+    },
+    Object {
+      "date": "2017-12-31",
+      "health_score": null,
+      "ranking": null,
+    },
+    Object {
+      "date": "2018-01-01",
+      "health_score": null,
+      "ranking": null,
+    },
+    Object {
+      "date": "2018-01-02",
+      "health_score": null,
+      "ranking": null,
+    },
+    Object {
+      "date": "2018-01-03",
+      "health_score": null,
+      "ranking": null,
+    },
+  ],
+  "loading": undefined,
+}
+`;
+
 exports[`Selectors: signals selectEngagementRecencyOverview returns all overview data 1`] = `
 Object {
   "data": Array [

--- a/src/selectors/tests/__snapshots__/signals.test.js.snap
+++ b/src/selectors/tests/__snapshots__/signals.test.js.snap
@@ -1036,53 +1036,67 @@ Object {
 
 exports[`Selectors: signals selectCurrentHealthScoreDashboard returns data 1`] = `
 Object {
-  "WoW": null,
-  "current_DoD": null,
-  "current_health_score": null,
+  "WoW": -7,
+  "current_DoD": 22.5,
+  "current_health_score": 98,
+  "current_weights": Array [],
   "error": undefined,
   "history": Array [
     Object {
       "date": "2017-12-27",
       "health_score": null,
+      "injections": null,
       "ranking": null,
     },
     Object {
       "date": "2017-12-28",
       "health_score": null,
+      "injections": null,
       "ranking": null,
     },
     Object {
       "date": "2017-12-29",
       "health_score": null,
+      "injections": null,
       "ranking": null,
     },
     Object {
       "date": "2017-12-30",
       "health_score": null,
+      "injections": null,
       "ranking": null,
     },
     Object {
       "date": "2017-12-31",
       "health_score": null,
+      "injections": null,
       "ranking": null,
     },
     Object {
       "date": "2018-01-01",
-      "health_score": null,
-      "ranking": null,
+      "health_score": 74.3,
+      "injections": 100,
+      "ranking": "warning",
+      "weights": Array [],
     },
     Object {
       "date": "2018-01-02",
-      "health_score": null,
-      "ranking": null,
+      "health_score": 80,
+      "injections": 100,
+      "ranking": "good",
     },
     Object {
+      "WoW": null,
       "date": "2018-01-03",
-      "health_score": null,
-      "ranking": null,
+      "health_score": 98,
+      "injections": 100,
+      "ranking": "good",
+      "weights": Array [],
     },
   ],
   "loading": undefined,
+  "sending_domain": "test.com",
+  "sid": -1,
 }
 `;
 

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -230,6 +230,34 @@ describe('Selectors: signals', () => {
               ]
             }
           ]
+        },
+        currentHealthScore: {
+          total_count: 10,
+          data: [
+            {
+              current_weights: [],
+              current_health_score: 0.98,
+              sending_domain: 'test.com',
+              WoW: -0.07,
+              history: [
+                {
+                  dt: '2018-01-01',
+                  health_score: 0.74321, // bad
+                  weights: []
+                },
+                {
+                  dt: '2018-01-02',
+                  health_score: 0.8
+                },
+                {
+                  dt: '2018-01-03',
+                  health_score: 0.98, // good
+                  weights: [],
+                  WoW: null
+                }
+              ]
+            }
+          ]
         }
       }
     };
@@ -427,6 +455,12 @@ describe('Selectors: signals', () => {
   describe('selectHealthScoreOverview', () => {
     it('returns all overview data', () => {
       expect(selectors.selectHealthScoreOverview(state, props)).toMatchSnapshot();
+    });
+  });
+
+  describe('selectCurrentHealthScoreDashboard', () => {
+    it('returns data', () => {
+      expect(selectors.selectCurrentHealthScoreDashboard(state, props)).toMatchSnapshot();
     });
   });
 });

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -235,6 +235,7 @@ describe('Selectors: signals', () => {
           total_count: 10,
           data: [
             {
+              sid: -1,
               current_weights: [],
               current_health_score: 0.98,
               sending_domain: 'test.com',
@@ -257,6 +258,13 @@ describe('Selectors: signals', () => {
                 }
               ]
             }
+          ]
+        },
+        injections: {
+          data: [
+            { injections: 100, spam_hits: 1, dt: '2018-01-01' },
+            { injections: 100, spam_hits: 1, dt: '2018-01-02' },
+            { injections: 100, spam_hits: 1, dt: '2018-01-03' }
           ]
         }
       }


### PR DESCRIPTION
### What Changed
- Created a new health score action for the dashboard that always gets the account aggregated current score (`-1`)

### How To Test
- [Point your local upstreams to staging](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
  - Data available in account 108 (spc)
- Log into appteam or enable the `feature_signals_v2` UI option
- Navigate to the new Health Score page from the main side nav
- Verify the top two panels contain valid data when changing the filters:
  - Date ranges (should update)
  - Facet filters (should not update)
  - Subaccount (should not update) 

### To Do

