### PR TITLE
EO-689 Shift behavior by cohorts to display data from 3 days ago 

### DIFF
--- a/src/pages/signals/containers/tests/__snapshots__/withDetails.test.js.snap
+++ b/src/pages/signals/containers/tests/__snapshots__/withDetails.test.js.snap
@@ -2,7 +2,16 @@
 
 exports[`Signals Details Container fetches data on mount correctly 1`] = `
 <Component
-  data={Array []}
+  data={
+    Array [
+      Object {
+        "date": "2015-01-01",
+      },
+      Object {
+        "date": "2015-01-05",
+      },
+    ]
+  }
   facet="sending_domain"
   facetId="test.com"
   gap={1}

--- a/src/pages/signals/containers/tests/withDetails.test.js
+++ b/src/pages/signals/containers/tests/withDetails.test.js
@@ -15,7 +15,7 @@ describe('Signals Details Container', () => {
     props = {
       component: Component,
       details: {
-        data: []
+        data: [{ date: '2015-01-01' }, { date: '2015-01-05' }]
       },
       facet: 'sending_domain',
       facetId: 'test.com',

--- a/src/pages/signals/containers/withDetails.js
+++ b/src/pages/signals/containers/withDetails.js
@@ -38,7 +38,6 @@ export class WithDetails extends Component {
       details,
       facet,
       facetId,
-      filters,
       selected,
       subaccountId
     } = this.props;
@@ -46,8 +45,15 @@ export class WithDetails extends Component {
     // Calculate gap here to share with preview and details
     const gap = details.data && details.data.length > 15 ? 0.2 : 1;
 
+    // The data's dates are used instead of dates in filters because
+    // the engagement behavior selectors trim displayed dates
+    const xTicks = getDateTicks({
+      from: _.first(details.data).date,
+      to: _.last(details.data).date
+    });
+
     return (
-      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} selected={selected} xTicks={getDateTicks(filters)} subaccountId={subaccountId} />
+      <WrappedComponent {...details} facet={facet} facetId={facetId} gap={gap} selected={selected} xTicks={xTicks} subaccountId={subaccountId} />
     );
   }
 }

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -116,15 +116,20 @@ export const selectEngagementRateByCohortDetails = createSelector(
     // Rename date key
     const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
 
+    // Engagement behavior charts do not contain data within the last 3 days (including today)
+    const shouldTrimTo = moment().diff(to, 'days') < 3;
+
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
       fill: {
         p_new_eng: null, p_14d_eng: null, p_90d_eng: null, p_365d_eng: null, p_uneng_eng: null, p_total_eng: null
       },
-      from, to
+      from,
+      to: shouldTrimTo ? moment().subtract(3, 'days') : to
     });
 
     const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_eng));
+
 
     return {
       details: {
@@ -148,6 +153,9 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
     // Rename date key
     const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
 
+    // Engagement behavior charts do not contain data within the last 3 days (including today)
+    const shouldTrimTo = moment().diff(to, 'days') < 3;
+
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
       fill: {
@@ -158,7 +166,8 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
         p_uneng_unsub: null,
         p_total_unsub: null
       },
-      from, to
+      from,
+      to: shouldTrimTo ? moment().subtract(3, 'days') : to
     });
 
     const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_unsub));
@@ -185,6 +194,9 @@ export const selectComplaintsByCohortDetails = createSelector(
     // Rename date key
     const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
 
+    // Engagement behavior charts do not contain data within the last 3 days (including today)
+    const shouldTrimTo = moment().diff(to, 'days') < 3;
+
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
       fill: {
@@ -195,7 +207,8 @@ export const selectComplaintsByCohortDetails = createSelector(
         p_uneng_fbl: null,
         p_total_fbl: null
       },
-      from, to
+      from,
+      to: shouldTrimTo ? moment().subtract(3, 'days') : to
     });
 
     const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_fbl));

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -108,6 +108,12 @@ export const selectEngagementRecencyDetails = createSelector(
   }
 );
 
+// Engagement behavior charts do not contain data within the last 3 days (including today)
+const excludeLastNDays = (date, n) =>
+  moment().diff(date, 'days') < n ? moment().subtract(3, 'days') : date;
+
+const engagementBehaviorDataLagDays = 3;
+
 export const selectEngagementRateByCohortDetails = createSelector(
   [getEngagementRateByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
   ({ loading, error, data }, facet, facetId, subaccountId, { from, to }) => {
@@ -116,16 +122,13 @@ export const selectEngagementRateByCohortDetails = createSelector(
     // Rename date key
     const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
 
-    // Engagement behavior charts do not contain data within the last 3 days (including today)
-    const shouldTrimTo = moment().diff(to, 'days') < 3;
-
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
       fill: {
         p_new_eng: null, p_14d_eng: null, p_90d_eng: null, p_365d_eng: null, p_uneng_eng: null, p_total_eng: null
       },
       from,
-      to: shouldTrimTo ? moment().subtract(3, 'days') : to
+      to: excludeLastNDays(to, engagementBehaviorDataLagDays)
     });
 
     const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_eng));
@@ -153,8 +156,6 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
     // Rename date key
     const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
 
-    // Engagement behavior charts do not contain data within the last 3 days (including today)
-    const shouldTrimTo = moment().diff(to, 'days') < 3;
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
@@ -167,7 +168,7 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
         p_total_unsub: null
       },
       from,
-      to: shouldTrimTo ? moment().subtract(3, 'days') : to
+      to: excludeLastNDays(to, engagementBehaviorDataLagDays)
     });
 
     const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_unsub));
@@ -194,8 +195,6 @@ export const selectComplaintsByCohortDetails = createSelector(
     // Rename date key
     const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
 
-    // Engagement behavior charts do not contain data within the last 3 days (including today)
-    const shouldTrimTo = moment().diff(to, 'days') < 3;
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
@@ -208,7 +207,7 @@ export const selectComplaintsByCohortDetails = createSelector(
         p_total_fbl: null
       },
       from,
-      to: shouldTrimTo ? moment().subtract(3, 'days') : to
+      to: excludeLastNDays(to, engagementBehaviorDataLagDays)
     });
 
     const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_fbl));

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -110,7 +110,7 @@ export const selectEngagementRecencyDetails = createSelector(
 
 // Engagement behavior charts do not contain data within the last 3 days (including today)
 const excludeLastNDays = (date, n) =>
-  moment().diff(date, 'days') < n ? moment().subtract(3, 'days') : date;
+  moment().diff(date, 'days') < n ? moment().subtract(n, 'days') : date;
 
 const engagementBehaviorDataLagDays = 3;
 

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -318,6 +318,13 @@ describe('Selectors: signals', () => {
       const stateWhenLoading = { ...state, signals: { engagementRateByCohort: { data: [], loading: true }}};
       expect(selectors.selectEngagementRateByCohortDetails(stateWhenLoading, props).details.empty).toBe(false);
     });
+
+    it('should cutoff to date if to is within 3 days of today', () => {
+      const mockNow = new Date('2018-01-05');
+      jest.spyOn(Date, 'now').mockImplementation(() => mockNow);
+      const data = selectors.selectEngagementRateByCohortDetails(state, props).details.data;
+      expect(data[data.length - 1].date).toEqual('2018-01-01');
+    });
   });
 
   describe('unsubscribe rate by cohort details', () => {
@@ -334,6 +341,13 @@ describe('Selectors: signals', () => {
       const stateWhenLoading = { ...state, signals: { unsubscribeRateByCohort: { data: [], loading: true }}};
       expect(selectors.selectUnsubscribeRateByCohortDetails(stateWhenLoading, props).details.empty).toBe(false);
     });
+
+    it('should cutoff to date if to is within 3 days of today', () => {
+      const mockNow = new Date('2018-01-05');
+      jest.spyOn(Date, 'now').mockImplementation(() => mockNow);
+      const data = selectors.selectUnsubscribeRateByCohortDetails(state, props).details.data;
+      expect(data[data.length - 1].date).toEqual('2018-01-01');
+    });
   });
 
   describe('complaints by cohort details', () => {
@@ -349,6 +363,13 @@ describe('Selectors: signals', () => {
     it('should not be empty when loading', () => {
       const stateWhenLoading = { ...state, signals: { complaintsByCohort: { data: [], loading: true }}};
       expect(selectors.selectComplaintsByCohortDetails(stateWhenLoading, props).details.empty).toBe(false);
+    });
+
+    it('should cutoff to date if to is within 3 days of today', () => {
+      const mockNow = new Date('2018-01-05');
+      jest.spyOn(Date, 'now').mockImplementation(() => mockNow);
+      const data = selectors.selectComplaintsByCohortDetails(state, props).details.data;
+      expect(data[data.length - 1].date).toEqual('2018-01-01');
     });
   });
 


### PR DESCRIPTION
### What Changed
- Engagement cohort behavioral charts no longer display **empty** data between now and 3 days ago

### Notes
- This PR only adjust what is displayed in the charts, and does not modify the requests or DateFilter
- This PR does not shift `from`, only `to`
- DateFilter does not represent its displayed dates. It is agnostic of its page/location, and we would need to consider some UX to make that change.
  - navigation between charts with custom dates (would need to store the displayed and intended dates separately in redux, and switch between those depending on location)
  - disabling last 3 days in datepicker depending on location
  - adjusting both `from` and `to` when selecting custom dates feels like a bad interaction to me

### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data
- Visit V2 engagement details pages
  - Play around with the date filter
  - Check chart data and x axis ticks

### To Do
- [ ] Address any feedback

