### PR TITLE
AC-692: Updated Test account to include new codes

### DIFF
--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -16,7 +16,7 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
     ? 'First dedicated IP address is free'
     : null;
 
-  const currentFreePlan = plan.code && ['free500-1018', 'free15K-1018'].includes(plan.code);
+  const currentFreePlan = plan.code && ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'].includes(plan.code);
   const planTitle = currentFreePlan ? 'Test Account' : `${plan.volume.toLocaleString()}`;
 
   const displayCsm = showCsm && plan.includesCsm;

--- a/src/components/billing/tests/PlanPrice.test.js
+++ b/src/components/billing/tests/PlanPrice.test.js
@@ -60,18 +60,26 @@ describe('PlanPrice', () => {
   });
 
   it('renders correctly for 30 day free plan', () => {
-    plan.monthly = 0;
-    plan.isFree = true;
-    plan.code = 'free15K-banana';
-    wrapper.setProps({ plan });
+    const free15kPlan = {
+      ...plan,
+      monthly: 0,
+      isFree: true,
+      code: 'free15K-banana'
+    };
+
+    wrapper.setProps({ plan: free15kPlan });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders correctly for eternal free plan', () => {
-    plan.monthly = 0;
-    plan.isFree = true;
-    plan.code = 'free500-banana';
-    wrapper.setProps({ plan });
+    const eternalFree = {
+      ...plan,
+      monthly: 0,
+      isFree: true,
+      code: 'free500-banana'
+    };
+
+    wrapper.setProps({ plan: eternalFree });
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -82,10 +90,14 @@ describe('PlanPrice', () => {
   });
 
   it('renders test account with current free plan', () => {
-    plan.monthly = 0;
-    plan.isFree = true;
-    plan.code = 'free500-0419';
-    wrapper.setProps({ plan });
+    const currentFreePlan = {
+      ...plan,
+      monthly: 0,
+      isFree: true,
+      code: 'free500-0419'
+    };
+
+    wrapper.setProps({ plan: currentFreePlan });
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/components/billing/tests/PlanPrice.test.js
+++ b/src/components/billing/tests/PlanPrice.test.js
@@ -81,6 +81,14 @@ describe('PlanPrice', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders test account with current free plan', () => {
+    plan.monthly = 0;
+    plan.isFree = true;
+    plan.code = 'free500-0419';
+    wrapper.setProps({ plan });
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders flat discount', () => {
     wrapper.setProps({ selectedPromo: { discount_amount: 5 }});
     expect(wrapper).toMatchSnapshot();

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -320,6 +320,24 @@ exports[`PlanPrice renders percent discount 1`] = `
 </span>
 `;
 
+exports[`PlanPrice renders test account with current free plan 1`] = `
+<span
+  className="notranslate"
+>
+  <span
+    className="MainLabel"
+  >
+    <strong>
+      Test Account
+    </strong>
+     
+  </span>
+  <span
+    className="SupportLabel"
+  />
+</span>
+`;
+
 exports[`PlanPrice renders with overage 1`] = `
 <span
   className="notranslate"


### PR DESCRIPTION
### What Changed
 - Added new free plan code into the list of plans considered 'Test Account'

### How To Test
 - With new free plan (to be rolled out in [AC-683](https://jira.int.messagesystems.com/browse/AC-683)), should show as 'Test Account' in PlanPicker on /account/billing/plan

### To Do
- [ ] Address feedback
