### PR TITLE
TR-1203: Template List Page UX Fix of Whitespace

### DIFF
--- a/src/pages/snippets/ListPage.js
+++ b/src/pages/snippets/ListPage.js
@@ -50,7 +50,7 @@ export default class ListPage extends React.Component {
             : undefined
         )}
         empty={{
-          show: snippets.length === 0,
+          show: !error && snippets.length === 0,
           image: Templates,
           title: 'Manage your template snippets',
           content: <p>Build, import, edit, and reuse snippets.</p>

--- a/src/pages/snippets/tests/ListPage.test.js
+++ b/src/pages/snippets/tests/ListPage.test.js
@@ -33,7 +33,7 @@ describe('ListPage', () => {
   });
 
   it('renders page with error banner', () => {
-    expect(subject({ error: new Error('Oh no!') })).toMatchSnapshot();
+    expect(subject({ error: new Error('Oh no!'), snippets: []})).toMatchSnapshot();
   });
 
   it('renders page without subaccount column', () => {

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -54,9 +54,7 @@ export default class ListPage extends Component {
     },
     {
       component: Actions,
-      header: {
-        content: null
-      },
+      header: null,
       visible: () => true
     }
   ]

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -17,7 +17,6 @@ export default class ListPage extends Component {
       component: Name,
       header: {
         label: 'Name',
-        width: '28%',
         sortKey: 'name'
       }
     },
@@ -25,7 +24,7 @@ export default class ListPage extends Component {
       component: Status,
       header: {
         label: 'Status',
-        width: '18%',
+        width: '150px',
         sortKey: (template) => [
           resolveTemplateStatus(template).publishedWithChanges,
           template.published
@@ -40,7 +39,7 @@ export default class ListPage extends Component {
       ),
       header: {
         label: 'Subaccount',
-        width: '18%',
+        width: '175px',
         sortKey: ({ subaccount_id, shared_with_subaccounts }) => (
           subaccount_id || shared_with_subaccounts
         )
@@ -53,12 +52,16 @@ export default class ListPage extends Component {
       component: LastUpdated,
       header: {
         label: 'Last Updated',
-        sortKey: 'last_update_time'
+        sortKey: 'last_update_time',
+        width: '175px'
       }
     },
     {
       component: Actions,
-      header: null
+      header: {
+        content: null,
+        width: '20px'
+      }
     }
   ]
 

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -34,9 +34,7 @@ export default class ListPage extends Component {
     },
     {
       component: ({ shared_with_subaccounts, subaccount_id }) => (
-        subaccount_id || shared_with_subaccounts
-          ? <SubaccountTag all={shared_with_subaccounts} id={subaccount_id} />
-          : null
+        <SubaccountTag all={shared_with_subaccounts} id={subaccount_id} />
       ),
       header: {
         label: 'Subaccount',
@@ -70,7 +68,7 @@ export default class ListPage extends Component {
   )
 
   render() {
-    const { canModify, count, error, listTemplates, loading, templates } = this.props;
+    const { canModify, error, listTemplates, loading, templates } = this.props;
     const visibleColumns = this.columns.filter(({ visible }) => visible(this.props));
 
     if (loading) {
@@ -86,7 +84,7 @@ export default class ListPage extends Component {
         )}
         title='Templates'
         empty={{
-          show: !error && count === 0,
+          show: !error && templates.length === 0,
           image: Templates,
           title: 'Manage your email templates',
           content: <p>Build, test, preview and send your transmissions.</p>

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -19,16 +19,6 @@ export default class ListPage extends Component {
     this.props.listTemplates();
   }
 
-  renderError() {
-    return (
-      <ApiErrorBanner
-        message={'Sorry, we seem to have had some trouble loading your templates.'}
-        errorDetails={this.props.error.message}
-        reload={this.props.listTemplates}
-      />
-    );
-  }
-
   getRowData = ({ shared_with_subaccounts, ...rowData }) => {
     const { hasSubaccounts, userAccessLevel } = this.props;
     const { subaccount_id } = rowData;
@@ -61,25 +51,8 @@ export default class ListPage extends Component {
     ];
   }
 
-  renderCollection() {
-    return (
-      <TableCollection
-        columns={this.getColumns()}
-        rows={this.props.templates}
-        getRowData={this.getRowData}
-        pagination
-        filterBox={{
-          show: true,
-          exampleModifiers: ['id', 'name'],
-          itemToStringKeys: ['name', 'id', 'subaccount_id']
-        }}
-        defaultSortColumn='name'
-      />
-    );
-  }
-
   render() {
-    const { canModify, count, loading, error } = this.props;
+    const { canModify, count, error, listTemplates, loading, templates } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -94,8 +67,29 @@ export default class ListPage extends Component {
           image: Templates,
           title: 'Manage your email templates',
           content: <p>Build, test, preview and send your transmissions.</p>
-        }} >
-        {error ? this.renderError() : this.renderCollection()}
+        }}
+      >
+        {error ? (
+          <ApiErrorBanner
+            message={'Sorry, we seem to have had some trouble loading your templates.'}
+            errorDetails={error.message}
+            reload={listTemplates}
+          />
+        ) : (
+          <TableCollection
+            columns={this.getColumns()}
+            rows={templates}
+            getRowData={this.getRowData}
+            pagination
+            filterBox={{
+              show: true,
+              exampleModifiers: ['id', 'name'],
+              itemToStringKeys: ['name', 'id', 'subaccount_id']
+            }}
+            defaultSortColumn="last_update_time"
+            defaultSortDirection="desc"
+          />
+        )}
       </Page>
     );
   }

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { Page } from '@sparkpost/matchbox';
-import { SubaccountTag, TableCollection, ApiErrorBanner, Loading } from 'src/components';
+import { TableCollection, ApiErrorBanner, Loading } from 'src/components';
 import { Templates } from 'src/components/images';
 import PageLink from 'src/components/pageLink';
 import { ROLES } from 'src/constants';
 import { resolveTemplateStatus } from 'src/helpers/templates';
-import { Name, Status, Actions, LastUpdated } from './components/ListComponents';
+import { Actions, LastUpdated, Name, Status, Subaccount } from './components/ListComponents';
 
 export default class ListPage extends Component {
   componentDidMount() {
@@ -33,9 +33,7 @@ export default class ListPage extends Component {
       visible: () => true
     },
     {
-      component: ({ shared_with_subaccounts, subaccount_id }) => (
-        <SubaccountTag all={shared_with_subaccounts} id={subaccount_id} />
-      ),
+      component: Subaccount,
       header: {
         label: 'Subaccount',
         sortKey: ({ subaccount_id, shared_with_subaccounts }) => (

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -18,7 +18,8 @@ export default class ListPage extends Component {
       header: {
         label: 'Name',
         sortKey: 'name'
-      }
+      },
+      visible: () => true
     },
     {
       component: Status,
@@ -28,7 +29,8 @@ export default class ListPage extends Component {
           resolveTemplateStatus(template).publishedWithChanges,
           template.published
         ]
-      }
+      },
+      visible: () => true
     },
     {
       component: ({ shared_with_subaccounts, subaccount_id }) => (
@@ -51,13 +53,15 @@ export default class ListPage extends Component {
       header: {
         label: 'Last Updated',
         sortKey: 'last_update_time'
-      }
+      },
+      visible: () => true
     },
     {
       component: Actions,
       header: {
         content: null
-      }
+      },
+      visible: () => true
     }
   ]
 
@@ -67,7 +71,7 @@ export default class ListPage extends Component {
 
   render() {
     const { canModify, count, error, listTemplates, loading, templates } = this.props;
-    const visibleColumns = this.columns.filter(({ visible = () => true }) => visible(this.props));
+    const visibleColumns = this.columns.filter(({ visible }) => visible(this.props));
 
     if (loading) {
       return <Loading />;

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -24,7 +24,6 @@ export default class ListPage extends Component {
       component: Status,
       header: {
         label: 'Status',
-        width: '150px',
         sortKey: (template) => [
           resolveTemplateStatus(template).publishedWithChanges,
           template.published
@@ -39,7 +38,6 @@ export default class ListPage extends Component {
       ),
       header: {
         label: 'Subaccount',
-        width: '175px',
         sortKey: ({ subaccount_id, shared_with_subaccounts }) => (
           subaccount_id || shared_with_subaccounts
         )
@@ -52,15 +50,13 @@ export default class ListPage extends Component {
       component: LastUpdated,
       header: {
         label: 'Last Updated',
-        sortKey: 'last_update_time',
-        width: '175px'
+        sortKey: 'last_update_time'
       }
     },
     {
       component: Actions,
       header: {
-        content: null,
-        width: '20px'
+        content: null
       }
     }
   ]

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -83,7 +83,7 @@ export default class ListPage extends Component {
         )}
         title='Templates'
         empty={{
-          show: count === 0,
+          show: !error && count === 0,
           image: Templates,
           title: 'Manage your email templates',
           content: <p>Build, test, preview and send your transmissions.</p>

--- a/src/pages/templates/components/ListComponents.js
+++ b/src/pages/templates/components/ListComponents.js
@@ -29,7 +29,13 @@ const Status = (rowData) => {
   }
 
   if (publishedWithChanges) {
-    return <Tooltip dark content='Contains unpublished changes'><Tag color='blue'>Published &bull;</Tag></Tooltip>;
+    return (
+      <Tooltip dark content='Contains unpublished changes'>
+        <Tag className={styles.PublishedWithChanges} color='blue'>
+          &bull; Published
+        </Tag>
+      </Tooltip>
+    );
   }
 
   return <Tag>Draft</Tag>;

--- a/src/pages/templates/components/ListComponents.js
+++ b/src/pages/templates/components/ListComponents.js
@@ -1,13 +1,14 @@
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { Popover, Button, ActionList, Tag, Tooltip } from '@sparkpost/matchbox';
 import { MoreHoriz } from '@sparkpost/matchbox-icons';
+import { SubaccountTag } from 'src/components/tags';
 import { formatDateTime } from 'src/helpers/date';
+import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { resolveTemplateStatus } from 'src/helpers/templates';
 import styles from './ListComponents.module.scss';
 
-const Name = ({ name, id, subaccount_id, ...rowData }) => {
+export const Name = ({ name, id, subaccount_id, ...rowData }) => {
   const { published } = resolveTemplateStatus(rowData);
   return (
     <Fragment>
@@ -21,7 +22,7 @@ const Name = ({ name, id, subaccount_id, ...rowData }) => {
   );
 };
 
-const Status = (rowData) => {
+export const Status = (rowData) => {
   const { published, publishedWithChanges } = resolveTemplateStatus(rowData);
 
   if (published) {
@@ -41,7 +42,7 @@ const Status = (rowData) => {
   return <Tag>Draft</Tag>;
 };
 
-const Actions = ({ id, subaccount_id, ...rowData }) => {
+export const Actions = ({ id, subaccount_id, ...rowData }) => {
   const { published, publishedWithChanges, draft } = resolveTemplateStatus(rowData);
 
   const actions = [
@@ -75,11 +76,8 @@ const Actions = ({ id, subaccount_id, ...rowData }) => {
   );
 };
 
-const LastUpdated = ({ last_update_time }) => <p className={styles.LastUpdated}>{formatDateTime(last_update_time)}</p>;
+export const LastUpdated = ({ last_update_time }) => <p className={styles.LastUpdated}>{formatDateTime(last_update_time)}</p>;
 
-export {
-  Name,
-  Status,
-  Actions,
-  LastUpdated
-};
+export const Subaccount = ({ shared_with_subaccounts, subaccount_id }) => (
+  <SubaccountTag all={shared_with_subaccounts} id={subaccount_id} />
+);

--- a/src/pages/templates/components/ListComponents.module.scss
+++ b/src/pages/templates/components/ListComponents.module.scss
@@ -14,3 +14,7 @@
   margin-bottom: 0;
   font-size: rem(14);
 }
+
+.PublishedWithChanges {
+  font-style: italic;
+}

--- a/src/pages/templates/components/tests/ListComponents.test.js
+++ b/src/pages/templates/components/tests/ListComponents.test.js
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import { Name, Actions, Status, LastUpdated } from '../ListComponents';
+import { Name, Actions, Status, LastUpdated, Subaccount } from '../ListComponents';
 
 describe('Template List Components', () => {
   let wrapper;
@@ -52,6 +52,13 @@ describe('Template List Components', () => {
   describe('LastUpdated', () => {
     it('should render', () => {
       expect(shallow(<LastUpdated last_update_time='2017-08-10T14:15:16+00:00' />)).toMatchSnapshot();
+    });
+  });
+
+  describe('Subaccount', () => {
+    it('should render', () => {
+      const wrapper = shallow(<Subaccount shared_with_subaccounts={false} subaccount_id={123} />);
+      expect(wrapper).toMatchSnapshot();
     });
   });
 });

--- a/src/pages/templates/components/tests/__snapshots__/ListComponents.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/ListComponents.test.js.snap
@@ -218,9 +218,10 @@ exports[`Template List Components Status should render unpublished changes 1`] =
   right={true}
 >
   <Tag
+    className="PublishedWithChanges"
     color="blue"
   >
-    Published •
+    • Published
   </Tag>
 </Tooltip>
 `;

--- a/src/pages/templates/components/tests/__snapshots__/ListComponents.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/ListComponents.test.js.snap
@@ -225,3 +225,13 @@ exports[`Template List Components Status should render unpublished changes 1`] =
   </Tag>
 </Tooltip>
 `;
+
+exports[`Template List Components Subaccount should render 1`] = `
+<SubaccountTag
+  all={false}
+  id={123}
+  isDefault={false}
+  master={false}
+  receiveAll={false}
+/>
+`;

--- a/src/pages/templates/containers/ListPage.container.js
+++ b/src/pages/templates/containers/ListPage.container.js
@@ -12,7 +12,6 @@ function mapStateToProps(state) {
   const canModify = hasGrants('templates/modify')(state);
 
   return {
-    count: templates.length,
     templates,
     hasSubaccounts: hasSubaccounts(state),
     userAccessLevel: state.currentUser.access_level,

--- a/src/pages/templates/tests/ListPage.test.js
+++ b/src/pages/templates/tests/ListPage.test.js
@@ -73,14 +73,14 @@ describe('ListPage', () => {
       const wrapper = subject({ hasSubaccounts: true, userAccessLevel: ROLES.SUBACCOUNT_REPORTING });
       const columns = wrapper.find('TableCollection').prop('columns');
 
-      expect(columns.find((column) => column.label === 'Subaccount')).toBeUndefined();
+      expect(columns.find((column) => column && column.label === 'Subaccount')).toBeUndefined();
     });
 
     it('without subaccount column for account without subaccounts', () => {
       const wrapper = subject({ hasSubaccounts: false });
       const columns = wrapper.find('TableCollection').prop('columns');
 
-      expect(columns.find((column) => column.label === 'Subaccount')).toBeUndefined();
+      expect(columns.find((column) => column && column.label === 'Subaccount')).toBeUndefined();
     });
   });
 

--- a/src/pages/templates/tests/ListPage.test.js
+++ b/src/pages/templates/tests/ListPage.test.js
@@ -105,7 +105,7 @@ it('renders rows correctly with NO subaccounts', () => {
 
 it('renders empty state', () => {
   wrapper.setProps({ count: 0 });
-  expect(wrapper.dive('Page')).toMatchSnapshot();
+  expect(wrapper).toHaveProp('empty', expect.objectContaining({ show: true }));
 });
 
 it('renders Loading', () => {
@@ -114,6 +114,6 @@ it('renders Loading', () => {
 });
 
 it('renders errors when present', () => {
-  wrapper.setProps({ error: { message: 'Uh oh! It broke. ' }});
+  wrapper.setProps({ count: 0, error: { message: 'Uh oh! It broke. ' }});
   expect(wrapper.find('ApiErrorBanner')).toMatchSnapshot();
 });

--- a/src/pages/templates/tests/ListPage.test.js
+++ b/src/pages/templates/tests/ListPage.test.js
@@ -25,6 +25,11 @@ const props = {
 
 let wrapper;
 
+const renderRows = (wrapper, rows) => {
+  const getRowData = wrapper.find('TableCollection').prop('getRowData');
+  return rows.map(getRowData);
+};
+
 beforeEach(() => {
   dateMock.format = jest.fn((a) => a);
   wrapper = shallow(<ListPage {...props} />);
@@ -80,8 +85,8 @@ it('renders rows correctly with subaccounts', () => {
   ];
 
   wrapper.setProps({ hasSubaccounts: true });
-  const rowData = rows.map(wrapper.instance().getRowData);
-  expect(rowData).toMatchSnapshot();
+  const result = renderRows(wrapper, rows);
+  expect(result).toMatchSnapshot();
 });
 
 it('renders rows correctly with NO subaccounts', () => {
@@ -94,8 +99,8 @@ it('renders rows correctly with NO subaccounts', () => {
     }
   ];
 
-  const rowData = rows.map(wrapper.instance().getRowData);
-  expect(rowData).toMatchSnapshot();
+  const result = renderRows(wrapper, rows);
+  expect(result).toMatchSnapshot();
 });
 
 it('renders empty state', () => {

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -86,8 +86,8 @@ exports[`renders correctly 1`] = `
         null,
       ]
     }
-    defaultSortColumn="name"
-    defaultSortDirection="asc"
+    defaultSortColumn="last_update_time"
+    defaultSortDirection="desc"
     filterBox={
       Object {
         "exampleModifiers": Array [
@@ -318,8 +318,8 @@ exports[`renders without primary action for read-only users 1`] = `
         null,
       ]
     }
-    defaultSortColumn="name"
-    defaultSortDirection="asc"
+    defaultSortColumn="last_update_time"
+    defaultSortDirection="desc"
     filterBox={
       Object {
         "exampleModifiers": Array [

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -1,26 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders columns correctly for subaccount reporting users 1`] = `
-Array [
-  Object {
-    "label": "Name",
-    "sortKey": "name",
-  },
-  Object {
-    "label": "Status",
-    "sortKey": [Function],
-  },
-  Object {
-    "label": "Last Updated",
-    "sortKey": "last_update_time",
-  },
-  Object {
-    "content": null,
-  },
-]
-`;
-
-exports[`renders columns correctly with subaccounts 1`] = `
+exports[`ListPage renders columns with all columns 1`] = `
 Array [
   Object {
     "label": "Name",
@@ -44,7 +24,7 @@ Array [
 ]
 `;
 
-exports[`renders correctly 1`] = `
+exports[`ListPage renders correctly 1`] = `
 <Page
   empty={
     Object {
@@ -106,10 +86,25 @@ exports[`renders correctly 1`] = `
     rows={
       Array [
         Object {
-          "name": "Temp 1",
+          "id": "id1",
+          "last_update_time": "2017-08-10T14:15:16+00:00",
+          "name": "subaccount template",
+          "published": true,
+          "shared_with_subaccounts": false,
+          "subaccount_id": 101,
         },
         Object {
-          "name": "Temp 2",
+          "id": "id2",
+          "last_update_time": "2017-08-10T14:15:16+00:00",
+          "name": "shared template",
+          "published": false,
+          "shared_with_subaccounts": true,
+        },
+        Object {
+          "id": "id3",
+          "last_update_time": "2017-08-10T14:15:16+00:00",
+          "name": "master template",
+          "published": false,
         },
       ]
     }
@@ -117,53 +112,7 @@ exports[`renders correctly 1`] = `
 </Page>
 `;
 
-exports[`renders errors when present 1`] = `
-<ApiErrorBanner
-  errorDetails="Uh oh! It broke. "
-  message="Sorry, we seem to have had some trouble loading your templates."
-  reload={
-    [MockFunction] {
-      "calls": Array [
-        Array [],
-      ],
-      "results": undefined,
-    }
-  }
-/>
-`;
-
-exports[`renders rows correctly with NO subaccounts 1`] = `
-Array [
-  Array [
-    <Name
-      id="id3"
-      last_update_time="2017-08-10T14:15:16+00:00"
-      name="no subs template"
-      published={true}
-    />,
-    <Status
-      id="id3"
-      last_update_time="2017-08-10T14:15:16+00:00"
-      name="no subs template"
-      published={true}
-    />,
-    <LastUpdated
-      id="id3"
-      last_update_time="2017-08-10T14:15:16+00:00"
-      name="no subs template"
-      published={true}
-    />,
-    <Actions
-      id="id3"
-      last_update_time="2017-08-10T14:15:16+00:00"
-      name="no subs template"
-      published={true}
-    />,
-  ],
-]
-`;
-
-exports[`renders rows correctly with subaccounts 1`] = `
+exports[`ListPage renders rows with all columns 1`] = `
 Array [
   Array [
     <Name
@@ -277,70 +226,4 @@ Array [
     />,
   ],
 ]
-`;
-
-exports[`renders without primary action for read-only users 1`] = `
-<Page
-  empty={
-    Object {
-      "content": <p>
-        Build, test, preview and send your transmissions.
-      </p>,
-      "image": [Function],
-      "show": false,
-      "title": "Manage your email templates",
-    }
-  }
-  title="Templates"
->
-  <TableCollection
-    columns={
-      Array [
-        Object {
-          "label": "Name",
-          "sortKey": "name",
-        },
-        Object {
-          "label": "Status",
-          "sortKey": [Function],
-        },
-        Object {
-          "label": "Last Updated",
-          "sortKey": "last_update_time",
-        },
-        Object {
-          "content": null,
-        },
-      ]
-    }
-    defaultSortColumn="last_update_time"
-    defaultSortDirection="desc"
-    filterBox={
-      Object {
-        "exampleModifiers": Array [
-          "id",
-          "name",
-        ],
-        "itemToStringKeys": Array [
-          "name",
-          "id",
-          "subaccount_id",
-        ],
-        "show": true,
-      }
-    }
-    getRowData={[Function]}
-    pagination={true}
-    rows={
-      Array [
-        Object {
-          "name": "Temp 1",
-        },
-        Object {
-          "name": "Temp 2",
-        },
-      ]
-    }
-  />
-</Page>
 `;

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -190,6 +190,7 @@ Array [
       last_update_time="2017-08-10T14:15:16+00:00"
       name="subaccount template"
       published={true}
+      shared_with_subaccounts={false}
       subaccount_id={101}
     />,
     <Status
@@ -197,20 +198,23 @@ Array [
       last_update_time="2017-08-10T14:15:16+00:00"
       name="subaccount template"
       published={true}
+      shared_with_subaccounts={false}
       subaccount_id={101}
     />,
-    <SubaccountTag
-      all={false}
-      id={101}
-      isDefault={false}
-      master={false}
-      receiveAll={false}
+    <component
+      id="id1"
+      last_update_time="2017-08-10T14:15:16+00:00"
+      name="subaccount template"
+      published={true}
+      shared_with_subaccounts={false}
+      subaccount_id={101}
     />,
     <LastUpdated
       id="id1"
       last_update_time="2017-08-10T14:15:16+00:00"
       name="subaccount template"
       published={true}
+      shared_with_subaccounts={false}
       subaccount_id={101}
     />,
     <Actions
@@ -218,6 +222,7 @@ Array [
       last_update_time="2017-08-10T14:15:16+00:00"
       name="subaccount template"
       published={true}
+      shared_with_subaccounts={false}
       subaccount_id={101}
     />,
   ],
@@ -227,31 +232,35 @@ Array [
       last_update_time="2017-08-10T14:15:16+00:00"
       name="shared template"
       published={false}
+      shared_with_subaccounts={true}
     />,
     <Status
       id="id2"
       last_update_time="2017-08-10T14:15:16+00:00"
       name="shared template"
       published={false}
+      shared_with_subaccounts={true}
     />,
-    <SubaccountTag
-      all={true}
-      id={null}
-      isDefault={false}
-      master={false}
-      receiveAll={false}
+    <component
+      id="id2"
+      last_update_time="2017-08-10T14:15:16+00:00"
+      name="shared template"
+      published={false}
+      shared_with_subaccounts={true}
     />,
     <LastUpdated
       id="id2"
       last_update_time="2017-08-10T14:15:16+00:00"
       name="shared template"
       published={false}
+      shared_with_subaccounts={true}
     />,
     <Actions
       id="id2"
       last_update_time="2017-08-10T14:15:16+00:00"
       name="shared template"
       published={false}
+      shared_with_subaccounts={true}
     />,
   ],
   Array [
@@ -267,7 +276,12 @@ Array [
       name="master template"
       published={false}
     />,
-    null,
+    <component
+      id="id3"
+      last_update_time="2017-08-10T14:15:16+00:00"
+      name="master template"
+      published={false}
+    />,
     <LastUpdated
       id="id3"
       last_update_time="2017-08-10T14:15:16+00:00"

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -18,9 +18,7 @@ Array [
     "label": "Last Updated",
     "sortKey": "last_update_time",
   },
-  Object {
-    "content": null,
-  },
+  null,
 ]
 `;
 
@@ -60,9 +58,7 @@ exports[`ListPage renders correctly 1`] = `
           "label": "Last Updated",
           "sortKey": "last_update_time",
         },
-        Object {
-          "content": null,
-        },
+        null,
       ]
     }
     defaultSortColumn="last_update_time"

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -9,16 +9,13 @@ Array [
   Object {
     "label": "Status",
     "sortKey": [Function],
-    "width": "150px",
   },
   Object {
     "label": "Last Updated",
     "sortKey": "last_update_time",
-    "width": "175px",
   },
   Object {
     "content": null,
-    "width": "20px",
   },
 ]
 `;
@@ -32,21 +29,17 @@ Array [
   Object {
     "label": "Status",
     "sortKey": [Function],
-    "width": "150px",
   },
   Object {
     "label": "Subaccount",
     "sortKey": [Function],
-    "width": "175px",
   },
   Object {
     "label": "Last Updated",
     "sortKey": "last_update_time",
-    "width": "175px",
   },
   Object {
     "content": null,
-    "width": "20px",
   },
 ]
 `;
@@ -82,16 +75,13 @@ exports[`renders correctly 1`] = `
         Object {
           "label": "Status",
           "sortKey": [Function],
-          "width": "150px",
         },
         Object {
           "label": "Last Updated",
           "sortKey": "last_update_time",
-          "width": "175px",
         },
         Object {
           "content": null,
-          "width": "20px",
         },
       ]
     }
@@ -313,16 +303,13 @@ exports[`renders without primary action for read-only users 1`] = `
         Object {
           "label": "Status",
           "sortKey": [Function],
-          "width": "150px",
         },
         Object {
           "label": "Last Updated",
           "sortKey": "last_update_time",
-          "width": "175px",
         },
         Object {
           "content": null,
-          "width": "20px",
         },
       ]
     }

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -118,24 +118,6 @@ exports[`renders correctly 1`] = `
 </Page>
 `;
 
-exports[`renders empty state 1`] = `
-<EmptyState
-  image={[Function]}
-  primaryAction={
-    Object {
-      "Component": [Function],
-      "content": "Create Template",
-      "to": "/templates/create",
-    }
-  }
-  title="Manage your email templates"
->
-  <p>
-    Build, test, preview and send your transmissions.
-  </p>
-</EmptyState>
-`;
-
 exports[`renders errors when present 1`] = `
 <ApiErrorBanner
   errorDetails="Uh oh! It broke. "

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -131,7 +131,7 @@ Array [
       shared_with_subaccounts={false}
       subaccount_id={101}
     />,
-    <component
+    <Subaccount
       id="id1"
       last_update_time="2017-08-10T14:15:16+00:00"
       name="subaccount template"
@@ -171,7 +171,7 @@ Array [
       published={false}
       shared_with_subaccounts={true}
     />,
-    <component
+    <Subaccount
       id="id2"
       last_update_time="2017-08-10T14:15:16+00:00"
       name="shared template"
@@ -206,7 +206,7 @@ Array [
       name="master template"
       published={false}
     />,
-    <component
+    <Subaccount
       id="id3"
       last_update_time="2017-08-10T14:15:16+00:00"
       name="master template"

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -5,18 +5,21 @@ Array [
   Object {
     "label": "Name",
     "sortKey": "name",
-    "width": "28%",
   },
   Object {
     "label": "Status",
     "sortKey": [Function],
-    "width": "18%",
+    "width": "150px",
   },
   Object {
     "label": "Last Updated",
     "sortKey": "last_update_time",
+    "width": "175px",
   },
-  null,
+  Object {
+    "content": null,
+    "width": "20px",
+  },
 ]
 `;
 
@@ -25,23 +28,26 @@ Array [
   Object {
     "label": "Name",
     "sortKey": "name",
-    "width": "28%",
   },
   Object {
     "label": "Status",
     "sortKey": [Function],
-    "width": "18%",
+    "width": "150px",
   },
   Object {
     "label": "Subaccount",
     "sortKey": [Function],
-    "width": "18%",
+    "width": "175px",
   },
   Object {
     "label": "Last Updated",
     "sortKey": "last_update_time",
+    "width": "175px",
   },
-  null,
+  Object {
+    "content": null,
+    "width": "20px",
+  },
 ]
 `;
 
@@ -72,18 +78,21 @@ exports[`renders correctly 1`] = `
         Object {
           "label": "Name",
           "sortKey": "name",
-          "width": "28%",
         },
         Object {
           "label": "Status",
           "sortKey": [Function],
-          "width": "18%",
+          "width": "150px",
         },
         Object {
           "label": "Last Updated",
           "sortKey": "last_update_time",
+          "width": "175px",
         },
-        null,
+        Object {
+          "content": null,
+          "width": "20px",
+        },
       ]
     }
     defaultSortColumn="last_update_time"
@@ -300,18 +309,21 @@ exports[`renders without primary action for read-only users 1`] = `
         Object {
           "label": "Name",
           "sortKey": "name",
-          "width": "28%",
         },
         Object {
           "label": "Status",
           "sortKey": [Function],
-          "width": "18%",
+          "width": "150px",
         },
         Object {
           "label": "Last Updated",
           "sortKey": "last_update_time",
+          "width": "175px",
         },
-        null,
+        Object {
+          "content": null,
+          "width": "20px",
+        },
       ]
     }
     defaultSortColumn="last_update_time"


### PR DESCRIPTION
Refer to [TR-1203](https://jira.int.messagesystems.com/browse/TR-1203) for more information.

### What Changed

- Template list page is initially sorted by last updated column descending
- Slightly modify published tag style — moved bullet to lead and italicized

<img width="604" alt="Screen Shot 2019-04-19 at 3 36 00 PM" src="https://user-images.githubusercontent.com/1335605/56441851-62a70f00-62bc-11e9-8a29-b2e78e8b0ea8.png">

- Removed static widths on metadata field columns to allow name column to grow

<img width="1387" alt="Screen Shot 2019-04-19 at 5 03 56 PM" src="https://user-images.githubusercontent.com/1335605/56444282-0fd25500-62c6-11e9-81a8-cb34da941fb4.png">
<img width="1389" alt="Screen Shot 2019-04-19 at 5 04 14 PM" src="https://user-images.githubusercontent.com/1335605/56444283-106aeb80-62c6-11e9-96a0-4d8557167029.png">

- Bonus: fixed both template and snippet list pages to show error banner if load error occurs


### How To Test
- Navigate to templates list page and observe list is sorted by last updated column and the metadata columns are fixed widths to allow room for long template names
- Find a appteam template that is in published, but has draft changes
- Block /templates request in devtools network tab, then reload the page, the error banner should be displayed