### PR TITLE
EO-663 More signals design feedback

### DIFF
--- a/src/pages/signals/ComplaintsByCohortPage.js
+++ b/src/pages/signals/ComplaintsByCohortPage.js
@@ -22,13 +22,17 @@ import HealthScorePreview from './components/previews/HealthScorePreview';
 import cohorts from './constants/cohorts';
 
 export class ComplaintsByCohortPage extends Component {
-  getYAxisProps = () => {
+  isEmpty = () => {
     const { data } = this.props;
-    return {
-      domain: data.every(({ p_total_fbl }) => !p_total_fbl) ? [0, 1] : ['auto', 'auto'],
-      tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
-    };
+
+    // Returns true with 0 total complaints
+    return data.every(({ p_total_fbl }) => !p_total_fbl);
   }
+
+  getYAxisProps = () => ({
+    domain: this.isEmpty() ? [0, 1] : ['auto', 'auto'],
+    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
+  })
 
   getXAxisProps = () => {
     const { xTicks } = this.props;

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -23,8 +23,15 @@ import cohorts from './constants/cohorts';
 
 export class EngagementRateByCohortPage extends Component {
 
+  isEmpty = () => {
+    const { data } = this.props;
+
+    // Returns true with 0 total engagement
+    return data.every(({ p_total_eng }) => !p_total_eng);
+  }
+
   getYAxisProps = () => ({
-    domain: this.props.data.every(({ p_total_eng }) => !p_total_eng) ? [0, 1] : ['auto', 'auto'],
+    domain: this.isEmpty() ? [0, 1] : ['auto', 'auto'],
     tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
   })
 

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -24,6 +24,7 @@ import cohorts from './constants/cohorts';
 export class EngagementRateByCohortPage extends Component {
 
   getYAxisProps = () => ({
+    domain: this.props.data.every(({ p_total_eng }) => !p_total_eng) ? [0, 1] : ['auto', 'auto'],
     tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
   })
 

--- a/src/pages/signals/SpamTrapPage.js
+++ b/src/pages/signals/SpamTrapPage.js
@@ -36,7 +36,7 @@ export class SpamTrapPage extends Component {
     const { calculation } = this.state;
 
     return {
-      tickFormatter: calculation === 'relative' ? (tick) => `${roundToPlaces(tick * 100, 2)}%` : (tick) => formatNumber(tick),
+      tickFormatter: calculation === 'relative' ? (tick) => `${roundToPlaces(tick * 100, 3)}%` : (tick) => formatNumber(tick),
       domain: data.every(({ relative_trap_hits }) => !relative_trap_hits) && calculation === 'relative'
         ? [0, 1] : ['auto', 'auto']
     };

--- a/src/pages/signals/UnsubscribeRateByCohortPage.js
+++ b/src/pages/signals/UnsubscribeRateByCohortPage.js
@@ -24,6 +24,7 @@ import cohorts from './constants/cohorts';
 export class UnsubscribeRateByCohortPage extends Component {
 
   getYAxisProps = () => ({
+    domain: this.props.data.every(({ p_total_unsub }) => !p_total_unsub) ? [0, 1] : ['auto', 'auto'],
     tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
   })
 

--- a/src/pages/signals/UnsubscribeRateByCohortPage.js
+++ b/src/pages/signals/UnsubscribeRateByCohortPage.js
@@ -22,9 +22,15 @@ import HealthScorePreview from './components/previews/HealthScorePreview';
 import cohorts from './constants/cohorts';
 
 export class UnsubscribeRateByCohortPage extends Component {
+  isEmpty = () => {
+    const { data } = this.props;
+
+    // Returns true with 0 total unsubscribes
+    return data.every(({ p_total_unsub }) => !p_total_unsub);
+  }
 
   getYAxisProps = () => ({
-    domain: this.props.data.every(({ p_total_unsub }) => !p_total_unsub) ? [0, 1] : ['auto', 'auto'],
+    domain: this.isEmpty() ? [0, 1] : ['auto', 'auto'],
     tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
   })
 

--- a/src/pages/signals/components/charts/barchart/BarChart.scss
+++ b/src/pages/signals/components/charts/barchart/BarChart.scss
@@ -4,6 +4,6 @@
   }
 
   .recharts-text.recharts-cartesian-axis-tick-value {
-    font-size: 11px;
+    font-size: 10px;
   }
 }

--- a/src/pages/signals/components/previews/HealthScorePreview.js
+++ b/src/pages/signals/components/previews/HealthScorePreview.js
@@ -7,7 +7,6 @@ import withHealthScoreDetails from '../../containers/HealthScoreDetailsContainer
 import BarChart from '../charts/barchart/BarChart';
 import ChartHeader from '../ChartHeader';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
-import { roundToPlaces } from 'src/helpers/units';
 
 export class HealthScorePreview extends Component {
   renderContent = () => {
@@ -30,7 +29,8 @@ export class HealthScorePreview extends Component {
         timeSeries={data}
         yKey='health_score'
         yAxisProps={{
-          tickFormatter: (tick) => `${roundToPlaces(tick * 100, 3)}%`
+          tickFormatter: (tick) => parseInt(tick * 100),
+          domain: [0,1]
         }}
         xAxisProps={{ hide: true }}
       />

--- a/src/pages/signals/components/previews/SpamTrapsPreview.js
+++ b/src/pages/signals/components/previews/SpamTrapsPreview.js
@@ -7,7 +7,7 @@ import withSpamTrapDetails from '../../containers/SpamTrapDetailsContainer';
 import BarChart from '../charts/barchart/BarChart';
 import ChartHeader from '../ChartHeader';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
-import { formatNumber } from 'src/helpers/units';
+import { roundToPlaces } from 'src/helpers/units';
 
 export class SpamTrapsPreview extends Component {
   renderContent = () => {
@@ -28,10 +28,10 @@ export class SpamTrapsPreview extends Component {
         margin={{ top: 12, left: 12, right: 0, bottom: 12 }}
         gap={gap}
         timeSeries={data}
-        yKey='trap_hits'
+        yKey='relative_trap_hits'
         yAxisProps={{
-          tickFormatter: (tick) => formatNumber(tick),
-          domain: ['auto', 'auto']
+          tickFormatter: (tick) => `${roundToPlaces(tick * 100, 2)}%`,
+          domain: data.every(({ relative_trap_hits }) => !relative_trap_hits) ? [0, 1] : ['auto', 'auto']
         }}
         xAxisProps={{ hide: true }}
 

--- a/src/pages/signals/components/previews/tests/HealthScorePreview.test.js
+++ b/src/pages/signals/components/previews/tests/HealthScorePreview.test.js
@@ -40,6 +40,6 @@ describe('Signals HealthScorePreview Component', () => {
 
   it('renders y ticks', () => {
     const axisProps = wrapper.find('BarChart').prop('yAxisProps');
-    expect(axisProps.tickFormatter(0.2468)).toEqual('24.68%');
+    expect(axisProps.tickFormatter(0.20000)).toEqual(20);
   });
 });

--- a/src/pages/signals/components/previews/tests/HealthScorePreview.test.js
+++ b/src/pages/signals/components/previews/tests/HealthScorePreview.test.js
@@ -40,6 +40,6 @@ describe('Signals HealthScorePreview Component', () => {
 
   it('renders y ticks', () => {
     const axisProps = wrapper.find('BarChart').prop('yAxisProps');
-    expect(axisProps.tickFormatter(0.20000)).toEqual(20);
+    expect(axisProps.tickFormatter(0.2468)).toEqual(24);
   });
 });

--- a/src/pages/signals/components/previews/tests/SpamTrapsPreview.test.js
+++ b/src/pages/signals/components/previews/tests/SpamTrapsPreview.test.js
@@ -38,8 +38,17 @@ describe('Signals SpamTrapsPreview Component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('gets y axis props', () => {
+  it('gets y axis props with default domain', () => {
+    wrapper.setProps({ data: [{ relative_trap_hits: null }]});
     const axisProps = wrapper.find('BarChart').prop('yAxisProps');
-    expect(axisProps.tickFormatter((2468))).toEqual('2.47K');
+    expect(axisProps.tickFormatter((0.2468))).toEqual('24.68%');
+    expect(axisProps.domain).toEqual([0,1]);
+  });
+
+  it('gets y axis with domain', () => {
+    wrapper.setProps({ data: [{ relative_trap_hits: 0.1 }]});
+    const axisProps = wrapper.find('BarChart').prop('yAxisProps');
+    expect(axisProps.tickFormatter((0.2468))).toEqual('24.68%');
+    expect(axisProps.domain).toEqual(['auto', 'auto']);
   });
 });

--- a/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
@@ -48,6 +48,10 @@ exports[`Signals HealthScorePreview Component renders correctly 1`] = `
         xKey="date"
         yAxisProps={
           Object {
+            "domain": Array [
+              0,
+              1,
+            ],
             "tickFormatter": [Function],
           }
         }

--- a/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
@@ -48,14 +48,14 @@ exports[`Signals SpamTrapsPreview Component renders correctly 1`] = `
         yAxisProps={
           Object {
             "domain": Array [
-              "auto",
-              "auto",
+              0,
+              1,
             ],
             "tickFormatter": [Function],
           }
         }
         yAxisRefLines={Array []}
-        yKey="trap_hits"
+        yKey="relative_trap_hits"
         yRange={
           Array [
             "auto",

--- a/src/pages/signals/tests/EngagementRateByCohortPage.test.js
+++ b/src/pages/signals/tests/EngagementRateByCohortPage.test.js
@@ -72,8 +72,16 @@ describe('Signals Engagement Rate By Cohort Page', () => {
     });
 
     it('gets y axis props', () => {
+      wrapper.setProps({ data: [{ p_total_eng: 0 }, { p_total_eng: null }]});
       const axisProps = wrapper.find('LineChart').prop('yAxisProps');
       expect(axisProps.tickFormatter(.253)).toEqual('25%');
+      expect(axisProps.domain).toEqual([0,1]);
+    });
+
+    it('gets y axis props with domain', () => {
+      wrapper.setProps({ data: [{ p_total_eng: 0.5 }, { p_total_eng: 0.6 }]});
+      const axisProps = wrapper.find('LineChart').prop('yAxisProps');
+      expect(axisProps.domain).toEqual(['auto', 'auto']);
     });
   });
 });

--- a/src/pages/signals/tests/UnsubscribeRateByCohortPage.test.js
+++ b/src/pages/signals/tests/UnsubscribeRateByCohortPage.test.js
@@ -72,9 +72,17 @@ describe('Signals Unsubscribe Rate Page', () => {
       expect(axisProps.tickFormatter('2018-12-05')).toEqual('12/5');
     });
 
-    it('gets y axis props', () => {
+    it('gets y axis props with default domain', () => {
+      wrapper.setProps({ data: [{ p_total_unsub: 0 }, { p_total_unsub: null }]});
       const axisProps = wrapper.find('LineChart').prop('yAxisProps');
       expect(axisProps.tickFormatter(.2523)).toEqual('25%');
+      expect(axisProps.domain).toEqual([0,1]);
+    });
+
+    it('gets y axis props with domain', () => {
+      wrapper.setProps({ data: [{ p_total_unsub: 0.5 }, { p_total_unsub: 0.6 }]});
+      const axisProps = wrapper.find('LineChart').prop('yAxisProps');
+      expect(axisProps.domain).toEqual(['auto', 'auto']);
     });
   });
 });

--- a/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
@@ -120,6 +120,10 @@ exports[`Signals Engagement Rate By Cohort Page renders correctly 1`] = `
             xKey="date"
             yAxisProps={
               Object {
+                "domain": Array [
+                  0,
+                  1,
+                ],
                 "tickFormatter": [Function],
               }
             }

--- a/src/pages/signals/tests/__snapshots__/UnsubscribeRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/UnsubscribeRateByCohortPage.test.js.snap
@@ -110,6 +110,10 @@ exports[`Signals Unsubscribe Rate Page renders correctly 1`] = `
             xKey="date"
             yAxisProps={
               Object {
+                "domain": Array [
+                  0,
+                  1,
+                ],
                 "tickFormatter": [Function],
               }
             }


### PR DESCRIPTION

### What Changed
- New engagement charts
  - Default Y domain is now [0, 1] for all charts with percent values. Recharts defaults to  [0, 4] with zero values.
- Spam Trap Preview
  - Y domain ticks should match the default calculation (ratio%) on the details page.
- Health Score Preview
  - Remove % from the Y tick formatters

### How To Test
- [Point your local upstreams to staging](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
  - appteam account has 0 values to test the default y domain cases
- Visit the new engagement charts
- Check spam trap preview
- Check health score preview

### To Do
- [ ] Feedback


Default Y domain on engagement charts:
![Screen Shot 2019-04-04 at 11 53 08 AM](https://user-images.githubusercontent.com/3903325/55569902-60e02780-56d0-11e9-9c90-17dffeb59d49.png)

Previews:
![Screen Shot 2019-04-04 at 11 51 35 AM](https://user-images.githubusercontent.com/3903325/55569937-71909d80-56d0-11e9-8e7b-5078d04649bf.png)
