### PR TITLE
EO-697 Abstract informational tooltips & Add to V2 pages

### DIFF
--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -9,6 +9,7 @@ import Callout from 'src/components/callout';
 import ChartHeader from './components/ChartHeader';
 import DateFilter from './components/filters/DateFilter';
 import EngagementRecencyActions from './components/actionContent/EngagementRecencyActions';
+import InfoTooltip from './components/InfoTooltip';
 import Legend from './components/charts/legend/Legend';
 import OtherChartsHeader from './components/OtherChartsHeader';
 import Page from './components/SignalsPage';
@@ -130,7 +131,12 @@ export class EngagementRecencyPage extends Component {
     return (
       <Page
         breadcrumbAction={{ content: 'Back to Overview', to: '/signals', component: Link }}
-        dimensionPrefix='Engagement Recency'
+        dimensionPrefix={
+          <>
+            Engagement Recency
+            <InfoTooltip content={ENGAGEMENT_RECENCY_INFO} />
+          </>
+        }
         facet={facet}
         facetId={facetId}
         subaccountId={subaccountId}

--- a/src/pages/signals/components/ChartHeader.js
+++ b/src/pages/signals/components/ChartHeader.js
@@ -1,20 +1,13 @@
 import React, { Fragment } from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
-import { InfoOutline } from '@sparkpost/matchbox-icons';
 import { formatDate } from 'src/helpers/date';
+import InfoTooltip from './InfoTooltip';
 import styles from './ChartHeader.module.scss';
 
 const ChartHeader = ({ date, title, primaryArea, hideLine, tooltipContent, padding = '' }) => (
   <Fragment>
     <div className={styles.ChartHeader} style={{ padding }}>
       <h6 className={styles.Title}>{title}{date && ` – ${formatDate(date)}`}</h6>
-      {tooltipContent && (
-        <div className={styles.Tooltip}>
-          <Tooltip dark horizontalOffset='-1rem' content={tooltipContent}>
-            <InfoOutline className={styles.TooltipIcon} size={17} />
-          </Tooltip>
-        </div>
-      )}
+      {tooltipContent && <InfoTooltip content={tooltipContent} size={17} />}
       {primaryArea && <div className={styles.PrimaryArea}>{primaryArea}</div>}
     </div>
     {!hideLine && <hr className={styles.Line} />}

--- a/src/pages/signals/components/ChartHeader.module.scss
+++ b/src/pages/signals/components/ChartHeader.module.scss
@@ -23,14 +23,3 @@
   flex-grow: 1;
   justify-content: flex-end;
 }
-
-.Tooltip {
-  display: inline-block;
-  line-height: normal;
-  margin: 0 spacing(small);
-}
-
-.TooltipIcon {
-  color: color(blue);
-  margin-top: -0.2em;
-}

--- a/src/pages/signals/components/InfoTooltip.js
+++ b/src/pages/signals/components/InfoTooltip.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Tooltip } from '@sparkpost/matchbox';
+import { InfoOutline } from '@sparkpost/matchbox-icons';
+import styles from './InfoTooltip.module.scss';
+
+function InfoTooltip({ content, size = 24 }) {
+  return (
+    <Tooltip
+      children={<InfoOutline className={styles.TooltipIcon} size={size} />}
+      content={content}
+      dark
+      horizontalOffset="-0.15rem"
+      right
+    />
+  );
+}
+
+export default InfoTooltip;

--- a/src/pages/signals/components/InfoTooltip.module.scss
+++ b/src/pages/signals/components/InfoTooltip.module.scss
@@ -1,0 +1,7 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.TooltipIcon {
+  color: color(blue);
+  margin-top: -0.05em;
+  margin-left: 1ch;
+}

--- a/src/pages/signals/components/tests/InfoTooltip.test.js
+++ b/src/pages/signals/components/tests/InfoTooltip.test.js
@@ -1,0 +1,24 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import InfoTooltip from '../InfoTooltip';
+
+describe('Signals InfoTooltip Component', () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      content: 'Foo'
+    };
+    wrapper = shallow(<InfoTooltip {...props}/>);
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with size correctly', () => {
+    wrapper.setProps({ size: 15 });
+    expect(wrapper.find('InfoOutline').prop('size')).toEqual(15);
+  });
+});

