### PR TITLE
EO-687 Increase precision on eng cohort charts

### DIFF
--- a/src/pages/signals/ComplaintsByCohortPage.js
+++ b/src/pages/signals/ComplaintsByCohortPage.js
@@ -31,7 +31,7 @@ export class ComplaintsByCohortPage extends Component {
 
   getYAxisProps = () => ({
     domain: this.isEmpty() ? [0, 1] : ['auto', 'auto'],
-    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
+    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 3)}%`
   })
 
   getXAxisProps = () => {
@@ -56,7 +56,7 @@ export class ComplaintsByCohortPage extends Component {
             color={metric.fill}
             label={metric.label}
             description={metric.description}
-            value={`${roundToPlaces(metric.value * 100, 1)}%`}
+            value={`${roundToPlaces(metric.value * 100, 3)}%`}
           />
         ))}
       </>

--- a/src/pages/signals/UnsubscribeRateByCohortPage.js
+++ b/src/pages/signals/UnsubscribeRateByCohortPage.js
@@ -31,7 +31,7 @@ export class UnsubscribeRateByCohortPage extends Component {
 
   getYAxisProps = () => ({
     domain: this.isEmpty() ? [0, 1] : ['auto', 'auto'],
-    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
+    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 3)}%`
   })
 
   getXAxisProps = () => {
@@ -56,7 +56,7 @@ export class UnsubscribeRateByCohortPage extends Component {
             color={metric.fill}
             label={metric.label}
             description={metric.description}
-            value={`${roundToPlaces(metric.value * 100, 1)}%`}
+            value={`${roundToPlaces(metric.value * 100, 3)}%`}
           />
         ))}
       </>

--- a/src/pages/signals/tests/ComplaintsByCohortPage.test.js
+++ b/src/pages/signals/tests/ComplaintsByCohortPage.test.js
@@ -56,7 +56,7 @@ describe('Signals Complaints Page', () => {
     it('renders tooltip content', () => {
       const Tooltip = wrapper.find('LineChart').prop('tooltipContent');
       expect(shallow(<Tooltip payload={{
-        p_uneng_fbl: 0.1,
+        p_uneng_fbl: 0.11111,
         p_365d_fbl: 0.2,
         p_90d_fbl: 0.3,
         p_14d_fbl: 0.4,
@@ -75,7 +75,7 @@ describe('Signals Complaints Page', () => {
     it('gets y axis props with default domain', () => {
       wrapper.setProps({ data: [{ p_total_fbl: 0 }, { p_total_fbl: null }]});
       const axisProps = wrapper.find('LineChart').prop('yAxisProps');
-      expect(axisProps.tickFormatter(.2523)).toEqual('25%');
+      expect(axisProps.tickFormatter(.252344)).toEqual('25.234%');
       expect(axisProps.domain).toEqual([0,1]);
     });
 

--- a/src/pages/signals/tests/UnsubscribeRateByCohortPage.test.js
+++ b/src/pages/signals/tests/UnsubscribeRateByCohortPage.test.js
@@ -56,7 +56,7 @@ describe('Signals Unsubscribe Rate Page', () => {
     it('renders tooltip content', () => {
       const Tooltip = wrapper.find('LineChart').prop('tooltipContent');
       expect(shallow(<Tooltip payload={{
-        p_uneng_unsub: 0.1,
+        p_uneng_unsub: 0.11111,
         p_365d_unsub: 0.2,
         p_90d_unsub: 0.3,
         p_14d_unsub: 0.4,
@@ -75,7 +75,7 @@ describe('Signals Unsubscribe Rate Page', () => {
     it('gets y axis props with default domain', () => {
       wrapper.setProps({ data: [{ p_total_unsub: 0 }, { p_total_unsub: null }]});
       const axisProps = wrapper.find('LineChart').prop('yAxisProps');
-      expect(axisProps.tickFormatter(.2523)).toEqual('25%');
+      expect(axisProps.tickFormatter(.252344)).toEqual('25.234%');
       expect(axisProps.domain).toEqual([0,1]);
     });
 

--- a/src/pages/signals/tests/__snapshots__/ComplaintsByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/ComplaintsByCohortPage.test.js.snap
@@ -35,7 +35,7 @@ exports[`Signals Complaints Page bar chart props renders tooltip content 1`] = `
     description="365+ days since last engagement"
     key="uneng"
     label="Never Engaged"
-    value="10%"
+    value="11.111%"
   />
 </Fragment>
 `;

--- a/src/pages/signals/tests/__snapshots__/UnsubscribeRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/UnsubscribeRateByCohortPage.test.js.snap
@@ -35,7 +35,7 @@ exports[`Signals Unsubscribe Rate Page bar chart props renders tooltip content 1
     description="365+ days since last engagement"
     key="uneng"
     label="Never Engaged"
-    value="10%"
+    value="11.111%"
   />
 </Fragment>
 `;


### PR DESCRIPTION
### What Changed
 - Increases Y axis tick and tooltip metric precision to 3 decimals

Example of current behavior:
![Screen Shot 2019-04-16 at 10 00 26 AM](https://user-images.githubusercontent.com/3903325/56216293-24e18680-602f-11e9-8c09-20096b6bf4e1.png)


### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data
- Visit v2 engagement details pages

### To Do
- [ ] Address any feedback
