### PR TITLE
EO-691 Guarantee -1 is returned to health dashboard

### DIFF
--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -21,7 +21,9 @@ export function HealthScoreDashboard(props) {
 
   // Gets injections and current score for gauge and timeseries only when dates change
   useEffect(() => {
-    getCurrentHealthScore({ relativeRange });
+    // Ordered by ascending sid to guarantee account rollup (-1) is returned
+    // order_by: 'sid' is the default behavior
+    getCurrentHealthScore({ relativeRange, order: 'asc', limit: 1 });
     getInjections({ relativeRange });
   }, [getCurrentHealthScore, getInjections, relativeRange]);
 

--- a/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
@@ -19,7 +19,7 @@ describe('Signals Health Score Dashboard', () => {
       getCurrentHealthScore={() => {}}
       getSubaccounts={() => {}}
       getInjections={() => {}}
-      filters={{ relativeRange: '90days' }}
+      relativeRange='90days'
       {...props}
     />
   );
@@ -38,7 +38,11 @@ describe('Signals Health Score Dashboard', () => {
     const getInjections = jest.fn();
     const getCurrentHealthScore = jest.fn();
     subject({ getInjections, getCurrentHealthScore }, mount);
-    expect(getInjections).toHaveBeenCalled();
-    expect(getCurrentHealthScore).toHaveBeenCalled();
+    expect(getInjections).toHaveBeenCalledWith({ relativeRange: '90days' });
+    expect(getCurrentHealthScore).toHaveBeenCalledWith({
+      limit: 1,
+      order: 'asc',
+      relativeRange: '90days'
+    });
   });
 });


### PR DESCRIPTION
### What Changed
Health score dashboard now requests data in ascending SID order, with a limit of 1. This is done to make sure the account rollup (sid -1) is always returned.

### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data
  - This bug is not obvious in appteam or 108, but was found on an enterprise tenant
- Visit the V2 health score dashboard
- Inspect the request to make sure -1 is returned

### To Do
- [ ] Feedback
