### PR TITLE
SA-560 Changed summary report typeahead to use metrics template endpoint

### DIFF
--- a/src/actions/metrics.js
+++ b/src/actions/metrics.js
@@ -42,6 +42,11 @@ export function fetchMetricsIpPools(params = {}) {
   const path = 'ip-pools';
   return fetch({ type, path, params });
 }
+export function fetchMetricsTemplates(params = {}) {
+  const type = 'FETCH_METRICS_TEMPLATES';
+  const path = 'templates';
+  return fetch({ type, path, params });
+}
 
 export function fetchDeliverability({ params, type }) {
   const path = 'deliverability';

--- a/src/actions/metrics.js
+++ b/src/actions/metrics.js
@@ -42,6 +42,7 @@ export function fetchMetricsIpPools(params = {}) {
   const path = 'ip-pools';
   return fetch({ type, path, params });
 }
+
 export function fetchMetricsTemplates(params = {}) {
   const type = 'FETCH_METRICS_TEMPLATES';
   const path = 'templates';

--- a/src/actions/reportOptions.js
+++ b/src/actions/reportOptions.js
@@ -2,10 +2,10 @@ import {
   fetchMetricsDomains,
   fetchMetricsCampaigns,
   fetchMetricsSendingIps,
-  fetchMetricsIpPools
+  fetchMetricsIpPools,
+  fetchMetricsTemplates
 } from './metrics';
 
-import { listTemplates } from './templates';
 import { list as listSubaccounts } from './subaccounts';
 import { list as listSendingDomains } from './sendingDomains';
 import { getRelativeDates } from 'src/helpers/date';
@@ -18,7 +18,8 @@ const metricLists = [
   fetchMetricsDomains,
   fetchMetricsCampaigns,
   fetchMetricsSendingIps,
-  fetchMetricsIpPools
+  fetchMetricsIpPools,
+  fetchMetricsTemplates
 ];
 
 /**
@@ -30,12 +31,8 @@ const metricLists = [
  */
 export function initTypeaheadCache() {
   return (dispatch, getState) => {
-    const { templates, subaccounts, sendingDomains } = getState();
+    const { subaccounts, sendingDomains } = getState();
     const requests = [];
-
-    if (templates.list.length === 0) {
-      requests.push(dispatch(listTemplates()));
-    }
 
     if (subaccounts.list.length === 0) {
       requests.push(dispatch(listSubaccounts()));

--- a/src/actions/tests/__snapshots__/metrics.test.js.snap
+++ b/src/actions/tests/__snapshots__/metrics.test.js.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Metrics Actions fetch Bounce Classifications 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability/bounce-classification",
+    },
+    "type": "FETCH_METRICS_BOUNCE_CLASSIFICATIONS",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch Bounce Reasons 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability/bounce-reason",
+    },
+    "type": "FETCH_METRICS_BOUNCE_REASONS",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch Bounce Reasons By Domain 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability/bounce-reason/domain",
+    },
+    "type": "FETCH_METRICS_BOUNCE_REASONS_BY_DOMAIN",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch Delay Reasons By Domain 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability/delay-reason/domain",
+    },
+    "type": "FETCH_METRICS_DELAY_REASONS_BY_DOMAIN",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch Deliverability 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability",
+    },
+    "type": "GET_ACCEPTED_AGGREGATES",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch Deliveries By Attempt 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability/attempt",
+    },
+    "type": "FETCH_METRICS_DELIVERIES_BY_ATTEMPT",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch Rejection Reasons By Domain 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability/rejection-reason/domain",
+    },
+    "type": "FETCH_METRICS_REJECTION_REASONS_BY_DOMAIN",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch metrics (time series) 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/deliverability/time-series",
+    },
+    "type": "FETCH_METRICS",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch metrics campaigns 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/campaigns",
+    },
+    "type": "FETCH_METRICS_CAMPAIGNS",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch metrics domains 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/domains",
+    },
+    "type": "FETCH_METRICS_DOMAINS",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch metrics ip pools 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/ip-pools",
+    },
+    "type": "FETCH_METRICS_IP_POOLS",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch metrics sending ips 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/sending-ips",
+    },
+    "type": "FETCH_METRICS_SENDING_IPS",
+  },
+]
+`;
+
+exports[`Metrics Actions fetch metrics templates 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "params": Object {},
+      "url": "/v1/metrics/templates",
+    },
+    "type": "FETCH_METRICS_TEMPLATES",
+  },
+]
+`;

--- a/src/actions/tests/metrics.test.js
+++ b/src/actions/tests/metrics.test.js
@@ -1,0 +1,60 @@
+import * as metrics from '../metrics';
+import { snapshotActionCases } from '../../__testHelpers__/snapshotActionHelpers';
+jest.mock('src/actions/helpers/sparkpostApiRequest');
+
+describe('Metrics Actions', () => {
+  snapshotActionCases('fetch', [
+    {
+      name: 'metrics domains',
+      action: metrics.fetchMetricsDomains
+    },
+    {
+      name: 'metrics campaigns',
+      action: metrics.fetchMetricsCampaigns
+    },
+    {
+      name: 'metrics sending ips',
+      action: metrics.fetchMetricsSendingIps
+    },
+    {
+      name: 'metrics ip pools',
+      action: metrics.fetchMetricsIpPools
+    },
+    {
+      name: 'metrics templates',
+      action: metrics.fetchMetricsTemplates
+    },
+    {
+      name: 'metrics (time series)',
+      action: metrics.getTimeSeries
+    },
+    {
+      name: 'Deliverability',
+      action: (() => metrics.fetchDeliverability({ params: {}, type: 'GET_ACCEPTED_AGGREGATES' }))
+    },
+    {
+      name: 'Bounce Classifications',
+      action: metrics.fetchBounceClassifications
+    },
+    {
+      name: 'Bounce Reasons',
+      action: metrics.fetchBounceReasons
+    },
+    {
+      name: 'Bounce Reasons By Domain',
+      action: (() => metrics.fetchBounceReasonsByDomain({}, 'FETCH_METRICS_BOUNCE_REASONS_BY_DOMAIN'))
+    },
+    {
+      name: 'Rejection Reasons By Domain',
+      action: metrics.fetchRejectionReasonsByDomain
+    },
+    {
+      name: 'Delay Reasons By Domain',
+      action: metrics.fetchDelayReasonsByDomain
+    },
+    {
+      name: 'Deliveries By Attempt',
+      action: metrics.fetchDeliveriesByAttempt
+    }
+  ]);
+});

--- a/src/actions/tests/reportOptions.test.js
+++ b/src/actions/tests/reportOptions.test.js
@@ -1,6 +1,5 @@
 import * as reportOptions from '../reportOptions';
 import * as metrics from 'src/actions/metrics';
-import { listTemplates } from 'src/actions/templates';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 import { list as listSendingDomains } from 'src/actions/sendingDomains';
 import { getRelativeDates, isSameDate } from 'src/helpers/date';
@@ -23,10 +22,8 @@ describe('Action Creator: Report Options', () => {
         campaigns: [],
         domains: [],
         sendingIps: [],
-        ipPools: []
-      },
-      templates: {
-        list: []
+        ipPools: [],
+        templates: []
       },
       subaccounts: {
         list: []
@@ -47,23 +44,20 @@ describe('Action Creator: Report Options', () => {
 
   describe('initTypeaheadCache', () => {
 
-    it('should dispatch 4 actions', () => {
+    it('should dispatch 2 actions', () => {
       reportOptions.initTypeaheadCache()(dispatchMock, getStateMock);
-      expect(dispatchMock).toHaveBeenCalledTimes(3);
-      expect(listTemplates).toHaveBeenCalledTimes(1);
+      expect(dispatchMock).toHaveBeenCalledTimes(2);
       expect(listSubaccounts).toHaveBeenCalledTimes(1);
       expect(listSendingDomains).toHaveBeenCalledTimes(1);
     });
 
     it('should skip calls if already in state', () => {
-      testState.templates.list.push('template');
       testState.subaccounts.list.push('subaccount');
       testState.sendingDomains.list.push('sending-domain');
 
       reportOptions.initTypeaheadCache()(dispatchMock, getStateMock);
 
       expect(dispatchMock).toHaveBeenCalledTimes(0);
-      expect(listTemplates).not.toHaveBeenCalled();
       expect(listSubaccounts).not.toHaveBeenCalled();
       expect(listSendingDomains).not.toHaveBeenCalled();
     });
@@ -76,6 +70,7 @@ describe('Action Creator: Report Options', () => {
     expect(metrics.fetchMetricsCampaigns).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsSendingIps).toHaveBeenCalledTimes(1);
     expect(metrics.fetchMetricsIpPools).toHaveBeenCalledTimes(1);
+    expect(metrics.fetchMetricsTemplates).toHaveBeenCalledTimes(1);
   });
 
   it('should load metrics lists for the typeahead from cache if exists', async () => {
@@ -90,6 +85,7 @@ describe('Action Creator: Report Options', () => {
     expect(metrics.fetchMetricsCampaigns).not.toHaveBeenCalled();
     expect(metrics.fetchMetricsSendingIps).not.toHaveBeenCalled();
     expect(metrics.fetchMetricsIpPools).not.toHaveBeenCalled();
+    expect(metrics.fetchMetricsTemplates).not.toHaveBeenCalled();
 
   });
 

--- a/src/reducers/metrics.js
+++ b/src/reducers/metrics.js
@@ -5,7 +5,8 @@ const initialState = {
   domains: [],
   campaigns: [],
   sendingIps: [],
-  ipPools: []
+  ipPools: [],
+  templates: []
 };
 
 export default (state = initialState, { type, payload }) => {
@@ -31,9 +32,12 @@ export default (state = initialState, { type, payload }) => {
     case 'FETCH_METRICS_IP_POOLS_SUCCESS':
       return { ...state, ipPools: payload['ip-pools'].sort() };
 
+    case 'FETCH_METRICS_TEMPLATES_SUCCESS':
+      return { ...state, templates: payload.templates.sort() };
+
     case 'UPDATE_METRICS_FROM_CACHE': {
-      const { domains, campaigns, 'sending-ips': sendingIps, 'ip-pools': ipPools } = payload;
-      return { ...state, domains, campaigns, sendingIps, ipPools };
+      const { domains, campaigns, 'sending-ips': sendingIps, 'ip-pools': ipPools, templates } = payload;
+      return { ...state, domains, campaigns, sendingIps, ipPools, templates };
     }
 
     default:

--- a/src/selectors/reportFilterTypeaheadCache.js
+++ b/src/selectors/reportFilterTypeaheadCache.js
@@ -5,17 +5,17 @@ function reshape(list, type) {
   return list.map((value) => ({ type, value }));
 }
 
-const selectTemplates = ({ templates }) => templates.list;
 const selectSubaccounts = ({ subaccounts }) => subaccounts.list;
 const selectSendingDomains = ({ sendingDomains }) => sendingDomains.list;
 const selectRecipientDomains = ({ metrics }) => metrics.domains;
 const selectCampaigns = ({ metrics }) => metrics.campaigns;
 const selectSendingIps = ({ metrics }) => metrics.sendingIps;
 const selectIpPools = ({ metrics }) => metrics.ipPools;
+const selectTemplates = ({ metrics }) => metrics.templates;
 
 const selectPreparedTemplates = createSelector(
   [selectTemplates],
-  (templates) => templates.map((t) => ({ type: 'Template', value: t.id }))
+  (templates) => reshape(templates, 'Template')
 );
 
 const selectPreparedSubaccounts = createSelector(

--- a/src/selectors/tests/reportFilterTypeaheadCache.test.js
+++ b/src/selectors/tests/reportFilterTypeaheadCache.test.js
@@ -6,20 +6,20 @@ describe('Selector: Report Filter Typeahead Cache', () => {
 
   beforeEach(() => {
     testState = {
-      templates: { list: []},
       subaccounts: { list: []},
       sendingDomains: { list: []},
       metrics: {
         campaigns: [],
         domains: [],
         sendingIps: [],
-        ipPools: []
+        ipPools: [],
+        templates: []
       }
     };
   });
 
   it('should reshape the templates', () => {
-    testState.templates.list = [{ id: 1, no: 'includey' }, { id: 2, ignore: 'me' }, { id: 3, hi: 'garbage' }];
+    testState.metrics.templates = [1,2,3];
     expect(selectCache(testState)).toEqual([
       { type: 'Template', value: 1 },
       { type: 'Template', value: 2 },
@@ -80,13 +80,13 @@ describe('Selector: Report Filter Typeahead Cache', () => {
   });
 
   it('should flatten all the caches together', () => {
-    testState.templates.list = [{ id: 1 }, { id: 2 }];
     testState.subaccounts.list = [{ name: 'A', id: 11 }, { name: 'B', id: 12 }];
     testState.sendingDomains.list = [{ domain: 'abc.com' }, { domain: 'xyz.biz' }];
     testState.metrics.domains = ['domain1', 'domain2'];
     testState.metrics.campaigns = ['campaign1', 'campaign2'];
     testState.metrics.sendingIps = ['ip1', 'ip2'];
     testState.metrics.ipPools = ['pool_1', 'pool_2'];
+    testState.metrics.templates = [1, 2];
 
     expect(selectCache(testState)).toHaveLength(14);
   });


### PR DESCRIPTION
### What Changed
The summary report typeahead no longer uses the `/templates` endpoint but the `/metrics/templates` endpoint. 

### How To Test
 - Search for a template in the summary page typeahead. The template should appear in the typeahead dropdown
 -  Can also test that accounts with >50k templates have all of them available. 

### To Do
- [x] Address review feedback
