### PR TITLE
TR-1206: AMP previewer for stored templates

### DIFF
--- a/src/hooks/useTabs.js
+++ b/src/hooks/useTabs.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+// This hook is intended to be used with Matchbox's Tabs component
+// note, initialTabs must be defined outside the component or provided by redux
+const useTabs = (initialTabs) => {
+  const [tabIndex, setIndex] = useState(0);
+  const [tabs, setTabs] = useState(initialTabs);
+
+  // only on mount attach click handler to tabs
+  useEffect(() => {
+    const tabsWithClickHandling = initialTabs.map((tab, index) => ({
+      ...tab, onClick: () => { setIndex(index); }
+    }));
+
+    setTabs(tabsWithClickHandling);
+  }, [initialTabs]);
+
+  return [tabIndex, tabs];
+};
+
+export default useTabs;

--- a/src/hooks/useTabs.test.js
+++ b/src/hooks/useTabs.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import useTabs from './useTabs';
+
+describe('useTabs', () => {
+  const HoodedComponent = (props) => {
+    const [tabIndex, tabs] = useTabs(props.tabs);
+
+    return (
+      <div tabIndex={tabIndex} tabs={tabs} />
+    );
+  };
+
+  const subject = () => mount(
+    <HoodedComponent tabs={[{ content: 'A' }, { content: 'B' }]} />
+  );
+
+  it('sets initial index to zero', () => {
+    const wrapper = subject();
+    expect(wrapper.children()).toHaveProp('tabIndex', 0);
+  });
+
+  it('changes index when clicked', () => {
+    const wrapper = subject();
+
+    act(() => {
+      wrapper.children().prop('tabs')[1].onClick();
+    });
+
+    wrapper.update();
+
+    expect(wrapper.children()).toHaveProp('tabIndex', 1);
+  });
+});

--- a/src/pages/templates/PreviewPage.js
+++ b/src/pages/templates/PreviewPage.js
@@ -118,7 +118,7 @@ export default class PreviewPage extends Component {
           }
           <TextField disabled label="From" value={name ? `${name} <${email}>` : email} />
           <TextField disabled label="Subject" value={preview.subject} />
-          <PreviewPanel html={preview.html} text={preview.text} />
+          <PreviewPanel ampHtml={preview.amp_html} html={preview.html} text={preview.text} />
         </Panel>
       </Page>
     );

--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -69,6 +69,15 @@ export default class PreviewFrame extends Component {
     const { contentDocument } = this.iframe;
 
     contentDocument.open();
+
+    // If you see a "[Violation] Avoid using document.write()" warning in your console, please
+    // ignore it.  Chrome's block will not apply because this component writes to an iframe.
+    // Here is the condition.
+    //
+    //   The document .write() is in a top level document. The intervention does not apply to
+    //   document.written scripts within iframes as they don't block the rendering of the main page.
+    //
+    // @see, https://developers.google.com/web/updates/2016/08/removing-document-write
     contentDocument.write(this.props.content);
     contentDocument.close();
   }

--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -5,9 +5,28 @@ import styles from './PreviewFrame.module.scss';
 // Manually pad to avoid scrollbars
 const PADDING = 5;
 
