### PR TITLE
Node.js v10 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ cache:
   directories:
     - build # shows bundle size diff per file/chunk
     - "$HOME/.npm" # to avoid fetching modules from npm every time
-before_install: npm install -g greenkeeper-lockfile@1
+before_install:
+  - npm i -g npm@^6.9.0
+  - npm install -g greenkeeper-lockfile@1
+  - npm -v
 install: npm ci --loglevel http
 before_script: greenkeeper-lockfile-update
 script: npm run travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
 cache:
   directories:
     - build # shows bundle size diff per file/chunk

--- a/package-lock.json
+++ b/package-lock.json
@@ -12192,7 +12192,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -17009,7 +17009,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -24425,7 +24425,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -34407,7 +34407,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "package-lock": true,
   "engines": {
-    "npm": ">=6"
+    "npm": ">=6.9.0",
+    "node": ">=10"
   },
   "scripts": {
     "start": "REACT_APP_VERSION=local-$USER-$(git rev-parse HEAD) node scripts/start.js",


### PR DESCRIPTION
Bumps node.js version to 10

pipeline pr: https://github.com/SparkPost/ux-cloudformation/pull/7

how to test:
- run tests
- run prod build
- use prod build using `npx serve build` and access `app.sparkpost.com`   (override /etc/hosts to point `app.sparkpost.com` to `127.0.0.1`). 
- verify branch is built using node 10 on travis and codebuild 
