### PR TITLE
SD-913: IP support ticket for manually billed

### DIFF
--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { hasOnlineSupport, hasStatus, hasStatusReasonCategory, isSuspendedForBilling, onPlanWithStatus } from 'src/helpers/conditions/account';
+import { hasOnlineSupport, hasStatus, hasStatusReasonCategory, isSuspendedForBilling, onPlanWithStatus, isSelfServeBilling } from 'src/helpers/conditions/account';
 import { isEmailVerified } from 'src/helpers/conditions/user';
 import { all, not, any } from 'src/helpers/conditions';
 import { isAdmin } from 'src/helpers/conditions/user';
@@ -77,6 +77,15 @@ const supportIssues = [
     label: 'Account upgrade/downgrade issues',
     type: SUPPORT,
     condition: isAdmin
+  },
+  {
+    id: 'request_new_ip',
+    label: 'Request new IP',
+    type: SUPPORT,
+    condition: all(
+      isAdmin,
+      not(isSelfServeBilling)
+    )
   },
   {
     id: 'general_billing',

--- a/src/pages/ipPools/EditPage.js
+++ b/src/pages/ipPools/EditPage.js
@@ -15,7 +15,7 @@ import { not } from 'src/helpers/conditions';
 import { selectCondition } from 'src/selectors/accessConditionState';
 import { isSelfServeBilling } from 'src/helpers/conditions/account';
 import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
-
+import { openSupportTicketForm } from 'src/actions/support';
 
 const breadcrumbAction = {
   content: 'IP Pools',
@@ -40,10 +40,7 @@ export class EditPage extends Component {
 
     if (isDefaultPool(id)) {
       const message = 'You can not edit default pool.';
-      showAlert({
-        type: 'error',
-        message
-      });
+      showAlert({ type: 'error', message });
 
       return Promise.reject(new Error(message));
     }
@@ -125,7 +122,7 @@ export class EditPage extends Component {
   }
 
   render() {
-    const { loading, pool, showPurchaseCTA } = this.props;
+    const { loading, pool, showPurchaseCTA, isManuallyBilled, openSupportTicketForm } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -144,7 +141,11 @@ export class EditPage extends Component {
           { content: 'Purchase IPs',
             to: '/account/billing',
             component: Link,
-            visible: showPurchaseCTA
+            visible: showPurchaseCTA && !isManuallyBilled
+          },
+          { content: 'Request IPs',
+            onClick: () => openSupportTicketForm({ issueId: 'request_new_ip' }),
+            visible: showPurchaseCTA && isManuallyBilled
           }]
         }>
 
@@ -177,4 +178,4 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-export default connect(mapStateToProps, { updatePool, deletePool, listPools, showAlert })(EditPage);
+export default connect(mapStateToProps, { updatePool, deletePool, listPools, showAlert, openSupportTicketForm })(EditPage);

--- a/src/pages/ipPools/EditPage.js
+++ b/src/pages/ipPools/EditPage.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
@@ -11,6 +11,10 @@ import { showAlert } from 'src/actions/globalAlert';
 import { deletePool, listPools, updatePool } from 'src/actions/ipPools';
 import { selectCurrentPool, selectIpsForCurrentPool, shouldShowIpPurchaseCTA } from 'src/selectors/ipPools';
 import isDefaultPool from './helpers/defaultPool';
+import { not } from 'src/helpers/conditions';
+import { selectCondition } from 'src/selectors/accessConditionState';
+import { isSelfServeBilling } from 'src/helpers/conditions/account';
+import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 
 const breadcrumbAction = {
@@ -94,16 +98,19 @@ export class EditPage extends Component {
   }
 
   renderIps() {
-    const { isNew, ips, pool, showPurchaseCTA } = this.props;
+    const { isNew, ips, pool, showPurchaseCTA, isManuallyBilled } = this.props;
 
     if (isNew) {
       return null;
     }
 
     const purchaseCTA = showPurchaseCTA
-      ? <Fragment>, or by <UnstyledLink to="/account/billing" component={Link}>purchasing new
-        IPs</UnstyledLink></Fragment>
-      : null;
+      ? (isManuallyBilled
+        ? <>, or by purchasing new IPs. Please <SupportTicketLink issueId='request_new_ip'>reach out to
+        the support team</SupportTicketLink> for assistance adding a new IP</>
+        : <>, or by <UnstyledLink to="/account/billing" component={Link}>purchasing new
+        IPs</UnstyledLink></>
+      ) : null;
 
     return (<Panel title='Sending IPs'>
       <Panel.Section>
@@ -165,13 +172,9 @@ const mapStateToProps = (state, props) => {
     pool: selectCurrentPool(state, props),
     ips: selectIpsForCurrentPool(state, props),
     listError,
+    isManuallyBilled: selectCondition(not(isSelfServeBilling))(state),
     showPurchaseCTA: shouldShowIpPurchaseCTA(state)
   };
 };
 
-export default connect(mapStateToProps, {
-  updatePool,
-  deletePool,
-  listPools,
-  showAlert
-})(EditPage);
+export default connect(mapStateToProps, { updatePool, deletePool, listPools, showAlert })(EditPage);

--- a/src/pages/ipPools/ListPage.js
+++ b/src/pages/ipPools/ListPage.js
@@ -7,6 +7,10 @@ import { Loading, TableCollection, ApiErrorBanner } from 'src/components';
 import { Page, Button,Banner } from '@sparkpost/matchbox';
 import { OpenInNew } from '@sparkpost/matchbox-icons';
 import { LINKS } from 'src/constants';
+import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
+import { not } from 'src/helpers/conditions';
+import { selectCondition } from 'src/selectors/accessConditionState';
+import { isSelfServeBilling } from 'src/helpers/conditions/account';
 
 const columns = [
   { label: 'Name', sortKey: 'name' },
@@ -55,11 +59,15 @@ export class IpPoolsList extends Component {
   }
 
   render() {
-    const { loading, error, showPurchaseCTA } = this.props;
+    const { loading, error, showPurchaseCTA, isManuallyBilled } = this.props;
     if (loading) { return <Loading />; }
 
     const createAction = { content: 'Create IP Pool', Component: Link, to: '/account/ip-pools/create' };
-    const purchaseActions = showPurchaseCTA ? [{ content: 'Purchase IPs', Component: Link, to: '/account/billing' }] : null;
+    const purchaseActions = showPurchaseCTA
+      ? (isManuallyBilled
+        ? [{ content: 'Request IPs', Component: SupportTicketLink, issueId: 'request_new_ip' } ]
+        : [{ content: 'Purchase IPs', Component: Link, to: '/account/billing' }])
+      : null;
 
     return (
       <Page
@@ -94,6 +102,7 @@ function mapStateToProps(state) {
     ipPools: getOrderedIpPools(state),
     loading: ipPools.listLoading,
     error: ipPools.listError,
+    isManuallyBilled: selectCondition(not(isSelfServeBilling))(state),
     showPurchaseCTA: shouldShowIpPurchaseCTA(state)
   };
 }

--- a/src/pages/ipPools/ListPage.js
+++ b/src/pages/ipPools/ListPage.js
@@ -7,7 +7,7 @@ import { Loading, TableCollection, ApiErrorBanner } from 'src/components';
 import { Page, Button,Banner } from '@sparkpost/matchbox';
 import { OpenInNew } from '@sparkpost/matchbox-icons';
 import { LINKS } from 'src/constants';
-import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
+import { openSupportTicketForm } from 'src/actions/support';
 import { not } from 'src/helpers/conditions';
 import { selectCondition } from 'src/selectors/accessConditionState';
 import { isSelfServeBilling } from 'src/helpers/conditions/account';
@@ -59,13 +59,13 @@ export class IpPoolsList extends Component {
   }
 
   render() {
-    const { loading, error, showPurchaseCTA, isManuallyBilled } = this.props;
+    const { loading, error, showPurchaseCTA, isManuallyBilled, openSupportTicketForm } = this.props;
     if (loading) { return <Loading />; }
 
     const createAction = { content: 'Create IP Pool', Component: Link, to: '/account/ip-pools/create' };
     const purchaseActions = showPurchaseCTA
       ? (isManuallyBilled
-        ? [{ content: 'Request IPs', Component: SupportTicketLink, issueId: 'request_new_ip' } ]
+        ? [{ content: 'Request IPs', onClick: () => openSupportTicketForm({ issueId: 'request_new_ip' }) }]
         : [{ content: 'Purchase IPs', Component: Link, to: '/account/billing' }])
       : null;
 
@@ -107,4 +107,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, { listPools })(IpPoolsList);
+export default connect(mapStateToProps, { listPools, openSupportTicketForm })(IpPoolsList);

--- a/src/pages/ipPools/tests/EditPage.test.js
+++ b/src/pages/ipPools/tests/EditPage.test.js
@@ -29,7 +29,8 @@ describe('IP Pools Edit Page', () => {
       loading: false,
       listPools: jest.fn(),
       listError: null,
-      showPurchaseCTA: true
+      showPurchaseCTA: true,
+      isManuallyBilled: false
     };
 
     wrapper = shallow(<EditPage {...props} />);
@@ -48,6 +49,11 @@ describe('IP Pools Edit Page', () => {
     it('should not show purchase action if showPurchaseCTA is false', () => {
       wrapper.setProps({ showPurchaseCTA: false });
       expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should show support ticket link if manually billed', () => {
+      wrapper.setProps({ isManuallyBilled: true });
+      expect(wrapper.find('Connect(SupportTicketLink)')).toExist();
     });
 
     it('should list pools and get pool when calling loadDependentData', () => {

--- a/src/pages/ipPools/tests/ListPage.test.js
+++ b/src/pages/ipPools/tests/ListPage.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { IpPoolsList, getRowData, IPWarmupReminderBanner } from '../ListPage';
+import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 describe('IP Pools List Page', () => {
   let props;
@@ -16,6 +17,7 @@ describe('IP Pools List Page', () => {
       ],
       listPools: jest.fn(() => []),
       showPurchaseCTA: true,
+      isManuallyBilled: false,
       isAdmin: true
     };
 
@@ -54,6 +56,11 @@ describe('IP Pools List Page', () => {
   it('does not render purchase action if showPurchaseCTA is false2', () => {
     wrapper.setProps({ ipPools: [{ name: 'Default', ips: []}], showPurchaseCTA: false });
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders request IP action if showPurchaseCTA is true and isManuallyBilled is true', () => {
+    wrapper.setProps({ isManuallyBilled: true });
+    expect(wrapper.prop('secondaryActions')).toEqual([{ content: 'Request IPs', Component: SupportTicketLink, issueId: 'request_new_ip' } ]);
   });
 
   it('does not render purchase action if isAdmin is false', () => {

--- a/src/pages/ipPools/tests/ListPage.test.js
+++ b/src/pages/ipPools/tests/ListPage.test.js
@@ -2,7 +2,6 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { IpPoolsList, getRowData, IPWarmupReminderBanner } from '../ListPage';
-import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 describe('IP Pools List Page', () => {
   let props;
@@ -60,7 +59,11 @@ describe('IP Pools List Page', () => {
 
   it('renders request IP action if showPurchaseCTA is true and isManuallyBilled is true', () => {
     wrapper.setProps({ isManuallyBilled: true });
-    expect(wrapper.prop('secondaryActions')).toEqual([{ content: 'Request IPs', Component: SupportTicketLink, issueId: 'request_new_ip' } ]);
+    expect(wrapper.prop('secondaryActions')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: 'Request IPs' })
+      ])
+    );
   });
 
   it('does not render purchase action if isAdmin is false', () => {

--- a/src/pages/ipPools/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/EditPage.test.js.snap
@@ -23,6 +23,11 @@ exports[`IP Pools Edit Page render tests should not show purchase action if show
         "to": "/account/billing",
         "visible": false,
       },
+      Object {
+        "content": "Request IPs",
+        "onClick": [Function],
+        "visible": false,
+      },
     ]
   }
   title="My Pool (my-pool)"
@@ -80,6 +85,11 @@ exports[`IP Pools Edit Page render tests should render the edit page correctly 1
         "content": "Purchase IPs",
         "to": "/account/billing",
         "visible": true,
+      },
+      Object {
+        "content": "Request IPs",
+        "onClick": [Function],
+        "visible": false,
       },
     ]
   }


### PR DESCRIPTION
### What Changed
 - IP Pools edit page has links for support tickets for IP requests

### How To Test
 To make manually billed account
 - Create new account
- PUT on /account/control with `{ "plan": "1M-0817" }`
Then
- Check IP pools edit page links to support ticket
- Check that on self serve billing still shows link to `/account/billing`

### To Do
- [ ] Address feedback
