### PR TITLE
EO-760 Default signal option dates to 30 days

### DIFF
--- a/src/reducers/signalOptions.js
+++ b/src/reducers/signalOptions.js
@@ -1,6 +1,6 @@
 import { getDates } from 'src/helpers/signals';
 
-const DEFAULT_RANGE = '90days';
+const DEFAULT_RANGE = '30days';
 const initialState = getDates({ relativeRange: DEFAULT_RANGE });
 
 const signalOptionsReducer = (state = initialState, action) => {

--- a/src/reducers/tests/__snapshots__/signalOptions.test.js.snap
+++ b/src/reducers/tests/__snapshots__/signalOptions.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Signal Options Reducer when init 1`] = `
 Object {
-  "relativeRange": "90days",
+  "relativeRange": "30days",
 }
 `;
 


### PR DESCRIPTION
### What Changed
- Changes default date filter  range to 30 days

### How To Test
- Go to any signals page
- Verify date filter defaults to 30 days

### To Do
- [ ] Feedback
