### PR TITLE
EO-669 Filter out master and all subaccounts row

### DIFF
--- a/src/pages/signals/components/HealthScoreOverview.js
+++ b/src/pages/signals/components/HealthScoreOverview.js
@@ -112,6 +112,10 @@ class HealthScoreOverview extends React.Component {
     const noFacetSelected = facet.key === 'sid';
     const noSubaccountFilter = subaccountFilter === undefined;
 
+    // Filter out account aggregate, there is no way to do it via api
+    // This is done here to preserve pagination functionality
+    const filteredData = _.filter(data, ({ sid }) => sid !== -1);
+
     return (
       <Panel>
         <div className={styles.Header}>
@@ -130,8 +134,8 @@ class HealthScoreOverview extends React.Component {
           </div>
         </div>
         <SummaryTable
-          data={data}
-          empty={data.length === 0}
+          data={filteredData}
+          empty={filteredData.length === 0}
           error={error && error.message}
           loading={loading}
           tableName={tableName}
@@ -175,8 +179,8 @@ class HealthScoreOverview extends React.Component {
             dataKey="history"
             label="Daily Health Score"
             width='30%'
-            component={({ history, ...data }) => {
-              const id = data[facet.key];
+            component={({ history, ...filteredData }) => {
+              const id = filteredData[facet.key];
 
               if (chartType === 'bar') {
                 return (
@@ -184,7 +188,7 @@ class HealthScoreOverview extends React.Component {
                     data={_.last(history)}
                     dataKey="health_score"
                     label="Health Score"
-                    onClick={this.handleClick(id, data.sid)}
+                    onClick={this.handleClick(id, filteredData.sid)}
                     relative={false}
                   />
                 );
@@ -195,7 +199,7 @@ class HealthScoreOverview extends React.Component {
                   data={history}
                   dataKey="health_score"
                   label="Health Score"
-                  onClick={this.handleClick(id, data.sid)}
+                  onClick={this.handleClick(id, filteredData.sid)}
                   relative={false}
                 />
               );

--- a/src/pages/signals/components/tests/HealthScoreOverview.test.js
+++ b/src/pages/signals/components/tests/HealthScoreOverview.test.js
@@ -247,4 +247,34 @@ describe('HealthScoreOverview', () => {
       expect(columnWrapper).toMatchSnapshot();
     });
   });
+
+
+  it('filters out master and all subaccounts row', () => {
+    const data = [
+      {
+        current_health_score: 98,
+        domain: 'example.com',
+        history: [
+          { date: '2018-01-13', health_score: 98 }
+        ],
+        average_health_score: 98,
+        WoW: 0.1,
+        sid: 123
+      },
+      {
+        current_health_score: 50,
+        domain: 'master-and-all.com',
+        history: [
+          { date: '2018-01-13', health_score: 50 }
+        ],
+        average_health_score: 50,
+        WoW: 0.5,
+        sid: -1
+      }
+    ];
+    const wrapper = subject({ data });
+    expect(wrapper.find(SummaryTable).prop('data')).toHaveLength(1);
+    expect(wrapper.find(SummaryTable).prop('data')[0]).toEqual(data[0]);
+  });
+
 });


### PR DESCRIPTION
### What Changed
- Filters out subaccount id `-1` from the health score summary table

### How To Test
- [Point your local upstreams to staging](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam
- Verify "master and all subaccounts" does not appear in table
- Verify pagination still works (if possible)

### To Do
- [ ] Address any feedback

Before: 
![Screen Shot 2019-04-04 at 11 50 33 AM](https://user-images.githubusercontent.com/3903325/55569997-8c631200-56d0-11e9-954e-20e5c26a3535.png)
