### PR TITLE
AC-712 Updated preview button to use transmission grant

### DIFF
--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -67,7 +67,7 @@ export default class EditPage extends Component {
   }
 
   getPageProps() {
-    const { canModify, handleSubmit, template, match, submitting, subaccountId } = this.props;
+    const { canSend, canModify, handleSubmit, template, match, submitting, subaccountId } = this.props;
     const published = template.has_published;
 
     const primaryAction = {
@@ -97,7 +97,7 @@ export default class EditPage extends Component {
         visible: canModify
       },
       {
-        content: canModify ? 'Preview & Send' : 'Preview',
+        content: canSend ? 'Preview & Send' : 'Preview',
         onClick: handleSubmit(this.handlePreview),
         visible: true
       }

--- a/src/pages/templates/containers/EditPage.container.js
+++ b/src/pages/templates/containers/EditPage.container.js
@@ -15,6 +15,7 @@ const FORM_NAME = 'templateEdit';
 const mapStateToProps = (state, props) => {
   const template = selectTemplateById(state, props).draft;
   const canModify = hasGrants('templates/modify')(state);
+  const canSend = hasGrants('transmissions/modify')(state);
 
   return {
     loading: state.templates.getDraftLoading,
@@ -23,6 +24,7 @@ const mapStateToProps = (state, props) => {
     subaccountId: selectSubaccountIdFromQuery(state, props),
     hasSubaccounts: hasSubaccounts(state),
     canModify,
+    canSend,
 
     // Redux Form
     formName: FORM_NAME,

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -26,7 +26,8 @@ describe('Template EditPage', () => {
       },
       subaccountId: 101,
       formName: 'templateEdit',
-      canModify: true
+      canModify: true,
+      canSend: true
     };
 
     wrapper = shallow(<EditPage {...props} />);
@@ -45,6 +46,14 @@ describe('Template EditPage', () => {
   it('should render correctly for read-only users', () => {
     wrapper.setProps({ canModify: false });
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render correctly for users who cannot send', () => {
+    wrapper.setProps({ canSend: false });
+    expect(wrapper.find('Page').props().secondaryActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: 'Preview' })
+      ]));
   });
 
   it('should handle errors when getting template', () => {

--- a/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
@@ -122,7 +122,7 @@ exports[`Template EditPage should render correctly for read-only users 1`] = `
         "visible": false,
       },
       Object {
-        "content": "Preview",
+        "content": "Preview & Send",
         "onClick": undefined,
         "visible": true,
       },


### PR DESCRIPTION
### What Changed
 - Templates view page uses `transmissions/modify` grant to check if it can send

### How To Test
 - Using an email or reporting user, open up a template Edit/View page
   - You would need UI option `developer_and_email_roles` if you need to create role
- Button should now say 'Preview' for email and reporting (previously would show Preview & Send for email users)

### To Do
- [ ] Address feedback