--- a/src/pages/signals/components/tests/__snapshots__/ChartHeader.test.js.snap
+++ b/src/pages/signals/components/tests/__snapshots__/ChartHeader.test.js.snap
@@ -92,31 +92,10 @@ exports[`Signals ChartHeader Component renders tooltip content correctly 1`] = `
       Foo
        – Feb 15 2018
     </h6>
-    <div
-      className="Tooltip"
-    >
-      <Tooltip
-        bottom={true}
-        content="tooltip content"
-        dark={true}
-        forcePosition={false}
-        horizontalOffset="-1rem"
-        preferredDirection={
-          Object {
-            "bottom": true,
-            "left": false,
-            "right": true,
-            "top": false,
-          }
-        }
-        right={true}
-      >
-        <InfoOutline
-          className="TooltipIcon"
-          size={17}
-        />
-      </Tooltip>
-    </div>
+    <InfoTooltip
+      content="tooltip content"
+      size={17}
+    />
   </div>
   <hr
     className="Line"

--- a/src/pages/signals/components/tests/__snapshots__/InfoTooltip.test.js.snap
+++ b/src/pages/signals/components/tests/__snapshots__/InfoTooltip.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signals InfoTooltip Component renders correctly 1`] = `
+<Tooltip
+  bottom={true}
+  content="Foo"
+  dark={true}
+  forcePosition={false}
+  horizontalOffset="-0.15rem"
+  preferredDirection={
+    Object {
+      "bottom": true,
+      "left": false,
+      "right": true,
+      "top": false,
+    }
+  }
+  right={true}
+>
+  <InfoOutline
+    className="TooltipIcon"
+    size={24}
+  />
+</Tooltip>
+`;

--- a/src/pages/signals/dashboards/EngagementRecencyDashboard.js
+++ b/src/pages/signals/dashboards/EngagementRecencyDashboard.js
@@ -7,6 +7,8 @@ import EngagementRecencyOverview from '../containers/EngagementRecencyOverviewCo
 import FacetFilter from '../components/filters/FacetFilter';
 import DateFilter from '../components/filters/DateFilter';
 import SubaccountFilter from '../components/filters/SubaccountFilter';
