### PR TITLE
EO-623 Details Pages

### DIFF
--- a/src/pages/signals/containers/ComplaintsByCohortDetailsContainer.js
+++ b/src/pages/signals/containers/ComplaintsByCohortDetailsContainer.js
@@ -5,6 +5,7 @@ import { getComplaintsByCohort } from 'src/actions/signals';
 import { selectComplaintsByCohortDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
 import { getDisplayName } from 'src/helpers/hoc';
+import _ from 'lodash';
 
 export class WithComplaintsByCohortDetails extends Component {
   componentDidMount() {
@@ -12,23 +13,25 @@ export class WithComplaintsByCohortDetails extends Component {
     getComplaintsByCohort({
       facet,
       filter: facetId,
+      from: filters.from,
       relativeRange: filters.relativeRange,
-      subaccount: subaccountId
+      subaccount: subaccountId,
+      to: filters.to
     });
   }
 
   componentDidUpdate(prevProps) {
     const { getComplaintsByCohort, facet, facetId, filters, subaccountId } = this.props;
-    const prevRange = prevProps.filters.relativeRange;
-    const nextRange = filters.relativeRange;
 
-    // Refresh when date range changes
-    if (prevRange !== nextRange) {
+    // Refresh when filters change
+    if (!_.isEqual(prevProps.filters, filters)) {
       getComplaintsByCohort({
         facet,
         filter: facetId,
-        relativeRange: nextRange,
-        subaccount: subaccountId
+        from: filters.from,
+        relativeRange: filters.relativeRange,
+        subaccount: subaccountId,
+        to: filters.to
       });
     }
   }
@@ -45,7 +48,7 @@ export class WithComplaintsByCohortDetails extends Component {
     } = this.props;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} xTicks={getDateTicks(filters)} selected={selected} subaccountId={subaccountId} />
     );
   }
 }

--- a/src/pages/signals/containers/EngagementRateByCohortDetailsContainer.js
+++ b/src/pages/signals/containers/EngagementRateByCohortDetailsContainer.js
@@ -5,6 +5,7 @@ import { getEngagementRateByCohort } from 'src/actions/signals';
 import { selectEngagementRateByCohortDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
 import { getDisplayName } from 'src/helpers/hoc';
+import _ from 'lodash';
 
 export class WithEngagementRateByCohortDetails extends Component {
   componentDidMount() {
@@ -12,23 +13,25 @@ export class WithEngagementRateByCohortDetails extends Component {
     getEngagementRateByCohort({
       facet,
       filter: facetId,
+      from: filters.from,
       relativeRange: filters.relativeRange,
-      subaccount: subaccountId
+      subaccount: subaccountId,
+      to: filters.to
     });
   }
 
   componentDidUpdate(prevProps) {
     const { getEngagementRateByCohort, facet, facetId, filters, subaccountId } = this.props;
-    const prevRange = prevProps.filters.relativeRange;
-    const nextRange = filters.relativeRange;
 
-    // Refresh when date range changes
-    if (prevRange !== nextRange) {
+    // Refresh when filters change
+    if (!_.isEqual(prevProps.filters, filters)) {
       getEngagementRateByCohort({
         facet,
         filter: facetId,
-        relativeRange: nextRange,
-        subaccount: subaccountId
+        from: filters.from,
+        relativeRange: filters.relativeRange,
+        subaccount: subaccountId,
+        to: filters.to
       });
     }
   }
@@ -45,7 +48,7 @@ export class WithEngagementRateByCohortDetails extends Component {
     } = this.props;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} xTicks={getDateTicks(filters)} selected={selected} subaccountId={subaccountId} />
     );
   }
 }

