### PR TITLE
Follow-up for FE-635: Set runtime environment correctly for enterprise tenants

### DIFF
--- a/src/config/env/index.js
+++ b/src/config/env/index.js
@@ -4,7 +4,11 @@ import stagingConfig from './staging-config';
 import testConfig from './test-config';
 import uatConfig from './uat-config';
 
-export default (nodeEnv, environment) => {
+
+export default (
+  nodeEnv,
+  environment = 'production' // for enterprise tenants
+) => {
   if (nodeEnv === 'production') {
     const configByEnvironment = {
       production: productionConfig,

--- a/src/config/tests/env.test.js
+++ b/src/config/tests/env.test.js
@@ -25,4 +25,8 @@ describe('Runtime Environment Configuration', () => {
   it('returns production configurations', () => {
     expect(env('production', 'production')).toEqual(productionConfig);
   });
+
+  it('returns production configurations when environment not set', () => {
+    expect(env('production')).toEqual(productionConfig);
+  });
 });


### PR DESCRIPTION
Needed to set a default environment for enterprise tenants.