+const FLEXIBLE_POLICY = [
+  'allow-forms',
+  'allow-popups',
+  'allow-popups-to-escape-sandbox',
+  'allow-presentation',
+  'allow-same-origin',
+  'allow-scripts',
+  'allow-top-navigation'
+];
+
+const STRICT_POLICY = [
+  'allow-same-origin',
+  'allow-top-navigation'
+];
+
 // @note This is a port of the previous fd.templates.preview.directive
 // @see https://github.com/SparkPost/webui/blob/master/src/app/templates/preview-directive.js
 export default class PreviewFrame extends Component {
+  static defaultProps = {
+    strict: true
+  }
+
   static propTypes = {
     content: PropTypes.string.isRequired
   }
@@ -66,13 +85,16 @@ export default class PreviewFrame extends Component {
   // @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
   // @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-srcdoc
   render() {
+    const { strict } = this.props;
+    const allowances = strict ? STRICT_POLICY : FLEXIBLE_POLICY;
+
     return (
       <iframe
         className={styles.PreviewFrame}
         height={this.state.height}
         ref={this.setRef}
         onLoad={this.onLoad}
-        sandbox="allow-same-origin allow-top-navigation"
+        sandbox={allowances.join(' ')}
         title="preview email template frame"
       />
     );

--- a/src/pages/templates/components/PreviewPanel.js
+++ b/src/pages/templates/components/PreviewPanel.js
@@ -1,51 +1,52 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs } from '@sparkpost/matchbox';
 import classnames from 'classnames';
 
+import useTabs from 'src/hooks/useTabs';
 import PreviewFrame from './PreviewFrame';
 import styles from './PreviewPanel.module.scss';
 
-export default class PreviewPanel extends Component {
-  static defaultProps = {
-    html: '',
-    text: ''
-  }
+const TABS = [
+  { content: 'HTML', key: 'html' },
+  { content: 'Text', key: 'text' },
+  { content: 'AMP HTML', key: 'ampHtml' }
+];
 
-  static propTypes = {
-    html: PropTypes.string,
-    text: PropTypes.string
-  }
+const PreviewPanel = ({ Frame, ...props }) => {
+  const [selectedTabIndex, tabs] = useTabs(TABS);
+  const selectedTabKey = tabs[selectedTabIndex].key;
 
-  state = {
-    contentType: 'HTML'
-  }
+  // Must wrap text content in <p> to apply style and must be a string for injecting into iframe
+  const content = selectedTabKey === 'text'
+    ? `<p style="white-space: pre-wrap">${props[selectedTabKey]}</p>`
+    : props[selectedTabKey];
 
-  onChange = (event) => {
-    this.setState({ contentType: event.currentTarget.text });
-  }
-
-  render() {
-    const tabs = [
-      { content: 'HTML', onClick: this.onChange },
-      { content: 'Text', onClick: this.onChange }
-    ];
-
-    const selectedTabIndex = tabs.findIndex(({ content }) => content === this.state.contentType);
-    const contentType = this.state.contentType.toLowerCase().replace(' ', '_');
-
-    // Must wrap text content in <p> to apply style and must be a string for injecting into iframe
-    const content = contentType === 'text'
-      ? `<p style="white-space: pre-wrap">${this.props[contentType]}</p>`
-      : this.props[contentType];
-
-    return (
-      <div className={classnames(styles.PreviewPanel, 'notranslate')}>
-        <Tabs selected={selectedTabIndex} tabs={tabs} />
-        <div className={styles.PreviewPanelWrapper}>
-          <PreviewFrame content={content} key={contentType} />
-        </div>
+  return (
+    <div className={classnames(styles.PreviewPanel, 'notranslate')}>
+      <Tabs selected={selectedTabIndex} tabs={tabs} />
+      <div className={styles.PreviewPanelWrapper}>
+        <Frame
+          content={content}
+          key={selectedTabKey} // must remount frame on content type change
+          strict={selectedTabKey !== 'ampHtml'}
+        />
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+PreviewPanel.defaultProps = {
+  ampHtml: '',
+  html: '',
+  text: '',
+  Frame: PreviewFrame
+};
+
+PreviewPanel.propTypes = {
+  ampHtml: PropTypes.string,
+  html: PropTypes.string,
+  text: PropTypes.string
+};
+
+export default PreviewPanel;

--- a/src/pages/templates/components/tests/PreviewFrame.test.js
+++ b/src/pages/templates/components/tests/PreviewFrame.test.js
@@ -3,59 +3,69 @@ import { mount } from 'enzyme';
 
 import PreviewFrame from '../PreviewFrame';
 
-const testContent = '<h1>Hello, World!</h1>';
-const createWrapper = (content, contentDocument = {}) => {
-  // This is an experimental way to mock a class method
-  // @see https://github.com/facebook/react/issues/9396
-  class MockPreviewFrame extends PreviewFrame {
-    // Must set the display name for snapshots
-    static displayName = 'PreviewFrame';
+describe('PreviewFrame', () => {
+  const testContent = '<h1>Hello, World!</h1>';
+  const createWrapper = ({ content, contentDocument = {}, strict }) => {
+    // This is an experimental way to mock a class method
+    // @see https://github.com/facebook/react/issues/9396
+    class MockPreviewFrame extends PreviewFrame {
+      // Must set the display name for snapshots
+      static displayName = 'PreviewFrame';
 
-    // Mock setting iframe ref
-    // @note Tried mocking contentWindow with jsdom, but didn't provide add value, so removed dep
-    setRef = (iframe) => {
-      this.iframe = {
-        contentDocument: {
-          close: jest.fn(),
-          getElementsByTagName: jest.fn(() => []),
-          open: jest.fn(),
-          write: jest.fn(),
-          ...contentDocument
-        }
-      };
+      // Mock setting iframe ref
+      // @note Tried mocking contentWindow with jsdom, but didn't provide add value, so removed dep
+      setRef = (iframe) => {
+        this.iframe = {
+          contentDocument: {
+            close: jest.fn(),
+            getElementsByTagName: jest.fn(() => []),
+            open: jest.fn(),
+            write: jest.fn(),
+            ...contentDocument
+          }
+        };
+      }
     }
-  }
 
-  return mount(<MockPreviewFrame content={content} />);
-};
+    return mount(<MockPreviewFrame content={content} strict={strict} />);
+  };
 
 
-test('renders an iframe', () => {
-  const wrapper = createWrapper(testContent);
-  expect(wrapper).toMatchSnapshot();
-});
-
-test('writes content to iframe document', () => {
-  const write = jest.fn();
-  createWrapper(testContent, { write });
-  expect(write).toHaveBeenCalledWith(testContent);
-});
-
-test('sets iframe height after it loads', () => {
-  const wrapper = createWrapper(testContent, {
-    body: {
-      offsetHeight: '94',
-      scrollHeight: '94'
-    },
-    documentElement: {
-      clientHeight: '94',
-      offsetHeight: '94',
-      scrollHeight: '94'
-    }
+  it('renders an iframe', () => {
+    const wrapper = createWrapper({ content: testContent });
+    expect(wrapper).toMatchSnapshot();
   });
 
-  wrapper.instance().onLoad();
-  wrapper.update();
+  it('renders an iframe with flexible policies', () => {
+    const wrapper = createWrapper({ content: testContent, strict: false });
+    expect(wrapper).toMatchSnapshot();
+  });
 
-  expect(wrapper).toMatchSnapshot();
+  it('writes content to iframe document', () => {
+    const write = jest.fn();
+    createWrapper({ content: testContent, contentDocument: { write }});
+    expect(write).toHaveBeenCalledWith(testContent);
+  });
+
+  it('sets iframe height after it loads', () => {
+    const wrapper = createWrapper({
+      content: testContent,
+      contentDocument: {
+        body: {
+          offsetHeight: '94',
+          scrollHeight: '94'
+        },
+        documentElement: {
+          clientHeight: '94',
+          offsetHeight: '94',
+          scrollHeight: '94'
+        }
+      }
+    });
+
+    wrapper.instance().onLoad();
+    wrapper.update();
+
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/pages/templates/components/tests/PreviewPanel.test.js
+++ b/src/pages/templates/components/tests/PreviewPanel.test.js
@@ -1,31 +1,38 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import { mount, shallow } from 'enzyme';
 
 import PreviewPanel from '../PreviewPanel';
 
-const props = {
-  html: '<h1>Test Template</h1>',
-  text: 'Test Template'
-};
+describe('PreviewPanel', () => {
+  it('renders blank panel', () => {
+    const wrapper = shallow(<PreviewPanel />);
+    expect(wrapper).toMatchSnapshot();
+  });
 
-it('renders blank panel', () => {
-  const wrapper = shallow(<PreviewPanel />);
-  expect(wrapper).toMatchSnapshot();
-});
+  it('renders HTML content by default', () => {
+    const html = '<!DOCTYPE html>';
+    const wrapper = shallow(<PreviewPanel html={html} />);
 
-it('renders HTML by default', () => {
-  const wrapper = shallow(<PreviewPanel {...props} />);
-  expect(wrapper).toMatchSnapshot();
-});
+    expect(wrapper.find('PreviewFrame')).toHaveProp('content', html);
+  });
 
-it('renders text on tab click', () => {
-  const wrapper = shallow(<PreviewPanel {...props} />);
+  it('renders AMP HTML content when tab is clicked', () => {
+    const ampHtml = '<html ⚡>';
+    const TestPreviewFrame = () => null; // stub frame for a safe mount
+    const wrapper = mount(<PreviewPanel ampHtml={ampHtml} Frame={TestPreviewFrame} />);
 
-  wrapper
-    .find('Tabs')
-    .prop('tabs')
-    .find(({ content }) => content === 'Text')
-    .onClick({ currentTarget: { text: 'Text' }});
+    act(() => {
+      wrapper
+        .find('Tabs')
+        .prop('tabs')
+        .find(({ key }) => key === 'ampHtml')
+        .onClick();
+    });
 
-  expect(wrapper).toMatchSnapshot();
+    wrapper.update();
+
+    expect(wrapper.find('TestPreviewFrame')).toHaveProp('content', ampHtml);
+    expect(wrapper.find('TestPreviewFrame')).toHaveProp('strict', false);
+  });
 });

--- a/src/pages/templates/components/tests/__snapshots__/PreviewFrame.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewFrame.test.js.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders an iframe 1`] = `
+exports[`PreviewFrame renders an iframe 1`] = `
 <PreviewFrame
   content="<h1>Hello, World!</h1>"
+  strict={true}
 >
   <iframe
     className="PreviewFrame"
@@ -13,9 +14,24 @@ exports[`renders an iframe 1`] = `
 </PreviewFrame>
 `;
 
-exports[`sets iframe height after it loads 1`] = `
+exports[`PreviewFrame renders an iframe with flexible policies 1`] = `
 <PreviewFrame
   content="<h1>Hello, World!</h1>"
+  strict={false}
+>
+  <iframe
+    className="PreviewFrame"
+    onLoad={[Function]}
+    sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation"
+    title="preview email template frame"
+  />
+</PreviewFrame>
+`;
+
+exports[`PreviewFrame sets iframe height after it loads 1`] = `
+<PreviewFrame
+  content="<h1>Hello, World!</h1>"
+  strict={true}
 >
   <iframe
     className="PreviewFrame"

--- a/src/pages/templates/components/tests/__snapshots__/PreviewPanel.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewPanel.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders HTML by default 1`] = `
+exports[`PreviewPanel renders blank panel 1`] = `
 <div
   className="PreviewPanel notranslate"
 >
@@ -12,43 +12,15 @@ exports[`renders HTML by default 1`] = `
       Array [
         Object {
           "content": "HTML",
-          "onClick": [Function],
+          "key": "html",
         },
         Object {
           "content": "Text",
-          "onClick": [Function],
-        },
-      ]
-    }
-  />
-  <div
-    className="PreviewPanelWrapper"
-  >
-    <PreviewFrame
-      content="<h1>Test Template</h1>"
-      key="html"
-    />
-  </div>
-</div>
-`;
-
-exports[`renders blank panel 1`] = `
-<div
-  className="PreviewPanel notranslate"
->
-  <Tabs
-    color="orange"
-    connectBelow={true}
-    selected={0}
-    tabs={
-      Array [
-        Object {
-          "content": "HTML",
-          "onClick": [Function],
+          "key": "text",
         },
         Object {
-          "content": "Text",
-          "onClick": [Function],
+          "content": "AMP HTML",
+          "key": "ampHtml",
         },
       ]
     }
@@ -59,38 +31,7 @@ exports[`renders blank panel 1`] = `
     <PreviewFrame
       content=""
       key="html"
-    />
-  </div>
-</div>
-`;
-
-exports[`renders text on tab click 1`] = `
-<div
-  className="PreviewPanel notranslate"
->
-  <Tabs
-    color="orange"
-    connectBelow={true}
-    selected={1}
-    tabs={
-      Array [
-        Object {
-          "content": "HTML",
-          "onClick": [Function],
-        },
-        Object {
-          "content": "Text",
-          "onClick": [Function],
-        },
-      ]
-    }
-  />
-  <div
-    className="PreviewPanelWrapper"
-  >
-    <PreviewFrame
-      content="<p style=\\"white-space: pre-wrap\\">Test Template</p>"
-      key="text"
+      strict={true}
     />
   </div>
 </div>

--- a/src/pages/templates/tests/PreviewPage.test.js
+++ b/src/pages/templates/tests/PreviewPage.test.js
@@ -15,7 +15,8 @@ const loadPreviewPage = async (overrides = {}) => {
       from: { email: 'test@example.com' },
       subject: 'Test Template',
       html: '<h1>Test Template</h1>',
-      text: 'Test Template'
+      text: 'Test Template',
+      amp_html: '<html ⚡><h1>Test Template</h1>'
     },
     returnPath: '/path/to/return',
     template: {

--- a/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/PreviewPage.test.js.snap
@@ -62,6 +62,8 @@ exports[`renders loading error 1`] = `
       value="Test Template"
     />
     <PreviewPanel
+      Frame={[Function]}
+      ampHtml="<html ⚡><h1>Test Template</h1>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />
@@ -101,6 +103,8 @@ exports[`renders preview page with read-only template 1`] = `
       value="Test Template"
     />
     <PreviewPanel
+      Frame={[Function]}
+      ampHtml="<html ⚡><h1>Test Template</h1>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />
@@ -155,6 +159,8 @@ exports[`renders preview page with template 1`] = `
       value="Test Template"
     />
     <PreviewPanel
+      Frame={[Function]}
+      ampHtml="<html ⚡><h1>Test Template</h1>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />
@@ -209,6 +215,8 @@ exports[`resets error message when user starts typing again 1`] = `
       value="Test Template"
     />
     <PreviewPanel
+      Frame={[Function]}
+      ampHtml="<html ⚡><h1>Test Template</h1>"
       html="<h1>Test Template</h1>"
       text="Test Template"
     />


### PR DESCRIPTION
Refer to [TR-1206](https://jira.int.messagesystems.com/browse/TR-1206) for more info.

### What Changed
- Users can now preview their AMP content

### How To Test

- Create a new template with AMP HTML content — an example is provided below
- Click "Save as Draft"
- Click "Preview & Send"
- Select the new "AMP HTML" tab

```html
<!doctype html>
<html ⚡4email>
<head>
  <meta charset="utf-8">
  <script async src="https://cdn.ampproject.org/v0.js"></script>
  <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
  <style amp4email-boilerplate>body{visibility:hidden}</style>
</head>
<body>
  <h1>AMP'd</h1>
  <div>
    <amp-anim 
      width="500"
      height="189"
      src="https://media.giphy.com/media/nem4a3nunlA4M/giphy.gif"
      alt="an animation"
    />
  </div>
</body>
</html>
```