--- a/src/pages/signals/containers/EngagementRecencyDetailsContainer.js
+++ b/src/pages/signals/containers/EngagementRecencyDetailsContainer.js
@@ -5,6 +5,7 @@ import { getEngagementRecency } from 'src/actions/signals';
 import { selectEngagementRecencyDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
 import { getDisplayName } from 'src/helpers/hoc';
+import _ from 'lodash';
 
 export class WithEngagementRecencyDetails extends Component {
   componentDidMount() {
@@ -12,23 +13,25 @@ export class WithEngagementRecencyDetails extends Component {
     getEngagementRecency({
       facet,
       filter: facetId,
+      from: filters.from,
       relativeRange: filters.relativeRange,
-      subaccount: subaccountId
+      subaccount: subaccountId,
+      to: filters.to
     });
   }
 
   componentDidUpdate(prevProps) {
     const { getEngagementRecency, facet, facetId, filters, subaccountId } = this.props;
-    const prevRange = prevProps.filters.relativeRange;
-    const nextRange = filters.relativeRange;
 
-    // Refresh when date range changes
-    if (prevRange !== nextRange) {
+    // Refresh when filters change
+    if (!_.isEqual(prevProps.filters, filters)) {
       getEngagementRecency({
         facet,
         filter: facetId,
-        relativeRange: nextRange,
-        subaccount: subaccountId
+        from: filters.from,
+        relativeRange: filters.relativeRange,
+        subaccount: subaccountId,
+        to: filters.to
       });
     }
   }
@@ -48,7 +51,7 @@ export class WithEngagementRecencyDetails extends Component {
     const gap = details.data && details.data.length > 15 ? 0.2 : 1;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters)} selected={selected} subaccountId={subaccountId} />
     );
   }
 }

