### PR TITLE
AC-779: Add link to FAQ page with account limits on onboarding and plan change page

### DIFF
--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -89,14 +89,12 @@ export class PlanPicker extends Component {
           <div className={listClasses}>{items}</div>
         </div>
         <div className={cx(styles.TierPlansInfo)}>
-          <small>
-            <span>Interested in learning more about our Starter and Premier premier plans? Check out our </span>
-            <ExternalLink
-              to='https://www.sparkpost.com/docs/faq/difference-between-starter-and-premier'
-            >
-              Knowledge Base
-            </ExternalLink>
-          </small>
+          <span>Interested in learning more about our Starter and Premier plans? Check out our </span>
+          <ExternalLink
+            to='https://www.sparkpost.com/docs/faq/difference-between-starter-and-premier'
+          >
+            Knowledge Base
+          </ExternalLink>
         </div>
       </div>
     );

--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -8,6 +8,7 @@ import { ExpandMore } from '@sparkpost/matchbox-icons';
 import Plan from './Plan';
 import styles from './PlanPicker.module.scss';
 import { PLAN_TIERS } from 'src/constants';
+import ExternalLink from 'src/components/externalLink/ExternalLink';
 
 const TIERS = [
   { key: 'default' },
@@ -86,6 +87,16 @@ export class PlanPicker extends Component {
           <Plan {...triggerProps} className={triggerClasses} planPriceProps={planPriceProps}/>
           <input {...getInputProps()} ref={(input) => this.input = input} className={styles.Input} />
           <div className={listClasses}>{items}</div>
+        </div>
+        <div className={cx(styles.TierPlansInfo)}>
+          <small>
+            <span>Interested in learning more about our Starter and Premier premier plans? Check out our </span>
+            <ExternalLink
+              to='https://www.sparkpost.com/docs/faq/difference-between-starter-and-premier'
+            >
+              Knowledge Base
+            </ExternalLink>
+          </small>
         </div>
       </div>
     );

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -141,5 +141,6 @@
 
 .TierPlansInfo {
   font-size: rem(12);
- padding: 0 spacing() spacing(small);
+  line-height: 1.5em;
+  padding: 0 spacing(large) spacing();
 }

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -138,3 +138,7 @@
   margin: 0;
   padding: 0 spacing() spacing();
 }
+
+.TierPlansInfo {
+ padding: 0 spacing() spacing(small);
+}

--- a/src/components/planPicker/PlanPicker.module.scss
+++ b/src/components/planPicker/PlanPicker.module.scss
@@ -140,5 +140,6 @@
 }
 
 .TierPlansInfo {
+  font-size: rem(12);
  padding: 0 spacing() spacing(small);
 }

--- a/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
+++ b/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
@@ -146,16 +146,14 @@ exports[`Plan Picker:  Render Function renders 1`] = `
   <div
     className="TierPlansInfo"
   >
-    <small>
-      <span>
-        Interested in learning more about our Starter and Premier premier plans? Check out our 
-      </span>
-      <ExternalLink
-        to="https://www.sparkpost.com/docs/faq/difference-between-starter-and-premier"
-      >
-        Knowledge Base
-      </ExternalLink>
-    </small>
+    <span>
+      Interested in learning more about our Starter and Premier plans? Check out our 
+    </span>
+    <ExternalLink
+      to="https://www.sparkpost.com/docs/faq/difference-between-starter-and-premier"
+    >
+      Knowledge Base
+    </ExternalLink>
   </div>
 </div>
 `;

--- a/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
+++ b/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
@@ -143,6 +143,20 @@ exports[`Plan Picker:  Render Function renders 1`] = `
       />
     </div>
   </div>
+  <div
+    className="TierPlansInfo"
+  >
+    <small>
+      <span>
+        Interested in learning more about our Starter and Premier premier plans? Check out our 
+      </span>
+      <ExternalLink
+        to="https://www.sparkpost.com/docs/faq/difference-between-starter-and-premier"
+      >
+        Knowledge Base
+      </ExternalLink>
+    </small>
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
### What Changed
 - Added info link informational for new plan tiers.

### How To Test
 - check link on `/onboarding/plan` and `/account/billing/plan`

### To Do
- [X] Wait for link to update
- [ ] Address Feedback
