### PR TITLE
AC-660: Release new user roles

### DIFF
--- a/src/pages/users/components/RoleRadioGroup.js
+++ b/src/pages/users/components/RoleRadioGroup.js
@@ -5,8 +5,6 @@ import { formValueSelector, clearFields } from 'redux-form';
 import { RadioGroup } from 'src/components/reduxFormWrappers';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 import { FORMS, ROLES, ROLE_LABELS } from 'src/constants';
-import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
-import { selectCondition } from 'src/selectors/accessConditionState';
 import SubaccountAssignment from './SubaccountAssignment';
 
 const ADMIN_ROLE = {
@@ -23,7 +21,7 @@ const DEVELOPER_ROLE = {
     'Setup and development user. Full access to API Keys, and all other email related setup, sending, and reporting features.'
 };
 
-const EMAIL_ROLE = {
+const TEMPLATES_ROLE = {
   label: <strong>{ROLE_LABELS[ROLES.TEMPLATES]}</strong>,
   value: ROLES.TEMPLATES,
   helpText:
@@ -59,15 +57,14 @@ export class RoleRadioGroup extends React.Component {
       selectedRole,
       hasSubaccounts,
       useSubaccountChecked,
-      showDeveloperRoles,
       allowSuperUser,
       allowSubaccountAssignment
     } = this.props;
 
     return [
       ADMIN_ROLE,
-      showDeveloperRoles ? DEVELOPER_ROLE : null,
-      showDeveloperRoles ? EMAIL_ROLE : null,
+      DEVELOPER_ROLE,
+      TEMPLATES_ROLE,
       {
         ...REPORTING_ROLE,
         children: allowSubaccountAssignment &&
@@ -106,8 +103,7 @@ RoleRadioGroup.defaultProps = {
 const mapStateToProps = (state) => ({
   selectedRole: formValueSelector(FORMS.INVITE_USER)(state, 'access'),
   hasSubaccounts: hasSubaccounts(state),
-  useSubaccountChecked: formValueSelector(FORMS.INVITE_USER)(state, 'useSubaccount'),
-  showDeveloperRoles: selectCondition(isAccountUiOptionSet('developer_and_email_roles', false))(state)
+  useSubaccountChecked: formValueSelector(FORMS.INVITE_USER)(state, 'useSubaccount')
 });
 
 const mapDispatchToProps = { clearFields };

--- a/src/pages/users/components/tests/RoleRadioGroup.test.js
+++ b/src/pages/users/components/tests/RoleRadioGroup.test.js
@@ -15,7 +15,6 @@ describe('Component: RoleRadioGroup', () => {
       allowSubaccountAssignment: false,
       hasSubaccounts: false,
       useSubaccountChecked: false,
-      developer_and_email_roles: false,
       clearFields: jest.fn()
     };
   });
@@ -31,30 +30,6 @@ describe('Component: RoleRadioGroup', () => {
 
   it('should render disabled', () => {
     expect(options(subject({ disabled: true }))).toEqual(expect.arrayContaining([expect.objectContaining({ disabled: true })]));
-  });
-
-  it('should render developer roles when the UI flag `developer_and_email_roles` is enabled', () => {
-    expect(subject({ showDeveloperRoles: true })
-      .find('RadioGroup[title="Role"]')
-      .prop('options'))
-      .toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ value: ROLES.DEVELOPER }),
-          expect.objectContaining({ value: ROLES.TEMPLATES })
-        ])
-      );
-  });
-
-  it('should not render developer roles when the UI flag `developer_and_email_roles` is disabled', () => {
-    expect(subject({ showDeveloperRoles: false })
-      .find('RadioGroup[title="Role"]')
-      .prop('options'))
-      .not.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ value: ROLES.DEVELOPER }),
-          expect.objectContaining({ value: ROLES.TEMPLATES })
-        ])
-      );
   });
 
   it('should render super user', () => {

--- a/src/pages/users/components/tests/__snapshots__/RoleRadioGroup.test.js.snap
+++ b/src/pages/users/components/tests/__snapshots__/RoleRadioGroup.test.js.snap
@@ -15,7 +15,6 @@ exports[`Component: RoleRadioGroup should render the RadioGroup 1`] = `
   allowSubaccountAssignment={false}
   allowSuperUser={false}
   clearFields={[MockFunction]}
-  developer_and_email_roles={false}
   hasSubaccounts={false}
   options={
     Array [
@@ -26,6 +25,22 @@ exports[`Component: RoleRadioGroup should render the RadioGroup 1`] = `
           Admin
         </strong>,
         "value": "admin",
+      },
+      Object {
+        "disabled": false,
+        "helpText": "Setup and development user. Full access to API Keys, and all other email related setup, sending, and reporting features.",
+        "label": <strong>
+          Developer
+        </strong>,
+        "value": "developer",
+      },
+      Object {
+        "disabled": false,
+        "helpText": "Content and deliverability management user. Has access to Templates, Recipients Lists, Suppressions, AB Testing, and all reporting features.",
+        "label": <strong>
+          Templates
+        </strong>,
+        "value": "email",
       },
       Object {
         "children": false,


### PR DESCRIPTION
### What Changed
 - Released new user roles
   - Removed ui feature flag `developer_and_email_roles`

### How To Test
 - Check that with an account (w/o ui feature flag), users can be invited w/ new role `Developer` or `Templates`
 - Check that existing user roles can be modified between roles

### To Do
- [ ] Address feedback
