### PR TITLE
SA-506 Fix view details page for events without message id

### DIFF
--- a/src/actions/messageEvents.js
+++ b/src/actions/messageEvents.js
@@ -152,6 +152,21 @@ export function getMessageHistory({ messageId }) {
   });
 }
 
+export function getSelectedEvent({ eventId }) {
+  return sparkpostApiRequest({
+    type: 'GET_SELECTED_EVENT',
+    meta: {
+      method: 'GET',
+      url: '/v1/events/message',
+      params: {
+        event_ids: eventId,
+        to: moment.utc().format(apiDateFormat),
+        from: moment.utc().subtract(retentionPeriodDays, 'days').startOf('day').format(apiDateFormat)
+      }
+    }
+  });
+}
+
 export function getDocumentation() {
   return sparkpostApiRequest({
     type: 'GET_MESSAGE_EVENTS_DOCUMENTATION',

--- a/src/actions/tests/__snapshots__/messageEvents.test.js.snap
+++ b/src/actions/tests/__snapshots__/messageEvents.test.js.snap
@@ -93,6 +93,21 @@ Object {
 }
 `;
 
+exports[`Action Creator: MessageEvents getSelectedEvent makes api call with defaults 1`] = `
+Object {
+  "meta": Object {
+    "method": "GET",
+    "params": Object {
+      "event_ids": "abcd,efgh",
+      "from": "2018-02-01T10:10",
+      "to": "2018-02-01T10:10",
+    },
+    "url": "/v1/events/message",
+  },
+  "type": "GET_SELECTED_EVENT",
+}
+`;
+
 exports[`Action Creator: MessageEvents updateMessageEventsSearchOptions dedupes filters 1`] = `
 Object {
   "payload": Object {

--- a/src/actions/tests/__snapshots__/messageEvents.test.js.snap
+++ b/src/actions/tests/__snapshots__/messageEvents.test.js.snap
@@ -98,7 +98,7 @@ Object {
   "meta": Object {
     "method": "GET",
     "params": Object {
-      "event_ids": "abcd,efgh",
+      "event_ids": "abc123",
       "from": "2018-02-01T10:10",
       "to": "2018-02-01T10:10",
     },

--- a/src/actions/tests/messageEvents.test.js
+++ b/src/actions/tests/messageEvents.test.js
@@ -125,6 +125,12 @@ describe('Action Creator: MessageEvents', () => {
     });
   });
 
+  describe('getSelectedEvent', () => {
+    it('makes api call with defaults', () => {
+      expect(messageEvents.getSelectedEvent({ eventId: 'abcd,efgh' })).toMatchSnapshot();
+    });
+  });
+
   describe('updateMessageEventsSearchOptions', () => {
     it('dedupes filters', () => {
       expect(messageEvents.updateMessageEventsSearchOptions({

--- a/src/actions/tests/messageEvents.test.js
+++ b/src/actions/tests/messageEvents.test.js
@@ -127,7 +127,7 @@ describe('Action Creator: MessageEvents', () => {
 
   describe('getSelectedEvent', () => {
     it('makes api call with defaults', () => {
-      expect(messageEvents.getSelectedEvent({ eventId: 'abcd,efgh' })).toMatchSnapshot();
+      expect(messageEvents.getSelectedEvent({ eventId: 'abc123' })).toMatchSnapshot();
     });
   });
 

--- a/src/pages/reports/messageEvents/EventPage.js
+++ b/src/pages/reports/messageEvents/EventPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-import { getMessageHistory, getDocumentation } from 'src/actions/messageEvents';
+import { getMessageHistory, getDocumentation, getSelectedEvent } from 'src/actions/messageEvents';
 import RedirectAndAlert from 'src/components/globalAlert/RedirectAndAlert';
 import { eventPageMSTP } from 'src/selectors/messageEvents';
 import { getDetailsPath } from 'src/helpers/messageEvents';
@@ -32,9 +32,11 @@ export class EventPage extends Component {
   }
 
   handleRefresh = () => {
-    const { messageId, getMessageHistory, isOrphanEvent } = this.props;
+    const { messageId, getMessageHistory, isOrphanEvent, selectedEventId, getSelectedEvent } = this.props;
     if (!isOrphanEvent) {
       getMessageHistory({ messageId });
+    } else {
+      getSelectedEvent({ eventId: selectedEventId });
     }
   }
 
@@ -96,4 +98,4 @@ export class EventPage extends Component {
   }
 }
 
-export default connect(eventPageMSTP, { getMessageHistory, getDocumentation })(EventPage);
+export default connect(eventPageMSTP, { getMessageHistory, getDocumentation, getSelectedEvent })(EventPage);

--- a/src/pages/reports/messageEvents/EventPage.js
+++ b/src/pages/reports/messageEvents/EventPage.js
@@ -33,10 +33,10 @@ export class EventPage extends Component {
 
   handleRefresh = () => {
     const { messageId, getMessageHistory, isOrphanEvent, selectedEventId, getSelectedEvent } = this.props;
-    if (!isOrphanEvent) {
-      getMessageHistory({ messageId });
-    } else {
+    if (isOrphanEvent) {
       getSelectedEvent({ eventId: selectedEventId });
+    } else {
+      getMessageHistory({ messageId });
     }
   }
 

--- a/src/pages/reports/messageEvents/tests/EventPage.test.js
+++ b/src/pages/reports/messageEvents/tests/EventPage.test.js
@@ -75,7 +75,7 @@ describe('Page: Event tests', () => {
       expect(props.getMessageHistory).toHaveBeenCalledWith({ messageId: 'id' });
     });
 
-    it('invokes getSpecificEvent if it is an orphan event', () => {
+    it('invokes getSelectedEvent if it is an orphan event', () => {
       wrapper.setProps({ isOrphanEvent: true });
       instance.handleRefresh();
       expect(props.getSelectedEvent).toHaveBeenCalledWith({ eventId: 'eventId' });

--- a/src/pages/reports/messageEvents/tests/EventPage.test.js
+++ b/src/pages/reports/messageEvents/tests/EventPage.test.js
@@ -6,6 +6,7 @@ describe('Page: Event tests', () => {
   const props = {
     getMessageHistory: jest.fn(),
     getDocumentation: jest.fn(),
+    getSelectedEvent: jest.fn(),
     history: {
       replace: jest.fn(),
       push: jest.fn()
@@ -18,7 +19,8 @@ describe('Page: Event tests', () => {
     isOrphanEvent: false,
     match: {
       params: {}
-    }
+    },
+    selectedEventId: 'eventId'
   };
 
   let wrapper;
@@ -73,10 +75,10 @@ describe('Page: Event tests', () => {
       expect(props.getMessageHistory).toHaveBeenCalledWith({ messageId: 'id' });
     });
 
-    it('does not invoke getMessageHistory if it is an orphan event', () => {
+    it('invokes getSpecificEvent if it is an orphan event', () => {
       wrapper.setProps({ isOrphanEvent: true });
       instance.handleRefresh();
-      expect(props.getMessageHistory).toHaveBeenCalledTimes(0);
+      expect(props.getSelectedEvent).toHaveBeenCalledWith({ eventId: 'eventId' });
     });
   });
 });

--- a/src/pages/reports/messageEvents/tests/__snapshots__/EventPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/EventPage.test.js.snap
@@ -62,6 +62,7 @@ exports[`Page: Event tests should render page correctly 1`] = `
             },
           ]
         }
+        selectedId="eventId"
       />
     </Grid.Column>
   </Grid>

--- a/src/reducers/messageEvents.js
+++ b/src/reducers/messageEvents.js
@@ -11,6 +11,7 @@ const initialState = {
   error: null,
   events: [],
   history: {},
+  selectedEvent: {},
   search: {
     dateOptions: {
       relativeRange: 'hour'
@@ -103,6 +104,20 @@ export default (state = initialState, { type, payload, meta, extra }) => {
     case 'GET_MESSAGE_HISTORY_FAIL':
       return { ...state, historyLoading: false, error: payload };
 
+      // Selected Event
+
+    case 'GET_SELECTED_EVENT_PENDING':
+      return { ...state, historyLoading: true, error: null };
+
+    case 'GET_SELECTED_EVENT_SUCCESS':
+      return {
+        ...state,
+        historyLoading: false,
+        selectedEvent: payload[0]
+      };
+
+    case 'GET_SELECTED_EVENT_FAIL':
+      return { ...state, historyLoading: false, error: payload };
 
       // Documentation
 

--- a/src/reducers/messageEvents.js
+++ b/src/reducers/messageEvents.js
@@ -8,6 +8,7 @@ const initialState = {
   loading: false,
   historyLoading: false,
   documentationLoading: false,
+  selectedEventLoading: false,
   error: null,
   events: [],
   history: {},
@@ -107,17 +108,17 @@ export default (state = initialState, { type, payload, meta, extra }) => {
       // Selected Event
 
     case 'GET_SELECTED_EVENT_PENDING':
-      return { ...state, historyLoading: true, error: null };
+      return { ...state, selectedEventLoading: true, error: null };
 
     case 'GET_SELECTED_EVENT_SUCCESS':
       return {
         ...state,
-        historyLoading: false,
+        selectedEventLoading: false,
         selectedEvent: payload[0]
       };
 
     case 'GET_SELECTED_EVENT_FAIL':
-      return { ...state, historyLoading: false, error: payload };
+      return { ...state, selectedEventLoading: false, error: payload };
 
       // Documentation
 

--- a/src/selectors/messageEvents.js
+++ b/src/selectors/messageEvents.js
@@ -5,6 +5,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 
 const getMessageEvents = (state) => state.messageEvents.events;
 const getMessageHistory = (state) => state.messageEvents.history;
+const getSingleSelectedEvent = (state) => state.messageEvents.selectedEvent;
 export const getMessageIdParam = (state, props) => props.match.params.messageId;
 const getEventIdParam = (state, props) => props.match.params.eventId;
 
@@ -55,18 +56,13 @@ export const getSelectedEventFromMessageHistory = createSelector(
   (messageHistory, eventId) => _.find(messageHistory, (event) => event.event_id === eventId)
 );
 
-export const getSelectedEventFromEventsList = createSelector(
-  [getMessageEvents, getEventIdParam],
-  (messageEvents, eventId) => _.find(messageEvents, (event) => event.event_id === eventId)
-);
-
 //whether the event is without a message_id (defaulted to _noid_)
 const isOrphanEvent = createSelector(
   [getMessageIdParam], (messageId) => messageId === '_noid_'
 );
 
 const getSelectedEvent = createSelector(
-  [isOrphanEvent, getSelectedEventFromEventsList, getSelectedEventFromMessageHistory], (isOrphanEvent, eventFromEventList, eventFromMessageHistory) => isOrphanEvent ? eventFromEventList : eventFromMessageHistory
+  [isOrphanEvent, getSingleSelectedEvent, getSelectedEventFromMessageHistory], (isOrphanEvent, selectedEvent, eventFromMessageHistory) => isOrphanEvent ? selectedEvent : eventFromMessageHistory
 );
 
 export const eventPageMSTP = (state, props) => createStructuredSelector({

--- a/src/selectors/messageEvents.js
+++ b/src/selectors/messageEvents.js
@@ -68,7 +68,9 @@ const getSelectedEvent = createSelector(
 export const eventPageMSTP = (state, props) => createStructuredSelector({
   isMessageHistoryEmpty: isMessageHistoryEmpty,
   isOrphanEvent: isOrphanEvent,
-  loading: (state) => !!(state.messageEvents.historyLoading || state.messageEvents.documentationLoading),
+  loading: (state) => !!(state.messageEvents.historyLoading ||
+    state.messageEvents.documentationLoading ||
+    state.messageEvents.selectedEventLoading),
   messageHistory: selectMessageHistory,
   messageId: getMessageIdParam,
   documentation: (state) => state.messageEvents.documentation,

--- a/src/selectors/tests/__snapshots__/messageEvents.test.js.snap
+++ b/src/selectors/tests/__snapshots__/messageEvents.test.js.snap
@@ -77,16 +77,14 @@ Object {
   "loading": false,
   "messageHistory": Array [],
   "messageId": "_noid_",
-  "selectedEvent": undefined,
+  "selectedEvent": Array [
+    Object {
+      "event_id": "default_id",
+      "foo": "bar",
+      "timestamp": "2017-11-09T00:00",
+    },
+  ],
   "selectedEventId": "default_id",
-}
-`;
-
-exports[`MessageEvents Selectors getSelectedEventFromEventsList returns correct event from events list 1`] = `
-Object {
-  "event_id": "default_id",
-  "foo": "bar",
-  "timestamp": "2017-11-09T00:00",
 }
 `;
 

--- a/src/selectors/tests/messageEvents.test.js
+++ b/src/selectors/tests/messageEvents.test.js
@@ -5,6 +5,7 @@ describe('MessageEvents Selectors', () => {
   let props;
   let messageEvents;
   let messageHistory;
+  let selectedEvent;
 
   beforeEach(() => {
     props = {
@@ -31,7 +32,13 @@ describe('MessageEvents Selectors', () => {
 
     messageEvents = { events: events };
     messageHistory = { history: { message_id: events }};
-
+    selectedEvent = [
+      {
+        event_id: 'default_id',
+        foo: 'bar',
+        timestamp: '2017-11-09T00:00'
+      }
+    ];
   });
 
 
@@ -129,17 +136,6 @@ describe('MessageEvents Selectors', () => {
     });
   });
 
-  describe('getSelectedEventFromEventsList', () => {
-    it('returns correct event from events list', () => {
-      props.match.params.eventId = 'default_id';
-      expect(selectors.getSelectedEventFromEventsList({ messageEvents }, props)).toMatchSnapshot();
-    });
-
-    it('returns undefined if event does not exist in messageHistory', () => {
-      expect(selectors.getSelectedEventFromEventsList({ messageEvents }, props)).toBe(undefined);
-    });
-  });
-
   describe('getMessageIdParam', () => {
     it('returns correct messageId value from path', () => {
       expect(selectors.getMessageIdParam({}, { match: { params: { messageId: 'xyz' }}})).toEqual('xyz');
@@ -154,7 +150,7 @@ describe('MessageEvents Selectors', () => {
     let store;
     let props;
     beforeEach(() => {
-      store = { messageEvents: { ...messageHistory, documentation: {}}};
+      store = { messageEvents: { ...messageHistory, selectedEvent, documentation: {}}};
       props = { match: { params: { messageId: 'message_id', eventId: 'default_id' }}};
     });
 


### PR DESCRIPTION
### What Changed
 - Added new action/reducer pair to get an event.
 - Removed some selector stuff
 - Added a conditional to call the new action/reducer if the event has no message id 

### How To Test
 - Go to reports/message-events and click view details button for an event without a message id. Do both regular click and open in new tab/window. All generation failure events should have no message ids. 

### To Do
- [x] Address review feedback

### Notes:
I could use the existing `GET_MESSAGE_EVENTS` redux action instead. This would result in a smaller codebase but more complex/confusing code. 
