### PR TITLE
TR-1285: Live previewing for prototype fullscreen code editor

### DIFF
--- a/src/pages/templates/EditAndPreviewPage.js
+++ b/src/pages/templates/EditAndPreviewPage.js
@@ -4,6 +4,7 @@ import { RedirectAndAlert } from 'src/components/globalAlert';
 import Loading from 'src/components/loading';
 import EditPrimaryArea from './components/EditPrimaryArea';
 import EditSection from './components/EditSection';
+import PreviewSection from './components/PreviewSection';
 import useEditorContext from './hooks/useEditorContext';
 
 const EditAndPreviewPage = () => {
@@ -33,7 +34,7 @@ const EditAndPreviewPage = () => {
           <EditSection />
         </Grid.Column>
         <Grid.Column xs={12} sm={6}>
-          insert preview panel here
+          <PreviewSection />
         </Grid.Column>
       </Grid>
     </Page>

--- a/src/pages/templates/components/EditSection.js
+++ b/src/pages/templates/components/EditSection.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Panel, Tabs } from '@sparkpost/matchbox';
 import tabs from '../constants/editTabs';
-import useEditorTabs from '../hooks/useEditorTabs';
+import useEditorContext from '../hooks/useEditorContext';
 
 const EditSection = () => {
-  const { currentTabIndex, setTab } = useEditorTabs();
+  const { currentTabIndex, setTab } = useEditorContext();
   const TabComponent = tabs[currentTabIndex].render;
 
   return (

--- a/src/pages/templates/components/Editor.js
+++ b/src/pages/templates/components/Editor.js
@@ -14,8 +14,12 @@ const Editor = ({ editorProps = {}, setOptions = {}, mode = 'text', value, ...pr
     }}
     fontSize={12}
     highlightActiveLine
+    // note, must global import modes
     mode={mode}
     setOptions={{
+      // note, disabling worker only disables linting annotations and does not affect syntax highlighting
+      // see, https://github.com/securingsincity/react-ace/issues/275
+      useWorker: false,
       ...setOptions,
       displayIndentGuides: false
     }}

--- a/src/pages/templates/components/PreviewErrorFrame.js
+++ b/src/pages/templates/components/PreviewErrorFrame.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { Warning } from '@sparkpost/matchbox-icons';
 import styles from './PreviewErrorFrame.module.scss';
 
-const PreviewErrorFrame = () => (
+const PreviewErrorFrame = ({ errors }) => (
   <div className={styles.PreviewErrorFrame}>
     <Warning size={72} />
     <h1>Oh no! An Error Occurred</h1>
     <p>
-      We are unable to load your template preview due to an error.
+      We are unable to load your template preview due to a {errors[0].message} on
+      line {errors[0].line} of your {errors[0].part}.
     </p>
     <p>
       If you notice this happens often, check your substitution data or code syntax as

--- a/src/pages/templates/components/PreviewErrorFrame.js
+++ b/src/pages/templates/components/PreviewErrorFrame.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Warning } from '@sparkpost/matchbox-icons';
+import styles from './PreviewErrorFrame.module.scss';
+
+const PreviewErrorFrame = () => (
+  <div className={styles.PreviewErrorFrame}>
+    <Warning size={72} />
+    <h1>Oh no! An Error Occurred</h1>
+    <p>
+      We are unable to load your template preview due to an error.
+    </p>
+    <p>
+      If you notice this happens often, check your substitution data or code syntax as
+      these are frequent causes of preview errors.
+    </p>
+  </div>
+);
+
+export default PreviewErrorFrame;

--- a/src/pages/templates/components/PreviewErrorFrame.module.scss
+++ b/src/pages/templates/components/PreviewErrorFrame.module.scss
@@ -1,0 +1,5 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.PreviewErrorFrame {
+  padding: 20%;
+}

--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -40,6 +40,12 @@ export default class PreviewFrame extends Component {
     this.writeContent();
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.content !== prevProps.content) {
+      this.writeContent();
+    }
+  }
+
   // Calculate height of loaded content and manually set iframe height to match to avoid
   // a scrollbar
   // @see http://www.dyn-web.com/tutorials/iframes/height/

--- a/src/pages/templates/components/PreviewSection.js
+++ b/src/pages/templates/components/PreviewSection.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Panel } from '@sparkpost/matchbox';
 import classNames from 'classnames';
+import isEmpty from 'lodash/isEmpty';
 import useEditorContext from '../hooks/useEditorContext';
+import PreviewErrorFrame from './PreviewErrorFrame';
 import PreviewFrame from './PreviewFrame';
 import styles from './PreviewSection.module.scss';
 
 const PreviewSection = () => {
-  const { currentTabKey, preview } = useEditorContext();
+  const { currentTabKey, hasFailedToPreview, preview } = useEditorContext();
 
   // Must wrap text content in <p> to apply style and must be a string for injecting into iframe
   const content = currentTabKey === 'text'
@@ -16,11 +18,16 @@ const PreviewSection = () => {
   return (
     <Panel>
       <div className={classNames(styles.PreviewFrameWrapper, 'notranslate')}>
-        <PreviewFrame
-          content={content || ''}
-          key={currentTabKey} // unmount for each content part
-          strict={currentTabKey !== 'amp_html'}
-        />
+        {hasFailedToPreview && isEmpty(preview) ? (
+          // only show full error frame if never able to generate a preview
+          <PreviewErrorFrame />
+        ) : (
+          <PreviewFrame
+            content={content || ''}
+            key={currentTabKey} // unmount for each content part
+            strict={currentTabKey !== 'amp_html'}
+          />
+        )}
       </div>
     </Panel>
   );

--- a/src/pages/templates/components/PreviewSection.js
+++ b/src/pages/templates/components/PreviewSection.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Panel } from '@sparkpost/matchbox';
+import classNames from 'classnames';
+import useEditorContext from '../hooks/useEditorContext';
+import PreviewFrame from './PreviewFrame';
+import styles from './PreviewSection.module.scss';
+
+const PreviewSection = () => {
+  const { currentTabKey, preview } = useEditorContext();
+
+  // Must wrap text content in <p> to apply style and must be a string for injecting into iframe
+  const content = currentTabKey === 'text'
+    ? `<p style="white-space: pre-wrap">${preview[currentTabKey]}</p>`
+    : preview[currentTabKey];
+
+  return (
+    <Panel>
+      <div className={classNames(styles.PreviewFrameWrapper, 'notranslate')}>
+        <PreviewFrame
+          content={content || ''}
+          key={currentTabKey} // unmount for each content part
+          strict={currentTabKey !== 'amp_html'}
+        />
+      </div>
+    </Panel>
+  );
+};
+
+export default PreviewSection;

--- a/src/pages/templates/components/PreviewSection.js
+++ b/src/pages/templates/components/PreviewSection.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Panel } from '@sparkpost/matchbox';
 import classNames from 'classnames';
-import isEmpty from 'lodash/isEmpty';
 import useEditorContext from '../hooks/useEditorContext';
 import PreviewErrorFrame from './PreviewErrorFrame';
 import PreviewFrame from './PreviewFrame';
 import styles from './PreviewSection.module.scss';
 
 const PreviewSection = () => {
-  const { currentTabKey, hasFailedToPreview, preview } = useEditorContext();
+  const { currentTabKey, hasFailedToPreview, preview, previewLineErrors } = useEditorContext();
 
   // Must wrap text content in <p> to apply style and must be a string for injecting into iframe
   const content = currentTabKey === 'text'
@@ -18,9 +17,9 @@ const PreviewSection = () => {
   return (
     <Panel>
       <div className={classNames(styles.PreviewFrameWrapper, 'notranslate')}>
-        {hasFailedToPreview && isEmpty(preview) ? (
+        {hasFailedToPreview ? (
           // only show full error frame if never able to generate a preview
-          <PreviewErrorFrame />
+          <PreviewErrorFrame errors={previewLineErrors} />
         ) : (
           <PreviewFrame
             content={content || ''}

--- a/src/pages/templates/components/PreviewSection.module.scss
+++ b/src/pages/templates/components/PreviewSection.module.scss
@@ -1,0 +1,6 @@
+.PreviewFrameWrapper {
+  height: 550px;
+  min-height: 50vh;
+  overflow-y: scroll;
+  position: relative;
+}

--- a/src/pages/templates/components/tests/EditSection.test.js
+++ b/src/pages/templates/components/tests/EditSection.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import useEditorTabs from '../../hooks/useEditorTabs';
+import useEditorContext from '../../hooks/useEditorContext';
 import EditSection from '../EditSection';
 
-jest.mock('../../hooks/useEditorTabs');
+jest.mock('../../hooks/useEditorContext');
 
 describe('EditSection', () => {
   const subject = ({ tabState }) => {
-    useEditorTabs.mockReturnValue(tabState);
+    useEditorContext.mockReturnValue(tabState);
     return shallow(<EditSection />);
   };
 

--- a/src/pages/templates/components/tests/PreviewErrorFrame.test.js
+++ b/src/pages/templates/components/tests/PreviewErrorFrame.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PreviewErrorFrame from '../PreviewErrorFrame';
+
+describe('PreviewErrorFrame', () => {
+  const subject = (props = {}) => shallow(
+    <PreviewErrorFrame {...props} />
+  );
+
+  it('renders error message', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+});

--- a/src/pages/templates/components/tests/PreviewErrorFrame.test.js
+++ b/src/pages/templates/components/tests/PreviewErrorFrame.test.js
@@ -4,7 +4,10 @@ import PreviewErrorFrame from '../PreviewErrorFrame';
 
 describe('PreviewErrorFrame', () => {
   const subject = (props = {}) => shallow(
-    <PreviewErrorFrame {...props} />
+    <PreviewErrorFrame
+      errors={[{ line: 1, message: 'oh no!', part: 'html' }]}
+      {...props}
+    />
   );
 
   it('renders error message', () => {

--- a/src/pages/templates/components/tests/PreviewFrame.test.js
+++ b/src/pages/templates/components/tests/PreviewFrame.test.js
@@ -41,10 +41,20 @@ describe('PreviewFrame', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('writes content to iframe document', () => {
+  it('writes content to iframe document on mount', () => {
     const write = jest.fn();
     createWrapper({ content: testContent, contentDocument: { write }});
     expect(write).toHaveBeenCalledWith(testContent);
+  });
+
+  it('writes content to iframe document on update', () => {
+    const write = jest.fn();
+    const updatedContent = '<h1>Updated!!</h1>';
+    const wrapper = createWrapper({ content: testContent, contentDocument: { write }});
+
+    wrapper.setProps({ content: updatedContent });
+
+    expect(write).toHaveBeenCalledWith(updatedContent);
   });
 
   it('sets iframe height after it loads', () => {

--- a/src/pages/templates/components/tests/PreviewSection.test.js
+++ b/src/pages/templates/components/tests/PreviewSection.test.js
@@ -42,13 +42,10 @@ describe('PreviewSection', () => {
     expect(wrapper.find('PreviewFrame')).toHaveProp('strict', false);
   });
 
-  it('renders last preview when preview fails', () => {
-    const wrapper = subject({ editorState: { hasFailedToPreview: true }});
-    expect(wrapper.find('PreviewFrame')).toExist();
-  });
-
   it('renders error frame', () => {
-    const wrapper = subject({ editorState: { hasFailedToPreview: true, preview: {}}});
-    expect(wrapper.find('PreviewErrorFrame')).toExist();
+    const previewLineErrors = [{ line: 1, message: 'Oh no!' }];
+    const wrapper = subject({ editorState: { hasFailedToPreview: true, previewLineErrors }});
+
+    expect(wrapper.find('PreviewErrorFrame')).toHaveProp('errors', previewLineErrors);
   });
 });

--- a/src/pages/templates/components/tests/PreviewSection.test.js
+++ b/src/pages/templates/components/tests/PreviewSection.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import useEditorContext from '../../hooks/useEditorContext';
+import PreviewSection from '../PreviewSection';
+
+jest.mock('../../hooks/useEditorContext');
+
+describe('PreviewSection', () => {
+  const subject = ({ editorState = {}} = {}) => {
+    useEditorContext.mockReturnValue({
+      currentTabKey: 'html',
+      preview: { html: '<h1>Test Example</h1>' },
+      ...editorState
+    });
+
+    return shallow(<PreviewSection />);
+  };
+
+  it('renders preview frame', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('renders empty string', () => {
+    const wrapper = subject({ editorState: { preview: {}}});
+    expect(wrapper.find('PreviewFrame')).toHaveProp('content', '');
+  });
+
+  it('wraps text content with styles paragraph tag', () => {
+    const wrapper = subject({
+      editorState: {
+        currentTabKey: 'text',
+        preview: { text: 'Test Example' }
+      }
+    });
+
+    expect(wrapper.find('PreviewFrame'))
+      .toHaveProp('content', '<p style="white-space: pre-wrap">Test Example</p>');
+  });
+
+  it('renders non-strict preview frame for AMP HTML', () => {
+    const wrapper = subject({ editorState: { currentTabKey: 'amp_html' }});
+    expect(wrapper.find('PreviewFrame')).toHaveProp('strict', false);
+  });
+});

--- a/src/pages/templates/components/tests/PreviewSection.test.js
+++ b/src/pages/templates/components/tests/PreviewSection.test.js
@@ -41,4 +41,14 @@ describe('PreviewSection', () => {
     const wrapper = subject({ editorState: { currentTabKey: 'amp_html' }});
     expect(wrapper.find('PreviewFrame')).toHaveProp('strict', false);
   });
+
+  it('renders last preview when preview fails', () => {
+    const wrapper = subject({ editorState: { hasFailedToPreview: true }});
+    expect(wrapper.find('PreviewFrame')).toExist();
+  });
+
+  it('renders error frame', () => {
+    const wrapper = subject({ editorState: { hasFailedToPreview: true, preview: {}}});
+    expect(wrapper.find('PreviewErrorFrame')).toExist();
+  });
 });

--- a/src/pages/templates/components/tests/__snapshots__/Editor.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/Editor.test.js.snap
@@ -34,6 +34,7 @@ exports[`Editor renders editor 1`] = `
   setOptions={
     Object {
       "displayIndentGuides": false,
+      "useWorker": false,
     }
   }
   showGutter={true}

--- a/src/pages/templates/components/tests/__snapshots__/PreviewErrorFrame.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewErrorFrame.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewErrorFrame renders error message 1`] = `
+<div
+  className="PreviewErrorFrame"
+>
+  <Warning
+    size={72}
+  />
+  <h1>
+    Oh no! An Error Occurred
+  </h1>
+  <p>
+    We are unable to load your template preview due to an error.
+  </p>
+  <p>
+    If you notice this happens often, check your substitution data or code syntax as these are frequent causes of preview errors.
+  </p>
+</div>
+`;

--- a/src/pages/templates/components/tests/__snapshots__/PreviewErrorFrame.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewErrorFrame.test.js.snap
@@ -11,7 +11,13 @@ exports[`PreviewErrorFrame renders error message 1`] = `
     Oh no! An Error Occurred
   </h1>
   <p>
-    We are unable to load your template preview due to an error.
+    We are unable to load your template preview due to a 
+    oh no!
+     on line 
+    1
+     of your 
+    html
+    .
   </p>
   <p>
     If you notice this happens often, check your substitution data or code syntax as these are frequent causes of preview errors.

--- a/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewSection renders preview frame 1`] = `
+<Panel>
+  <div
+    className="PreviewFrameWrapper notranslate"
+  >
+    <PreviewFrame
+      content="<h1>Test Example</h1>"
+      key="html"
+      strict={true}
+    />
+  </div>
+</Panel>
+`;

--- a/src/pages/templates/containers/EditAndPreviewPage.container.js
+++ b/src/pages/templates/containers/EditAndPreviewPage.container.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { getDraft, getPublished, update } from 'src/actions/templates';
-import { selectDraftTemplate, selectPublishedTemplate } from 'src/selectors/templates';
+import { getDraft, getPreview, getPublished, update } from 'src/actions/templates';
+import {
+  selectDraftTemplate,
+  selectDraftTemplatePreview,
+  selectPublishedTemplate
+} from 'src/selectors/templates';
 import { EditorContextProvider } from '../context/EditorContext';
 import EditAndPreviewPage from '../EditAndPreviewPage';
 
@@ -21,12 +25,14 @@ const mapStateToProps = (state, props) => {
     hasDraftFailedToLoad: Boolean(state.templates.getDraftError),
     isDraftLoading: !draft || Boolean(state.templates.getDraftLoading),
     isDraftUpdating: Boolean(state.templates.updating),
+    preview: selectDraftTemplatePreview(state, id),
     published
   };
 };
 
 const mapDispatchToProps = {
   getDraft,
+  getPreview,
   getPublished,
   updateDraft: update
 };

--- a/src/pages/templates/containers/EditAndPreviewPage.container.js
+++ b/src/pages/templates/containers/EditAndPreviewPage.container.js
@@ -4,6 +4,7 @@ import { getDraft, getPreview, getPublished, update } from 'src/actions/template
 import {
   selectDraftTemplate,
   selectDraftTemplatePreview,
+  selectPreviewErrors,
   selectPublishedTemplate
 } from 'src/selectors/templates';
 import { EditorContextProvider } from '../context/EditorContext';
@@ -18,14 +19,17 @@ const EditAndPreviewPageContainer = (props) => (
 const mapStateToProps = (state, props) => {
   const id = props.match.params.id;
   const draft = selectDraftTemplate(state, id);
+  const previewErrors = selectPreviewErrors(state);
   const published = selectPublishedTemplate(state, id);
 
   return {
     draft,
     hasDraftFailedToLoad: Boolean(state.templates.getDraftError),
+    hasFailedToPreview: Boolean(previewErrors.length),
     isDraftLoading: !draft || Boolean(state.templates.getDraftLoading),
     isDraftUpdating: Boolean(state.templates.updating),
     preview: selectDraftTemplatePreview(state, id),
+    previewErrors,
     published
   };
 };

--- a/src/pages/templates/containers/EditAndPreviewPage.container.js
+++ b/src/pages/templates/containers/EditAndPreviewPage.container.js
@@ -4,7 +4,6 @@ import { getDraft, getPreview, getPublished, update } from 'src/actions/template
 import {
   selectDraftTemplate,
   selectDraftTemplatePreview,
-  selectPreviewErrors,
   selectPublishedTemplate
 } from 'src/selectors/templates';
 import { EditorContextProvider } from '../context/EditorContext';
@@ -19,17 +18,15 @@ const EditAndPreviewPageContainer = (props) => (
 const mapStateToProps = (state, props) => {
   const id = props.match.params.id;
   const draft = selectDraftTemplate(state, id);
-  const previewErrors = selectPreviewErrors(state);
   const published = selectPublishedTemplate(state, id);
 
   return {
     draft,
     hasDraftFailedToLoad: Boolean(state.templates.getDraftError),
-    hasFailedToPreview: Boolean(previewErrors.length),
+    hasFailedToPreview: Boolean(state.templates.contentPreview.error),
     isDraftLoading: !draft || Boolean(state.templates.getDraftLoading),
     isDraftUpdating: Boolean(state.templates.updating),
-    preview: selectDraftTemplatePreview(state, id),
-    previewErrors,
+    preview: selectDraftTemplatePreview(state, id, {}),
     published
   };
 };

--- a/src/pages/templates/containers/EditAndPreviewPage.container.js
+++ b/src/pages/templates/containers/EditAndPreviewPage.container.js
@@ -4,6 +4,7 @@ import { getDraft, getPreview, getPublished, update } from 'src/actions/template
 import {
   selectDraftTemplate,
   selectDraftTemplatePreview,
+  selectPreviewLineErrors,
   selectPublishedTemplate
 } from 'src/selectors/templates';
 import { EditorContextProvider } from '../context/EditorContext';
@@ -27,6 +28,7 @@ const mapStateToProps = (state, props) => {
     isDraftLoading: !draft || Boolean(state.templates.getDraftLoading),
     isDraftUpdating: Boolean(state.templates.updating),
     preview: selectDraftTemplatePreview(state, id, {}),
+    previewLineErrors: selectPreviewLineErrors(state),
     published
   };
 };

--- a/src/pages/templates/context/EditorContext.js
+++ b/src/pages/templates/context/EditorContext.js
@@ -1,27 +1,31 @@
 import React, { createContext, useEffect } from 'react';
 import useRouter from 'src/hooks/useRouter';
 import useEditorContent from '../hooks/useEditorContent';
+import useEditorPreview from '../hooks/useEditorPreview';
 import useEditorTabs from '../hooks/useEditorTabs';
 
 const EditorContext = createContext();
 
-export const EditorContextProvider = ({
-  children,
-  value: { getDraft, getPublished, ...value }
-}) => {
-  const contentState = useEditorContent(value.draft);
-  const tabState = useEditorTabs();
+const chainHooks = (...hooks) => (
+  hooks.reduce((acc, hook) => ({ ...acc, ...hook(acc) }), {})
+);
+
+export const EditorContextProvider = ({ children, value }) => {
   const { requestParams } = useRouter();
+  const state = chainHooks(
+    () => value,
+    useEditorContent,
+    useEditorPreview,
+    useEditorTabs
+  );
 
   useEffect(() => {
-    getDraft(requestParams.id, requestParams.subaccount);
-    getPublished(requestParams.id, requestParams.subaccount);
-  }, [getDraft, getPublished, requestParams.id, requestParams.subaccount]);
+    state.getDraft(requestParams.id, requestParams.subaccount);
+    state.getPublished(requestParams.id, requestParams.subaccount);
+  }, [state.getDraft, state.getPublished, requestParams.id, requestParams.subaccount, state]);
 
   return (
-    <EditorContext.Provider
-      value={{ ...value, ...contentState, ...tabState }}
-    >
+    <EditorContext.Provider value={state}>
       {children}
     </EditorContext.Provider>
   );

--- a/src/pages/templates/context/EditorContext.js
+++ b/src/pages/templates/context/EditorContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useEffect } from 'react';
 import useRouter from 'src/hooks/useRouter';
 import useEditorContent from '../hooks/useEditorContent';
+import useEditorTabs from '../hooks/useEditorTabs';
 
 const EditorContext = createContext();
 
@@ -9,6 +10,7 @@ export const EditorContextProvider = ({
   value: { getDraft, getPublished, ...value }
 }) => {
   const contentState = useEditorContent(value.draft);
+  const tabState = useEditorTabs();
   const { requestParams } = useRouter();
 
   useEffect(() => {
@@ -17,7 +19,9 @@ export const EditorContextProvider = ({
   }, [getDraft, getPublished, requestParams.id, requestParams.subaccount]);
 
   return (
-    <EditorContext.Provider value={{ ...value, ...contentState }}>
+    <EditorContext.Provider
+      value={{ ...value, ...contentState, ...tabState }}
+    >
       {children}
     </EditorContext.Provider>
   );

--- a/src/pages/templates/context/EditorContext.js
+++ b/src/pages/templates/context/EditorContext.js
@@ -10,7 +10,10 @@ const chainHooks = (...hooks) => (
   hooks.reduce((acc, hook) => ({ ...acc, ...hook(acc) }), {})
 );
 
-export const EditorContextProvider = ({ children, value }) => {
+export const EditorContextProvider = ({
+  children,
+  value: { getDraft, getPublished, ...value }
+}) => {
   const { requestParams } = useRouter();
   const state = chainHooks(
     () => value,
@@ -20,9 +23,9 @@ export const EditorContextProvider = ({ children, value }) => {
   );
 
   useEffect(() => {
-    state.getDraft(requestParams.id, requestParams.subaccount);
-    state.getPublished(requestParams.id, requestParams.subaccount);
-  }, [state.getDraft, state.getPublished, requestParams.id, requestParams.subaccount, state]);
+    getDraft(requestParams.id, requestParams.subaccount);
+    getPublished(requestParams.id, requestParams.subaccount);
+  }, [getDraft, getPublished, requestParams.id, requestParams.subaccount]);
 
   return (
     <EditorContext.Provider value={state}>

--- a/src/pages/templates/context/tests/EditorContext.test.js
+++ b/src/pages/templates/context/tests/EditorContext.test.js
@@ -4,7 +4,6 @@ import useRouter from 'src/hooks/useRouter';
 import { EditorContextProvider } from '../EditorContext';
 
 jest.mock('src/hooks/useRouter');
-jest.mock('../../hooks/useEditorContent', () => () => ({ content: { text: 'Example' }}));
 
 describe('EditorContext', () => {
   describe('EditorContextProvider', () => {

--- a/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
+++ b/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
@@ -4,11 +4,13 @@ exports[`EditorContext EditorContextProvider renders children wrapped by a conte
 <ContextProvider
   value={
     Object {
-      "content": Object {
-        "text": "Example",
-      },
+      "content": Object {},
       "currentTabIndex": 0,
       "currentTabKey": "html",
+      "getDraft": [Function],
+      "getPublished": [Function],
+      "preview": Object {},
+      "setContent": [Function],
       "setTab": [Function],
     }
   }

--- a/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
+++ b/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
@@ -7,6 +7,9 @@ exports[`EditorContext EditorContextProvider renders children wrapped by a conte
       "content": Object {
         "text": "Example",
       },
+      "currentTabIndex": 0,
+      "currentTabKey": "html",
+      "setTab": [Function],
     }
   }
 >

--- a/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
+++ b/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
@@ -7,7 +7,6 @@ exports[`EditorContext EditorContextProvider renders children wrapped by a conte
       "content": Object {},
       "currentTabIndex": 0,
       "currentTabKey": "html",
-      "preview": Object {},
       "setContent": [Function],
       "setTab": [Function],
     }

--- a/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
+++ b/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
@@ -7,8 +7,6 @@ exports[`EditorContext EditorContextProvider renders children wrapped by a conte
       "content": Object {},
       "currentTabIndex": 0,
       "currentTabKey": "html",
-      "getDraft": [Function],
-      "getPublished": [Function],
       "preview": Object {},
       "setContent": [Function],
       "setTab": [Function],

--- a/src/pages/templates/hooks/tests/useEditorContent.test.js
+++ b/src/pages/templates/hooks/tests/useEditorContent.test.js
@@ -4,8 +4,8 @@ import { mount } from 'enzyme';
 import useEditorContent from '../useEditorContent';
 
 describe('useEditorContent', () => {
-  const useTestWrapper = (draft) => {
-    const TestComponent = () => <div hooked={useEditorContent(draft)} />;
+  const useTestWrapper = (value = {}) => {
+    const TestComponent = () => <div hooked={useEditorContent(value)} />;
     return mount(<TestComponent />);
   };
   const useHook = (wrapper) => wrapper.update().children().prop('hooked');
@@ -19,8 +19,10 @@ describe('useEditorContent', () => {
 
   it('hydrates when draft is provided', () => {
     const wrapper = useTestWrapper({
-      content: { html: '<h1>Test</h1>', text: 'Test' },
-      last_update_time: '2019-05-16T02:25:00+00:00'
+      draft: {
+        content: { html: '<h1>Test</h1>', text: 'Test' },
+        last_update_time: '2019-05-16T02:25:00+00:00'
+      }
     });
     const { content } = useHook(wrapper);
 
@@ -29,8 +31,10 @@ describe('useEditorContent', () => {
 
   it('merges updated content', () => {
     const wrapper = useTestWrapper({
-      content: { html: '<h1>Test</h1>', text: 'Test' },
-      last_update_time: '2019-05-16T02:25:00+00:00'
+      draft: {
+        content: { html: '<h1>Test</h1>', text: 'Test' },
+        last_update_time: '2019-05-16T02:25:00+00:00'
+      }
     });
 
     act(() => {

--- a/src/pages/templates/hooks/tests/useEditorPreview.test.js
+++ b/src/pages/templates/hooks/tests/useEditorPreview.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import useEditorPreview from '../useEditorPreview';
+
+describe('useEditorPreview', () => {
+  const useTestWrapper = (value = {}) => {
+    const TestComponent = () => <div hooked={useEditorPreview(value)} />;
+    return mount(<TestComponent />);
+  };
+  const useHook = (wrapper) => wrapper.update().children().prop('hooked');
+
+  it('returns empty object by default', () => {
+    const wrapper = useTestWrapper();
+    expect(useHook(wrapper)).toEqual({ preview: {}});
+  });
+
+  it('returns received preview', () => {
+    const preview = { html: '<h1>Test Example</h1>' };
+    const wrapper = useTestWrapper({ preview });
+
+    expect(useHook(wrapper)).toEqual({ preview });
+  });
+
+  it('calls getPreview when content changes', () => {
+    const getPreview = jest.fn();
+    const debounceAction = jest.fn((fn) => fn());
+    const content = { html: '<h1>Test Example</h1>' };
+    const draft = { id: 'test-template', subaccount_id: 123 };
+
+    useTestWrapper({ content, debounceAction, draft, getPreview });
+
+    expect(getPreview).toHaveBeenCalledWith({
+      id: draft.id,
+      content,
+      mode: 'draft',
+      subaccountId: draft.subaccount_id,
+      substitution_data: {}
+    });
+  });
+
+  it('ignores effect when content is empty', () => {
+    const debounceAction = jest.fn();
+    useTestWrapper({ content: {}, debounceAction });
+    expect(debounceAction).not.toHaveBeenCalled();
+  });
+
+  it('cancels remaining debounced calls', () => {
+    const debounceAction = { cancel: jest.fn() };
+    const wrapper = useTestWrapper({ debounceAction });
+
+    wrapper.unmount();
+
+    expect(debounceAction.cancel).toHaveBeenCalled();
+  });
+});

--- a/src/pages/templates/hooks/tests/useEditorPreview.test.js
+++ b/src/pages/templates/hooks/tests/useEditorPreview.test.js
@@ -11,14 +11,7 @@ describe('useEditorPreview', () => {
 
   it('returns empty object by default', () => {
     const wrapper = useTestWrapper();
-    expect(useHook(wrapper)).toEqual({ preview: {}});
-  });
-
-  it('returns received preview', () => {
-    const preview = { html: '<h1>Test Example</h1>' };
-    const wrapper = useTestWrapper({ preview });
-
-    expect(useHook(wrapper)).toEqual({ preview });
+    expect(useHook(wrapper)).toEqual({});
   });
 
   it('calls getPreview when content changes', () => {

--- a/src/pages/templates/hooks/useEditorContent.js
+++ b/src/pages/templates/hooks/useEditorContent.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 // the store for in progress content changes
-const useEditorContent = (draft = {}) => {
+const useEditorContent = ({ draft = {}}) => {
   const [state, setState] = useState({});
   const setContent = (nextState) => {
     setState({ ...state, ...nextState }); // merge-in

--- a/src/pages/templates/hooks/useEditorPreview.js
+++ b/src/pages/templates/hooks/useEditorPreview.js
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
+
+// note, use caution when setting the debounce interval, content-previewer endpoint is old and not
+//   built for heavy traffic
+const debouncer = debounce((fn) => fn(), 1000);
+
+// tracks changes to content and requests preview update
+const useEditorPreview = ({
+  content,
+  draft = {},
+  getPreview,
+  preview = {},
+  debounceAction = debouncer
+}) => {
+  useEffect(() => {
+    if (!isEmpty(content)) {
+      debounceAction(() => {
+        getPreview({
+          id: draft.id,
+          content,
+          mode: 'draft',
+          subaccountId: draft.subaccount_id,
+          substitution_data: {}
+        });
+      });
+    }
+  }, [getPreview, content, debounceAction, draft.id, draft.subaccount_id]);
+
+  // clean-up debounced state when unmounted
+  useEffect(() => () => { debounceAction.cancel(); }, [debounceAction]);
+
+  return { preview };
+};
+
+export default useEditorPreview;

--- a/src/pages/templates/hooks/useEditorPreview.js
+++ b/src/pages/templates/hooks/useEditorPreview.js
@@ -11,7 +11,6 @@ const useEditorPreview = ({
   content,
   draft = {},
   getPreview,
-  preview = {},
   debounceAction = debouncer
 }) => {
   useEffect(() => {
@@ -31,7 +30,7 @@ const useEditorPreview = ({
   // clean-up debounced state when unmounted
   useEffect(() => () => { debounceAction.cancel(); }, [debounceAction]);
 
-  return { preview };
+  return {};
 };
 
 export default useEditorPreview;

--- a/src/pages/templates/tests/__snapshots__/EditAndPreviewPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/EditAndPreviewPage.test.js.snap
@@ -23,7 +23,7 @@ exports[`EditAndPreviewPage renders a page 1`] = `
       sm={6}
       xs={12}
     >
-      insert preview panel here
+      <PreviewSection />
     </Grid.Column>
   </Grid>
 </Page>

--- a/src/reducers/templates.js
+++ b/src/reducers/templates.js
@@ -59,11 +59,16 @@ export default (state = initialState, { now = new Date(), ...action }) => {
     case 'GET_TEMPLATE_TEST_DATA':
       return { ...state, testData: action.payload };
 
+    // note, purposely don't clear error on pending action, so errors can be displayed while pending
+    case 'GET_TEMPLATE_PREVIEW_FAIL':
+      return { ...state, contentPreview: { ...state.contentPreview, error: action.payload }};
+
     case 'GET_TEMPLATE_PREVIEW_SUCCESS':
       return {
         ...state,
         contentPreview: {
           ...state.contentPreview,
+          error: undefined,
           [action.meta.context.mode]: {
             ...state.contentPreview[action.meta.context.mode],
             [action.meta.context.id]: {

--- a/src/reducers/tests/__snapshots__/templates.test.js.snap
+++ b/src/reducers/tests/__snapshots__/templates.test.js.snap
@@ -54,6 +54,19 @@ Object {
 }
 `;
 
+exports[`Template reducer stores preview error 1`] = `
+Object {
+  "byId": Object {},
+  "contentPreview": Object {
+    "draft": Object {},
+    "error": [Error: Oh no!],
+    "published": Object {},
+  },
+  "list": Array [],
+  "listError": null,
+}
+`;
+
 exports[`Template reducer stores preview of draft with obj from 1`] = `
 Object {
   "byId": Object {},
@@ -68,6 +81,7 @@ Object {
         "subject": "Preview of Test Template",
       },
     },
+    "error": undefined,
     "published": Object {},
   },
   "list": Array [],
@@ -89,6 +103,7 @@ Object {
         "subject": "Preview of Test Template",
       },
     },
+    "error": undefined,
     "published": Object {},
   },
   "list": Array [],

--- a/src/reducers/tests/templates.test.js
+++ b/src/reducers/tests/templates.test.js
@@ -46,6 +46,10 @@ const TEST_CASES = {
     },
     type: 'GET_TEMPLATE_PREVIEW_SUCCESS'
   },
+  'stores preview error': {
+    type: 'GET_TEMPLATE_PREVIEW_FAIL',
+    payload: new Error('Oh no!')
+  },
   'updates updating state when update fails': {
     type: 'UPDATE_TEMPLATE_FAIL'
   },

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -13,6 +13,9 @@ export const selectDraftTemplate = (state, id) => _.get(state, ['templates', 'by
 export const selectPublishedTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);
 export const selectDraftTemplatePreview = (state, id) => state.templates.contentPreview.draft[id];
 export const selectPublishedTemplatePreview = (state, id) => state.templates.contentPreview.published[id];
+export const selectPreviewErrors = (state) => (
+  _.get(state, 'templates.contentPreview.error.response.data.errors', [])
+);
 
 export const selectDefaultTestData = () => JSON.stringify(config.templates.testData, null, 2);
 export const selectTemplateTestData = (state) => JSON.stringify(state.templates.testData || config.templates.testData, null, 2);

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -11,9 +11,13 @@ export const selectTemplateById = (state, props) => state.templates.byId[props.m
 
 export const selectDraftTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'draft']);
 export const selectPublishedTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);
-export const selectDraftTemplatePreview = (state, id) => state.templates.contentPreview.draft[id];
-export const selectPublishedTemplatePreview = (state, id) => state.templates.contentPreview.published[id];
-export const selectPreviewErrors = (state) => (
+export const selectDraftTemplatePreview = (state, id, defaultValue) => (
+  state.templates.contentPreview.draft[id] || defaultValue
+);
+export const selectPublishedTemplatePreview = (state, id, defaultValue) => (
+  state.templates.contentPreview.published[id] || defaultValue
+);
+export const selectPreviewLineErrors = (state) => (
   _.get(state, 'templates.contentPreview.error.response.data.errors', [])
 );
 

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -10,6 +10,8 @@ Object {
 
 exports[`Templates selectors .selectDraftTemplate returns undefined when unknown 1`] = `undefined`;
 
+exports[`Templates selectors .selectDraftTemplatePreview returns default value when unknown 1`] = `Object {}`;
+
 exports[`Templates selectors .selectDraftTemplatePreview returns preview of draft template 1`] = `
 Object {
   "html": "<h1>Southeastern Asia</h1>",
@@ -28,6 +30,8 @@ Object {
 `;
 
 exports[`Templates selectors .selectPublishedTemplate returns undefined when unknown 1`] = `undefined`;
+
+exports[`Templates selectors .selectPublishedTemplatePreview returns default value when unknown 1`] = `Object {}`;
 
 exports[`Templates selectors .selectPublishedTemplatePreview returns preview of draft template 1`] = `
 Object {

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -205,4 +205,21 @@ describe('Templates selectors', () => {
       expect(selector.selectPublishedTemplatesBySubaccount(store)).toMatchSnapshot();
     });
   });
+
+  describe('selectPreviewErrors', () => {
+    it('should return an empty ', () => {
+      expect(selector.selectPreviewErrors(store)).toEqual([]);
+    });
+
+    it('should return an array of errors', () => {
+      const errors = [
+        { line: 1, message: 'Oh no!' },
+        { line: 2, message: 'Oh no!' }
+      ];
+
+      store.templates.contentPreview.error = { response: { data: { errors }}};
+
+      expect(selector.selectPreviewErrors(store)).toEqual(errors);
+    });
+  });
 });

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -114,18 +114,20 @@ describe('Templates selectors', () => {
     'returns undefined when unknown': { id: 'unknown' }
   });
 
-  cases('.selectDraftTemplatePreview', ({ id }) => {
-    expect(selector.selectDraftTemplatePreview(store, id)).toMatchSnapshot();
+  cases('.selectDraftTemplatePreview', ({ defaultValue, id }) => {
+    expect(selector.selectDraftTemplatePreview(store, id, defaultValue)).toMatchSnapshot();
   }, {
     'returns preview of draft template': { id: 'ape' },
-    'returns undefined when unknown': { id: 'unknown' }
+    'returns undefined when unknown': { id: 'unknown' },
+    'returns default value when unknown': { id: 'unknown', defaultValue: {}}
   });
 
-  cases('.selectPublishedTemplatePreview', ({ id }) => {
-    expect(selector.selectPublishedTemplatePreview(store, id)).toMatchSnapshot();
+  cases('.selectPublishedTemplatePreview', ({ defaultValue, id }) => {
+    expect(selector.selectPublishedTemplatePreview(store, id, defaultValue)).toMatchSnapshot();
   }, {
     'returns preview of draft template': { id: 'ape' },
-    'returns undefined when unknown': { id: 'unknown' }
+    'returns undefined when unknown': { id: 'unknown' },
+    'returns default value when unknown': { id: 'unknown', defaultValue: {}}
   });
 
   describe('cloneTemplate', () => {
@@ -206,9 +208,9 @@ describe('Templates selectors', () => {
     });
   });
 
-  describe('selectPreviewErrors', () => {
+  describe('selectPreviewLineErrors', () => {
     it('should return an empty ', () => {
-      expect(selector.selectPreviewErrors(store)).toEqual([]);
+      expect(selector.selectPreviewLineErrors(store)).toEqual([]);
     });
 
     it('should return an array of errors', () => {
@@ -219,7 +221,7 @@ describe('Templates selectors', () => {
 
       store.templates.contentPreview.error = { response: { data: { errors }}};
 
-      expect(selector.selectPreviewErrors(store)).toEqual(errors);
+      expect(selector.selectPreviewLineErrors(store)).toEqual(errors);
     });
   });
 });


### PR DESCRIPTION
Refer to subtask [TR-1285](https://jira.int.messagesystems.com/browse/TR-1285).

### What Changed

- The preview automatically updates when content on left is modified.

![amp_preview](https://user-images.githubusercontent.com/1335605/57956514-38e70500-78c7-11e9-9fa5-62e3006fbabd.gif)

- Display an error with some guidance if there is a preview error.

<img width="1391" alt="Screen Shot 2019-05-20 at 10 07 58 AM" src="https://user-images.githubusercontent.com/1335605/58027673-2f3be800-7ae7-11e9-8c41-7c9159678a78.png">

*** I was going to surface line errors in the editors margin as annotations, but found that our API only returns the first error.

### How To Test

1. Modify some content in next editor — should update content in preview
1. Update content with `{{ break; }}` — should present full panel error message
