### PR TITLE
EO-623 Custom Time Ranges

### DIFF
--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -15,14 +15,21 @@ const ORDER_BY_MAPPING = {
 const signalsActionCreator = ({ dimension, type }) => ({
   facet = '',
   filter,
+  from,
   limit,
   offset,
   order,
   orderBy,
   relativeRange,
-  subaccount
+  subaccount,
+  to
 }) => {
-  const { from , to } = getRelativeDates(relativeRange, { now: moment().subtract(1, 'day') });
+  let dates = { from, to };
+
+  if (relativeRange !== 'custom') {
+    dates = getRelativeDates(relativeRange, { now: moment().subtract(1, 'day') });
+  }
+
   let order_by;
 
   // note, to order by subaccount, only pass order direction and do not set order_by
@@ -45,12 +52,12 @@ const signalsActionCreator = ({ dimension, type }) => ({
       showErrorAlert: false,
       params: {
         filter,
-        from: formatInputDate(from),
+        from: formatInputDate(dates.from),
         limit,
         offset,
         order,
         order_by,
-        to: formatInputDate(to)
+        to: formatInputDate(dates.to)
       }
     }
   });
@@ -92,9 +99,16 @@ export const getSpamHits = signalsActionCreator({
 });
 
 export const getInjections = ({
-  relativeRange
+  from,
+  relativeRange,
+  to
 }) => {
-  const { from , to } = getRelativeDates(relativeRange, { now: moment().subtract(1, 'day') });
+
+  let dates = { from, to };
+
+  if (relativeRange !== 'custom') {
+    dates = getRelativeDates(relativeRange, { now: moment().subtract(1, 'day') });
+  }
 
   return sparkpostApiRequest({
     type: 'GET_INJECTIONS',
@@ -104,8 +118,8 @@ export const getInjections = ({
       url: '/v1/signals/injections',
       showErrorAlert: false,
       params: {
-        from: formatInputDate(from),
-        to: formatInputDate(to)
+        from: formatInputDate(dates.from),
+        to: formatInputDate(dates.to)
       }
     }
   });

--- a/src/actions/tests/__snapshots__/signals.test.js.snap
+++ b/src/actions/tests/__snapshots__/signals.test.js.snap
@@ -156,6 +156,29 @@ Array [
 ]
 `;
 
+exports[`Signals Actions .getSpamHits with a custom date range 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "headers": Object {},
+      "method": "GET",
+      "params": Object {
+        "filter": undefined,
+        "from": "2018-01-01",
+        "limit": undefined,
+        "offset": undefined,
+        "order": undefined,
+        "order_by": undefined,
+        "to": "2018-01-07",
+      },
+      "showErrorAlert": false,
+      "url": "/v1/signals/spam-hits/",
+    },
+    "type": "GET_SPAM_HITS",
+  },
+]
+`;
+
 exports[`Signals Actions .getSpamHits with a facet 1`] = `
 Array [
   Object {

--- a/src/actions/tests/signals.test.js
+++ b/src/actions/tests/signals.test.js
@@ -44,6 +44,9 @@ describe('Signals Actions', () => {
     },
     'with a subaccount': {
       action: () => actions.getSpamHits({ ...requiredOptions, subaccount: { id: 123 }})
+    },
+    'with a custom date range': {
+      action: () => actions.getSpamHits({ ...requiredOptions, to: '2018-01-07', from: '2018-01-01', relativeRange: 'custom' })
     }
   });
 

--- a/src/components/datePicker/DatePicker.module.scss
+++ b/src/components/datePicker/DatePicker.module.scss
@@ -8,3 +8,11 @@
 .Apply {
   margin-right: spacing();
 }
+
+
+.Error {
+  display: inline-block;
+  margin-left: spacing();
+  vertical-align: middle;
+  line-height: rem(18);
+}

--- a/src/components/datePicker/tests/DatePicker.test.js
+++ b/src/components/datePicker/tests/DatePicker.test.js
@@ -66,6 +66,11 @@ describe('Component: DatePicker', () => {
     expect(instance.syncTimeToState).toHaveBeenCalledTimes(1);
   });
 
+  it('should not render form fields when manual entry is hidden', () => {
+    wrapper.setProps({ hideManualEntry: true });
+    expect(wrapper.find('ManualEntryForm')).not.toExist();
+  });
+
   describe('syncTimeToState', () => {
 
     const before = { from: 'unchanged', to: 'unchanged' };
@@ -220,6 +225,22 @@ describe('Component: DatePicker', () => {
       expect(dateHelpers.getEndOfDay).toHaveBeenCalledWith(mockClicked, { preventFuture: true });
       expect(wrapper.state('selected')).toEqual(mockNewSelected);
       expect(wrapper.state('beforeSelected')).toEqual(mockNewSelected);
+      expect(wrapper.state('selecting')).toEqual(true);
+    });
+
+    it('should handle a day click whith a validation error', () => {
+      const validate = jest.fn(() => 'error oh no');
+      const mockSelected = {};
+      const mockClicked = {};
+
+      dateHelpers.isSameDate = jest.fn(() => true);
+
+      wrapper.setProps({ validate });
+      wrapper.setState({ selecting: false, selected: mockSelected, beforeSelected: null });
+      const mockNewSelected = { from: 'start-of-day', to: 'end-of-day' };
+
+      instance.handleDayClick(mockClicked);
+      expect(validate).toHaveBeenCalledWith(mockNewSelected);
       expect(wrapper.state('selecting')).toEqual(true);
     });
 
@@ -386,6 +407,15 @@ describe('Component: DatePicker', () => {
       expect(wrapper.state('showDatePicker')).toEqual(false);
       expect(wrapper.state('selecting')).toEqual(false);
       expect(props.onChange).toHaveBeenCalledWith({ ...mockSelected, relativeRange: 'custom' });
+    });
+
+    it('should not do anything with a validation error', () => {
+      const mockSelected = { a: 1, b: 2, c: 3 };
+      wrapper.setState({ showDatePicker: true, selecting: true, selected: mockSelected, validationError: 'oh no' });
+      instance.handleSubmit();
+      expect(wrapper.state('showDatePicker')).toEqual(true);
+      expect(wrapper.state('selecting')).toEqual(true);
+      expect(props.onChange).not.toHaveBeenCalled();
     });
 
   });

--- a/src/components/dateSelector/DateSelector.js
+++ b/src/components/dateSelector/DateSelector.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import DayPicker, { DateUtils } from 'react-day-picker';
-
+import classnames from 'classnames';
 import { ArrowForward, ArrowBack } from '@sparkpost/matchbox-icons';
 import styles from './DateSelector.module.scss';
 
@@ -8,7 +8,9 @@ export class Navbar extends Component {
   render() {
     const {
       onPreviousClick,
-      onNextClick
+      onNextClick,
+      showNextButton,
+      showPreviousButton
     } = this.props;
 
     return (
@@ -16,11 +18,11 @@ export class Navbar extends Component {
         <ArrowBack
           size={21}
           onClick={() => onPreviousClick()}
-          className={styles.Prev} />
+          className={classnames(styles.Prev, showPreviousButton && styles.show)} />
         <ArrowForward
           size={21}
           onClick={() => onNextClick()}
-          className={styles.Next} />
+          className={classnames(styles.Next, showNextButton && styles.show)} />
       </div>
     );
   }

--- a/src/components/dateSelector/DateSelector.module.scss
+++ b/src/components/dateSelector/DateSelector.module.scss
@@ -3,6 +3,7 @@
 /* DayPicker styles */
 .container {
   display: block;
+  margin-bottom: spacing();
 }
 
 .wrapper {
@@ -77,11 +78,9 @@
   flex-basis: 0;
   min-width: rem(24);
 
-  padding: rem(3) rem(7);
-  margin-bottom: -1px;
-  margin-right: -1px;
+  padding: rem(0) rem(6);
+  margin: rem(2) 0;
 
-  border: 1px solid color(gray, 9);
   font-size: rem(12);
   font-weight: 400;
   text-align: center;
@@ -94,7 +93,7 @@
   }
 
   &:hover:not(.disabled):not(.inBetween):not(.firstSelected):not(.lastSelected) {
-    background: color(gray, 9);
+    background: color(gray, 8);
   }
 
   &:active:not(.disabled) {
@@ -114,7 +113,6 @@
 
 .inBetween {
   background: rgba(color(blue), 0.3);
-  border: 1px solid rgba(color(blue), 0.4);
   z-index: 100;
   color: color(gray, 1);
   font-weight: 600;
@@ -127,7 +125,12 @@
   &.inBetween {
     background: rgba(color(blue), 0.12) !important;
     color: color(gray, 7) !important;
-    border: 1px solid rgba(color(blue), 0.15);
+    font-weight: 400;
+  }
+
+  &.lastSelected, &.firstSelected {
+    background: rgba(color(blue, dark), 0.4);
+    color: color(gray, 9) !important;
   }
 }
 
@@ -140,14 +143,14 @@
   color: white;
   background: color(blue, dark);
   border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px
+  border-bottom-left-radius: 4px;
 }
 
 .lastSelected {
   color: white;
   background-color: color(blue, dark);
   border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px
+  border-bottom-right-radius: 4px;
 }
 
 // Custom Components
@@ -163,8 +166,9 @@
   display: inline-block;
   cursor: pointer;
 
-  fill: color(gray, 5);
   transition: 0.15s;
+  fill: rgba(color(gray, 5), 0);
+  pointer-events: none;
 
   &:hover {
     fill: color(blue, dark);
@@ -173,3 +177,7 @@
 
 .Prev { left: rem(24); }
 .Next { right: rem(24); }
+.show {
+  fill: rgba(color(gray, 5), 1);
+  pointer-events: auto;
+}

--- a/src/components/dateSelector/tests/DateSelector.test.js
+++ b/src/components/dateSelector/tests/DateSelector.test.js
@@ -40,7 +40,13 @@ describe('dateselector', () => {
 describe('Navbar', () => {
 
   it('should render correctly', () => {
-    expect(shallow(<Navbar />)).toMatchSnapshot();
+    expect(shallow(<Navbar/>)).toMatchSnapshot();
+  });
+
+  it('should be able to show prev and next buttons', () => {
+    const wrapper = shallow(<Navbar showNextButton showPreviousButton />);
+    expect(wrapper.find('ArrowForward').prop('className')).toContain('show');
+    expect(wrapper.find('ArrowBack').prop('className')).toContain('show');
   });
 
   it('should call previous button handler', () => {

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -185,14 +185,19 @@ export const fillByDate = ({ dataSet, fill = {}, from, now, relativeRange, to } 
  * Generates 3 dates based off relative range
  * Returns first date, middle date, and 1 day before to
  */
-export function getDateTicks(relativeRange) {
-  const { from, to } = getRelativeDates(relativeRange, { now: moment().subtract(1, 'day') });
-  const diff = moment(to).diff(from, 'days');
-  const middle = moment(from).add(diff / 2, 'days');
+export function getDateTicks({ relativeRange, to, from }) {
+  let dates = { to, from };
+
+  if (relativeRange !== 'custom') {
+    dates = getRelativeDates(relativeRange, { now: moment().subtract(1, 'day') });
+  }
+
+  const diff = moment(dates.to).diff(dates.from, 'days');
+  const middle = moment(dates.from).add(diff / 2, 'days');
 
   return [
-    formatInputDate(from),
+    formatInputDate(dates.from),
     formatInputDate(middle),
-    formatInputDate(to)
+    formatInputDate(dates.to)
   ];
 }

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -8,6 +8,7 @@ export const relativeDateOptions = [
   { value: 'day', label: 'Last 24 Hours' },
   { value: '7days', label: 'Last 7 Days' },
   { value: '10days', label: 'Last 10 Days' },
+  { value: '14days', label: 'Last 14 Days' },
   { value: '30days', label: 'Last 30 Days' },
   { value: '90days', label: 'Last 90 Days' },
   { value: 'custom', label: 'Custom' }
@@ -155,12 +156,17 @@ export const parseDate = (str) => moment(str, FORMATS.INPUT_DATES, true);
 export const parseTime = (str) => moment(str, FORMATS.INPUT_TIMES, true);
 export const parseDatetime = (...args) => moment(args.join(' '), FORMATS.INPUT_DATETIMES, true);
 
-export const fillByDate = ({ dataSet, fill = {}, now, relativeRange } = {}) => {
-  const { from, to } = getRelativeDates(relativeRange, { now });
+export const fillByDate = ({ dataSet, fill = {}, from, now, relativeRange, to } = {}) => {
+  let dates = { from, to };
+
+  if (relativeRange && relativeRange !== 'custom') {
+    dates = getRelativeDates(relativeRange, { now });
+  }
+
   const orderedData = dataSet.sort((a, b) => new Date(a.date) - new Date(b.date));
   let filledDataSet = [];
 
-  for (let time = moment(from), index = 0; time.isBefore(moment(to)); time.add(1, 'day')) {
+  for (let time = moment(dates.from), index = 0; time.isBefore(moment(dates.to)); time.add(1, 'day')) {
     const data = orderedData[index];
     const fillData = { ...fill, date: formatInputDate(time) };
 

--- a/src/helpers/tests/__snapshots__/date.test.js.snap
+++ b/src/helpers/tests/__snapshots__/date.test.js.snap
@@ -36,3 +36,16 @@ Array [
   },
 ]
 `;
+
+exports[`Date helpers fillByDate returns sorted and filled dataset with custom date 1`] = `
+Array [
+  Object {
+    "date": "2018-02-01",
+    "value": null,
+  },
+  Object {
+    "date": "2018-02-02",
+    "value": null,
+  },
+]
+`;

--- a/src/helpers/tests/date.test.js
+++ b/src/helpers/tests/date.test.js
@@ -312,6 +312,16 @@ describe('Date helpers', () => {
 
       expect(fillByDate({ dataSet, fill, now, relativeRange })).toMatchSnapshot();
     });
+
+    it('returns sorted and filled dataset with custom date', () => {
+      const dataSet = [
+        { date: '2018-02-02', value: 234 },
+        { date: '2018-01-30', value: 123 }
+      ];
+      const fill = { value: null };
+
+      expect(fillByDate({ dataSet, fill, now, relativeRange: 'custom', to: '2018-02-03', from: '2018-02-01' })).toMatchSnapshot();
+    });
   });
 
   describe('getDateTicks', () => {

--- a/src/helpers/tests/date.test.js
+++ b/src/helpers/tests/date.test.js
@@ -327,10 +327,19 @@ describe('Date helpers', () => {
   describe('getDateTicks', () => {
     it('returns an array of start, end and middle days', () => {
       jest.spyOn(Date, 'now').mockImplementation(() => '2018-02-02T04:20:00-04:00');
-      expect(getDateTicks('14days')).toEqual([
+      expect(getDateTicks({ relativeRange: '14days' })).toEqual([
         '2018-01-18',
         '2018-01-25',
         '2018-02-01'
+      ]);
+    });
+
+    it('returns an array of start, end and middle days with a custom range', () => {
+      jest.spyOn(Date, 'now').mockImplementation(() => '2018-02-02T04:20:00-04:00');
+      expect(getDateTicks({ relativeRange: 'custom', to: '2018-05-25T04:20:00-04:00', from: '2018-05-01T04:20:00-04:00' })).toEqual([
+        '2018-05-01',
+        '2018-05-13',
+        '2018-05-25'
       ]);
     });
   });

--- a/src/helpers/tests/validation.test.js
+++ b/src/helpers/tests/validation.test.js
@@ -112,6 +112,10 @@ const memoizedCases = {
     // The null case below is for the redux-form validation that sometimes occurs before underlying fields are available
     good: [[1024, { size: 1000 }], [1, null]],
     bad: [[1024, { size: 1025 }]]
+  },
+  minDays: {
+    good: [[7, { from: '2018-01-01', to: '2017-12-01' }], [7, { from: '2018-01-01', to: '2018-01-08' }]],
+    bad: [[7, { from: '2018-01-01', to: '2017-12-31' }], [7, { from: '2018-01-01', to: '2018-01-03' }]]
   }
 };
 

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -5,6 +5,7 @@ import { isEmailAddress, isEmailLocalPart, isRecipientEmailAddress } from 'src/h
 import { domainRegex, slugRegex } from './regex';
 import isURL from 'validator/lib/isURL';
 import Payment from 'payment';
+import moment from 'moment';
 
 export function required(value) {
   return value ? undefined : 'Required';
@@ -152,3 +153,12 @@ export const json = (value) => {
     return 'Must be valid JSON';
   }
 };
+
+// Date validator for the DatePicker component
+export const minDays = _.memoize(function minDays(min) {
+  return function (dates) {
+    return Math.abs(moment(dates.from).diff(moment(dates.to), 'days')) < min
+      ? 'Select a range of at least 7 days'
+      : undefined;
+  };
+});

--- a/src/pages/signals/components/filters/DateFilter.js
+++ b/src/pages/signals/components/filters/DateFilter.js
@@ -1,34 +1,62 @@
-import React from 'react';
-import { Select } from '@sparkpost/matchbox';
+import React, { useState, useEffect } from 'react';
+import { FORMATS } from 'src/constants';
+import { getRelativeDates, getStartOfDay } from 'src/helpers/date';
+import DatePicker from 'src/components/datePicker/DatePicker';
 import withSignalOptions from '../../containers/withSignalOptions';
-import styles from './DateFilter.module.scss';
+import { minDays } from 'src/helpers/validation';
+import moment from 'moment';
 
 const OPTIONS = [
-  { label: 'Last 7 Days', value: '7days' },
-  { label: 'Last 14 Days', value: '14days' },
-  { label: 'Last 30 Days', value: '30days' },
-  { label: 'Last 90 Days', value: '90days' }
+  '7days',
+  '14days',
+  '30days',
+  '90days',
+  'custom'
 ];
 
-export class DateFilter extends React.Component {
-  handleChange = (event) => {
-    const { changeSignalOptions } = this.props;
-    changeSignalOptions({ relativeRange: event.currentTarget.value });
+export function DateFilter({ signalOptions, changeSignalOptions, left, now = new Date() }) {
+  // Start of day is used to prevent unwanted side effects when now changes
+  const relativeNow = getStartOfDay(moment(now).subtract(1, 'day')).toString();
+  const [dates, setDates] = useState({ to: null, from: null });
+  const { relativeRange, from, to } = signalOptions;
+
+  // Creates dates for the datepicker from signal options
+  useEffect(() => {
+    let updates = { from, to };
+
+    if (relativeRange !== 'custom') {
+      updates = getRelativeDates(relativeRange, { now: new Date(relativeNow) });
+    }
+
+    setDates(updates);
+  }, [relativeRange, from, to, relativeNow]);
+
+  function handleChange(updates) {
+    changeSignalOptions(updates);
   }
 
-  render() {
-    const { signalOptions: { relativeRange }} = this.props;
-
-    return (
-      <div className={styles.DateFilter}>
-        <Select
-          onChange={this.handleChange}
-          options={OPTIONS}
-          value={relativeRange}
-        />
-      </div>
-    );
-  }
+  return (
+    <DatePicker
+      now={moment(now).subtract(1, 'day').toDate()}
+      from={dates.from}
+      to={dates.to}
+      relativeDateOptions={OPTIONS}
+      relativeRange={signalOptions.relativeRange}
+      onChange={handleChange}
+      dateFieldFormat={FORMATS.DATE}
+      datePickerProps={{
+        disabledDays: {
+          after: moment(now).subtract(1, 'day').toDate(),
+          before: moment(now).subtract(91, 'day').toDate()
+        },
+        fromMonth: moment(now).subtract(91, 'day').toDate()
+      }}
+      roundToPrecision={false}
+      hideManualEntry
+      left={left}
+      validate={minDays(7)}
+    />
+  );
 }
 
 export default withSignalOptions(DateFilter);

--- a/src/pages/signals/components/filters/tests/DateFilter.test.js
+++ b/src/pages/signals/components/filters/tests/DateFilter.test.js
@@ -1,20 +1,31 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 import { DateFilter } from '../DateFilter';
 
 describe('DateFilter', () => {
-  const subject = (props = {}) => shallow(<DateFilter signalOptions={{}} {...props} />);
+  const now = '2018-01-01T05:00:00Z';
+  const subject = (props = {}) => mount(<DateFilter left signalOptions={{}} {...props} now={now} />);
 
-  it('renders a select', () => {
-    expect(subject()).toMatchSnapshot();
+  it('renders datepicker', () => {
+    expect(subject().find('AppDatePicker').props()).toMatchSnapshot();
   });
 
-  it('calls changeSignalOptions when select changes', () => {
+  it('calls changeSignalOptions when dates changes', () => {
     const changeSignalOptions = jest.fn();
     const wrapper = subject({ changeSignalOptions });
+    wrapper.find('AppDatePicker').prop('onChange')('update');
+    expect(changeSignalOptions).toHaveBeenCalledWith('update');
+  });
 
-    wrapper.find('Select').simulate('change', { currentTarget: { value: '14days' }});
+  it('sets dates with a relative range', () => {
+    const wrapper = subject({ signalOptions: { relativeRange: '7days' }});
+    expect(wrapper.find('AppDatePicker').prop('to').toString()).toMatch('Dec 31 2017');
+    expect(wrapper.find('AppDatePicker').prop('from').toString()).toMatch('Dec 24 2017');
+  });
 
-    expect(changeSignalOptions).toHaveBeenCalledWith({ relativeRange: '14days' });
+  it('sets dates with a custom date', () => {
+    const wrapper = subject({ signalOptions: { relativeRange: 'custom', from: new Date('2015-01-04T05:00:00Z'), to: new Date('2015-01-09T05:00:00Z') }});
+    expect(wrapper.find('AppDatePicker').prop('to').toString()).toMatch('Jan 09 2015');
+    expect(wrapper.find('AppDatePicker').prop('from').toString()).toMatch('Jan 04 2015');
   });
 });

--- a/src/pages/signals/components/filters/tests/__snapshots__/DateFilter.test.js.snap
+++ b/src/pages/signals/components/filters/tests/__snapshots__/DateFilter.test.js.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DateFilter renders a select 1`] = `
-<div
-  className="DateFilter"
->
-  <Select
-    onChange={[Function]}
-    options={
-      Array [
-        Object {
-          "label": "Last 7 Days",
-          "value": "7days",
-        },
-        Object {
-          "label": "Last 14 Days",
-          "value": "14days",
-        },
-        Object {
-          "label": "Last 30 Days",
-          "value": "30days",
-        },
-        Object {
-          "label": "Last 90 Days",
-          "value": "90days",
-        },
-      ]
-    }
-  />
-</div>
+exports[`DateFilter renders datepicker 1`] = `
+Object {
+  "dateFieldFormat": "MMM Do",
+  "datePickerProps": Object {
+    "disabledDays": Object {
+      "after": 2017-12-31T05:00:00.000Z,
+      "before": 2017-10-02T04:00:00.000Z,
+    },
+    "fromMonth": 2017-10-02T04:00:00.000Z,
+  },
+  "from": undefined,
+  "hideManualEntry": true,
+  "left": true,
+  "now": 2017-12-31T05:00:00.000Z,
+  "onChange": [Function],
+  "preventFuture": true,
+  "relativeDateOptions": Array [
+    "7days",
+    "14days",
+    "30days",
+    "90days",
+    "custom",
+  ],
+  "relativeRange": undefined,
+  "roundToPrecision": false,
+  "to": undefined,
+  "validate": [Function],
+}
 `;

--- a/src/pages/signals/containers/withDateSelection.js
+++ b/src/pages/signals/containers/withDateSelection.js
@@ -30,7 +30,7 @@ export class WithDateSelection extends Component {
     // Select last date in time series
     if (dataSetChanged && !selectedDataByDay) {
       selectedDataByDay = _.last(data);
-      this.setState({ selectedDate: selectedDataByDay.date });
+      this.setState({ selectedDate: _.get(selectedDataByDay, 'date') });
     }
   }
 

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -30,7 +30,7 @@ export const getInjections = (state, props) => _.get(state, 'signals.injections'
 // Details
 export const selectSpamHitsDetails = createSelector(
   [getSpamHitsData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange }) => {
+  ({ loading, error, data }, facet, facetId, subaccountId, { from, now, relativeRange, to }) => {
     const match = data.find((item) => String(item[facet]) === facetId) || {};
     const history = match.history || [];
     const normalizedHistory = history.map(({ dt: date, ...values }) => ({ date, ...values }));
@@ -42,7 +42,7 @@ export const selectSpamHitsDetails = createSelector(
         relative_trap_hits: null,
         trap_hits: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 
@@ -64,7 +64,7 @@ export const selectSpamHitsDetails = createSelector(
 
 export const selectEngagementRecencyDetails = createSelector(
   [getEngagementRecencyData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange }) => {
+  ({ loading, error, data }, facet, facetId, subaccountId, { from, now, relativeRange, to }) => {
     const match = data.find((item) => String(item[facet]) === facetId) || {};
 
     const calculatePercentages = (data) => data.map(({ c_total, dt, ...absolutes }) => {
@@ -90,7 +90,7 @@ export const selectEngagementRecencyDetails = createSelector(
         c_uneng: null,
         c_total: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 
@@ -112,7 +112,7 @@ export const selectEngagementRecencyDetails = createSelector(
 
 export const selectEngagementRateByCohortDetails = createSelector(
   [getEngagementRateByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange }) => {
+  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange, from, to }) => {
     const match = data.find((item) => String(item[facet]) === facetId) || {};
 
     // Rename date key
@@ -123,7 +123,7 @@ export const selectEngagementRateByCohortDetails = createSelector(
       fill: {
         p_new_eng: null, p_14d_eng: null, p_90d_eng: null, p_365d_eng: null, p_uneng_eng: null, p_total_eng: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 
@@ -145,7 +145,7 @@ export const selectEngagementRateByCohortDetails = createSelector(
 
 export const selectUnsubscribeRateByCohortDetails = createSelector(
   [getUnsubscribeRateByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange }) => {
+  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange, from, to }) => {
     const match = data.find((item) => String(item[facet]) === facetId) || {};
 
     // Rename date key
@@ -161,7 +161,7 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
         p_uneng_unsub: null,
         p_total_unsub: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 
@@ -183,7 +183,7 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
 
 export const selectComplaintsByCohortDetails = createSelector(
   [getComplaintsByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange }) => {
+  ({ loading, error, data }, facet, facetId, subaccountId, { now, relativeRange, from, to }) => {
     const match = data.find((item) => String(item[facet]) === facetId) || {};
 
     // Rename date key
@@ -199,7 +199,7 @@ export const selectComplaintsByCohortDetails = createSelector(
         p_uneng_fbl: null,
         p_total_fbl: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 
@@ -242,7 +242,7 @@ function rankHealthScore(value) {
 
 export const selectHealthScoreDetails = createSelector(
   [getHealthScoreData, selectSpamHitsDetails, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ loading, error, data }, { details: spamDetails }, facet, facetId, subaccountId, { now, relativeRange }) => {
+  ({ loading, error, data }, { details: spamDetails }, facet, facetId, subaccountId, { from, now, relativeRange, to }) => {
     const match = data.find((item) => String(item[facet]) === facetId) || {};
 
     const history = _.get(match, 'history', []);
@@ -267,7 +267,7 @@ export const selectHealthScoreDetails = createSelector(
         ],
         health_score: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 
@@ -295,7 +295,7 @@ export const selectHealthScoreDetails = createSelector(
 
 export const selectEngagementRecencyOverviewData = createSelector(
   getEngagementRecencyData, getOptions,
-  ({ data }, { now, relativeRange }) => data.map(({ WoW, ...rowOfData }) => {
+  ({ data }, { from, now, relativeRange, to }) => data.map(({ WoW, ...rowOfData }) => {
     const history = rowOfData.history || [];
     const normalizedHistory = history.map(({ dt: date, ...values }) => {
       const relative_engaged_recipients = (values.c_14d / values.c_total) * 100;
@@ -313,7 +313,7 @@ export const selectEngagementRecencyOverviewData = createSelector(
         engaged_recipients: null,
         relative_engaged_recipients: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 
@@ -370,7 +370,7 @@ export const selectEngagementRecencyOverview = createSelector(
 
 export const selectHealthScoreOverviewData = createSelector(
   getHealthScoreData, getOptions,
-  ({ data }, { now, relativeRange }) => data.map(({ current_health_score, WoW, ...rowOfData }) => {
+  ({ data }, { from, now, relativeRange, to }) => data.map(({ current_health_score, WoW, ...rowOfData }) => {
     const history = rowOfData.history || [];
     const normalizedHistory = history.map(({ dt: date, health_score, ...values }) => {
       const roundedHealthScore = roundToPlaces(health_score * 100, 1);
@@ -388,13 +388,13 @@ export const selectHealthScoreOverviewData = createSelector(
         health_score: null,
         ranking: null
       },
-      now,
+      from, to, now,
       relativeRange
     });
 
     return {
       ...rowOfData,
-      current_health_score: _.last(filledHistory).health_score,
+      current_health_score: _.get(_.last(filledHistory), 'health_score'),
       history: filledHistory,
       average_health_score: roundToPlaces(
         normalizedHistory.reduce((total, { health_score }) => total + health_score, 0) / normalizedHistory.length,
@@ -408,7 +408,7 @@ export const selectHealthScoreOverviewData = createSelector(
 
 export const selectCurrentHealthScoreDashboard = createSelector(
   [getCurrentHealthScoreData, getOptions, getInjections],
-  ({ data, loading, error }, { now, relativeRange }, injections) => {
+  ({ data, loading, error }, { from, now, relativeRange, to }, injections) => {
     const accountData = _.find(data, ['sid', -1]) || {};
     const history = accountData.history || [];
 
@@ -432,17 +432,19 @@ export const selectCurrentHealthScoreDashboard = createSelector(
         ranking: null,
         injections: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
+
+    const latestHealthScore = _.get(_.last(filledHistory), 'health_score');
 
     return {
       ...accountData,
       loading, error,
-      current_health_score: _.last(filledHistory).health_score,
+      current_health_score: latestHealthScore,
       history: filledHistory,
       WoW: _.isNil(accountData.WoW) ? null : roundToPlaces(accountData.WoW * 100, 0),
-      current_DoD: getDoD(_.last(filledHistory).health_score, filledHistory[filledHistory.length - 2].health_score)
+      current_DoD: getDoD(latestHealthScore, _.get(filledHistory, `[${filledHistory.length - 2}].health_score`))
     };
   }
 );
@@ -458,7 +460,7 @@ export const selectHealthScoreOverview = createSelector(
 
 export const selectSpamHitsOverviewData = createSelector(
   getSpamHitsData, getOptions,
-  ({ data }, { now, relativeRange }) => data.map(({ WoW, ...rowOfData }) => {
+  ({ data }, { from, now, relativeRange, to }) => data.map(({ WoW, ...rowOfData }) => {
     const history = rowOfData.history || [];
     const normalizedHistory = history.map(({ dt: date, relative_trap_hits, ...values }) => ({
       ...values,
@@ -475,7 +477,7 @@ export const selectSpamHitsOverviewData = createSelector(
         relative_trap_hits: null,
         trap_hits: null
       },
-      now,
+      now, from, to,
       relativeRange
     });
 

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -276,6 +276,15 @@ describe('Selectors: signals', () => {
       expect(selectors.selectSpamHitsDetails(state, props)).toMatchSnapshot();
     });
 
+    it('should select spam hits details with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectSpamHitsDetails(stateWithDates, props).details.data;
+      expect(data).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
+    });
+
     it('should be empty with only fill data when not loading', () => {
       const stateWhenEmpty = { ...state, signals: { spamHits: { data: [], loading: false }}};
       expect(selectors.selectSpamHitsDetails(stateWhenEmpty, props)).toMatchSnapshot();
@@ -290,6 +299,15 @@ describe('Selectors: signals', () => {
   describe('engagement recency details', () => {
     it('should select details', () => {
       expect(selectors.selectEngagementRecencyDetails(state, props)).toMatchSnapshot();
+    });
+
+    it('should select details with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectEngagementRecencyDetails(stateWithDates, props).details.data;
+      expect(data).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
     });
 
     it('should be empty with only fill data when not loading', () => {
@@ -308,6 +326,15 @@ describe('Selectors: signals', () => {
       expect(selectors.selectEngagementRateByCohortDetails(state, props)).toMatchSnapshot();
     });
 
+    it('should select details with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectEngagementRateByCohortDetails(stateWithDates, props).details.data;
+      expect(data).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
+    });
+
     it('should be empty with only fill data when not loading', () => {
       const stateWhenEmpty = { ...state, signals: { engagementRateByCohort: { data: [], loading: false }}};
       expect(selectors.selectEngagementRateByCohortDetails(stateWhenEmpty, props).details.empty).toBe(true);
@@ -322,6 +349,15 @@ describe('Selectors: signals', () => {
   describe('unsubscribe rate by cohort details', () => {
     it('should select details', () => {
       expect(selectors.selectUnsubscribeRateByCohortDetails(state, props)).toMatchSnapshot();
+    });
+
+    it('should select details with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectUnsubscribeRateByCohortDetails(stateWithDates, props).details.data;
+      expect(data).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
     });
 
     it('should be empty with only fill data when not loading', () => {
@@ -340,6 +376,15 @@ describe('Selectors: signals', () => {
       expect(selectors.selectComplaintsByCohortDetails(state, props)).toMatchSnapshot();
     });
 
+    it('should select details with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectComplaintsByCohortDetails(stateWithDates, props).details.data;
+      expect(data).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
+    });
+
     it('should be empty with only fill data when not loading', () => {
       const stateWhenEmpty = { ...state, signals: { complaintsByCohort: { data: [], loading: false }}};
       expect(selectors.selectComplaintsByCohortDetails(stateWhenEmpty, props).details.empty).toBe(true);
@@ -354,6 +399,15 @@ describe('Selectors: signals', () => {
   describe('health score details', () => {
     it('should select details', () => {
       expect(selectors.selectHealthScoreDetails(state, props)).toMatchSnapshot();
+    });
+
+    it('should select details with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectHealthScoreDetails(stateWithDates, props).details.data;
+      expect(data).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
     });
 
     it('should be empty with only fill data when not loading', () => {
@@ -376,6 +430,15 @@ describe('Selectors: signals', () => {
   describe('selectEngagementRecencyOverviewData', () => {
     it('returns data', () => {
       expect(selectors.selectEngagementRecencyOverviewData(state, props)).toMatchSnapshot();
+    });
+
+    it('returns data with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectEngagementRecencyOverviewData(stateWithDates, props);
+      expect(data[0].history).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
     });
 
     it('returns empty array', () => {
@@ -416,6 +479,15 @@ describe('Selectors: signals', () => {
       expect(selectors.selectSpamHitsOverviewData(state, props)).toMatchSnapshot();
     });
 
+    it('returns data with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectSpamHitsOverviewData(stateWithDates, props);
+      expect(data[0].history).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
+    });
+
     it('returns empty array', () => {
       const stateWhenEmpty = { ...state, signals: { spamHits: { data: []}}};
       expect(selectors.selectSpamHitsOverviewData(stateWhenEmpty, props)).toEqual([]);
@@ -452,6 +524,15 @@ describe('Selectors: signals', () => {
   describe('selectHealthScoreOverviewData', () => {
     it('returns data', () => {
       expect(selectors.selectHealthScoreOverviewData(state, props)).toMatchSnapshot();
+    });
+
+    it('returns data with custom range', () => {
+      const stateWithDates = { ...state, signalOptions: { relativeRange: 'custom', to: '2018-01-03', from: '2018-01-01' }};
+      const data = selectors.selectHealthScoreOverviewData(stateWithDates, props);
+      expect(data[0].history).toEqual([
+        expect.objectContaining({ date: '2018-01-01' }),
+        expect.objectContaining({ date: '2018-01-02' })
+      ]);
     });
 
     it('returns empty array', () => {


### PR DESCRIPTION
This is a base PR of shared changes needed by all Signals pages. The pages are not hooked up in this PR, and only relative ranges will work in this branch.

### Additional PRs
- [ ] V1 and V2 Details Pages (#944)
- [ ] V1 and V2 Summary Tables (#945)
- [ ] V2 Dashboards & Filter Restructure (#946)

### What Changed
- Signals Custom Time Ranges
  - Modifies `DateFilter` to use the date picker
  - Adds support for custom `to` and `from` in all signals actions, selectors
- DatePicker
  - Adds a 7 day minimum validator and adds a `validate` prop to the datepicker
  - Month changer now correctly hides next/previous buttons

### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data

### To Do
- [ ] Address any feedback
- [ ] Merge in additional PRs

