### PR TITLE
AC-735: Warn account they are on an old plan

### DIFF
--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -58,7 +58,7 @@ export class Confirmation extends React.Component {
           <Warning className={styles.icon} size={32}/>
         </div>
         <div className={styles.content}>The current plan you are on is no longer available.
-      If you switch to a different plan, you will not be able to switch back to this one.</div>
+      If you switch to the new plan, you will not be able to switch back to your current one.</div>
       </div>
     );
   }

--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -58,7 +58,7 @@ export class Confirmation extends React.Component {
           <Warning className={styles.icon} size={32}/>
         </div>
         <div className={styles.content}>The current plan you are on is no longer available.
-      If you switch to the new plan, you will not be able to switch back to your current one.</div>
+      If you switch to the selected plan, you will not be able to switch back to your current one.</div>
       </div>
     );
   }

--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -8,6 +8,7 @@ import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLin
 import Brightback from 'src/components/brightback/Brightback';
 import styles from './Confirmation.module.scss';
 import { PLAN_TIERS } from 'src/constants';
+import { Warning } from '@sparkpost/matchbox-icons';
 export class Confirmation extends React.Component {
 
   renderSelectedPlanMarkup() {
@@ -42,6 +43,23 @@ export class Confirmation extends React.Component {
           promoError={promoError}
         />
       </Panel.Section>
+    );
+  }
+
+  renderDeprecatedWarning() {
+    const { current = {}, selected = {}} = this.props;
+
+    if (current.code === selected.code || current.status !== 'deprecated') {
+      return null;
+    }
+    return (
+      <div name='deprecated-warning' className={styles.DeprecatedWarning}>
+        <div className={styles.iconContainer}>
+          <Warning className={styles.icon} size={32}/>
+        </div>
+        <div className={styles.content}>The current plan you are on is no longer available.
+      If you switch to a different plan, you will not be able to switch back to this one.</div>
+      </div>
     );
   }
 
@@ -114,6 +132,7 @@ export class Confirmation extends React.Component {
           {effectiveDateMarkup}
           {ipMarkup}
           {addonMarkup}
+          {this.renderDeprecatedWarning()}
         </Panel.Section>
         <Panel.Section>
           <Brightback

--- a/src/pages/billing/components/Confirmation.module.scss
+++ b/src/pages/billing/components/Confirmation.module.scss
@@ -4,3 +4,23 @@
   display: block;
   color: color(orange);
 }
+
+.DeprecatedWarning {
+  position: relative;
+  display: flex;
+}
+
+.iconContainer {
+  position: relative;
+  flex: 1 0 0;
+  max-width: 40px;
+}
+
+.icon {
+  color: color(red);
+}
+
+.content {
+  flex: 1 0 0;
+  font-weight: 500;
+}

--- a/src/pages/billing/components/tests/Confirmation.test.js
+++ b/src/pages/billing/components/tests/Confirmation.test.js
@@ -15,6 +15,13 @@ describe('Confirmation: ', () => {
     includesIp: true
   };
 
+  const olderPlan = {
+    monthly: 100,
+    volume: 1000,
+    code: 'oldhundred',
+    status: 'deprecated'
+  };
+
   const upgrade = {
     monthly: 200,
     volume: 2000,
@@ -89,5 +96,21 @@ describe('Confirmation: ', () => {
   it('renders correctly when billing not enabled', () => {
     wrapper.setProps({ billingEnabled: false });
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('Deprecated Plan Warning', () => {
+    it('should render null if selected plan is the same as current', () => {
+      expect(wrapper.find({ name: 'deprecated-warning' })).not.toExist();
+    });
+
+    it('should render null if current plan is not deprecated', () => {
+      wrapper.setProps({ current, selected: upgrade });
+      expect(wrapper.find({ name: 'deprecated-warning' })).not.toExist();
+    });
+
+    it('should render warning if current plan has status deprecated', () => {
+      wrapper.setProps({ current: olderPlan, selected: upgrade });
+      expect(wrapper.find({ name: 'deprecated-warning' })).toExist();
+    });
   });
 });


### PR DESCRIPTION
### What Changed
 - Message shows in `/account/billing/plan` confirmation (right side) if on an old plan changing to a newer plan.

### How To Test
 - On an account that has an old plan, check that plans selection shows message
 - On an account that has an old plan, check that when no new plan selected, does not show message
 - On any account that has a new plan, check that message never shows.

### To Do
- [ ] Address feedback
