### PR TITLE
FE-675 handle case when response is undefined

### DIFF
--- a/src/helpers/axiosInterceptors.js
+++ b/src/helpers/axiosInterceptors.js
@@ -10,7 +10,7 @@ export const sparkpostErrorHandler = (err) => {
 
 
   // Retries for any 5XX Error
-  if (/^5\d\d/.test(String(response.status)) && retries < MAX_RETRIES) {
+  if (response && /^5\d\d/.test(String(response.status)) && retries < MAX_RETRIES) {
     return new Promise((resolve) => setTimeout(() => resolve(sparkpostAxios({ ...config, retries: retries + 1 })), TIMEOUT));
   }
   return Promise.reject(err);

--- a/src/helpers/tests/axiosInterceptors.test.js
+++ b/src/helpers/tests/axiosInterceptors.test.js
@@ -63,4 +63,9 @@ describe('Sparkpost Axios error interceptor', () => {
     expect(sparkpostErrorHandler(err)).rejects.toMatchObject(err);
   });
 
+  it('should reject promise if response is undefined', () => {
+    const error = { config: err.config };
+    expect(sparkpostErrorHandler(error)).rejects.toMatchObject(error);
+  });
+
 });


### PR DESCRIPTION
Checks if `response` is truthy before accessing property

# How to Test
- Go to a webhook 
- Open chrome's network panel
- Check `Offline`
- click `Send Test Batch` (or `Re-send batch`)
it should show Network error instead of `Cannot read property 'status' of undefined`