### PR TITLE
FE-679: SSO functional tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,4 @@ Note: Give your PR a short title. Something like "_TICKET NUMBER: feature descri
 ### To Do
 - [ ] Any outstanding tasks go here
     > Manage reviewers' expectations on missing features, tests, bugs, late design changes, ...)
+- [ ] Tag new routes in Pendo

--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -50,6 +50,7 @@ jest.mock('moment', () => {
 Object.defineProperty(global.navigator, 'userAgent', { value: 'node.js', configurable: true });
 Object.defineProperty(global.navigator, 'language', { value: 'en-US', configurable: true });
 Object.defineProperty(global.window, 'scrollTo', { value: jest.fn(), configurable: true });
+Object.defineProperty(global.window.location, 'assign', { value: jest.fn(), configurable: true });
 
 // Show a stack track for unhandled rejections to help
 // track them down.

--- a/src/__func__/auth/__snapshots__/ssoNonSsoUser.test.js.snap
+++ b/src/__func__/auth/__snapshots__/ssoNonSsoUser.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Single sign-on flow: non SSO user 1`] = `
+Array [
+  Array [
+    Object {
+      "data": undefined,
+      "headers": undefined,
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/users/test-username/saml",
+    },
+  ],
+]
+`;

--- a/src/__func__/auth/__snapshots__/ssoOut.test.js.snap
+++ b/src/__func__/auth/__snapshots__/ssoOut.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Single sign-on flow: navigate to identity provider 1`] = `
+Array [
+  Array [
+    Object {
+      "data": undefined,
+      "headers": undefined,
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/users/sso-username/saml",
+    },
+  ],
+]
+`;

--- a/src/__func__/auth/__snapshots__/ssoReturn.test.js.snap
+++ b/src/__func__/auth/__snapshots__/ssoReturn.test.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Single sign-on flow: return from identity provider 1`] = `
+Array [
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "get",
+      "params": Object {},
+      "responseType": "json",
+      "url": "/v1/account",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/account/plans",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/users/sso-username",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "get",
+      "params": Object {
+        "beta": false,
+        "role": undefined,
+      },
+      "responseType": "json",
+      "url": "/v1/authenticate/grants",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "get",
+      "params": Object {
+        "include": "usage",
+      },
+      "responseType": "json",
+      "url": "/v1/account",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "get",
+      "params": Object {
+        "limit": 1,
+        "sources": "Manually Added",
+      },
+      "responseType": "json",
+      "url": "/v1/suppression-list",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/sending-domains",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+        "x-msys-subaccount": 0,
+      },
+      "method": "get",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/api-keys",
+    },
+  ],
+]
+`;

--- a/src/__func__/auth/ssoNonSsoUser.test.js
+++ b/src/__func__/auth/ssoNonSsoUser.test.js
@@ -1,0 +1,13 @@
+import mountRoute from 'src/__testHelpers__/mountRoute';
+import getFormFiller from 'src/__testHelpers__/fill';
+
+test('Single sign-on flow: non SSO user', async () => {
+  const page = await mountRoute('/auth/sso', { authenticated: false });
+  const formFiller = getFormFiller(page.wrapper);
+  formFiller({ name: 'username', value: 'test-username' });
+  await page.simulate('form', 'submit');
+
+  expect(global.window.location.assign).not.toHaveBeenCalled();
+
+  expect(page.mockApiCalls).toMatchSnapshot();
+});

--- a/src/__func__/auth/ssoNonSsoUser.test.js
+++ b/src/__func__/auth/ssoNonSsoUser.test.js
@@ -9,5 +9,7 @@ test('Single sign-on flow: non SSO user', async () => {
 
   expect(global.window.location.assign).not.toHaveBeenCalled();
 
+  expect(page.find('Error')).toExist();
+
   expect(page.mockApiCalls).toMatchSnapshot();
 });

--- a/src/__func__/auth/ssoOut.test.js
+++ b/src/__func__/auth/ssoOut.test.js
@@ -1,0 +1,16 @@
+import mountRoute from 'src/__testHelpers__/mountRoute';
+import getFormFiller from 'src/__testHelpers__/fill';
+
+test('Single sign-on flow: navigate to identity provider', async () => {
+  const page = await mountRoute('/auth/sso', { authenticated: false });
+  const formFiller = getFormFiller(page.wrapper);
+  formFiller({ name: 'username', value: 'sso-username' });
+  await page.simulate('form', 'submit');
+
+  // Note: jdom does not implement navigation. It will throw if you attempt it so we
+  // install a mock in config/jest/setup.js and use it here instead.
+  expect(global.window.location.assign).toHaveBeenCalledTimes(1);
+  expect(global.window.location.assign.mock.calls[0][0]).toMatch(/\/v1\/users\/saml\/login\/sso-username/);
+
+  expect(page.mockApiCalls).toMatchSnapshot();
+});

--- a/src/__func__/auth/ssoReturn.test.js
+++ b/src/__func__/auth/ssoReturn.test.js
@@ -1,0 +1,11 @@
+import mountRoute from 'src/__testHelpers__/mountRoute';
+
+const SSOEncodedToken = Buffer.from(
+  JSON.stringify({ username: 'sso-username', accessToken: 'mock-access-token' })
+).toString('base64');
+
+test('Single sign-on flow: return from identity provider', async () => {
+  const page = await mountRoute(`/sso?ad=${SSOEncodedToken}`, { authenticated: false });
+  expect(page.currentRoute()).toEqual('/dashboard');
+  expect(page.mockApiCalls).toMatchSnapshot();
+});

--- a/src/__func__/auth/ssoReturnInvalidToken.test.js
+++ b/src/__func__/auth/ssoReturnInvalidToken.test.js
@@ -1,0 +1,8 @@
+import mountRoute from 'src/__testHelpers__/mountRoute';
+
+const SSOEncodedToken = 'probably-not-valid-base64';
+
+test('Single sign-on flow: return from identity provider without valid token', async () => {
+  const page = await mountRoute(`/sso?ad=${SSOEncodedToken}`, { authenticated: false });
+  expect(page.currentRoute()).toEqual('/auth');
+});

--- a/src/__integration__/http-responses/v1/users/sso-username/saml/get.js
+++ b/src/__integration__/http-responses/v1/users/sso-username/saml/get.js
@@ -1,0 +1,3 @@
+export default ({ url }) => ({
+  results: { saml: /\/v1\/users\/sso-username\/saml$/.test(url) }
+});

--- a/src/__integration__/http-responses/v1/users/test-username/saml/get.js
+++ b/src/__integration__/http-responses/v1/users/test-username/saml/get.js
@@ -1,0 +1,3 @@
+export default () => ({
+  results: { saml: false }
+});


### PR DESCRIPTION
### What Changed
 - Added a mock `window.location.assign()`
 - Added func tests for the following single sign-on flows, including failure cases:
    - `/auth/sso` -> _SAML identity provider_
    - _SAML identity provider_ -> `/sso` -> `/dashboard`

### How To Test
 - `npm test -- __func__/auth/sso`

### To Do
- [ ] Address feedback

