### PR TITLE
EO-722 Fix engagement by cohort precision

### DIFF
--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -34,7 +34,7 @@ export class EngagementRateByCohortPage extends Component {
 
   getYAxisProps = () => ({
     domain: this.isEmpty() ? [0, 1] : ['auto', 'auto'],
-    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`
+    tickFormatter: (tick) => `${roundToPlaces(tick * 100, 1)}%`
   })
 
   getXAxisProps = () => {
@@ -59,7 +59,7 @@ export class EngagementRateByCohortPage extends Component {
             color={metric.fill}
             label={metric.label}
             description={metric.description}
-            value={`${roundToPlaces(metric.value, 1) * 100}%`}
+            value={`${roundToPlaces(metric.value * 100, 1)}%`}
           />
         ))}
       </>

--- a/src/pages/signals/tests/EngagementRateByCohortPage.test.js
+++ b/src/pages/signals/tests/EngagementRateByCohortPage.test.js
@@ -55,7 +55,7 @@ describe('Signals Engagement Rate By Cohort Page', () => {
     it('renders tooltip content', () => {
       const Tooltip = wrapper.find('LineChart').prop('tooltipContent');
       expect(shallow(<Tooltip payload={{
-        p_uneng_eng: 0.1,
+        p_uneng_eng: 0.111,
         p_365d_eng: 0.2,
         p_90d_eng: 0.3,
         p_14d_eng: 0.4,

--- a/src/pages/signals/tests/EngagementRateByCohortPage.test.js
+++ b/src/pages/signals/tests/EngagementRateByCohortPage.test.js
@@ -74,7 +74,7 @@ describe('Signals Engagement Rate By Cohort Page', () => {
     it('gets y axis props', () => {
       wrapper.setProps({ data: [{ p_total_eng: 0 }, { p_total_eng: null }]});
       const axisProps = wrapper.find('LineChart').prop('yAxisProps');
-      expect(axisProps.tickFormatter(.253)).toEqual('25%');
+      expect(axisProps.tickFormatter(.253)).toEqual('25.3%');
       expect(axisProps.domain).toEqual([0,1]);
     });
 

--- a/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
@@ -45,7 +45,7 @@ exports[`Signals Engagement Rate By Cohort Page bar chart props renders tooltip 
     description="365+ days since last engagement"
     key="uneng"
     label="Never Engaged"
-    value="10%"
+    value="11.1%"
   />
 </Fragment>
 `;


### PR DESCRIPTION
### What Changed
- Fixes a bug that rounded out tooltip metric values
- Y axis now also matches precision

### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data
- Go to the engagement rate by cohort details page
- Verify tooltip values round to the nearest tenth

### To Do
- [ ] Address any feedback