--- a/src/pages/signals/containers/HealthScoreDetailsContainer.js
+++ b/src/pages/signals/containers/HealthScoreDetailsContainer.js
@@ -5,6 +5,7 @@ import { getHealthScore, getSpamHits } from 'src/actions/signals';
 import { selectHealthScoreDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
 import { getDisplayName } from 'src/helpers/hoc';
+import _ from 'lodash';
 
 export class WithHealthScoreDetails extends Component {
   componentDidMount() {
@@ -13,11 +14,9 @@ export class WithHealthScoreDetails extends Component {
 
   componentDidUpdate(prevProps) {
     const { filters } = this.props;
-    const prevRange = prevProps.filters.relativeRange;
-    const nextRange = filters.relativeRange;
 
-    // Refresh when date range changes
-    if (prevRange !== nextRange) {
+    // Refresh when filters change
+    if (!_.isEqual(prevProps.filters, filters)) {
       this.getData();
     }
   }
@@ -27,8 +26,10 @@ export class WithHealthScoreDetails extends Component {
     const options = {
       facet,
       filter: facetId,
+      from: filters.from,
       relativeRange: filters.relativeRange,
-      subaccount: subaccountId
+      subaccount: subaccountId,
+      to: filters.to
     };
     getHealthScore(options);
     getSpamHits(options);
@@ -49,7 +50,7 @@ export class WithHealthScoreDetails extends Component {
     const gap = details.data && details.data.length > 15 ? 0.2 : 1;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} selected={selected} xTicks={getDateTicks(filters.relativeRange)} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} selected={selected} xTicks={getDateTicks(filters)} subaccountId={subaccountId} />
     );
   }
 }

--- a/src/pages/signals/containers/SpamTrapDetailsContainer.js
+++ b/src/pages/signals/containers/SpamTrapDetailsContainer.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { getSpamHits } from 'src/actions/signals';
 import { selectSpamHitsDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
+import _ from 'lodash';
 
 export class WithSpamTrapDetails extends Component {
   componentDidMount() {
@@ -11,23 +12,25 @@ export class WithSpamTrapDetails extends Component {
     getSpamHits({
       facet,
       filter: facetId,
+      from: filters.from,
       relativeRange: filters.relativeRange,
-      subaccount: subaccountId
+      subaccount: subaccountId,
+      to: filters.to
     });
   }
 
   componentDidUpdate(prevProps) {
     const { getSpamHits, facet, facetId, filters, subaccountId } = this.props;
-    const prevRange = prevProps.filters.relativeRange;
-    const nextRange = filters.relativeRange;
 
-    // Refresh when date range changes
-    if (prevRange !== nextRange) {
+    // Refresh when filters change
+    if (!_.isEqual(prevProps.filters, filters)) {
       getSpamHits({
         facet,
         filter: facetId,
-        relativeRange: nextRange,
-        subaccount: subaccountId
+        from: filters.from,
+        relativeRange: filters.relativeRange,
+        subaccount: subaccountId,
+        to: filters.to
       });
     }
   }
@@ -47,7 +50,7 @@ export class WithSpamTrapDetails extends Component {
     const gap = details.data && details.data.length > 15 ? 0.2 : 1;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} xTicks={getDateTicks(filters)} selected={selected} subaccountId={subaccountId} />
     );
   }
 }

--- a/src/pages/signals/containers/UnsubscribeRateByCohortDetailsContainer.js
+++ b/src/pages/signals/containers/UnsubscribeRateByCohortDetailsContainer.js
@@ -5,6 +5,7 @@ import { getUnsubscribeRateByCohort } from 'src/actions/signals';
 import { selectUnsubscribeRateByCohortDetails, getSelectedDateFromRouter } from 'src/selectors/signals';
 import { getDateTicks } from 'src/helpers/date';
 import { getDisplayName } from 'src/helpers/hoc';
+import _ from 'lodash';
 
 export class WithUnsubscribeRateByCohortDetails extends Component {
   componentDidMount() {
@@ -12,23 +13,25 @@ export class WithUnsubscribeRateByCohortDetails extends Component {
     getUnsubscribeRateByCohort({
       facet,
       filter: facetId,
+      from: filters.from,
       relativeRange: filters.relativeRange,
-      subaccount: subaccountId
+      subaccount: subaccountId,
+      to: filters.to
     });
   }
 
   componentDidUpdate(prevProps) {
     const { getUnsubscribeRateByCohort, facet, facetId, filters, subaccountId } = this.props;
-    const prevRange = prevProps.filters.relativeRange;
-    const nextRange = filters.relativeRange;
 
-    // Refresh when date range changes
-    if (prevRange !== nextRange) {
+    // Refresh when filters change
+    if (!_.isEqual(prevProps.filters, filters)) {
       getUnsubscribeRateByCohort({
         facet,
         filter: facetId,
-        relativeRange: nextRange,
-        subaccount: subaccountId
+        from: filters.from,
+        relativeRange: filters.relativeRange,
+        subaccount: subaccountId,
+        to: filters.to
       });
     }
   }
@@ -45,7 +48,7 @@ export class WithUnsubscribeRateByCohortDetails extends Component {
     } = this.props;
 
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} xTicks={getDateTicks(filters.relativeRange)} selected={selected} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} xTicks={getDateTicks(filters)} selected={selected} subaccountId={subaccountId} />
     );
   }
 }

--- a/src/pages/signals/containers/tests/ComplaintsByCohortContainer.test.js
+++ b/src/pages/signals/containers/tests/ComplaintsByCohortContainer.test.js
@@ -19,7 +19,9 @@ describe('Signals Complaints by Cohort Details Container', () => {
       facet: 'sending_domain',
       facetId: 'test.com',
       filters: {
-        relativeRange: '14days'
+        from: '2015-01-01',
+        relativeRange: '14days',
+        to: '2015-01-05'
       },
       getComplaintsByCohort: jest.fn(),
       selected: '2015-01-01',
@@ -32,21 +34,35 @@ describe('Signals Complaints by Cohort Details Container', () => {
 
   it('gets complaints by cohort on mount correctly', () => {
     expect(wrapper).toMatchSnapshot();
-    expect(props.getComplaintsByCohort,).toHaveBeenCalledWith({
+    expect(props.getComplaintsByCohort).toHaveBeenCalledWith({
       facet: 'sending_domain',
       filter: 'test.com',
+      from: '2015-01-01',
       relativeRange: '14days',
-      subaccount: '101'
+      subaccount: '101',
+      to: '2015-01-05'
     });
   });
 
   it('gets complaints by cohort when range is updated', () => {
     wrapper.setProps({ filters: { relativeRange: '30days' }});
-    expect(props.getComplaintsByCohort,).toHaveBeenCalledWith({
+    expect(props.getComplaintsByCohort).toHaveBeenCalledWith({
       facet: 'sending_domain',
       filter: 'test.com',
       relativeRange: '30days',
       subaccount: '101'
+    });
+  });
+
+  it('gets complaints by cohort when dates are updated', () => {
+    wrapper.setProps({ filters: { relativeRange: 'custom', to: '2016-01-02', from: '2016-01-01' }});
+    expect(props.getComplaintsByCohort).toHaveBeenCalledWith({
+      facet: 'sending_domain',
+      filter: 'test.com',
+      from: '2016-01-01',
+      relativeRange: 'custom',
+      subaccount: '101',
+      to: '2016-01-02'
     });
   });
 

--- a/src/pages/signals/containers/tests/EngagementRateByCohortDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/EngagementRateByCohortDetailsContainer.test.js
@@ -19,7 +19,9 @@ describe('Signals Engagement Rate by Cohort Details Container', () => {
       facet: 'sending_domain',
       facetId: 'test.com',
       filters: {
-        relativeRange: '14days'
+        from: '2015-01-01',
+        relativeRange: '14days',
+        to: '2015-01-05'
       },
       getEngagementRateByCohort: jest.fn(),
       selected: '2015-01-01',
@@ -35,8 +37,10 @@ describe('Signals Engagement Rate by Cohort Details Container', () => {
     expect(props.getEngagementRateByCohort,).toHaveBeenCalledWith({
       facet: 'sending_domain',
       filter: 'test.com',
+      from: '2015-01-01',
       relativeRange: '14days',
-      subaccount: '101'
+      subaccount: '101',
+      to: '2015-01-05'
     });
   });
 
@@ -47,6 +51,18 @@ describe('Signals Engagement Rate by Cohort Details Container', () => {
       filter: 'test.com',
       relativeRange: '30days',
       subaccount: '101'
+    });
+  });
+
+  it('gets engagement rate by cohort when dates are updated', () => {
+    wrapper.setProps({ filters: { relativeRange: 'custom', to: '2016-01-02', from: '2016-01-01' }});
+    expect(props.getEngagementRateByCohort).toHaveBeenCalledWith({
+      facet: 'sending_domain',
+      filter: 'test.com',
+      from: '2016-01-01',
+      relativeRange: 'custom',
+      subaccount: '101',
+      to: '2016-01-02'
     });
   });
 

--- a/src/pages/signals/containers/tests/EngagementRecencyDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/EngagementRecencyDetailsContainer.test.js
@@ -20,7 +20,9 @@ describe('Signals Engagement Recency Details Container', () => {
       facet: 'sending_domain',
       facetId: 'test.com',
       filters: {
-        relativeRange: '14days'
+        from: '2015-01-01',
+        relativeRange: '14days',
+        to: '2015-01-05'
       },
       getEngagementRecency: jest.fn(),
       selected: '2015-01-01',
@@ -36,8 +38,10 @@ describe('Signals Engagement Recency Details Container', () => {
     expect(props.getEngagementRecency).toHaveBeenCalledWith({
       facet: 'sending_domain',
       filter: 'test.com',
+      from: '2015-01-01',
       relativeRange: '14days',
-      subaccount: '101'
+      subaccount: '101',
+      to: '2015-01-05'
     });
   });
 
@@ -48,6 +52,18 @@ describe('Signals Engagement Recency Details Container', () => {
       filter: 'test.com',
       relativeRange: '30days',
       subaccount: '101'
+    });
+  });
+
+  it('gets engagement recency when dates are updated', () => {
+    wrapper.setProps({ filters: { relativeRange: 'custom', to: '2016-01-02', from: '2016-01-01' }});
+    expect(props.getEngagementRecency).toHaveBeenCalledWith({
+      facet: 'sending_domain',
+      filter: 'test.com',
+      from: '2016-01-01',
+      relativeRange: 'custom',
+      subaccount: '101',
+      to: '2016-01-02'
     });
   });
 

--- a/src/pages/signals/containers/tests/HealthScoreDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/HealthScoreDetailsContainer.test.js
@@ -20,7 +20,9 @@ describe('Signals Health Score Details Container', () => {
       facet: 'sending_domain',
       facetId: 'test.com',
       filters: {
-        relativeRange: '14days'
+        from: '2015-01-01',
+        relativeRange: '14days',
+        to: '2015-01-05'
       },
       getSpamHits: jest.fn(),
       getHealthScore: jest.fn(),
@@ -37,8 +39,10 @@ describe('Signals Health Score Details Container', () => {
     const options = {
       facet: 'sending_domain',
       filter: 'test.com',
+      from: '2015-01-01',
       relativeRange: '14days',
-      subaccount: '101'
+      subaccount: '101',
+      to: '2015-01-05'
     };
     expect(props.getSpamHits).toHaveBeenCalledWith(options);
     expect(props.getHealthScore).toHaveBeenCalledWith(options);
@@ -52,6 +56,20 @@ describe('Signals Health Score Details Container', () => {
       subaccount: '101'
     };
     wrapper.setProps({ filters: { relativeRange: '30days' }});
+    expect(props.getSpamHits).toHaveBeenCalledWith(options);
+    expect(props.getHealthScore).toHaveBeenCalledWith(options);
+  });
+
+  it('gets health score when dates are updated', () => {
+    wrapper.setProps({ filters: { relativeRange: 'custom', to: '2016-01-02', from: '2016-01-01' }});
+    const options = {
+      facet: 'sending_domain',
+      filter: 'test.com',
+      from: '2016-01-01',
+      relativeRange: 'custom',
+      subaccount: '101',
+      to: '2016-01-02'
+    };
     expect(props.getSpamHits).toHaveBeenCalledWith(options);
     expect(props.getHealthScore).toHaveBeenCalledWith(options);
   });

--- a/src/pages/signals/containers/tests/SpamTrapDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/SpamTrapDetailsContainer.test.js
@@ -20,7 +20,9 @@ describe('Signals Spam Trap Details Container', () => {
       facet: 'sending_domain',
       facetId: 'test.com',
       filters: {
-        relativeRange: '14days'
+        from: '2015-01-01',
+        relativeRange: '14days',
+        to: '2015-01-05'
       },
       getSpamHits: jest.fn(),
       selected: '2015-01-01',
@@ -36,8 +38,10 @@ describe('Signals Spam Trap Details Container', () => {
     expect(props.getSpamHits).toHaveBeenCalledWith({
       facet: 'sending_domain',
       filter: 'test.com',
+      from: '2015-01-01',
       relativeRange: '14days',
-      subaccount: '101'
+      subaccount: '101',
+      to: '2015-01-05'
     });
   });
 
@@ -48,6 +52,18 @@ describe('Signals Spam Trap Details Container', () => {
       filter: 'test.com',
       relativeRange: '30days',
       subaccount: '101'
+    });
+  });
+
+  it('gets spam hits when dates are updated', () => {
+    wrapper.setProps({ filters: { relativeRange: 'custom', to: '2016-01-02', from: '2016-01-01' }});
+    expect(props.getSpamHits).toHaveBeenCalledWith({
+      facet: 'sending_domain',
+      filter: 'test.com',
+      from: '2016-01-01',
+      relativeRange: 'custom',
+      subaccount: '101',
+      to: '2016-01-02'
     });
   });
 

--- a/src/pages/signals/containers/tests/UnsubscribeRateByCohortDetailsContainer.test.js
+++ b/src/pages/signals/containers/tests/UnsubscribeRateByCohortDetailsContainer.test.js
@@ -19,7 +19,9 @@ describe('Signals Unsubscribe Rate by Cohort Details Container', () => {
       facet: 'sending_domain',
       facetId: 'test.com',
       filters: {
-        relativeRange: '14days'
+        from: '2015-01-01',
+        relativeRange: '14days',
+        to: '2015-01-05'
       },
       getUnsubscribeRateByCohort: jest.fn(),
       selected: '2015-01-01',
@@ -32,21 +34,35 @@ describe('Signals Unsubscribe Rate by Cohort Details Container', () => {
 
   it('gets unsubscribe rate by cohort on mount correctly', () => {
     expect(wrapper).toMatchSnapshot();
-    expect(props.getUnsubscribeRateByCohort,).toHaveBeenCalledWith({
+    expect(props.getUnsubscribeRateByCohort).toHaveBeenCalledWith({
       facet: 'sending_domain',
       filter: 'test.com',
+      from: '2015-01-01',
       relativeRange: '14days',
-      subaccount: '101'
+      subaccount: '101',
+      to: '2015-01-05'
     });
   });
 
   it('gets unsubscribe rate by cohort when range is updated', () => {
     wrapper.setProps({ filters: { relativeRange: '30days' }});
-    expect(props.getUnsubscribeRateByCohort,).toHaveBeenCalledWith({
+    expect(props.getUnsubscribeRateByCohort).toHaveBeenCalledWith({
       facet: 'sending_domain',
       filter: 'test.com',
       relativeRange: '30days',
       subaccount: '101'
+    });
+  });
+
+  it('gets unsubscribe rate by cohort when dates are updated', () => {
+    wrapper.setProps({ filters: { relativeRange: 'custom', to: '2016-01-02', from: '2016-01-01' }});
+    expect(props.getUnsubscribeRateByCohort).toHaveBeenCalledWith({
+      facet: 'sending_domain',
+      filter: 'test.com',
+      from: '2016-01-01',
+      relativeRange: 'custom',
+      subaccount: '101',
+      to: '2016-01-02'
     });
   });
 


### PR DESCRIPTION
This PR is created against (#931)

### What Changed
- Adds support for custom `to` and `from` in all signals details pages
  - Spam Trap Page
  - Health Score Page 
  - Engagement Recency Page & all three V2 sub pages

