### PR TITLE
AC-734: Plan picker uses tiered dropdown

### DIFF
--- a/src/__testHelpers__/fill.js
+++ b/src/__testHelpers__/fill.js
@@ -74,6 +74,7 @@ export default function getFiller(mounted) {
         case 'typeahead': {
           control.props().onChange(args.value);
           updated = true;
+          break;
         }
 
         // eslint-disable-next-line no-fallthrough

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -16,9 +16,6 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
     ? 'First dedicated IP address is free'
     : null;
 
-  const currentFreePlan = plan.code && ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'].includes(plan.code);
-  const planTitle = currentFreePlan ? 'Test Account' : `${plan.volume.toLocaleString()}`;
-
   const displayCsm = showCsm && plan.includesCsm;
 
   let discountAmount = priceInfo.price;
@@ -34,8 +31,10 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
-        <strong>{planTitle}</strong> {!currentFreePlan && 'emails/month'}
-        {priceInfo.price > 0 && <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>}
+        <strong>{plan.volume.toLocaleString()}</strong><span> emails/month </span>
+        {priceInfo.price > 0
+          ? <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>
+          : <span> FREE </span>}
       </span>
       <span className={styles.SupportLabel}>
         {showOverage && overage}

--- a/src/components/billing/tests/PlanPrice.test.js
+++ b/src/components/billing/tests/PlanPrice.test.js
@@ -89,18 +89,6 @@ describe('PlanPrice', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders test account with current free plan', () => {
-    const currentFreePlan = {
-      ...plan,
-      monthly: 0,
-      isFree: true,
-      code: 'free500-0419'
-    };
-
-    wrapper.setProps({ plan: currentFreePlan });
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('renders flat discount', () => {
     wrapper.setProps({ selectedPromo: { discount_amount: 5 }});
     expect(wrapper).toMatchSnapshot();

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -107,7 +107,7 @@ exports[`PlanPrice renders correctly for 30 day free plan 1`] = `
        emails/month 
     </span>
     <span>
-       Free 
+       FREE 
     </span>
   </span>
   <span
@@ -163,9 +163,9 @@ exports[`PlanPrice renders correctly for eternal free plan 1`] = `
     <span>
        emails/month 
     </span>
-    <strong>
-       Free 
-    </strong>
+    <span>
+       FREE 
+    </span>
   </span>
   <span
     className="SupportLabel"

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -10,8 +10,9 @@ exports[`PlanPrice allows class name overriding 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <strong>
@@ -38,8 +39,9 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <s
@@ -72,8 +74,9 @@ exports[`PlanPrice renders correctly 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <strong>
@@ -100,8 +103,12 @@ exports[`PlanPrice renders correctly for 30 day free plan 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
+    <span>
+       Free 
+    </span>
   </span>
   <span
     className="SupportLabel"
@@ -119,8 +126,9 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <strong>
@@ -152,8 +160,12 @@ exports[`PlanPrice renders correctly for eternal free plan 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
+    <strong>
+       Free 
+    </strong>
   </span>
   <span
     className="SupportLabel"
@@ -171,8 +183,9 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <strong>
@@ -199,8 +212,9 @@ exports[`PlanPrice renders flat discount 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <s
@@ -233,8 +247,9 @@ exports[`PlanPrice renders free ip 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <strong>
@@ -263,8 +278,9 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <strong>
@@ -296,8 +312,9 @@ exports[`PlanPrice renders percent discount 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <s
@@ -320,24 +337,6 @@ exports[`PlanPrice renders percent discount 1`] = `
 </span>
 `;
 
-exports[`PlanPrice renders test account with current free plan 1`] = `
-<span
-  className="notranslate"
->
-  <span
-    className="MainLabel"
-  >
-    <strong>
-      Test Account
-    </strong>
-     
-  </span>
-  <span
-    className="SupportLabel"
-  />
-</span>
-`;
-
 exports[`PlanPrice renders with overage 1`] = `
 <span
   className="notranslate"
@@ -348,8 +347,9 @@ exports[`PlanPrice renders with overage 1`] = `
     <strong>
       50,000
     </strong>
-     
-    emails/month
+    <span>
+       emails/month 
+    </span>
     <span>
        at 
       <strong>

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -75,11 +75,6 @@ export class PlanPicker extends Component {
       selectedPromo
     };
 
-    const selectedPlan = (<>
-        {PLAN_TIERS[selectedItem.tier] && <div className={cx(styles.DropdownLabel)}>{PLAN_TIERS[selectedItem.tier]}</div>}
-        <Plan {...triggerProps} className={triggerClasses} planPriceProps={planPriceProps}/>
-    </>);
-
     return (
       <div className={styles.PlanPicker}>
         <div {...triggerProps} className={cx(styles.TriggerHeader)}>
@@ -87,7 +82,8 @@ export class PlanPicker extends Component {
           <ExpandMore size={24} className={styles.Chevron} />
         </div>
         <div className={cx(styles.PlanContainer)}>
-          {selectedPlan}
+          {PLAN_TIERS[selectedItem.tier] && <div className={cx(styles.DropdownLabel)}>{PLAN_TIERS[selectedItem.tier]}</div>}
+          <Plan {...triggerProps} className={triggerClasses} planPriceProps={planPriceProps}/>
           <input {...getInputProps()} ref={(input) => this.input = input} className={styles.Input} />
           <div className={listClasses}>{items}</div>
         </div>

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -100,7 +100,7 @@ export class PlanPicker extends Component {
       <Downshift
         onChange={onChange}
         itemToString={(item) => (item ? item.code : '')} // prevents the downshift console warning
-        initialSelectedItem={(value && value.code) ? value : plansByTier.default[0]} >
+        initialSelectedItem={(value && value.code) ? value : (plansByTier.default && plansByTier.default[0])} >
         {this.planFn}
       </Downshift>
     );

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -73,7 +73,6 @@ export class PlanPicker extends Component {
     const planPriceProps = {
       selectedPromo
     };
-
     return (
       <div className={styles.PlanPicker}>
         <div className={listClasses}>{items}</div>

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -77,20 +77,20 @@ export class PlanPicker extends Component {
 
     const selectedPlan = (<>
         {PLAN_TIERS[selectedItem.tier] && <div className={cx(styles.DropdownLabel)}>{PLAN_TIERS[selectedItem.tier]}</div>}
-        <Plan plan={selectedItem} className={triggerClasses} planPriceProps={planPriceProps}/>
+        <Plan {...triggerProps} className={triggerClasses} planPriceProps={planPriceProps}/>
     </>);
 
     return (
       <div className={styles.PlanPicker}>
-        <div {...triggerProps}>
-          <div className={cx(styles.TriggerHeader)}>
-            Select A Plan
-            <ExpandMore size={24} className={styles.Chevron} />
-          </div>
-          {selectedPlan}
+        <div {...triggerProps} className={cx(styles.TriggerHeader)}>
+          <span>Select A Plan</span>
+          <ExpandMore size={24} className={styles.Chevron} />
         </div>
-        <input {...getInputProps()} ref={(input) => this.input = input} className={styles.Input} />
-        <div className={listClasses}>{items}</div>
+        <div className={cx(styles.PlanContainer)}>
+          {selectedPlan}
+          <input {...getInputProps()} ref={(input) => this.input = input} className={styles.Input} />
+          <div className={listClasses}>{items}</div>
+        </div>
       </div>
     );
   };

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -33,9 +33,9 @@ export class PlanPicker extends Component {
     selectedItem,
     highlightedIndex
   }) => {
-    const { plans, input, disabled, selectedPromo } = this.props;
+    const { plansByTier, input, disabled, selectedPromo } = this.props;
 
-    if (!selectedItem || _.isEmpty(plans)) {
+    if (!selectedItem || _.isEmpty(plansByTier)) {
       return null;
     }
 
@@ -43,13 +43,13 @@ export class PlanPicker extends Component {
     const items = [];
 
     TIERS.forEach((tier) => {
-      const tierPlans = plans[tier.key];
+      const tierPlans = plansByTier[tier.key];
       if (tierPlans) {
         if (tier.label) {
           items.push(<div key={`label_${tier.key}`} className={cx(styles.DropdownLabel)}>{tier.label}:</div>);
         }
 
-        plans[tier.key].forEach((item) => {
+        plansByTier[tier.key].forEach((item) => {
           const classes = cx(
             styles.DropdownPlan,
             selectedItem.code === item.code && styles.selected,
@@ -97,18 +97,18 @@ export class PlanPicker extends Component {
 
 
   render() {
-    const { plans, input } = this.props;
+    const { plansByTier, input } = this.props;
     const { onChange, value } = input;
 
     return (
       <Downshift
         onChange={onChange}
         itemToString={(item) => (item ? item.code : '')} // prevents the downshift console warning
-        initialSelectedItem={(value && value.code) ? value : plans[0]} >
+        initialSelectedItem={(value && value.code) ? value : plansByTier.default[0]} >
         {this.planFn}
       </Downshift>
     );
   }
 }
 
-export default ({ plans = [], ...rest }) => <Field component={PlanPicker} name='planpicker' plans={plans} {...rest} />;
+export default ({ plans = {}, ...rest }) => <Field component={PlanPicker} name='planpicker' plansByTier={plans} {...rest} />;

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -7,12 +7,13 @@ import _ from 'lodash';
 import { ExpandMore } from '@sparkpost/matchbox-icons';
 import Plan from './Plan';
 import styles from './PlanPicker.module.scss';
+import { PLAN_TIERS } from 'src/constants';
 
 const TIERS = [
   { key: 'default' },
-  { key: 'test', label: 'Test Account' },
-  { key: 'starter', label: 'Starter' },
-  { key: 'premier', label: 'Premier' }
+  { key: 'test', label: PLAN_TIERS.test },
+  { key: 'starter', label: PLAN_TIERS.starter },
+  { key: 'premier', label: PLAN_TIERS.premier }
 ];
 
 /**
@@ -73,12 +74,23 @@ export class PlanPicker extends Component {
     const planPriceProps = {
       selectedPromo
     };
+
+    const selectedPlan = (<>
+        {PLAN_TIERS[selectedItem.tier] && <div className={cx(styles.DropdownLabel)}>{PLAN_TIERS[selectedItem.tier]}</div>}
+        <Plan plan={selectedItem} className={triggerClasses} planPriceProps={planPriceProps}/>
+    </>);
+
     return (
       <div className={styles.PlanPicker}>
-        <div className={listClasses}>{items}</div>
-        <ExpandMore size={24} className={styles.Chevron} />
+        <div {...triggerProps}>
+          <div className={cx(styles.TriggerHeader)}>
+            Select A Plan
+            <ExpandMore size={24} className={styles.Chevron} />
+          </div>
+          {selectedPlan}
+        </div>
         <input {...getInputProps()} ref={(input) => this.input = input} className={styles.Input} />
-        <Plan {...triggerProps} className={triggerClasses} planPriceProps={planPriceProps}/>
+        <div className={listClasses}>{items}</div>
       </div>
     );
   };

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -2,10 +2,18 @@ import React, { Component } from 'react';
 import Downshift from 'downshift';
 import { Field } from 'redux-form';
 import cx from 'classnames';
+import _ from 'lodash';
 
 import { ExpandMore } from '@sparkpost/matchbox-icons';
 import Plan from './Plan';
 import styles from './PlanPicker.module.scss';
+
+const TIERS = [
+  { key: 'default' },
+  { key: 'test', label: 'Test Account' },
+  { key: 'starter', label: 'Starter' },
+  { key: 'premier', label: 'Premier' }
+];
 
 /**
  * This component will register the a redux-form field named 'planpicker'
@@ -26,18 +34,30 @@ export class PlanPicker extends Component {
   }) => {
     const { plans, input, disabled, selectedPromo } = this.props;
 
-    if (!selectedItem || !plans) {
+    if (!selectedItem || _.isEmpty(plans)) {
       return null;
     }
 
-    const items = plans.map((item, index) => {
-      const classes = cx(
-        styles.DropdownPlan,
-        selectedItem.code === item.code && styles.selected,
-        highlightedIndex === index && styles.highlighted
-      );
+    let index = 0;
+    const items = [];
 
-      return <Plan key={index} className={classes} {...getItemProps({ item, index, plan: item })} />;
+    TIERS.forEach((tier) => {
+      const tierPlans = plans[tier.key];
+      if (tierPlans) {
+        if (tier.label) {
+          items.push(<div key={`label_${tier.key}`} className={cx(styles.DropdownLabel)}>{tier.label}:</div>);
+        }
+
+        plans[tier.key].forEach((item) => {
+          const classes = cx(
+            styles.DropdownPlan,
+            selectedItem.code === item.code && styles.selected,
+            highlightedIndex === index && styles.highlighted
+          );
+          items.push(<Plan key={index} className={classes} {...getItemProps({ item, index, plan: item })} />);
+          index++;
+        });
+      }
     });
 
     const listClasses = cx(styles.List, isOpen && styles.open);

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -26,7 +26,7 @@
 
   .MainLabel {
     color: color(orange);
-    font-size: rem(25);
+    font-size: rem(16);
   }
 
   &.disabled {
@@ -40,11 +40,12 @@
   padding: spacing();
   background: color(gray, 10);
   border-top: 1px solid color(gray, 9);
+  font-weight: 600;
 }
 
 .DropdownPlan {
   display: block;
-  padding: spacing() spacing(large); 
+  padding: spacing() spacing(larger); 
   background: color(gray, 10);
   transition: 0.15s;
 
@@ -80,7 +81,7 @@
   left: 0;
   right: 0;
 
-  max-height: rem(280);
+  max-height: rem(300);
   overflow: auto;
 
   box-shadow: shadow(deep);

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -14,11 +14,22 @@
   }
 }
 
+.TriggerHeader {
+  display: block;
+  z-index: 2000;
+  padding: spacing(large);
+  font-size: rem(16);
+  font-weight: 600;
+  color: color(gray, 2);
+  cursor: pointer;
+  border-bottom: 1px solid color(gray, 9);
+}
+
 .TriggerPlan {
-  position: float;
+  position: relative;
   z-index: 1;
   display: block;
-  padding: spacing(large);
+  padding: spacing() spacing(large);
 
   &.triggerOpen {
     box-shadow: shadow(deep);
@@ -33,15 +44,6 @@
     opacity: 0.5;
     pointer-events: none;
   }
-}
-
-.TriggerHeader {
-  display: block;
-  z-index: 2000;
-  padding: spacing(large);
-  font-size: rem(16);
-  color: color(gray, 2);
-  cursor: pointer;
 }
 
 .DropdownLabel {
@@ -77,6 +79,10 @@
   }
 }
 
+.PlanContainer {
+  position: relative;
+}
+
 .SupportLabel {
   display: block;
   color: color(gray, 4);
@@ -86,7 +92,7 @@
 .List {
   position: absolute;
   z-index: 100;
-  top: 100%;
+  top: 0;
   left: 0;
   right: 0;
 

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -28,7 +28,8 @@
   position: relative;
   z-index: 1;
   display: block;
-  padding: spacing() spacing(large);
+  padding: spacing() rem(40);
+ 
 
   &.triggerOpen {
     box-shadow: shadow(deep);
@@ -50,12 +51,14 @@
   padding: spacing() spacing() spacing(smaller);
   background: color(gray, 10);
   border-top: 1px solid color(gray, 9);
-  font-weight: 600;
+  font-weight: 500;
+  color: color(gray, 1);
 }
 
 .DropdownPlan {
   display: block;
   padding: spacing() spacing(larger); 
+  padding-left: rem(40);
   background: color(gray, 10);
   transition: 0.15s;
 

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -16,11 +16,10 @@
 
 .TriggerHeader {
   display: block;
-  z-index: 2000;
   padding: spacing(large);
   font-size: rem(16);
   font-weight: 600;
-  color: color(gray, 2);
+  color: color(gray, 1);
   cursor: pointer;
   border-bottom: 1px solid color(gray, 9);
 }

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -15,7 +15,7 @@
 }
 
 .TriggerPlan {
-  position: relative;
+  position: float;
   z-index: 1;
   display: block;
   padding: spacing(large);
@@ -35,9 +35,18 @@
   }
 }
 
+.TriggerHeader {
+  display: block;
+  z-index: 2000;
+  padding: spacing(large);
+  font-size: rem(16);
+  color: color(gray, 2);
+  cursor: pointer;
+}
+
 .DropdownLabel {
   display: block;
-  padding: spacing();
+  padding: spacing() spacing() spacing(smaller);
   background: color(gray, 10);
   border-top: 1px solid color(gray, 9);
   font-weight: 600;
@@ -102,8 +111,6 @@
 .Chevron {
   position: absolute;
   right: spacing(large);
-  top: 50%;
-  transform: translate(0, -50%);
   pointer-events: none;
   fill: color(orange);
 }

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -35,10 +35,16 @@
   }
 }
 
+.DropdownLabel {
+  display: block;
+  padding: spacing();
+  background: color(gray, 10);
+  border-top: 1px solid color(gray, 9);
+}
+
 .DropdownPlan {
   display: block;
-  padding: spacing() spacing(large);
-  border-bottom: 1px solid color(gray, 9);
+  padding: spacing() spacing(large); 
   background: color(gray, 10);
   transition: 0.15s;
 

--- a/src/components/planPicker/tests/PlanPicker.test.js
+++ b/src/components/planPicker/tests/PlanPicker.test.js
@@ -8,16 +8,16 @@ describe('Plan Picker: ', () => {
   let props;
 
   beforeEach(() => {
-    const plans = [
-      {
+    const plans = {
+      'default': [{
         code: '1',
         includesIp: true,
         monthly: 100,
         name: 'One',
         overage: 0.1,
         volume: 1
-      },
-      {
+      }],
+      'test': [{
         code: '2',
         includesIp: false,
         monthly: 0,
@@ -25,15 +25,15 @@ describe('Plan Picker: ', () => {
         overage: 0.2,
         volume: 2,
         isFree: true
-      },
-      {
+      }],
+      'starter': [{
         code: '3',
         monthly: 300,
         name: 'Three',
         overage: 0.3,
         volume: 3
-      }
-    ];
+      }]
+    };
 
     props = {
       input: { onChange: jest.fn() },

--- a/src/components/planPicker/tests/PlanPicker.test.js
+++ b/src/components/planPicker/tests/PlanPicker.test.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import PlanPicker from '../PlanPicker';
+import PlanPicker, { PlanPicker as PlanPickerComponent } from '../PlanPicker';
 
 describe('Plan Picker: ', () => {
   let wrapper;
   let props;
 
   beforeEach(() => {
-    const plans = {
+    const plansByTier = {
       'default': [{
         code: '1',
         includesIp: true,
@@ -37,7 +37,7 @@ describe('Plan Picker: ', () => {
 
     props = {
       input: { onChange: jest.fn() },
-      plans
+      plansByTier
     };
 
     wrapper = shallow(<PlanPicker {...props} />);
@@ -59,5 +59,40 @@ describe('Plan Picker: ', () => {
     const wrapper = shallow(<PlanPicker {...selectedProps} />);
     expect(wrapper).toMatchSnapshot();
   });
+
+
+  describe('Render Function', () => {
+
+    const subject = (subProps) => shallow(<PlanPickerComponent {...props} {...subProps}/>);
+
+    const renderFn = (wrapper, props = {}) => {
+      const Component = wrapper.prop('children');
+
+      return shallow(
+        <Component
+          getInputProps={jest.fn((props) => props)}
+          getItemProps={jest.fn((props) => props)}
+          getToggleButtonProps={jest.fn((props) => props)}
+          {...props}
+        />
+      );
+    };
+
+    it('renders', () => {
+      const selected = {
+        code: '4',
+        monthly: 400,
+        name: 'Four',
+        overage: 0.4,
+        volume: 4
+      };
+
+      const wrapper = subject();
+
+      const thing = renderFn(wrapper, { selectedItem: selected });
+      expect(thing).toMatchSnapshot();
+    });
+  });
+
 
 });

--- a/src/components/planPicker/tests/PlanPicker.test.js
+++ b/src/components/planPicker/tests/PlanPicker.test.js
@@ -88,9 +88,24 @@ describe('Plan Picker: ', () => {
       };
 
       const wrapper = subject();
+      expect(renderFn(wrapper, { selectedItem: selected })).toMatchSnapshot();
+    });
 
-      const thing = renderFn(wrapper, { selectedItem: selected });
-      expect(thing).toMatchSnapshot();
+    it('renders null if no initial selectedPlan', () => {
+      const wrapper = subject();
+      expect(renderFn(wrapper)).toBeEmptyRender();
+    });
+
+    it('renders null if no plans', () => {
+      const selected = {
+        code: '4',
+        monthly: 400,
+        name: 'Four',
+        overage: 0.4,
+        volume: 4
+      };
+      const wrapper = subject({ plansByTier: {}});
+      expect(renderFn(wrapper, { selectedItem: selected })).toBeEmptyRender();
     });
   });
 

--- a/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
+++ b/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
@@ -1,5 +1,151 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Plan Picker:  Render Function renders 1`] = `
+<div
+  className="PlanPicker"
+>
+  <div
+    className="TriggerHeader"
+    onClick={[Function]}
+    plan={
+      Object {
+        "code": "4",
+        "monthly": 400,
+        "name": "Four",
+        "overage": 0.4,
+        "volume": 4,
+      }
+    }
+  >
+    <span>
+      Select A Plan
+    </span>
+    <ExpandMore
+      className="Chevron"
+      size={24}
+    />
+  </div>
+  <div
+    className="PlanContainer"
+  >
+    <Plan
+      className="TriggerPlan"
+      onClick={[Function]}
+      plan={
+        Object {
+          "code": "4",
+          "monthly": 400,
+          "name": "Four",
+          "overage": 0.4,
+          "volume": 4,
+        }
+      }
+      planPriceProps={
+        Object {
+          "selectedPromo": undefined,
+        }
+      }
+    />
+    <input
+      className="Input"
+    />
+    <div
+      className="List"
+    >
+      <Plan
+        className="DropdownPlan"
+        index={0}
+        item={
+          Object {
+            "code": "1",
+            "includesIp": true,
+            "monthly": 100,
+            "name": "One",
+            "overage": 0.1,
+            "volume": 1,
+          }
+        }
+        key="0"
+        plan={
+          Object {
+            "code": "1",
+            "includesIp": true,
+            "monthly": 100,
+            "name": "One",
+            "overage": 0.1,
+            "volume": 1,
+          }
+        }
+      />
+      <div
+        className="DropdownLabel"
+        key="label_test"
+      >
+        Test Account
+        :
+      </div>
+      <Plan
+        className="DropdownPlan"
+        index={1}
+        item={
+          Object {
+            "code": "2",
+            "includesIp": false,
+            "isFree": true,
+            "monthly": 0,
+            "name": "Two",
+            "overage": 0.2,
+            "volume": 2,
+          }
+        }
+        key="1"
+        plan={
+          Object {
+            "code": "2",
+            "includesIp": false,
+            "isFree": true,
+            "monthly": 0,
+            "name": "Two",
+            "overage": 0.2,
+            "volume": 2,
+          }
+        }
+      />
+      <div
+        className="DropdownLabel"
+        key="label_starter"
+      >
+        Starter
+        :
+      </div>
+      <Plan
+        className="DropdownPlan"
+        index={2}
+        item={
+          Object {
+            "code": "3",
+            "monthly": 300,
+            "name": "Three",
+            "overage": 0.3,
+            "volume": 3,
+          }
+        }
+        key="2"
+        plan={
+          Object {
+            "code": "3",
+            "monthly": 300,
+            "name": "Three",
+            "overage": 0.3,
+            "volume": 3,
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Plan Picker:  renders correctly 1`] = `
 <Field
   component={[Function]}

--- a/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
+++ b/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
@@ -10,32 +10,38 @@ exports[`Plan Picker:  renders correctly 1`] = `
   }
   name="planpicker"
   plans={
-    Array [
-      Object {
-        "code": "1",
-        "includesIp": true,
-        "monthly": 100,
-        "name": "One",
-        "overage": 0.1,
-        "volume": 1,
-      },
-      Object {
-        "code": "2",
-        "includesIp": false,
-        "isFree": true,
-        "monthly": 0,
-        "name": "Two",
-        "overage": 0.2,
-        "volume": 2,
-      },
-      Object {
-        "code": "3",
-        "monthly": 300,
-        "name": "Three",
-        "overage": 0.3,
-        "volume": 3,
-      },
-    ]
+    Object {
+      "default": Array [
+        Object {
+          "code": "1",
+          "includesIp": true,
+          "monthly": 100,
+          "name": "One",
+          "overage": 0.1,
+          "volume": 1,
+        },
+      ],
+      "starter": Array [
+        Object {
+          "code": "3",
+          "monthly": 300,
+          "name": "Three",
+          "overage": 0.3,
+          "volume": 3,
+        },
+      ],
+      "test": Array [
+        Object {
+          "code": "2",
+          "includesIp": false,
+          "isFree": true,
+          "monthly": 0,
+          "name": "Two",
+          "overage": 0.2,
+          "volume": 2,
+        },
+      ],
+    }
   }
 />
 `;
@@ -57,32 +63,38 @@ exports[`Plan Picker:  renders correctly with an initial value 1`] = `
   }
   name="planpicker"
   plans={
-    Array [
-      Object {
-        "code": "1",
-        "includesIp": true,
-        "monthly": 100,
-        "name": "One",
-        "overage": 0.1,
-        "volume": 1,
-      },
-      Object {
-        "code": "2",
-        "includesIp": false,
-        "isFree": true,
-        "monthly": 0,
-        "name": "Two",
-        "overage": 0.2,
-        "volume": 2,
-      },
-      Object {
-        "code": "3",
-        "monthly": 300,
-        "name": "Three",
-        "overage": 0.3,
-        "volume": 3,
-      },
-    ]
+    Object {
+      "default": Array [
+        Object {
+          "code": "1",
+          "includesIp": true,
+          "monthly": 100,
+          "name": "One",
+          "overage": 0.1,
+          "volume": 1,
+        },
+      ],
+      "starter": Array [
+        Object {
+          "code": "3",
+          "monthly": 300,
+          "name": "Three",
+          "overage": 0.3,
+          "volume": 3,
+        },
+      ],
+      "test": Array [
+        Object {
+          "code": "2",
+          "includesIp": false,
+          "isFree": true,
+          "monthly": 0,
+          "name": "Two",
+          "overage": 0.2,
+          "volume": 2,
+        },
+      ],
+    }
   }
 />
 `;

--- a/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
+++ b/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
@@ -9,7 +9,7 @@ exports[`Plan Picker:  renders correctly 1`] = `
     }
   }
   name="planpicker"
-  plans={
+  plansByTier={
     Object {
       "default": Array [
         Object {
@@ -62,7 +62,7 @@ exports[`Plan Picker:  renders correctly with an initial value 1`] = `
     }
   }
   name="planpicker"
-  plans={
+  plansByTier={
     Object {
       "default": Array [
         Object {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -159,3 +159,9 @@ export const MAILBOX_PROVIDERS = {
   other_european_providers: 'Other European Providers',
   other: 'Other Providers'
 };
+
+export const PLAN_TIERS = {
+  test: 'Test Account',
+  starter: 'Starter',
+  premier: 'Premier'
+};

--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -7,7 +7,7 @@ import PromoCode from 'src/components/billing/PromoCode';
 import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 import Brightback from 'src/components/brightback/Brightback';
 import styles from './Confirmation.module.scss';
-
+import { PLAN_TIERS } from 'src/constants';
 export class Confirmation extends React.Component {
 
   renderSelectedPlanMarkup() {
@@ -16,7 +16,10 @@ export class Confirmation extends React.Component {
       ? <p>Select a plan on the left to update your subscription</p>
       : <div>
         <small>New Plan</small>
-        <h5><PlanPrice className={styles.MainLabel} plan={selected} selectedPromo={selectedPromo}/></h5>
+        <h5 className={styles.MainLabel}>
+          {PLAN_TIERS[selected.tier] && <span>{PLAN_TIERS[selected.tier].toUpperCase()}:</span>}
+          <PlanPrice plan={selected} selectedPromo={selectedPromo}/>
+        </h5>
       </div>;
   }
 

--- a/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
@@ -73,9 +73,10 @@ exports[`Confirmation:  should render correctly for an upgrade effectively immed
       <small>
         New Plan
       </small>
-      <h5>
+      <h5
+        className="MainLabel"
+      >
         <PlanPrice
-          className="MainLabel"
           plan={
             Object {
               "code": "twohundred",
@@ -146,9 +147,10 @@ exports[`Confirmation:  should render correctly with a downgrade 1`] = `
       <small>
         New Plan
       </small>
-      <h5>
+      <h5
+        className="MainLabel"
+      >
         <PlanPrice
-          className="MainLabel"
           plan={
             Object {
               "code": "fifty",
@@ -239,9 +241,10 @@ exports[`Confirmation:  should render correctly with a downgrade to free 1`] = `
       <small>
         New Plan
       </small>
-      <h5>
+      <h5
+        className="MainLabel"
+      >
         <PlanPrice
-          className="MainLabel"
           plan={
             Object {
               "code": "zero",
@@ -321,9 +324,10 @@ exports[`Confirmation:  should render correctly with an upgrade 1`] = `
       <small>
         New Plan
       </small>
-      <h5>
+      <h5
+        className="MainLabel"
+      >
         <PlanPrice
-          className="MainLabel"
           plan={
             Object {
               "code": "twohundred",
@@ -399,9 +403,10 @@ exports[`Confirmation:  should render correctly with an upgrade with IP 1`] = `
       <small>
         New Plan
       </small>
-      <h5>
+      <h5
+        className="MainLabel"
+      >
         <PlanPrice
-          className="MainLabel"
           plan={
             Object {
               "code": "twohundred",

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -11,7 +11,7 @@ import billingUpdate from 'src/actions/billingUpdate';
 import { showAlert } from 'src/actions/globalAlert';
 import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
 import {
-  currentPlanSelector, canUpdateBillingInfoSelector, selectVisiblePlans, selectAccountBilling
+  currentPlanSelector, canUpdateBillingInfoSelector, selectTieredVisiblePlans, selectAccountBilling
 } from 'src/selectors/accountBillingInfo';
 import { Panel, Grid } from '@sparkpost/matchbox';
 import { Loading, PlanPicker, ApiErrorBanner } from 'src/components';
@@ -124,7 +124,7 @@ export class ChangePlanForm extends Component {
         <Grid>
           <Grid.Column>
             <Panel title='Select A Plan'>
-              {plans.length
+              {!_.isEmpty(plans)
                 ? <PlanPicker disabled={submitting} plans={plans} onChange={this.onPlanSelect}/>
                 : null
               }
@@ -159,11 +159,11 @@ export class ChangePlanForm extends Component {
 const mapStateToProps = (state, props) => {
   const selector = formValueSelector(FORMNAME);
   const { code: planCode } = qs.parse(props.location.search);
-  const plans = selectVisiblePlans(state);
+  const plans = selectTieredVisiblePlans(state);
   const { account, loading } = selectAccountBilling(state);
 
   return {
-    loading: (!account.created && loading) || (plans.length === 0 && state.billing.plansLoading),
+    loading: (!account.created && loading) || (!_.isEmpty(plans) && state.billing.plansLoading),
     isAws: selectCondition(isAws)(state),
     account,
     billing: state.billing,

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -123,7 +123,7 @@ export class ChangePlanForm extends Component {
       <form onSubmit={this.props.handleSubmit(this.onSubmit)}>
         <Grid>
           <Grid.Column>
-            <Panel title='Select A Plan'>
+            <Panel>
               {!_.isEmpty(plans)
                 ? <PlanPicker disabled={submitting} plans={plans} onChange={this.onPlanSelect}/>
                 : null

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -163,7 +163,7 @@ const mapStateToProps = (state, props) => {
   const { account, loading } = selectAccountBilling(state);
 
   return {
-    loading: (!account.created && loading) || (!_.isEmpty(plans) && state.billing.plansLoading),
+    loading: (!account.created && loading) || (_.isEmpty(plans) && state.billing.plansLoading),
     isAws: selectCondition(isAws)(state),
     account,
     billing: state.billing,

--- a/src/pages/billing/forms/tests/__snapshots__/ChangePlanForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/ChangePlanForm.test.js.snap
@@ -4,9 +4,7 @@ exports[`Form Container: Change Plan should not show plans 1`] = `
 <form>
   <Grid>
     <Grid.Column>
-      <Panel
-        title="Select A Plan"
-      />
+      <Panel />
       <AccessControl
         condition={[Function]}
       >
@@ -49,9 +47,7 @@ exports[`Form Container: Change Plan should render 1`] = `
 <form>
   <Grid>
     <Grid.Column>
-      <Panel
-        title="Select A Plan"
-      >
+      <Panel>
         <_default
           onChange={[Function]}
           plans={
@@ -121,9 +117,7 @@ exports[`Form Container: Change Plan should show saved card 1`] = `
 <form>
   <Grid>
     <Grid.Column>
-      <Panel
-        title="Select A Plan"
-      >
+      <Panel>
         <_default
           onChange={[Function]}
           plans={

--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -135,7 +135,7 @@ export class OnboardingPlanPage extends Component {
         <CenteredLogo />
         <Grid>
           <Grid.Column>
-            <Panel title='Select A Plan'>
+            <Panel>
               <PlanPicker selectedPromo={billing.selectedPromo} disabled={disableSubmit} plans={plans} onChange={this.onPlanSelect}/>
               <AccessControl condition={not(isAws)}>
                 {!selectedPlan.isFree && this.renderPromoCodeField()}

--- a/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
+++ b/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
@@ -5,9 +5,7 @@ exports[`ChoosePlan page tests should disable submit and plan picker when submit
   <CenteredLogo />
   <Grid>
     <Grid.Column>
-      <Panel
-        title="Select A Plan"
-      >
+      <Panel>
         <_default
           disabled={true}
           onChange={[Function]}
@@ -59,9 +57,7 @@ exports[`ChoosePlan page tests should render correctly 1`] = `
   <CenteredLogo />
   <Grid>
     <Grid.Column>
-      <Panel
-        title="Select A Plan"
-      >
+      <Panel>
         <_default
           disabled={false}
           onChange={[Function]}
@@ -115,9 +111,7 @@ exports[`ChoosePlan page tests should show free bullets when isFree is selected 
   <CenteredLogo />
   <Grid>
     <Grid.Column>
-      <Panel
-        title="Select A Plan"
-      >
+      <Panel>
         <_default
           disabled={false}
           onChange={[Function]}

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -13,6 +13,7 @@ const selectIsSelfServeBilling = selectCondition(isSelfServeBilling);
 const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
 const selectIsFree1 = selectCondition(onPlan('free1'));
 const selectOnZuoraPlan = selectCondition(onZuoraPlan);
+const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'];
 
 export const currentSubscriptionSelector = (state) => state.account.subscription;
 
@@ -84,6 +85,18 @@ export const selectVisiblePlans = createSelector(
   )
 );
 
+export const selectTieredVisiblePlans = createSelector(
+  [selectVisiblePlans],
+  (plans) => {
+    const result = {};
+    plans.forEach((plan) => {
+      const tier = plan.tier || (currentFreePlans.includes(plan.code) ? 'test' : 'default');
+      result[tier] = result[tier] || [];
+      result[tier].push(plan);
+    });
+    return result;
+  }
+);
 export const selectAccount = (state) => state.account;
 
 export const selectAccountBilling = createSelector(

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -87,13 +87,12 @@ export const selectVisiblePlans = createSelector(
 export const selectTieredVisiblePlans = createSelector(
   [selectVisiblePlans],
   (plans) => {
-    const result = {};
-    plans.forEach((plan) => {
-      const tier = plan.tier || (currentFreePlans.includes(plan.code) ? 'test' : 'default');
-      result[tier] = result[tier] || [];
-      result[tier].push(plan);
-    });
-    return result;
+    const normalizedPlans = plans.map((plan) => ({
+      ...plan,
+      tier: plan.tier || (currentFreePlans.includes(plan.code) ? 'test' : 'default')
+    }));
+
+    return _.groupBy(normalizedPlans, 'tier');
   }
 );
 export const selectAccount = (state) => state.account;

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -78,9 +78,8 @@ export const selectAvailablePlans = createSelector(
 
 export const selectVisiblePlans = createSelector(
   [selectAvailablePlans, selectIsFree1, currentPlanCodeSelector],
-  (plans, isOnLegacyFree1Plan, currentPlan) => plans.filter(({ isFree, status, code }) =>
-    currentPlan === code || //Plan only shows if currently on free15K plan
-      status === 'public' &&
+  (plans, isOnLegacyFree1Plan) => plans.filter(({ isFree, status }) =>
+    status === 'public' &&
       !(isOnLegacyFree1Plan && isFree) //hide new free plans if on legacy free1 plan
   )
 );

--- a/src/selectors/onboarding.js
+++ b/src/selectors/onboarding.js
@@ -1,6 +1,6 @@
 import { formValueSelector } from 'redux-form';
 import { createStructuredSelector } from 'reselect';
-import { selectVisiblePlans } from 'src/selectors/accountBillingInfo';
+import { selectTieredVisiblePlans } from 'src/selectors/accountBillingInfo';
 import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
 
 const getChoosePlanInitialValues = (state, props) => {
@@ -13,7 +13,7 @@ const getChoosePlanInitialValues = (state, props) => {
 export const choosePlanMSTP = (formName) => createStructuredSelector({
   loading: (state) => Boolean(state.account.loading || state.billing.plansLoading || state.billing.countriesLoading),
   billing: (state) => state.billing,
-  plans: (state) => selectVisiblePlans(state),
+  plans: (state) => selectTieredVisiblePlans(state),
   initialValues: getChoosePlanInitialValues,
   selectedPlan: (state) => formValueSelector(formName)(state, 'planpicker'),
   hasError: (state) => Boolean(state.billing.plansError || state.billing.countriesError)

--- a/src/selectors/tests/__snapshots__/accountBillingInfo.test.js.snap
+++ b/src/selectors/tests/__snapshots__/accountBillingInfo.test.js.snap
@@ -77,6 +77,11 @@ Array [
     "status": "public",
     "tier": "premier",
   },
+  Object {
+    "code": "free500-0419",
+    "isFree": true,
+    "status": "public",
+  },
 ]
 `;
 
@@ -137,6 +142,11 @@ Array [
     "status": "public",
     "tier": "premier",
   },
+  Object {
+    "code": "free500-0419",
+    "isFree": true,
+    "status": "public",
+  },
 ]
 `;
 
@@ -166,6 +176,12 @@ Object {
   "test": Array [
     Object {
       "code": "pub-free",
+      "isFree": true,
+      "status": "public",
+      "tier": "test",
+    },
+    Object {
+      "code": "free500-0419",
       "isFree": true,
       "status": "public",
       "tier": "test",

--- a/src/selectors/tests/__snapshots__/accountBillingInfo.test.js.snap
+++ b/src/selectors/tests/__snapshots__/accountBillingInfo.test.js.snap
@@ -146,6 +146,7 @@ Object {
     Object {
       "code": "pub",
       "status": "public",
+      "tier": "default",
     },
   ],
   "premier": Array [

--- a/src/selectors/tests/__snapshots__/accountBillingInfo.test.js.snap
+++ b/src/selectors/tests/__snapshots__/accountBillingInfo.test.js.snap
@@ -38,6 +38,16 @@ Array [
     "code": "sec",
     "status": "secret",
   },
+  Object {
+    "code": "starter",
+    "status": "public",
+    "tier": "starter",
+  },
+  Object {
+    "code": "premier",
+    "status": "public",
+    "tier": "premier",
+  },
 ]
 `;
 
@@ -51,22 +61,21 @@ Array [
     "code": "pub-free",
     "isFree": true,
     "status": "public",
+    "tier": "test",
   },
   Object {
     "code": "sec",
     "status": "secret",
   },
-]
-`;
-
-exports[`plan selector selectVisiblePlans should not return new free plans if customer on free1 plan 1`] = `
-Array [
   Object {
-    "code": "pub",
+    "code": "starter",
     "status": "public",
+    "tier": "starter",
   },
   Object {
-    "code": "free1",
+    "code": "premier",
+    "status": "public",
+    "tier": "premier",
   },
 ]
 `;
@@ -93,6 +102,16 @@ Array [
     "code": "pub",
     "status": "public",
   },
+  Object {
+    "code": "starter",
+    "status": "public",
+    "tier": "starter",
+  },
+  Object {
+    "code": "premier",
+    "status": "public",
+    "tier": "premier",
+  },
 ]
 `;
 
@@ -106,24 +125,50 @@ Array [
     "code": "pub-free",
     "isFree": true,
     "status": "public",
+    "tier": "test",
+  },
+  Object {
+    "code": "starter",
+    "status": "public",
+    "tier": "starter",
+  },
+  Object {
+    "code": "premier",
+    "status": "public",
+    "tier": "premier",
   },
 ]
 `;
 
-exports[`plan selector selectVisiblePlans should show current plan regardless of status 1`] = `
-Array [
-  Object {
-    "code": "pub",
-    "status": "public",
-  },
-  Object {
-    "code": "pub-free",
-    "isFree": true,
-    "status": "public",
-  },
-  Object {
-    "code": "prv",
-    "status": "private",
-  },
-]
+exports[`plan selector selectedTieredVisiblePlans should separate plans into tiers 1`] = `
+Object {
+  "default": Array [
+    Object {
+      "code": "pub",
+      "status": "public",
+    },
+  ],
+  "premier": Array [
+    Object {
+      "code": "premier",
+      "status": "public",
+      "tier": "premier",
+    },
+  ],
+  "starter": Array [
+    Object {
+      "code": "starter",
+      "status": "public",
+      "tier": "starter",
+    },
+  ],
+  "test": Array [
+    Object {
+      "code": "pub-free",
+      "isFree": true,
+      "status": "public",
+      "tier": "test",
+    },
+  ],
+}
 `;

--- a/src/selectors/tests/__snapshots__/onboarding.test.js.snap
+++ b/src/selectors/tests/__snapshots__/onboarding.test.js.snap
@@ -6,9 +6,9 @@ Object {
   "hasError": false,
   "initialValues": "change-plan-initial-values",
   "loading": false,
-  "plans": Array [
-    "visible plans",
-  ],
+  "plans": Object {
+    "default": Array [],
+  },
   "selectedPlan": "selected-plan-redux-form-value",
 }
 `;

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -171,11 +171,13 @@ describe('plan selector', () => {
       billing: {
         plans: [
           { code: 'pub', status: 'public' },
-          { code: 'pub-free', status: 'public', isFree: true },
+          { code: 'pub-free', status: 'public', tier: 'test', isFree: true },
           { code: 'pub-aws', status: 'public', awsMarketplace: true },
           { code: 'pub-aws-free', status: 'public', awsMarketplace: true, isFree: true },
           { code: 'sec', status: 'secret' },
-          { code: 'sec-aws', status: 'secret', awsMarketplace: true }
+          { code: 'sec-aws', status: 'secret', awsMarketplace: true },
+          { code: 'starter', status: 'public', tier: 'starter' },
+          { code: 'premier', status: 'public', tier: 'premier' }
         ]
       }
     };
@@ -211,17 +213,11 @@ describe('plan selector', () => {
       state.account.subscription.type = 'aws';
       expect(billingInfo.selectVisiblePlans(state)).toMatchSnapshot();
     });
+  });
 
-    it('should not return new free plans if customer on free1 plan', () => {
-      state.account.subscription.code = 'free1';
-      state.billing.plans.push({ code: 'free1' });
-      expect(billingInfo.selectVisiblePlans(state)).toMatchSnapshot();
-    });
-
-    it('should show current plan regardless of status', () => {
-      state.account.subscription.code = 'prv';
-      state.billing.plans.push({ code: 'prv', status: 'private' });
-      expect(billingInfo.selectVisiblePlans(state)).toMatchSnapshot();
+  describe('selectedTieredVisiblePlans', () => {
+    it('should separate plans into tiers', () => {
+      expect(billingInfo.selectTieredVisiblePlans(state)).toMatchSnapshot();
     });
   });
 });

--- a/src/selectors/tests/accountBillingInfo.test.js
+++ b/src/selectors/tests/accountBillingInfo.test.js
@@ -177,7 +177,8 @@ describe('plan selector', () => {
           { code: 'sec', status: 'secret' },
           { code: 'sec-aws', status: 'secret', awsMarketplace: true },
           { code: 'starter', status: 'public', tier: 'starter' },
-          { code: 'premier', status: 'public', tier: 'premier' }
+          { code: 'premier', status: 'public', tier: 'premier' },
+          { code: 'free500-0419', status: 'public', isFree: true }
         ]
       }
     };

--- a/src/selectors/tests/onboarding.test.js
+++ b/src/selectors/tests/onboarding.test.js
@@ -10,7 +10,8 @@ jest.mock('src/selectors/accountBillingForms', () => ({
 }));
 
 jest.mock('src/selectors/accountBillingInfo', () => ({
-  selectVisiblePlans: jest.fn(() => ['visible plans'])
+  selectVisiblePlans: jest.fn(() => ['visible plans']),
+  selectTieredVisiblePlans: jest.fn(() => ({ 'default': []}))
 }));
 
 describe('choosePlanMSTP', () => {

--- a/src/selectors/tests/onboarding.test.js
+++ b/src/selectors/tests/onboarding.test.js
@@ -10,7 +10,6 @@ jest.mock('src/selectors/accountBillingForms', () => ({
 }));
 
 jest.mock('src/selectors/accountBillingInfo', () => ({
-  selectVisiblePlans: jest.fn(() => ['visible plans']),
   selectTieredVisiblePlans: jest.fn(() => ({ 'default': []}))
 }));
 


### PR DESCRIPTION
[Wireframe](https://jira.int.messagesystems.com/browse/UX-91?focusedCommentId=491696&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-491696)

### What Changed
 - Separates plans with tiers into "Test Account", "Starter", or "Premier"
 
### How To Test
 - Open `/account/billing/plan` or `/onboarding/plan` and check that the new dropdown uses those tiers
 - Check that billing flow still works correctly with selecting new plans

### To Do
- [x] Update styling to UX
- [x] Separate tier to constants file
- [x] Layer list on top of selected plan
- [x] Add testing for Downshift render function
- [ ] Address any feedback
