### PR TITLE
SA-604 Add formatted date column to Events Search downloadable CSV

### DIFF
--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -8,7 +8,7 @@ import DisplayDate from './components/DisplayDate';
 import MessageEventsSearch from './components/MessageEventsSearch';
 import ViewDetailsButton from './components/ViewDetailsButton';
 import { getMessageEvents, changePage, getMessageEventsCSV, clearCSV } from 'src/actions/messageEvents';
-import { selectMessageEvents } from 'src/selectors/messageEvents';
+import { selectMessageEvents, selectMessageEventsCSV } from 'src/selectors/messageEvents';
 import { formatToCsv, download } from 'src/helpers/downloading';
 import { DEFAULT_PER_PAGE_BUTTONS } from 'src/constants';
 import CursorPaging from './components/CursorPaging';
@@ -174,8 +174,9 @@ export class MessageEventsPage extends Component {
 
 const mapStateToProps = (state) => {
   const events = selectMessageEvents(state);
+  const eventsCSV = selectMessageEventsCSV(state);
   const { messageEvents } = state;
-  const { loading, error, search, totalCount, hasMorePagesAvailable, eventsCSV, eventsCSVLoading } = messageEvents;
+  const { loading, error, search, totalCount, hasMorePagesAvailable, eventsCSVLoading } = messageEvents;
   return {
     events: events,
     loading,

--- a/src/selectors/messageEvents.js
+++ b/src/selectors/messageEvents.js
@@ -4,25 +4,30 @@ import moment from 'moment';
 import { createSelector, createStructuredSelector } from 'reselect';
 
 const getMessageEvents = (state) => state.messageEvents.events;
+const getMessageEventsCSV = (state) => state.messageEvents.eventsCSV;
 const getMessageHistory = (state) => state.messageEvents.history;
 const getSingleSelectedEvent = (state) => state.messageEvents.selectedEvent;
 export const getMessageIdParam = (state, props) => props.match.params.messageId;
 const getEventIdParam = (state, props) => props.match.params.eventId;
 
+const appendFormattedDate = (event) => ({
+  ...event,
+  formattedDate: formatDateTime(event.timestamp)
+});
+
 export const selectMessageEvents = createSelector(
   [ getMessageEvents ],
-  (events) => _.map(events, (event) => ({
-    ...event,
-    formattedDate: formatDateTime(event.timestamp)
-  }))
+  (events) => _.map(events, appendFormattedDate)
+);
+
+export const selectMessageEventsCSV = createSelector(
+  [ getMessageEventsCSV ],
+  (events) => _.map(events, appendFormattedDate)
 );
 
 export const selectMessageHistory = createSelector(
   [getMessageHistory, getMessageIdParam],
-  (history, id) => _.map(history[id], (event) => ({
-    ...event,
-    formattedDate: formatDateTime(event.timestamp)
-  }))
+  (history, id) => _.map(history[id], appendFormattedDate)
 );
 
 export const selectInitialEventId = createSelector(

--- a/src/selectors/tests/__snapshots__/messageEvents.test.js.snap
+++ b/src/selectors/tests/__snapshots__/messageEvents.test.js.snap
@@ -1,8 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MessageEvents Selectors Selectors: Initial Event Id returns default event_id 1`] = `"default_id"`;
-
-exports[`MessageEvents Selectors Selectors: Initial Event Id returns event_id 1`] = `"selected_id"`;
+exports[`MessageEvents Selectors Selectors: Message Events CSV returns formatted message events CSV data 1`] = `
+Array [
+  Object {
+    "event_id": "default_id",
+    "foo": "bar",
+    "formattedDate": "Nov 9 2017, 12:00am",
+    "timestamp": "2017-11-09T00:00",
+  },
+  Object {
+    "bat": "baz",
+    "foo": "bar",
+    "formattedDate": "Nov 8 2017, 11:00am",
+    "timestamp": "2017-11-08T11:00",
+  },
+]
+`;
 
 exports[`MessageEvents Selectors Selectors: Message Events returns formatted message event data 1`] = `
 Array [
@@ -79,21 +92,12 @@ Object {
   "messageId": "_noid_",
   "selectedEvent": Array [
     Object {
-      "event_id": "default_id",
+      "event_id": "selected_id",
       "foo": "bar",
       "timestamp": "2017-11-09T00:00",
     },
   ],
   "selectedEventId": "default_id",
-}
-`;
-
-exports[`MessageEvents Selectors getSelectedEventFromMessageHistory returns correct event from messageHistory 1`] = `
-Object {
-  "event_id": "default_id",
-  "foo": "bar",
-  "formattedDate": "Nov 9 2017, 12:00am",
-  "timestamp": "2017-11-09T00:00",
 }
 `;
 

--- a/src/selectors/tests/messageEvents.test.js
+++ b/src/selectors/tests/messageEvents.test.js
@@ -1,11 +1,12 @@
 import * as selectors from '../messageEvents';
 
-
 describe('MessageEvents Selectors', () => {
   let props;
   let messageEvents;
+  let messageEventsCSV;
   let messageHistory;
   let selectedEvent;
+  let formattedEvents;
 
   beforeEach(() => {
     props = {
@@ -30,11 +31,19 @@ describe('MessageEvents Selectors', () => {
       }
     ];
 
+    formattedEvents = [
+      { ...events[0],
+        formattedDate: 'Nov 9 2017, 12:00am' },
+      { ...events[1],
+        formattedDate: 'Nov 8 2017, 11:00am' }
+    ];
+
     messageEvents = { events: events };
+    messageEventsCSV = { eventsCSV: events };
     messageHistory = { history: { message_id: events }};
     selectedEvent = [
       {
-        event_id: 'default_id',
+        event_id: 'selected_id',
         foo: 'bar',
         timestamp: '2017-11-09T00:00'
       }
@@ -48,6 +57,12 @@ describe('MessageEvents Selectors', () => {
     });
   });
 
+  describe('Selectors: Message Events CSV', () => {
+    it('returns formatted message events CSV data', () => {
+      expect(selectors.selectMessageEventsCSV({ messageEvents: messageEventsCSV })).toMatchSnapshot();
+    });
+  });
+
   describe('Selectors: Message History', () => {
     it('returns formatted message history data', () => {
       expect(selectors.selectMessageHistory({ messageEvents: messageHistory }, props)).toMatchSnapshot();
@@ -56,12 +71,12 @@ describe('MessageEvents Selectors', () => {
 
   describe('Selectors: Initial Event Id', () => {
     it('returns event_id', () => {
-      expect(selectors.selectInitialEventId({ messageEvents: messageHistory }, props)).toMatchSnapshot();
+      expect(selectors.selectInitialEventId({ messageEvents: messageHistory }, props)).toEqual(props.match.params.eventId);
     });
 
     it('returns default event_id', () => {
       props.match.params.eventId = null;
-      expect(selectors.selectInitialEventId({ messageEvents: messageHistory }, props)).toMatchSnapshot();
+      expect(selectors.selectInitialEventId({ messageEvents: messageHistory }, props)).toEqual(formattedEvents[0].event_id);
     });
   });
 
@@ -128,7 +143,7 @@ describe('MessageEvents Selectors', () => {
   describe('getSelectedEventFromMessageHistory', () => {
     it('returns correct event from messageHistory', () => {
       props.match.params.eventId = 'default_id';
-      expect(selectors.getSelectedEventFromMessageHistory({ messageEvents: messageHistory }, props)).toMatchSnapshot();
+      expect(selectors.getSelectedEventFromMessageHistory({ messageEvents: messageHistory }, props)).toEqual(formattedEvents[0]);
     });
 
     it('returns undefined if event does not exist in messageHistory', () => {
@@ -162,7 +177,6 @@ describe('MessageEvents Selectors', () => {
       props.match.params.messageId = '_noid_';
       expect(selectors.eventPageMSTP()(store, props)).toMatchSnapshot();
     });
-
 
   });
 });


### PR DESCRIPTION
### What Changed
 - Added selector for CSV events that adds a formatted date to each event.
      - Refactored some selector code because same add formatted date anon function was being used 3 times
 - Refactored some tests to improve readability and decrease usage of snapshots.
     - Returned complex object-> kept as snapshots/ returned single value -> assert the value. 
     - Changed the value of the `event_id` in `selectedEvent` so that the snapshot isn't the same as another test

### How To Test
 - Go to reports->Events Search, download the CSV, make sure there is a column called formattedDate(should be rightmost).

### To Do
- [x] Address feedback
