### PR TITLE
Track customer release uptake

### DIFF
--- a/scripts/dumpReleases.js
+++ b/scripts/dumpReleases.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const readline = require('readline');
+
+//
+// To dump the last 32 merges to master by date (aka releases):
+//   git checkout master
+//   git log --format=medium --merges -n 32 --date=iso-strict | ag 'commit|Date' --no-color | node scripts/dumpReleases.js > releases.csv
+//
+
+const parseThing = (regex, line, lineIdx) => {
+  const thing = line.match(regex);
+  if (!thing) {
+    console.error(new Error(`Could not parse line ${lineIdx}`));
+  }
+  return thing[1];
+}
+
+const parseCommit = (line, lineIdx) =>  parseThing(/^commit\s+([a-f0-9]+)$/, line, lineIdx);
+
+const parseDate = (line, lineIdx) => {
+  const dateStr = parseThing(/^Date:\s+(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(Z|[+-]\d\d:\d\d))$/, line, lineIdx);
+  return dateStr ? new Date(dateStr).toISOString() : null;
+}
+
+function dumpReleases() {
+  const rl = readline.createInterface({
+    input: process.stdin
+  });
+
+  // CSV Header
+  console.log(`timestamp,release`);
+
+  // Read lines 2 at a time
+  let lineIdx = 0;
+  let commit;
+  let date;
+  rl.on('line', (line) => {
+    // Parse commit, date from line N and N+1
+    if (lineIdx % 2 == 0) {
+      // Line N: commit
+      commit = parseCommit(line, lineIdx);
+      if (!commit) {
+        rl.close();
+        return;
+      }
+    } else {
+      // Line N+1: date
+      date = parseDate(line, lineIdx);
+      if (!date) {
+        rl.close();
+        return;
+      }
+      // Write commit,date\n
+      console.log(`${date},${commit}`);
+    }
+    lineIdx += 1;
+  });
+}
+
+dumpReleases();

--- a/scripts/oldReleaseUsers.js
+++ b/scripts/oldReleaseUsers.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// Usage:
+//   1. Pull the "Visitors Releases" report as CSV from Pendo
+//   2. Pull Git release history: `git checkout master && git log --format=medium --merges -n 32 --date=iso-strict | ag 'commit|Date' --no-color | node scripts/dumpReleases.js > releases.csv`
+//   4. Run report: `node oldReleaseUsers.js <visitors.csv> <releases.csv>`
+//
+// Note this will write report findings to stderr and a CSV of results to stdout
+
+const fs = require('fs');
+const papa = require('papaparse');
+const moment = require('moment');
+
+const defaultCsvConfig = { header: true, skipEmptyLines: true };
+const validateCsvLoad = ({ data, errors }) => {
+  if (errors.length) {
+    console.error(errors);
+    throw new Error(`CSV parse failed`);
+  }
+  return data;
+};
+
+const loadCsv = (path, config = {}) => validateCsvLoad(papa.parse(fs.readFileSync(path, { encoding: 'utf8' }), {...defaultCsvConfig, ...config }));
+
+const formatVisitorRecord = ([visitorId,release,tenant,plan,serviceLevel,lastVisit]) => ({
+  visitorId,
+  release,
+  tenant,
+  plan,
+  serviceLevel,
+  lastVisit: moment(lastVisit).add(4, 'h').toDate() // Visitor lastVisit field is in EDT (!)
+});
+
+// Load visitor records
+const visitorsFilePath = process.argv[2];
+const visitors = loadCsv(visitorsFilePath, { header: false }).slice(1).map(formatVisitorRecord);
+
+// Load release records and sort ascending
+const releasesFilePath = process.argv[3]
+const formatReleaseColumn = (value, key) => key === 'timestamp' ? moment(value).toDate() : value;
+const releases = loadCsv(releasesFilePath, { transform: formatReleaseColumn }).sort((a, b) => a.timestamp - b.timestamp);
+
+// Pull the latest release for each visitor, based on their last visit time.
+const releaseDetailsForVisitor = (visitor, releases) => {
+  const visibleReleases = releases.filter(release => release.timestamp <= visitor.lastVisit);
+  const latestRelease = visibleReleases[visibleReleases.length-1];
+  const releaseAge = visitor.lastVisit - latestRelease.timestamp;
+  return {
+    latestRelease,
+    releaseAge,
+    displayReleaseAge: releaseAge > 0 ? moment.duration(releaseAge).humanize() : 'current'
+  };
+};
+
+const visitorsWithReleaseDetails = visitors.map(visitor => ({
+  ...visitor,
+  ...releaseDetailsForVisitor(visitor, releases)
+}));
+
+// Calculate the proportion of visitors running old releases
+const visitorsOnOldReleases = visitorsWithReleaseDetails.filter(visitor => visitor.release !== visitor.latestRelease.release)
+console.warn(`${visitorsOnOldReleases.length} of ${visitors.length} visitors are running old releases`);
+
+// Estimate the distribution of old release age
+const oldReleaseAges = visitorsOnOldReleases.map(visitor => visitor.releaseAge);
+const mean = oldReleaseAges.reduce((a, b) => a + b, 0) / oldReleaseAges.length;
+console.warn(`Mean age of releases for people on old releases: ${moment.duration(mean).humanize()}`);
+
+// Dump visitor list with release age details
+const textSafeVisitors = visitorsWithReleaseDetails.map(({ latestRelease, displayReleaseAge, lastVisit, ...rest}) => ({
+  lastVisit: lastVisit.toISOString(),
+  ...rest,
+}));
+console.log(papa.unparse(textSafeVisitors));


### PR DESCRIPTION
We need a clear view of how long new releases take to percolate through our user base.

This PR includes some simple tools to dump releases and, using a Pendo report, to calculate the age of release that visitors are using.

[Here's a review of the results](https://docs.google.com/spreadsheets/d/13JJEisJqcOsO7EmrwohWMyw0z3TzB9YnP7gs3Jo3pCc/edit?usp=sharing). 

tl;dr - it looks like most people have releases which are about a day old.

## How To Test
1. `npm install papaparse@latest` - ick
1. Follow instructions at the top of `scripts/oldReleaseUsers.js`

## TODO
 - [ ] Peer review the calculations in `scripts/oldReleaseUsers.js`
 - [ ] Let squads know what to expect wrt FE feature uptake