+import InfoTooltip from '../components/InfoTooltip';
+import { ENGAGEMENT_RECENCY_INFO } from '../constants/info';
 
 export class EngagementRecencyDashboard extends Component {
   componentDidMount() {
@@ -17,7 +19,12 @@ export class EngagementRecencyDashboard extends Component {
     const { subaccounts } = this.props;
 
     return (
-      <Page title='Engagement Recency'>
+      <Page title={
+        <>
+          Engagement Recency
+          <InfoTooltip content={ENGAGEMENT_RECENCY_INFO} />
+        </>
+      }>
         <Panel sectioned>
           <Grid>
             <Grid.Column lg={4}>

--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -10,6 +10,8 @@ import DateFilter from '../components/filters/DateFilter';
 import SubaccountFilter from '../components/filters/SubaccountFilter';
 import CurrentHealthGauge from './components/CurrentHealthGauge/CurrentHealthGauge';
 import HealthScoreChart from './components/HealthScoreChart/HealthScoreChart';
+import InfoTooltip from '../components/InfoTooltip';
+import { HEALTH_SCORE_INFO } from '../constants/info';
 
 export function HealthScoreDashboard(props) {
   const { from, getCurrentHealthScore, getInjections, getSubaccounts, relativeRange, subaccounts, to } = props;
@@ -28,7 +30,15 @@ export function HealthScoreDashboard(props) {
   }, [getCurrentHealthScore, getInjections, relativeRange, from, to]);
 
   return (
-    <Page title='Health Score' primaryArea={<DateFilter left />}>
+    <Page
+      title={
+        <>
+          Health Score
+          <InfoTooltip content={HEALTH_SCORE_INFO} />
+        </>
+      }
+      primaryArea={<DateFilter left />}
+    >
       <Grid>
         <Grid.Column xs={12} lg={5} xl={4}>
           <CurrentHealthGauge />

--- a/src/pages/signals/dashboards/SpamTrapDashboard.js
+++ b/src/pages/signals/dashboards/SpamTrapDashboard.js
@@ -7,6 +7,8 @@ import SpamTrapOverview from '../containers/SpamTrapOverviewContainer';
 import FacetFilter from '../components/filters/FacetFilter';
 import DateFilter from '../components/filters/DateFilter';
 import SubaccountFilter from '../components/filters/SubaccountFilter';
+import InfoTooltip from '../components/InfoTooltip';
+import { SPAM_TRAP_INFO } from '../constants/info';
 
 export class SpamTrapDashboard extends Component {
   componentDidMount() {
@@ -17,7 +19,12 @@ export class SpamTrapDashboard extends Component {
     const { subaccounts } = this.props;
 
     return (
-      <Page title='Spam Trap Monitoring' >
+      <Page title={
+          <>
+            Spam Trap Monitoring
+            <InfoTooltip content={SPAM_TRAP_INFO} />
+          </>
+      }>
         <Panel sectioned>
           <Grid>
             <Grid.Column xs={4}>

--- a/src/pages/signals/dashboards/components/CurrentHealthGauge/CurrentHealthGauge.js
+++ b/src/pages/signals/dashboards/components/CurrentHealthGauge/CurrentHealthGauge.js
@@ -2,15 +2,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { getCaretProps } from 'src/helpers/signals';
 import { selectCurrentHealthScoreDashboard } from 'src/selectors/signals';
-import { Panel, Tooltip } from '@sparkpost/matchbox';
-import { InfoOutline } from '@sparkpost/matchbox-icons';
+import { Panel } from '@sparkpost/matchbox';
 import { PanelLoading } from 'src/components';
 import Callout from 'src/components/callout';
 import { formatDate } from 'src/helpers/date';
 import { FORMATS } from 'src/constants';
 import Gauge from './Gauge';
 import MetricDisplay from '../MetricDisplay/MetricDisplay';
-import { HEALTH_SCORE_INFO } from '../../../constants/info';
 import thresholds from '../../../constants/healthScoreThresholds';
 
 import _ from 'lodash';
@@ -58,16 +56,7 @@ export function CurrentHealthGauge(props) {
   return (
     <Panel sectioned>
       <div className={styles.Content}>
-        <h2 className={styles.Header}>
-          {title}
-          <Tooltip
-            children={<InfoOutline className={styles.TooltipIcon} size={18} />}
-            content={HEALTH_SCORE_INFO}
-            dark
-            horizontalOffset='-1rem'
-            right
-          />
-        </h2>
+        <h2 className={styles.Header}>{title}</h2>
         {noData && <div><Callout height='auto'>Current Health Score Not Available</Callout></div>}
         {!noData && (
           <>

--- a/src/pages/signals/dashboards/components/CurrentHealthGauge/CurrentHealthGauge.module.scss
+++ b/src/pages/signals/dashboards/components/CurrentHealthGauge/CurrentHealthGauge.module.scss
@@ -88,12 +88,6 @@
   line-height: 1.4em;
 }
 
-.TooltipIcon {
-  color: color(blue);
-  margin-top: -0.1em;
-  margin-left: 1ch;
-}
-
 .Metrics {
   text-align: center;
   display: flex;

--- a/src/pages/signals/dashboards/components/CurrentHealthGauge/tests/__snapshots__/CurrentHealthGauge.test.js.snap
+++ b/src/pages/signals/dashboards/components/CurrentHealthGauge/tests/__snapshots__/CurrentHealthGauge.test.js.snap
@@ -22,31 +22,6 @@ exports[`Signals Health Score Gauge Container renders happy path correctly 1`] =
       className="Header"
     >
       Current Health Score
-      <Tooltip
-        bottom={true}
-        content="
-  This is a predictive score that monitors your email health to identify problems before
-  they negatively impact email delivery. This score is informed by message events,
-  including bounces, spam trap hits, and engagement across our entire network.
-"
-        dark={true}
-        forcePosition={false}
-        horizontalOffset="-1rem"
-        preferredDirection={
-          Object {
-            "bottom": true,
-            "left": false,
-            "right": true,
-            "top": false,
-          }
-        }
-        right={true}
-      >
-        <InfoOutline
-          className="TooltipIcon"
-          size={18}
-        />
-      </Tooltip>
     </h2>
     <Gauge
       score={88}

--- a/src/pages/signals/dashboards/tests/__snapshots__/EngagementRecencyDashboard.test.js.snap
+++ b/src/pages/signals/dashboards/tests/__snapshots__/EngagementRecencyDashboard.test.js.snap
@@ -2,7 +2,17 @@
 
 exports[`Signals Engagement Recency Dashboard renders page 1`] = `
 <SignalsPage
-  title="Engagement Recency"
+  title={
+    <React.Fragment>
+      Engagement Recency
+      <InfoTooltip
+        content="
+  The share over time of your email that has been sent to recipients who most recently
+  opened messages or clicked links during several defined time periods.
+"
+      />
+    </React.Fragment>
+  }
 >
   <Panel
     sectioned={true}

--- a/src/pages/signals/dashboards/tests/__snapshots__/HealthScoreDashboard.test.js.snap
+++ b/src/pages/signals/dashboards/tests/__snapshots__/HealthScoreDashboard.test.js.snap
@@ -7,7 +7,18 @@ exports[`Signals Health Score Dashboard renders page 1`] = `
       left={true}
     />
   }
-  title="Health Score"
+  title={
+    <React.Fragment>
+      Health Score
+      <InfoTooltip
+        content="
+  This is a predictive score that monitors your email health to identify problems before
+  they negatively impact email delivery. This score is informed by message events,
+  including bounces, spam trap hits, and engagement across our entire network.
+"
+      />
+    </React.Fragment>
+  }
 >
   <Grid>
     <Grid.Column

--- a/src/pages/signals/dashboards/tests/__snapshots__/SpamTrapDashboard.test.js.snap
+++ b/src/pages/signals/dashboards/tests/__snapshots__/SpamTrapDashboard.test.js.snap
@@ -2,7 +2,17 @@
 
 exports[`Signals Spam Trap Dashboard Dashboard renders page 1`] = `
 <SignalsPage
-  title="Spam Trap Monitoring"
+  title={
+    <React.Fragment>
+      Spam Trap Monitoring
+      <InfoTooltip
+        content="
+  The share over time of your total email that has been sent to known spam traps. An
+  excessive rate of spam trap hits is an indicator of poor list procurement and hygiene practices.
+"
+      />
+    </React.Fragment>
+  }
 >
   <Panel
     sectioned={true}

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -59,7 +59,17 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
       "to": "/signals",
     }
   }
-  dimensionPrefix="Engagement Recency"
+  dimensionPrefix={
+    <React.Fragment>
+      Engagement Recency
+      <InfoTooltip
+        content="
+  The share over time of your email that has been sent to recipients who most recently
+  opened messages or clicked links during several defined time periods.
+"
+      />
+    </React.Fragment>
+  }
   facet="sending-domain"
   facetId="test.com"
   primaryArea={
@@ -316,7 +326,17 @@ exports[`Signals Engagement Recency Page renders error correctly 1`] = `
       "to": "/signals",
     }
   }
-  dimensionPrefix="Engagement Recency"
+  dimensionPrefix={
+    <React.Fragment>
+      Engagement Recency
+      <InfoTooltip
+        content="
+  The share over time of your email that has been sent to recipients who most recently
+  opened messages or clicked links during several defined time periods.
+"
+      />
+    </React.Fragment>
+  }
   facet="sending-domain"
   facetId="test.com"
   primaryArea={


### PR DESCRIPTION
### What Changed
- Abstracts the blue tooltips in Signals
- Adds tooltips to v2 dashboards and engagement recency page

### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data
- Visit v2 dashboards, and the v1 engagement recency details page
- Verify tooltips appear in the page title
- Verify other tooltips are still there (preview components, v1 overview)

### To Do
- [ ] Address any feedback
