### PR TITLE
EO-763 Hide injections chart when faceted by mb provider

### DIFF
--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -116,6 +116,10 @@ export class HealthScorePage extends Component {
                   }}
                   xAxisProps={this.getXAxisProps()}
                 />
+                {/*
+                  Spam Trap data when faceted by mailbox providers does not exist
+                  Remove when injections are returned from the health score endpoint
+                */}
                 {facet !== 'mb_provider' && (
                   <>
                     <ChartHeader title='Injections' tooltipContent={INJECTIONS_INFO} />

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -57,7 +57,7 @@ export class HealthScorePage extends Component {
   }
 
   renderContent = () => {
-    const { data = [], handleDateSelect, handleDateHover, loading, gap, empty, error, selectedDate, hoveredDate, resetDateHover } = this.props;
+    const { data = [], facet, handleDateSelect, handleDateHover, loading, gap, empty, error, selectedDate, hoveredDate, resetDateHover } = this.props;
     const { selectedComponent } = this.state;
 
     const selectedWeights = _.get(_.find(data, ['date', selectedDate]), 'weights', []);
@@ -116,25 +116,30 @@ export class HealthScorePage extends Component {
                   }}
                   xAxisProps={this.getXAxisProps()}
                 />
-                <ChartHeader title='Injections' tooltipContent={INJECTIONS_INFO} />
-                <BarChart
-                  gap={gap}
-                  height={190}
-                  onClick={handleDateSelect}
-                  onMouseOver={handleDateHover}
-                  selected={selectedDate}
-                  hovered={hoveredDate}
-                  onMouseOut={resetDateHover}
-                  timeSeries={data}
-                  tooltipContent={({ payload = {}}) => (
-                    <TooltipMetric label='Injections' value={formatFullNumber(payload.injections)} />
-                  )}
-                  yKey='injections'
-                  yAxisProps={{
-                    tickFormatter: (tick) => formatNumber(tick)
-                  }}
-                  xAxisProps={this.getXAxisProps()}
-                />
+                {facet !== 'mb_provider' && (
+                  <>
+                    <ChartHeader title='Injections' tooltipContent={INJECTIONS_INFO} />
+                    <BarChart
+                      gap={gap}
+                      height={190}
+                      onClick={handleDateSelect}
+                      onMouseOver={handleDateHover}
+                      selected={selectedDate}
+                      hovered={hoveredDate}
+                      onMouseOut={resetDateHover}
+                      timeSeries={data}
+                      tooltipContent={({ payload = {}}) => (
+                        <TooltipMetric label='Injections' value={formatFullNumber(payload.injections)} />
+                      )}
+                      yKey='injections'
+                      yAxisProps={{
+                        tickFormatter: (tick) => formatNumber(tick)
+                      }}
+                      xAxisProps={this.getXAxisProps()}
+                    />
+                  </>
+                )}
+
                 {(selectedComponent && !selectedWeightsAreEmpty) && (
                   <Fragment>
                     <ChartHeader title={HEALTH_SCORE_COMPONENTS[selectedComponent].chartTitle} />

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -60,6 +60,13 @@ describe('Signals Health Score Page', () => {
     expect(wrapper.find('withRouter(Connect(WithDetails(SpamTrapsPreview)))')).not.toContainMatchingElement();
   });
 
+  it('does not render injections chart when faceted by mailbox provider', () => {
+    wrapper.setProps({ facet: 'mb_provider' });
+    wrapper.update();
+    expect(wrapper.find({ title: 'Injections' })).not.toExist();
+    expect(wrapper.find({ yKey: 'injections' })).not.toExist();
+  });
+
   it('renders error correctly', () => {
     wrapper.setProps({ error: { message: 'error message' }});
     expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
Refer to ticket EO-763 for why the injections chart is hidden.

### What Changed
- Hides the injections chart when faceted by mailbox provider

### How To Test
- [Point your local upstreams to staging or production](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams)
- Log into appteam or account 108 for data
- Go to health score dashboard, and select mailbox provider as a facet
- Click on a mailbox provider to go to the details page (second column)
- Verify injections chart does not display

### Notes
- The request to spam hits still runs, and fails. There's no easy way to conditionally make this call without refactor.

### To Do
- [ ] Feedback

