### PR TITLE
SA-605 Fix byte conversion from 1000 to 1024

### DIFF
--- a/src/components/formatters/tests/__snapshots__/Size.test.js.snap
+++ b/src/components/formatters/tests/__snapshots__/Size.test.js.snap
@@ -4,7 +4,7 @@ exports[`Size should render size in GB 1`] = `
 <Size
   value={1074000000}
 >
-  1.07GB
+  1GB
 </Size>
 `;
 
@@ -12,7 +12,7 @@ exports[`Size should render size in KB 1`] = `
 <Size
   value={1025}
 >
-  1.02KB
+  1KB
 </Size>
 `;
 
@@ -20,7 +20,7 @@ exports[`Size should render size in MB 1`] = `
 <Size
   value={1049000}
 >
-  1.05MB
+  1MB
 </Size>
 `;
 
@@ -28,7 +28,7 @@ exports[`Size should render size in PB 1`] = `
 <Size
   value={1126000000000000}
 >
-  1.13PB
+  1PB
 </Size>
 `;
 
@@ -36,7 +36,7 @@ exports[`Size should render size in TB 1`] = `
 <Size
   value={1100000000000}
 >
-  1.1TB
+  1TB
 </Size>
 `;
 

--- a/src/helpers/chart.js
+++ b/src/helpers/chart.js
@@ -42,8 +42,7 @@ function getLineChartFormatters(precision) {
   return formatters;
 }
 
