### PR TITLE
TR-1205: Do not lose focus on content tab after save

### DIFF
--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -38,13 +38,13 @@ export default class EditPage extends Component {
     });
   }
 
-  handleSave = (values) => {
-    const { update, match, getDraft, showAlert, getTestData, subaccountId } = this.props;
-    return update(_.omit(values, 'published'), subaccountId).then(() => {
-      getDraft(match.params.id, subaccountId);
-      getTestData({ id: match.params.id, mode: 'draft' });
-      showAlert({ type: 'success', message: 'Template saved' });
-    });
+  handleSave = ({ published, ...values }) => { // must omit published value
+    const { showAlert, subaccountId, update } = this.props;
+
+    return (
+      update(values, subaccountId)
+        .then(() => showAlert({ type: 'success', message: 'Template saved' }))
+    );
   }
 
   handleDelete = () => {

--- a/src/pages/templates/EditPage.js
+++ b/src/pages/templates/EditPage.js
@@ -85,14 +85,20 @@ export default class EditPage extends Component {
       },
       {
         content: 'Save as Draft',
-        onClick: handleSubmit(this.handleSave),
         disabled: submitting,
+        onClick: handleSubmit(this.handleSave),
         visible: canModify
       },
-      { content: 'Delete', onClick: this.handleDeleteModalToggle, visible: canModify },
+      {
+        content: 'Delete',
+        disabled: submitting,
+        onClick: this.handleDeleteModalToggle,
+        visible: canModify
+      },
       {
         content: 'Duplicate',
         component: Link,
+        disabled: submitting,
         to: `/templates/create/${match.params.id}`,
         visible: canModify
       },

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -111,4 +111,33 @@ describe('Template EditPage', () => {
       expect(props.history.push).toHaveBeenCalledWith('/templates/preview/id?subaccount=101');
     });
   });
+
+  describe('when submitting', () => {
+    const findSecondaryAction = (content) => (
+      wrapper.prop('secondaryActions').find((action) => action.content === content)
+    );
+
+    beforeEach(() => {
+      wrapper.setProps({ submitting: true });
+    });
+
+    it('disables primary action button', () => {
+      expect(wrapper).toHaveProp('primaryAction', expect.objectContaining({ disabled: true }));
+    });
+
+    it('disables save action button', () => {
+      const action = findSecondaryAction('Save as Draft');
+      expect(action).toHaveProperty('disabled', true);
+    });
+
+    it('disables delete action button', () => {
+      const action = findSecondaryAction('Delete');
+      expect(action).toHaveProperty('disabled', true);
+    });
+
+    it('disables duplicate action button', () => {
+      const action = findSecondaryAction('Duplicate');
+      expect(action).toHaveProperty('disabled', true);
+    });
+  });
 });

--- a/src/pages/templates/tests/EditPage.test.js
+++ b/src/pages/templates/tests/EditPage.test.js
@@ -91,8 +91,6 @@ describe('Template EditPage', () => {
     it('should handle success', async () => {
       wrapper.setProps({ update: jest.fn(() => Promise.resolve()) });
       await wrapper.instance().handleSave('values');
-      expect(props.getDraft).toHaveBeenCalledWith('id', 101);
-      expect(props.getTestData).toHaveBeenCalledWith({ id: 'id', mode: 'draft' });
       expect(props.showAlert).toHaveBeenCalledWith({ type: 'success', message: 'Template saved' });
     });
   });

--- a/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/EditPage.test.js.snap
@@ -33,12 +33,14 @@ exports[`Template EditPage should render correctly 1`] = `
       },
       Object {
         "content": "Delete",
+        "disabled": undefined,
         "onClick": [Function],
         "visible": true,
       },
       Object {
         "component": [Function],
         "content": "Duplicate",
+        "disabled": undefined,
         "to": "/templates/create/id",
         "visible": true,
       },
@@ -112,12 +114,14 @@ exports[`Template EditPage should render correctly for read-only users 1`] = `
       },
       Object {
         "content": "Delete",
+        "disabled": undefined,
         "onClick": [Function],
         "visible": false,
       },
       Object {
         "component": [Function],
         "content": "Duplicate",
+        "disabled": undefined,
         "to": "/templates/create/id",
         "visible": false,
       },


### PR DESCRIPTION
Refer to [TR-1205](https://jira.int.messagesystems.com/browse/TR-1205) for AC.

### What Changed

- After saving a template draft, we were refetching the template.  I believe this was a safeguard, but it was causing a full page reload which would cause the user to lose focus on the current content tab and their place in the content editor.  The fix is to not refetch after save.
- Bonus: Disabled delete and duplicate secondary actions when saving.

### How To Test

1. Open a draft template
2. Switch to "Text" or "AMP HTML" tab 
3. Click "Save as Draft" button

Expected Result: The primary and secondary should all disable temporarily while saving and user should not lose the focus on content tab.