### PR TITLE
AC-713: Brightback uses new free plan

### DIFF
--- a/scripts/generateConfigs/tenants/production.js
+++ b/scripts/generateConfigs/tenants/production.js
@@ -25,7 +25,7 @@ const productionTenants = {
       mxValue: 'smtp.eu.sparkpostmail.com'
     },
     brightback: {
-      freePlan: 'free500-SPCEU-1018'
+      freePlan: 'free500-SPCEU-0419'
     },
     crossLinkTenant: 'spc',
     featureFlags: {

--- a/scripts/generateConfigs/tests/__snapshots__/index.func.test.js.snap
+++ b/scripts/generateConfigs/tests/__snapshots__/index.func.test.js.snap
@@ -236,7 +236,7 @@ Object {
       "mxValue": "smtp.eu.sparkpostmail.com",
     },
     "brightback": Object {
-      "freePlan": "free500-SPCEU-1018",
+      "freePlan": "free500-SPCEU-0419",
     },
     "crossLinkTenant": "spc",
     "environment": "production",

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -108,7 +108,7 @@ const config = (identifier) => ({
       billing_url: '/account/billing/plan' // Billing URL to direct end-users to enter coupon code or other billing changes
     },
     freePlan: 'free500-0419',
-    enabled: true
+    enabled: false
   },
   smtpAuth: {
     host: `${identifier}.smtp.e.sparkpost.com`,

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -108,7 +108,7 @@ const config = (identifier) => ({
       billing_url: '/account/billing/plan' // Billing URL to direct end-users to enter coupon code or other billing changes
     },
     freePlan: 'free500-0419',
-    enabled: false
+    enabled: true
   },
   smtpAuth: {
     host: `${identifier}.smtp.e.sparkpost.com`,

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -107,7 +107,7 @@ const config = (identifier) => ({
       cancel_confirmation_url: '/account/billing/plan/change', // Return URL from Brightback for end-users who cancel
       billing_url: '/account/billing/plan' // Billing URL to direct end-users to enter coupon code or other billing changes
     },
-    freePlan: 'free500-1018',
+    freePlan: 'free500-0419',
     enabled: false
   },
   smtpAuth: {

--- a/src/config/env/production-config.js
+++ b/src/config/env/production-config.js
@@ -9,6 +9,9 @@ const productionConfig = {
       appID: 'SFXAWCYDV8',
       index: 'production_site_posts_support_article'
     }
+  },
+  brightback: {
+    enabled: true
   }
 };
 

--- a/src/config/env/production-config.js
+++ b/src/config/env/production-config.js
@@ -9,9 +9,6 @@ const productionConfig = {
       appID: 'SFXAWCYDV8',
       index: 'production_site_posts_support_article'
     }
-  },
-  brightback: {
-    enabled: true
   }
 };
 

--- a/src/config/env/staging-config.js
+++ b/src/config/env/staging-config.js
@@ -10,6 +10,9 @@ const stagingConfig = {
       index: 'staging_site_posts_support_article'
     },
     enabled: true
+  },
+  brightback: {
+    enabled: true
   }
 };
 

--- a/src/selectors/tests/__snapshots__/brightback.test.js.snap
+++ b/src/selectors/tests/__snapshots__/brightback.test.js.snap
@@ -11,7 +11,7 @@ Object {
   },
   "app_id": "9N0rWBvKGR",
   "billing_url": "http://phoenix.test/billing_url",
-  "cancel_confirmation_url": "http://phoenix.test/cancel_confirmation_url?immediatePlanChange=free500-1018",
+  "cancel_confirmation_url": "http://phoenix.test/cancel_confirmation_url?immediatePlanChange=free500-0419",
   "context": Object {
     "locale": "en-US",
     "referrer": "",


### PR DESCRIPTION
### What Changed
 - Brightback will use the new free plan code (free500-0419) to downgrade to

### How To Test
 - Enable Brightback by setting `brightback: { enabled: true }` in `src/config/env/dev-config.js`
 - Downgrade from a paid to free plan
-  Check that /precancel brightback request is using the free plan code in `cancel_confirmation_url`
- Check that cancellation properly downgrades to new free plan code

### To Do
- [ ] Address any feedback