-const formatYAxisPercent = _.memoize((v) => `${roundToPlaces(v, v < 1 ? 3 : 1)}%`
-);
+const formatYAxisPercent = _.memoize((v) => `${roundToPlaces(v, v < 1 ? 3 : 1)}%`);
 
 export {
   getDayLines,

--- a/src/helpers/chart.js
+++ b/src/helpers/chart.js
@@ -42,9 +42,8 @@ function getLineChartFormatters(precision) {
   return formatters;
 }
 
-function formatYAxisPercent(v) {
-  return `${roundToPlaces(v, v < 1 ? 3 : 1)}%`;
-}
+const formatYAxisPercent = _.memoize((v) => `${roundToPlaces(v, v < 1 ? 3 : 1)}%`
+);
 
 export {
   getDayLines,

--- a/src/helpers/tests/units.test.js
+++ b/src/helpers/tests/units.test.js
@@ -64,7 +64,6 @@ describe('Formatting helpers', () => {
       expect(formatting.formatBytes(999)).toMatch(/B$/);
       expect(formatting.formatBytes(kb)).toMatch(/KB$/);
       expect(formatting.formatBytes(kb * kb)).toMatch(/MB$/);
-      expect(formatting.formatBytes(kb * kb)).toMatch(/MB$/);
       expect(formatting.formatBytes(kb * kb * kb)).toMatch(/GB$/);
       expect(formatting.formatBytes(kb * kb * kb * kb)).toMatch(/TB$/);
       expect(formatting.formatBytes(kb * kb * kb * kb * kb)).toMatch(/PB$/);

--- a/src/helpers/tests/units.test.js
+++ b/src/helpers/tests/units.test.js
@@ -61,7 +61,7 @@ describe('Formatting helpers', () => {
       expect(formatting.formatBytes(iceCream)).toBe(iceCream);
     });
     it('should include suffixes where appropriate', () => {
-      expect(formatting.formatBytes(999)).toMatch(/B$/);
+      expect(formatting.formatBytes(1023)).toMatch(/B$/);
       expect(formatting.formatBytes(kb)).toMatch(/KB$/);
       expect(formatting.formatBytes(kb * kb)).toMatch(/MB$/);
       expect(formatting.formatBytes(kb * kb * kb)).toMatch(/GB$/);

--- a/src/helpers/tests/units.test.js
+++ b/src/helpers/tests/units.test.js
@@ -55,18 +55,19 @@ describe('Formatting helpers', () => {
   });
 
   describe('formatBytes', () => {
+    const kb = 1024;
     it('should leave non-numbers alone', () => {
       const iceCream = 'vanilla';
       expect(formatting.formatBytes(iceCream)).toBe(iceCream);
     });
     it('should include suffixes where appropriate', () => {
       expect(formatting.formatBytes(999)).toMatch(/B$/);
-      expect(formatting.formatBytes(1000)).toMatch(/KB$/);
-      expect(formatting.formatBytes(1000 * 1000)).toMatch(/MB$/);
-      expect(formatting.formatBytes(1000 * 1000)).toMatch(/MB$/);
-      expect(formatting.formatBytes(1000 * 1000 * 1000)).toMatch(/GB$/);
-      expect(formatting.formatBytes(1000 * 1000 * 1000 * 1000)).toMatch(/TB$/);
-      expect(formatting.formatBytes(1000 * 1000 * 1000 * 1000 * 1000)).toMatch(/PB$/);
+      expect(formatting.formatBytes(kb)).toMatch(/KB$/);
+      expect(formatting.formatBytes(kb * kb)).toMatch(/MB$/);
+      expect(formatting.formatBytes(kb * kb)).toMatch(/MB$/);
+      expect(formatting.formatBytes(kb * kb * kb)).toMatch(/GB$/);
+      expect(formatting.formatBytes(kb * kb * kb * kb)).toMatch(/TB$/);
+      expect(formatting.formatBytes(kb * kb * kb * kb * kb)).toMatch(/PB$/);
     });
   });
 

--- a/src/helpers/units.js
+++ b/src/helpers/units.js
@@ -1,10 +1,5 @@
 import _ from 'lodash';
 
-const MILLION = Math.pow(10, 6);
-const BILLION = Math.pow(10, 9);
-const TRILLION = Math.pow(10, 12);
-const QUARDRILLION = Math.pow(10, 15);
-
 export const isNumber = (value) => isNaN(parseFloat(value)) === false || isFinite(value) === true;
 
 export function roundToPlaces(number, places) {
@@ -13,7 +8,7 @@ export function roundToPlaces(number, places) {
 }
 
 // Formats bytes into a readable size value
-export const formatBytes = (value) => {
+export const formatBytes = _.memoize((value) => {
   if (!isNumber(value)) {
     return value;
   }
@@ -23,11 +18,11 @@ export const formatBytes = (value) => {
   let suffix = 'B';
 
   const formatters = {
-    'PB': QUARDRILLION,
-    'TB': TRILLION,
-    'GB': BILLION,
-    'MB': MILLION,
-    'KB': 1000
+    'PB': Math.pow(2, 50),
+    'TB': Math.pow(2, 40),
+    'GB': Math.pow(2, 30),
+    'MB': Math.pow(2, 20),
+    'KB': Math.pow(2, 10)
   };
 
   _.forEach(formatters, (unit, key) => {
@@ -38,11 +33,11 @@ export const formatBytes = (value) => {
     }
   });
 
-  return `${roundToPlaces(formatted, 2).toLocaleString()}${suffix}`;
-};
+  return `${roundToPlaces(formatted, 2).toLocaleString(undefined, { maximumSignificantDigits: 4 })}${suffix}`;
+});
 
 // Formats milliseconds into a readable duration value
-export const formatMilliseconds = (value) => {
+export const formatMilliseconds = _.memoize((value) => {
   if (!isNumber(value)) {
     return value;
   }
@@ -66,10 +61,10 @@ export const formatMilliseconds = (value) => {
   });
 
   return `${roundToPlaces(formatted, 2).toLocaleString()}${suffix}`;
-};
+});
 
 // Formats number count into a abbreviated count
-export const formatNumber = (value) => {
+export const formatNumber = _.memoize((value) => {
   if (!isNumber(value)) {
     return value;
   }
@@ -79,8 +74,8 @@ export const formatNumber = (value) => {
   let suffix = '';
 
   const formatters = {
-    'B': BILLION,
-    'M': MILLION,
+    'B': Math.pow(10, 9),
+    'M': Math.pow(10, 6),
     'K': 1000
   };
 
@@ -93,7 +88,7 @@ export const formatNumber = (value) => {
   });
 
   return `${roundToPlaces(formatted, 2).toLocaleString()}${suffix}`;
-};
+});
 
 // Formats number count to sting with commas
 export const formatFullNumber = (value) => {

--- a/src/pages/reports/summary/components/async/LineChart.scss
+++ b/src/pages/reports/summary/components/async/LineChart.scss
@@ -3,6 +3,7 @@
 .sp-linechart-wrapper {
   position: relative;
   margin-bottom: rem(30);
+  transform: translate(10px, 0);
 
   &:last-child {
     margin-bottom: 0;
@@ -11,7 +12,7 @@
   // Tick label
   .recharts-text.recharts-cartesian-axis-tick-value {
     fill: color(gray, 5);
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 500;
   }
 
@@ -30,7 +31,7 @@
   .sp-linechart-yLabel {
     position: absolute;
     top: 50%;
-    transform: rotate(-90deg);
+    transform: rotate(-90deg) translate(0, -3px);
     transform-origin: 0;
 
     color: color(gray, 4);
@@ -86,7 +87,7 @@
 
           .recharts-tooltip-item-name {}
           .recharts-tooltip-item-separator {
-            padding-right: rem(50);
+            padding-right: rem(55);
           }
           .recharts-tooltip-item-value {
             font-weight: 600;


### PR DESCRIPTION
### What Changed
 - Changed Byte conversion factor from 1000 to 1024. 
 - Memoized Y-axis-formatter function because it is being called every mouseover. 
 - Changed the chart CSS to improve readability.

### How To Test
 - Go to reports-> summary, select `Delivery Message Volume` as a metric. Compare the chart values to the values returned in the JSON response. It should be dividing by 1024 instead of 1000. 
 - Change various time intervals to make sure graph is legible. Also hover over various chart data points. 

### To Do
- [x] Address feedback
