### PR TITLE
EO-738 Fix health score subaccount sorting behavior

### DIFF
--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -24,9 +24,14 @@ const signalsActionCreator = ({ dimension, type }) => ({
 }) => {
   let order_by;
 
-  // note, to order by subaccount, only pass order direction and do not set order_by
-  if (orderBy && orderBy !== 'sid') {
+  if (orderBy) {
     order_by = ORDER_BY_MAPPING[orderBy] || orderBy;
+  }
+
+  // To order by subaccount, only pass order direction and do not set order_by
+  // does not apply to health score, and health score should set order_by: 'sid'
+  if (orderBy === 'sid' && dimension !== 'health-score') {
+    order_by = undefined;
   }
 
   if (facet === 'sid') {

--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -25,13 +25,11 @@ const signalsActionCreator = ({ dimension, type }) => ({
   let order_by;
 
   if (orderBy) {
-    order_by = ORDER_BY_MAPPING[orderBy] || orderBy;
-  }
-
-  // To order by subaccount, only pass order direction and do not set order_by
-  // does not apply to health score, and health score should set order_by: 'sid'
-  if (orderBy === 'sid' && dimension !== 'health-score') {
-    order_by = undefined;
+    // To order by subaccount, only pass order direction and do not set order_by
+    // does not apply to health score, and health score should set order_by: 'sid'
+    order_by = orderBy === 'sid' && dimension !== 'health-score'
+      ? undefined
+      : ORDER_BY_MAPPING[orderBy] || orderBy;
   }
 
   if (facet === 'sid') {

--- a/src/actions/tests/__snapshots__/signals.test.js.snap
+++ b/src/actions/tests/__snapshots__/signals.test.js.snap
@@ -115,6 +115,29 @@ Array [
 ]
 `;
 
+exports[`Signals Actions .getHealthScore with an order by subaccount 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "headers": Object {},
+      "method": "GET",
+      "params": Object {
+        "filter": undefined,
+        "from": "2018-01-12",
+        "limit": undefined,
+        "offset": undefined,
+        "order": "asc",
+        "order_by": "sid",
+        "to": "2018-01-13",
+      },
+      "showErrorAlert": false,
+      "url": "/v1/signals/health-score/",
+    },
+    "type": "GET_HEALTH_SCORE",
+  },
+]
+`;
+
 exports[`Signals Actions .getInjections by default 1`] = `
 Array [
   Object {

--- a/src/actions/tests/signals.test.js
+++ b/src/actions/tests/signals.test.js
@@ -71,6 +71,9 @@ describe('Signals Actions', () => {
   snapshotActionCases('.getHealthScore', {
     'by default': {
       action: () => actions.getHealthScore({ ...requiredOptions })
+    },
+    'with an order by subaccount': {
+      action: () => actions.getHealthScore({ ...requiredOptions, order: 'asc', orderBy: 'sid' })
     }
   });
 


### PR DESCRIPTION
### What Changed
- In the health score dashboard, sorting by subaccount with a facet selected now works correctly

### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data
- Visit overview page and v2 dashboards
- Verify sorting works with and without a facet

### To Do
- [ ] Address any feedback

