### PR TITLE
AC-688: Changed description of email role

### DIFF
--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -541,7 +541,7 @@ const routes = [
   {
     path: '/account/tracking-domains',
     component: trackingDomains.ListPage,
-    condition: hasGrants('tracking_domains/view'),
+    condition: hasGrants('tracking_domains/manage'),
     layout: App,
     title: 'Tracking Domains',
     supportDocSearch: 'tracking domain'

--- a/src/pages/users/components/RoleRadioGroup.js
+++ b/src/pages/users/components/RoleRadioGroup.js
@@ -27,7 +27,7 @@ const EMAIL_ROLE = {
   label: <strong>Email</strong>,
   value: ROLES.EMAIL,
   helpText:
-    'Content and deliverability management user. Has access to Templates, Recipients Lists, Suppressions, AB Testing, IP Pools, and all reporting features.'
+    'Content and deliverability management user. Has access to Templates, Recipients Lists, Suppressions, AB Testing, and all reporting features.'
 };
 
 const REPORTING_ROLE = {


### PR DESCRIPTION
Grants are going to be modified to remove the modify permission of IP pools from this role
### What Changed
 - Modified description of email role. Will not have access to IP pools pages
 - Tracking domains hidden for those without tracking_domain/manage grant

### How To Test
 - Enable UI option "developer_and_email_roles"
 - Under the invite user page, check that the description for email role no longer includes IP pools
 - Create email user and login as user
 - Check that tracking_domains page is hidden

### To Do
- [ ] Address feedback
