### PR TITLE
TR-1208 Create Recipients List

### DIFF
--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -112,7 +112,7 @@ export class Collection extends Component {
   }
 
   renderPagination() {
-    const { rows, perPageButtons, pagination } = this.props;
+    const { rows, perPageButtons, pagination, saveCsv = true } = this.props;
     const { currentPage, perPage, filteredRows } = this.state;
 
     if (!pagination || !currentPage) { return null; }
@@ -125,6 +125,7 @@ export class Collection extends Component {
         perPageButtons={perPageButtons}
         onPageChange={this.handlePageChange}
         onPerPageChange={this.handlePerPageChange}
+        saveCsv={saveCsv}
       />
     );
   }

--- a/src/components/collection/Collection.propTypes.js
+++ b/src/components/collection/Collection.propTypes.js
@@ -30,6 +30,7 @@ export default {
   ]),
   perPageButtons: PropTypes.array,
   pagination: PropTypes.bool,
+  saveCsv: PropTypes.bool,
   filterBox: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.object

--- a/src/components/collection/tests/Collection.test.js
+++ b/src/components/collection/tests/Collection.test.js
@@ -31,7 +31,8 @@ describe('Component: Collection', () => {
       },
       history: {
         push: pushStub
-      }
+      },
+      saveCsv: true
     };
   });
 
@@ -70,6 +71,30 @@ describe('Component: Collection', () => {
     const wrapper = shallow(<Collection {...props} />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(FilterBox)).toHaveLength(1);
+  });
+
+  describe('save as csv button', () => {
+    let wrapper;
+    beforeEach(() => {
+      addRows(1);
+      wrapper = shallow(<Collection {...props} />);
+    });
+
+    it('should render save as csv button when saveCsv prop is unset', () => {
+      wrapper.setProps({ pagination: true });
+      expect(wrapper.find('CollectionPagination').prop('saveCsv')).toBe(true);
+    });
+
+    it('should render save as csv button when saveCsv is true', () => {
+      wrapper.setProps({ pagination: true, saveCsv: true });
+      expect(wrapper.find('CollectionPagination').prop('saveCsv')).toBe(true);
+    });
+
+    it('should not render save as csv button when saveCsv is false', () => {
+      wrapper.setProps({ pagination: true, saveCsv: false });
+      expect(wrapper.find('CollectionPagination').prop('saveCsv')).toBe(false);
+    });
+
   });
 
   describe('state changes', () => {

--- a/src/pages/recipientLists/CreatePage.js
+++ b/src/pages/recipientLists/CreatePage.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
 import { Link, withRouter } from 'react-router-dom';
+import { change, getFormValues, reduxForm } from 'redux-form';
 
 import { Page } from '@sparkpost/matchbox';
 
@@ -9,39 +9,90 @@ import { createRecipientList } from 'src/actions/recipientLists';
 import { showAlert } from 'src/actions/globalAlert';
 
 import RecipientListForm from './components/RecipientListForm';
+import RecipientsCollection from './components/RecipientsCollection';
+import parseRecipientListCsv from './helpers/csv';
+
+const formName = 'recipientListForm';
 
 export class CreatePage extends Component {
-
-  createRecipientList = (values) => {
-    const { createRecipientList, showAlert, history } = this.props;
-
-    return createRecipientList(values).then(() => {
-      showAlert({
-        type: 'success',
-        message: 'Created recipient list'
-      });
-      history.push('/lists/recipient-lists');
-    });
+  state = {
+    recipients: []
   };
 
+  createRecipientList = ({ name, id, description }) => {
+    const { createRecipientList, showAlert, history } = this.props;
+    const data = {
+      name,
+      id,
+      description,
+      recipients: this.state.recipients
+    };
+
+    return createRecipientList(data)
+      .then(() => {
+        showAlert({
+          type: 'success',
+          message: 'Created recipient list'
+        });
+        history.push('/lists/recipient-lists');
+      });
+  };
+
+  parseCsv = (csv) => {
+    const { showAlert } = this.props;
+    return parseRecipientListCsv(csv)
+      .then((recipients) => {
+        this.setState({ recipients });
+      })
+      .catch((csvErrors) => {
+        showAlert({ type: 'error', message: 'Error while parsing CSV file' });
+      });
+  };
+
+  componentDidUpdate(prevProps, prevState) {
+    const { formValues } = this.props;
+    if (prevProps.formValues && formValues.csv !== prevProps.formValues.csv) {
+      this.parseCsv(formValues.csv);
+    }
+  }
+
   render() {
+    const { handleSubmit } = this.props;
+    const { recipients } = this.state;
 
     return <Page
       title='Create Recipient List'
       breadcrumbAction={{
         content: 'Recipient Lists',
         Component: Link,
-        to: '/lists/recipient-lists' }}>
+        to: '/lists/recipient-lists'
+      }}>
 
-      <RecipientListForm onSubmit={this.createRecipientList} />
-
+      <form onSubmit={handleSubmit(this.createRecipientList)}>
+        <RecipientListForm formName={formName} onSubmit={this.createRecipientList}/>
+        {!!recipients.length &&
+        <RecipientsCollection recipients={recipients}/>
+        }
+      </form>
     </Page>;
   }
 }
 
+const mapStateToProps = (state, props) => ({
+  initialValues: {},
+  formValues: getFormValues(formName)(state)
+});
+
 const mapDispatchToProps = {
   createRecipientList,
-  showAlert
+  showAlert,
+  change
 };
 
-export default withRouter(connect(undefined, mapDispatchToProps)(CreatePage));
+const formOptions = {
+  form: formName,
+  enableReinitialize: true
+};
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(reduxForm(formOptions)(CreatePage)));
+

--- a/src/pages/recipientLists/CreatePage.js
+++ b/src/pages/recipientLists/CreatePage.js
@@ -49,6 +49,7 @@ export class CreatePage extends Component {
         this.setState({ recipients });
       })
       .catch((csvErrors) => {
+        this.setState({ recipients: []});
         showAlert({ type: 'error', message: csvErrors });
       });
   };
@@ -74,7 +75,7 @@ export class CreatePage extends Component {
 
       <form onSubmit={handleSubmit(this.createRecipientsList)}>
         <RecipientListForm formName={formName}/>
-        <RecipientsCollection hasCsv={!!csv} recipients={recipients}/>
+        {csv && <RecipientsCollection recipients={recipients}/>}
       </form>
     </Page>;
   }

--- a/src/pages/recipientLists/CreatePage.js
+++ b/src/pages/recipientLists/CreatePage.js
@@ -29,12 +29,16 @@ export class CreatePage extends Component {
     };
 
     return createRecipientList(data)
-      .then((result) => {
+      .then(({ id, total_rejected_recipients }) => {
+        let message = 'Successfully created recipient list.';
+        if (total_rejected_recipients) {
+          message = `${message} ${total_rejected_recipients} ${total_rejected_recipients === 1 ? 'recipient was' : 'recipients were'} rejected!`;
+        }
         showAlert({
           type: 'success',
-          message: 'Created recipient list'
+          message
         });
-        history.push(`/lists/recipient-lists/edit/${result.id}`);
+        history.push(`/lists/recipient-lists/edit/${id}`);
       });
   };
 
@@ -78,7 +82,6 @@ export class CreatePage extends Component {
 
 const valueSelector = formValueSelector(formName);
 const mapStateToProps = (state, props) => ({
-  initialValues: {},
   csv: valueSelector(state, 'csv')
 });
 

--- a/src/pages/recipientLists/EditPage.js
+++ b/src/pages/recipientLists/EditPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-
+import { reduxForm } from 'redux-form';
 import { Link, withRouter } from 'react-router-dom';
 
 import { Page } from '@sparkpost/matchbox';
@@ -67,7 +67,7 @@ export class EditPage extends Component {
   }
 
   render() {
-    const { loading } = this.props;
+    const { loading, handleSubmit } = this.props;
 
     if (loading) {
       return <Loading />;
@@ -81,7 +81,10 @@ export class EditPage extends Component {
         Component: Link,
         to: '/lists/recipient-lists' }}>
 
-      <RecipientListForm editMode={true} onSubmit={this.updateRecipientList} />
+      <form onSubmit={handleSubmit(this.updateRecipientList)}>
+        <RecipientListForm formName={formName} editMode={true} />
+      </form>
+
 
       <DeleteModal
         open={this.state.showDelete}
@@ -98,7 +101,8 @@ const mapStateToProps = (state) => ({
   current: state.recipientLists.current,
   loading: state.recipientLists.currentLoading,
   list: state.recipientLists.list,
-  error: state.recipientLists.error
+  error: state.recipientLists.error,
+  initialValues: state.recipientLists.current
 });
 
 const mapDispatchToProps = {
@@ -107,5 +111,9 @@ const mapDispatchToProps = {
   deleteRecipientList,
   showAlert
 };
-
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EditPage));
+const formName = 'recipientListForm';
+const formOptions = {
+  form: formName,
+  enableReinitialize: true
+};
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(reduxForm(formOptions)(EditPage)));

--- a/src/pages/recipientLists/components/Form.module.scss
+++ b/src/pages/recipientLists/components/Form.module.scss
@@ -1,0 +1,4 @@
+.Spacer {
+  margin-bottom: 10px;
+}
+

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { autofill, change, Field, isPristine, isSubmitting, isValid } from 'redux-form';
 
 import config from 'src/config';
-import { Banner, Button, Error, Grid, Panel } from '@sparkpost/matchbox';
+import { Button, Grid, Panel } from '@sparkpost/matchbox';
 import { DownloadLink, TextFieldWrapper } from 'src/components';
 import { maxFileSize, maxLength, required, slug } from 'src/helpers/validation';
 import { slugify } from 'src/helpers/string';
@@ -13,13 +13,6 @@ import exampleRecipientListPath from './example-recipient-list.csv';
 import styles from './Form.module.scss';
 
 export class RecipientListForm extends Component {
-  renderCsvErrors() {
-    const { error } = this.props;
-    return <Banner status='danger' title='CSV Format Errors'>
-      {error.map((err, idx) => <Error key={idx} error={err}/>)}
-    </Banner>;
-  }
-
   // Fills in identifier field based on Name
   handleIdFill = (e) => {
     const { editMode, autofill, formName } = this.props;
@@ -31,7 +24,7 @@ export class RecipientListForm extends Component {
   };
 
   render() {
-    const { editMode, pristine, valid, error, submitting } = this.props;
+    const { editMode, pristine, valid, submitting } = this.props;
 
     const submitDisabled = pristine || !valid || submitting;
 
@@ -46,7 +39,6 @@ export class RecipientListForm extends Component {
     }
 
     return <div>
-      {error && this.renderCsvErrors()}
       <Panel>
         <Panel.Section>
           <Grid className={styles.Spacer}>

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -66,6 +66,7 @@ export class RecipientListForm extends Component {
               <Field
                 name='id'
                 label='Identifier'
+                helpText={'A unique ID for your recipient list, we\'ll fill this for you but, once set, this can not be modified.'}
                 placeholder='my-favorite-recipients'
                 validate={[required, maxLength(64), slug]}
                 disabled={submitting || editMode}

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -10,6 +10,7 @@ import { slugify } from 'src/helpers/string';
 
 import FileFieldWrapper from 'src/components/reduxFormWrappers/FileFieldWrapper';
 import exampleRecipientListPath from './example-recipient-list.csv';
+import styles from './Form.module.scss';
 
 export class RecipientListForm extends Component {
   renderCsvErrors() {
@@ -48,7 +49,7 @@ export class RecipientListForm extends Component {
       {error && this.renderCsvErrors()}
       <Panel>
         <Panel.Section>
-          <Grid>
+          <Grid className={styles.Spacer}>
             <Grid.Column>
               <Field
                 name='name'
@@ -62,18 +63,18 @@ export class RecipientListForm extends Component {
               />
             </Grid.Column>
             <Grid.Column>
-              {!editMode && <Field
+              <Field
                 name='id'
                 label='Identifier'
                 placeholder='my-favorite-recipients'
                 validate={[required, maxLength(64), slug]}
-                disabled={submitting}
+                disabled={submitting || editMode}
                 component={TextFieldWrapper}
                 required
-              />}
+              />
             </Grid.Column>
           </Grid>
-          <Grid>
+          <Grid className={styles.Spacer}>
             <Grid.Column>
               <Field
                 name='description'
@@ -85,7 +86,7 @@ export class RecipientListForm extends Component {
               />
             </Grid.Column>
           </Grid>
-          <Grid>
+          <Grid className={styles.Spacer}>
             <Grid.Column>
               <Field
                 component={FileFieldWrapper}
@@ -114,10 +115,15 @@ export class RecipientListForm extends Component {
   }
 }
 
-const mapStateToProps = (state, props) => ({
-  pristine: isPristine(props.formName)(state),
-  valid: isValid(props.formName)(state),
-  submitting: isSubmitting(props.formName)(state)
-});
+const mapStateToProps = (state, props) => {
+  const { formName } = props;
+  return {
+    pristine: isPristine(formName)(state),
+    valid: isValid(formName)(state),
+    submitting: isSubmitting(formName)(state)
+  };
+};
 
-export default connect(mapStateToProps, { change, autofill })(RecipientListForm);
+const connectedForm = connect(mapStateToProps, { change, autofill })(RecipientListForm);
+connectedForm.displayName = 'RecipientsListForm';
+export default connectedForm;

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -1,50 +1,17 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Field, SubmissionError, reduxForm } from 'redux-form';
-
-import _ from 'lodash';
-
-import { Panel, Banner, Button, Error } from '@sparkpost/matchbox';
-import { DownloadLink, TextFieldWrapper } from 'src/components';
-import { required, maxLength, maxFileSize } from 'src/helpers/validation';
-
-import FileFieldWrapper from 'src/components/reduxFormWrappers/FileFieldWrapper';
-
-import parseRecipientListCsv from '../helpers/csv';
+import { autofill, change, Field, isPristine, isSubmitting, isValid } from 'redux-form';
 
 import config from 'src/config';
+import { Banner, Button, Error, Grid, Panel } from '@sparkpost/matchbox';
+import { DownloadLink, TextFieldWrapper } from 'src/components';
+import { maxFileSize, maxLength, required, slug } from 'src/helpers/validation';
+import { slugify } from 'src/helpers/string';
 
+import FileFieldWrapper from 'src/components/reduxFormWrappers/FileFieldWrapper';
 import exampleRecipientListPath from './example-recipient-list.csv';
 
-const formName = 'recipientListForm';
-
 export class RecipientListForm extends Component {
-  parseCsv = (csv) => parseRecipientListCsv(csv)
-    .catch((csvErrors) => {
-      throw new SubmissionError({ _error: csvErrors });
-    });
-
-  // `csv` is an internal field. The outer conponent can access the parsed records in `recipients`.
-  formatValues = (values) => _.omit(values, ['csv']);
-
-  submitWithRecipients = (values, recipients) => this.props.onSubmit({
-    recipients,
-    ...this.formatValues(values)
-  });
-
-  submitWithoutRecipients = (values) => this.props.onSubmit(this.formatValues(values));
-
-  // Parse CSV, store JSON result, collect and show parsing errors
-  preSubmit = (values) => {
-    if (values.csv) {
-      // CSV upload is optional in edit mode
-      return this.parseCsv(values.csv)
-        .then((recipients) => this.submitWithRecipients(values, recipients));
-    } else {
-      return this.submitWithoutRecipients(this.formatValues(values));
-    }
-  };
-
   renderCsvErrors() {
     const { error } = this.props;
     return <Banner status='danger' title='CSV Format Errors'>
@@ -52,8 +19,18 @@ export class RecipientListForm extends Component {
     </Banner>;
   }
 
+  // Fills in identifier field based on Name
+  handleIdFill = (e) => {
+    const { editMode, autofill, formName } = this.props;
+    if (editMode) {
+      return;
+    }
+
+    autofill(formName, 'id', slugify(e.target.value));
+  };
+
   render() {
-    const { editMode, pristine, valid, error, submitting, handleSubmit } = this.props;
+    const { editMode, pristine, valid, error, submitting } = this.props;
 
     const submitDisabled = pristine || !valid || submitting;
 
@@ -68,66 +45,79 @@ export class RecipientListForm extends Component {
     }
 
     return <div>
-      { error && this.renderCsvErrors() }
-      <form onSubmit={handleSubmit(this.preSubmit)}>
-        <Panel>
-          <Panel.Section>
-            <Field
-              name='name'
-              label='Label'
-              placeholder='My favorite recipients'
-              validate={[required, maxLength(64)]}
-              disabled={submitting}
-              component={TextFieldWrapper}
-              required
-            />
-            { ! editMode && <Field
-              name='id'
-              label='Identifier'
-              placeholder='my-favorite-recipients'
-              validate={[required, maxLength(64)]}
-              disabled={submitting}
-              component={TextFieldWrapper}
-              required
-            /> }
-            <Field
-              name='description'
-              label='Description'
-              placeholder='All my favorite recipients'
-              validate={[maxLength(1024)]}
-              disabled={submitting}
-              component={TextFieldWrapper}
-            />
-            <Field
-              component={FileFieldWrapper}
-              disabled={submitting}
-              fileType="csv"
-              helpText={
-                <span>
+      {error && this.renderCsvErrors()}
+      <Panel>
+        <Panel.Section>
+          <Grid>
+            <Grid.Column>
+              <Field
+                name='name'
+                label='Name'
+                placeholder='My favorite recipients'
+                validate={[required, maxLength(64)]}
+                onChange={this.handleIdFill}
+                disabled={submitting}
+                component={TextFieldWrapper}
+                required
+              />
+            </Grid.Column>
+            <Grid.Column>
+              {!editMode && <Field
+                name='id'
+                label='Identifier'
+                placeholder='my-favorite-recipients'
+                validate={[required, maxLength(64), slug]}
+                disabled={submitting}
+                component={TextFieldWrapper}
+                required
+              />}
+            </Grid.Column>
+          </Grid>
+          <Grid>
+            <Grid.Column>
+              <Field
+                name='description'
+                label='Description'
+                placeholder='All my favorite recipients'
+                validate={[maxLength(1024)]}
+                disabled={submitting}
+                component={TextFieldWrapper}
+              />
+            </Grid.Column>
+          </Grid>
+          <Grid>
+            <Grid.Column>
+              <Field
+                component={FileFieldWrapper}
+                disabled={submitting}
+                fileType="csv"
+                helpText={
+                  <span>
                   You can download
                   a <DownloadLink href={exampleRecipientListPath}>CSV template here</DownloadLink> to
                   use when formatting your recipient list for upload.
-                </span>
-              }
-              label={uploadHint}
-              name="csv"
-              validate={uploadValidators}
-              required
-            />
-          </Panel.Section>
-          <Panel.Section>
-            <Button primary submit disabled={submitDisabled}>{actionText} Recipient List</Button>
-          </Panel.Section>
-        </Panel>
-      </form>
+                  </span>
+                }
+                label={uploadHint}
+                name="csv"
+                validate={uploadValidators}
+                required
+              />
+            </Grid.Column>
+          </Grid>
+        </Panel.Section>
+        <Panel.Section>
+          <Button primary submit disabled={submitDisabled}>{actionText} Recipient List</Button>
+        </Panel.Section>
+      </Panel>
     </div>;
   }
 }
 
-const WrappedForm = reduxForm({ form: formName })(RecipientListForm);
-
 const mapStateToProps = (state, props) => ({
-  initialValues: props.editMode ? state.recipientLists.current : {}
+  pristine: isPristine(props.formName)(state),
+  valid: isValid(props.formName)(state),
+  submitting: isSubmitting(props.formName)(state)
 });
 
-export default connect(mapStateToProps)(WrappedForm);
+export default connect(mapStateToProps, { change, autofill })(RecipientListForm);

--- a/src/pages/recipientLists/components/RecipientsCollection.js
+++ b/src/pages/recipientLists/components/RecipientsCollection.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { TableCollection } from 'src/components';
+import { Panel } from '@sparkpost/matchbox';
+
+const columns = [
+  { label: 'Address', sortKey: 'email' },
+  { label: 'Name', sortKey: 'name' }
+];
+
+export class RecipientsCollection extends Component {
+  getRowData = ({ address }) => [address.email, address.name]
+
+  render() {
+    const { recipients } = this.props;
+
+    return (<Panel title='Preview Contacts'>
+      <TableCollection
+        columns={columns}
+        rows={recipients}
+        getRowData={this.getRowData}
+        pagination={true}
+      />
+    </Panel>);
+  }
+}
+
+RecipientsCollection.defaultProps = {
+  recipients: []
+};
+
+export default RecipientsCollection;

--- a/src/pages/recipientLists/components/RecipientsCollection.js
+++ b/src/pages/recipientLists/components/RecipientsCollection.js
@@ -3,8 +3,8 @@ import { TableCollection } from 'src/components';
 import { Panel } from '@sparkpost/matchbox';
 
 const columns = [
-  { label: 'Address', sortKey: 'email' },
-  { label: 'Name', sortKey: 'name' }
+  { label: 'Address', sortKey: 'address.email' },
+  { label: 'Name', sortKey: 'address.name' }
 ];
 
 export class RecipientsCollection extends Component {
@@ -28,6 +28,7 @@ export class RecipientsCollection extends Component {
       rows={recipients}
       getRowData={this.getRowData}
       pagination={true}
+      saveCsv={false}
     />);
   };
 

--- a/src/pages/recipientLists/components/RecipientsCollection.js
+++ b/src/pages/recipientLists/components/RecipientsCollection.js
@@ -8,14 +8,20 @@ const columns = [
 ];
 
 export class RecipientsCollection extends Component {
-  getRowData = ({ address }) => [address.email, address.name]
+  getRowData = ({ address }) => [address.email, address.name];
 
-  renderEmpty = () => <Panel.Section>
+  renderNoCsv = () => <Panel.Section>
     <p>Once you upload a CSV, recipients will be previewed here.</p>
-  </Panel.Section>
+  </Panel.Section>;
 
   renderCollection = () => {
     const { recipients } = this.props;
+
+    if (recipients.length === 0) {
+      return (<Panel.Section>
+        <p>There are no recipients in your uploaded CSV!</p>
+      </Panel.Section>);
+    }
 
     return (<TableCollection
       columns={columns}
@@ -23,13 +29,14 @@ export class RecipientsCollection extends Component {
       getRowData={this.getRowData}
       pagination={true}
     />);
-  }
+  };
+
   render() {
-    const { hasCsv, recipients } = this.props;
+    const { hasCsv } = this.props;
 
     return (<Panel title='Preview Contacts'>
-      {!hasCsv && this.renderEmpty()}
-      {recipients.length > 0 && this.renderCollection()}
+      {!hasCsv && this.renderNoCsv()}
+      {hasCsv && this.renderCollection()}
     </Panel>);
   }
 }

--- a/src/pages/recipientLists/components/RecipientsCollection.js
+++ b/src/pages/recipientLists/components/RecipientsCollection.js
@@ -10,22 +10,33 @@ const columns = [
 export class RecipientsCollection extends Component {
   getRowData = ({ address }) => [address.email, address.name]
 
-  render() {
+  renderEmpty = () => <Panel.Section>
+    <p>Once you upload a CSV, recipients will be previewed here.</p>
+  </Panel.Section>
+
+  renderCollection = () => {
     const { recipients } = this.props;
 
+    return (<TableCollection
+      columns={columns}
+      rows={recipients}
+      getRowData={this.getRowData}
+      pagination={true}
+    />);
+  }
+  render() {
+    const { hasCsv, recipients } = this.props;
+
     return (<Panel title='Preview Contacts'>
-      <TableCollection
-        columns={columns}
-        rows={recipients}
-        getRowData={this.getRowData}
-        pagination={true}
-      />
+      {!hasCsv && this.renderEmpty()}
+      {recipients.length > 0 && this.renderCollection()}
     </Panel>);
   }
 }
 
 RecipientsCollection.defaultProps = {
-  recipients: []
+  recipients: [],
+  hasCsv: false
 };
 
 export default RecipientsCollection;

--- a/src/pages/recipientLists/components/RecipientsCollection.js
+++ b/src/pages/recipientLists/components/RecipientsCollection.js
@@ -10,17 +10,21 @@ const columns = [
 export class RecipientsCollection extends Component {
   getRowData = ({ address }) => [address.email, address.name];
 
-  renderNoCsv = () => <Panel.Section>
-    <p>Once you upload a CSV, recipients will be previewed here.</p>
-  </Panel.Section>;
+  renderNoCsv = () => <Panel>
+    <Panel.Section>
+      <p>Once you upload a CSV, recipients will be previewed here.</p>
+    </Panel.Section>
+  </Panel>;
 
   renderCollection = () => {
     const { recipients } = this.props;
 
     if (recipients.length === 0) {
-      return (<Panel.Section>
-        <p>There are no recipients in your uploaded CSV!</p>
-      </Panel.Section>);
+      return (<Panel>
+        <Panel.Section>
+          <p>There are no recipients in your uploaded CSV!</p>
+        </Panel.Section>
+      </Panel>);
     }
 
     return (<TableCollection
@@ -35,10 +39,10 @@ export class RecipientsCollection extends Component {
   render() {
     const { hasCsv } = this.props;
 
-    return (<Panel title='Preview Contacts'>
-      {!hasCsv && this.renderNoCsv()}
-      {hasCsv && this.renderCollection()}
-    </Panel>);
+    return <>
+      <h1>Preview Contacts</h1>
+      {hasCsv ? this.renderCollection() : this.renderNoCsv()}
+    </>;
   }
 }
 

--- a/src/pages/recipientLists/components/RecipientsCollection.js
+++ b/src/pages/recipientLists/components/RecipientsCollection.js
@@ -10,22 +10,14 @@ const columns = [
 export class RecipientsCollection extends Component {
   getRowData = ({ address }) => [address.email, address.name];
 
-  renderNoCsv = () => <Panel>
+  renderEmptyState = () => (<Panel>
     <Panel.Section>
-      <p>Once you upload a CSV, recipients will be previewed here.</p>
+      <p>There are no valid recipients in your uploaded CSV!</p>
     </Panel.Section>
-  </Panel>;
+  </Panel>)
 
   renderCollection = () => {
     const { recipients } = this.props;
-
-    if (recipients.length === 0) {
-      return (<Panel>
-        <Panel.Section>
-          <p>There are no recipients in your uploaded CSV!</p>
-        </Panel.Section>
-      </Panel>);
-    }
 
     return (<TableCollection
       columns={columns}
@@ -37,18 +29,17 @@ export class RecipientsCollection extends Component {
   };
 
   render() {
-    const { hasCsv } = this.props;
+    const { recipients } = this.props;
 
     return <>
       <h1>Preview Contacts</h1>
-      {hasCsv ? this.renderCollection() : this.renderNoCsv()}
+      {recipients.length ? this.renderCollection() : this.renderEmptyState()}
     </>;
   }
 }
 
 RecipientsCollection.defaultProps = {
-  recipients: [],
-  hasCsv: false
+  recipients: []
 };
 
 export default RecipientsCollection;

--- a/src/pages/recipientLists/components/tests/RecipientListForm.test.js
+++ b/src/pages/recipientLists/components/tests/RecipientListForm.test.js
@@ -10,7 +10,13 @@ describe('RecipientListForm', () => {
 
   beforeEach(() => {
     props = {
-      onSubmit: jest.fn()
+      onSubmit: jest.fn(),
+      editMode: false,
+      autofill: jest.fn(),
+      formName: 'fooForm',
+      valid: true,
+      pristine: true,
+      submitting: false
     };
 
     wrapper = shallow(<RecipientListForm {...props} />);
@@ -33,6 +39,28 @@ describe('RecipientListForm', () => {
   it('should disable form elements during submit', () => {
     wrapper.setProps({ submitting: true });
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should disable submit when form is invalid', () => {
+    wrapper.setProps({ pristine: true, valid: false });
+    expect(wrapper.find('Button').prop('disabled')).toBe(true);
+  });
+
+  it('should disable submit when form is pristine', () => {
+    wrapper.setProps({ pristine: true, valid: true });
+    expect(wrapper.find('Button').prop('disabled')).toBe(true);
+  });
+
+  it('autofills id on name change on create mode', () => {
+    wrapper.find('Field[name="name"]').simulate('change', { target: { value: 'FOo bAr' }});
+    // expect(wrapper.find('Field[name="id"]').value).toEqual('foo-bar');
+    expect(props.autofill).toHaveBeenCalledWith('fooForm', 'id', 'foo-b-ar');
+  });
+
+  it('does not autofill id on name change on edit mode', () => {
+    wrapper.setProps({ editMode: true });
+    wrapper.find('Field[name="name"]').simulate('change', { target: { value: 'FOo bAr' }});
+    expect(props.autofill).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/recipientLists/components/tests/RecipientListForm.test.js
+++ b/src/pages/recipientLists/components/tests/RecipientListForm.test.js
@@ -6,85 +6,33 @@ import { RecipientListForm } from '../RecipientListForm';
 
 describe('RecipientListForm', () => {
   let props;
-  let formValues;
-  let csv;
+  let wrapper;
 
   beforeEach(() => {
     props = {
-      handleSubmit: jest.fn()
-    };
-    formValues = {
-      name: 'Freddie II Jr',
-      id: 'fred-2-jr',
-      description: 'Royalty amongst the fredericks'
+      onSubmit: jest.fn()
     };
 
-    csv = 'email,metadata\nscratch@example.com,"{""flavor"":""vanilla""}"\n';
+    wrapper = shallow(<RecipientListForm {...props} />);
   });
 
   it('defaults to create mode', () => {
-    const wrapper = shallow(<RecipientListForm {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders correctly in create mode', () => {
-    const wrapper = shallow(<RecipientListForm editMode={false} {...props} />);
+    wrapper.setProps({ editMode: false });
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders correctly in edit mode', () => {
-    const wrapper = shallow(<RecipientListForm editMode={true} {...props} />);
+  it('renders disable id in edit mode', () => {
+    wrapper.setProps({ editMode: true });
+    expect(wrapper.find('Field[name="id"]').prop('disabled')).toBe(true);
+  });
+
+  it('should disable form elements during submit', () => {
+    wrapper.setProps({ submitting: true });
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it('renders CSV errors', () => {
-    const wrapper = shallow(<RecipientListForm editMode={false} {...props} />);
-    const csvErrors = [
-      'Line 73: Too many notes',
-      'Line 247: Vanilla is unacceptable'
-    ];
-    wrapper.setProps({ error: csvErrors });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should disable form elements on submit', () => {
-    const wrapper = shallow(<RecipientListForm submitting={true} {...props} />);
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should submit without recipients', async() => {
-    const onSubmit = jest.fn();
-    const wrapper = shallow(<RecipientListForm onSubmit={onSubmit} {...props} />);
-    await wrapper.instance().preSubmit(formValues);
-    expect(onSubmit).toHaveBeenCalledWith(formValues);
-  });
-
-  it('should submit with recipients', async() => {
-    const formValuesWithCsv = { csv, ...formValues };
-    const parsedFormValues = {
-      recipients: [
-        {
-          address: {
-            email: 'scratch@example.com'
-          },
-          metadata: { flavor: 'vanilla' }
-        }
-      ],
-      ...formValues
-    };
-    const onSubmit = jest.fn();
-    const wrapper = shallow(<RecipientListForm onSubmit={onSubmit} {...props} />);
-    await wrapper.instance().preSubmit(formValuesWithCsv);
-    expect(onSubmit).toHaveBeenCalledWith(parsedFormValues);
-  });
-
-  it('should throw on submit if CSV parsing fails', () => {
-    const csv = 'email,metadata\nscratchexample.com,"{""flavor"":""vanilla"""\n';
-    const formValuesWithCsv = { csv, ...formValues };
-    const onSubmit = jest.fn();
-    const wrapper = shallow(<RecipientListForm onSubmit={onSubmit} {...props} />);
-    expect(wrapper.instance().preSubmit(formValuesWithCsv)).rejects.toMatchSnapshot();
-    expect(onSubmit).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pages/recipientLists/components/tests/RecipientListForm.test.js
+++ b/src/pages/recipientLists/components/tests/RecipientListForm.test.js
@@ -53,7 +53,6 @@ describe('RecipientListForm', () => {
 
   it('autofills id on name change on create mode', () => {
     wrapper.find('Field[name="name"]').simulate('change', { target: { value: 'FOo bAr' }});
-    // expect(wrapper.find('Field[name="id"]').value).toEqual('foo-bar');
     expect(props.autofill).toHaveBeenCalledWith('fooForm', 'id', 'foo-b-ar');
   });
 

--- a/src/pages/recipientLists/components/tests/RecipientsCollection.test.js
+++ b/src/pages/recipientLists/components/tests/RecipientsCollection.test.js
@@ -20,14 +20,9 @@ describe('RecipientsCollection', () => {
     wrapper = shallow(<RecipientsCollection {...props} />);
   });
 
-  it('renders correctly when hasCsv is false', () => {
-    wrapper.setProps({ hasCsv: false });
-    expect(wrapper.find('p')).toHaveText('Once you upload a CSV, recipients will be previewed here.');
-  });
-
-  it('renders correctly when hasCsv is true but no recipients', () => {
+  it('renders correctly with no recipients', () => {
     wrapper.setProps({ hasCsv: true });
-    expect(wrapper.find('p')).toHaveText('There are no recipients in your uploaded CSV!');
+    expect(wrapper.find('p')).toHaveText('There are no valid recipients in your uploaded CSV!');
   });
 
   it('renders collection correctly', () => {

--- a/src/pages/recipientLists/components/tests/RecipientsCollection.test.js
+++ b/src/pages/recipientLists/components/tests/RecipientsCollection.test.js
@@ -6,37 +6,43 @@ import RecipientsCollection from '../RecipientsCollection';
 describe('RecipientsCollection', () => {
   let props;
   let wrapper;
+  let recipients;
 
   beforeEach(() => {
     props = {
       recipients: []
     };
+    recipients = [
+      { address: { name: 'foo', email: 'foo@domain.com' }},
+      { address: { name: 'bar', email: 'bar@domain.com' }}
+    ];
 
     wrapper = shallow(<RecipientsCollection {...props} />);
   });
 
   it('renders correctly when hasCsv is false', () => {
     wrapper.setProps({ hasCsv: false });
-    expect(wrapper.find('p').text()).toEqual('Once you upload a CSV, recipients will be previewed here.');
+    expect(wrapper.find('p')).toHaveText('Once you upload a CSV, recipients will be previewed here.');
   });
 
   it('renders correctly when hasCsv is true but no recipients', () => {
     wrapper.setProps({ hasCsv: true });
-    expect(wrapper.find('p').text()).toEqual('There are no recipients in your uploaded CSV!');
+    expect(wrapper.find('p')).toHaveText('There are no recipients in your uploaded CSV!');
   });
 
   it('renders collection correctly', () => {
     wrapper.setProps({
       hasCsv: true,
-      recipients: [
-        { address: { name: 'foo', email: 'foo@domain.com' }},
-        { address: { name: 'bar', email: 'bar@domain.com' }}
-      ]
+      recipients
     });
 
     expect(wrapper).toMatchSnapshot();
   });
 
-
+  describe('getRowData', () => {
+    it('returns formatted recipient', () => {
+      expect(wrapper.instance().getRowData(recipients[0])).toEqual([recipients[0].address.email, recipients[0].address.name]);
+    });
+  });
 });
 

--- a/src/pages/recipientLists/components/tests/RecipientsCollection.test.js
+++ b/src/pages/recipientLists/components/tests/RecipientsCollection.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import RecipientsCollection from '../RecipientsCollection';
+
+describe('RecipientsCollection', () => {
+  let props;
+  let wrapper;
+
+  beforeEach(() => {
+    props = {
+      recipients: []
+    };
+
+    wrapper = shallow(<RecipientsCollection {...props} />);
+  });
+
+  it('renders correctly when hasCsv is false', () => {
+    wrapper.setProps({ hasCsv: false });
+    expect(wrapper.find('p').text()).toEqual('Once you upload a CSV, recipients will be previewed here.');
+  });
+
+  it('renders correctly when hasCsv is true but no recipients', () => {
+    wrapper.setProps({ hasCsv: true });
+    expect(wrapper.find('p').text()).toEqual('There are no recipients in your uploaded CSV!');
+  });
+
+  it('renders collection correctly', () => {
+    wrapper.setProps({
+      hasCsv: true,
+      recipients: [
+        { address: { name: 'foo', email: 'foo@domain.com' }},
+        { address: { name: 'bar', email: 'bar@domain.com' }}
+      ]
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+
+});
+

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
@@ -10,6 +10,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            disabled={false}
             label="Name"
             name="name"
             onChange={[Function]}
@@ -26,6 +27,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            disabled={false}
             helpText="A unique ID for your recipient list, we'll fill this for you but, once set, this can not be modified."
             label="Identifier"
             name="id"
@@ -47,6 +49,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            disabled={false}
             label="Description"
             name="description"
             placeholder="All my favorite recipients"
@@ -64,6 +67,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            disabled={false}
             fileType="csv"
             helpText={
               <span>
@@ -114,6 +118,7 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            disabled={false}
             label="Name"
             name="name"
             onChange={[Function]}
@@ -152,6 +157,7 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            disabled={false}
             label="Description"
             name="description"
             placeholder="All my favorite recipients"
@@ -169,6 +175,7 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            disabled={false}
             fileType="csv"
             helpText={
               <span>

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
@@ -26,6 +26,7 @@ exports[`RecipientListForm defaults to create mode 1`] = `
         <Grid.Column>
           <Field
             component={[Function]}
+            helpText="A unique ID for your recipient list, we'll fill this for you but, once set, this can not be modified."
             label="Identifier"
             name="id"
             placeholder="my-favorite-recipients"
@@ -130,6 +131,7 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
           <Field
             component={[Function]}
             disabled={false}
+            helpText="A unique ID for your recipient list, we'll fill this for you but, once set, this can not be modified."
             label="Identifier"
             name="id"
             placeholder="my-favorite-recipients"
@@ -235,6 +237,7 @@ exports[`RecipientListForm should disable form elements during submit 1`] = `
           <Field
             component={[Function]}
             disabled={true}
+            helpText="A unique ID for your recipient list, we'll fill this for you but, once set, this can not be modified."
             label="Identifier"
             name="id"
             placeholder="my-favorite-recipients"

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
@@ -2,420 +2,314 @@
 
 exports[`RecipientListForm defaults to create mode 1`] = `
 <div>
-  <form>
-    <Panel>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          label="Label"
-          name="name"
-          placeholder="My favorite recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          label="Identifier"
-          name="id"
-          placeholder="my-favorite-recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          label="Description"
-          name="description"
-          placeholder="All my favorite recipients"
-          validate={
-            Array [
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          fileType="csv"
-          helpText={
-            <span>
-              You can download a 
-              <DownloadLink
-                href="example-recipient-list.csv"
-              >
-                CSV template here
-              </DownloadLink>
-               to use when formatting your recipient list for upload.
-            </span>
-          }
-          label="Upload a CSV file of recipients"
-          name="csv"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          disabled={true}
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Create
-           Recipient List
-        </Button>
-      </Panel.Section>
-    </Panel>
-  </form>
-</div>
-`;
-
-exports[`RecipientListForm renders CSV errors 1`] = `
-<div>
-  <Banner
-    status="danger"
-    title="CSV Format Errors"
-  >
-    <Error
-      error="Line 73: Too many notes"
-      key="0"
-    />
-    <Error
-      error="Line 247: Vanilla is unacceptable"
-      key="1"
-    />
-  </Banner>
-  <form>
-    <Panel>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          label="Label"
-          name="name"
-          placeholder="My favorite recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          label="Identifier"
-          name="id"
-          placeholder="my-favorite-recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          label="Description"
-          name="description"
-          placeholder="All my favorite recipients"
-          validate={
-            Array [
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          fileType="csv"
-          helpText={
-            <span>
-              You can download a 
-              <DownloadLink
-                href="example-recipient-list.csv"
-              >
-                CSV template here
-              </DownloadLink>
-               to use when formatting your recipient list for upload.
-            </span>
-          }
-          label="Upload a CSV file of recipients"
-          name="csv"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          disabled={true}
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Create
-           Recipient List
-        </Button>
-      </Panel.Section>
-    </Panel>
-  </form>
+  <Panel>
+    <Panel.Section>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            label="Name"
+            name="name"
+            onChange={[Function]}
+            placeholder="My favorite recipients"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            label="Identifier"
+            name="id"
+            placeholder="my-favorite-recipients"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            label="Description"
+            name="description"
+            placeholder="All my favorite recipients"
+            validate={
+              Array [
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            fileType="csv"
+            helpText={
+              <span>
+                You can download a 
+                <DownloadLink
+                  href="example-recipient-list.csv"
+                >
+                  CSV template here
+                </DownloadLink>
+                 to use when formatting your recipient list for upload.
+              </span>
+            }
+            label="Upload a CSV file of recipients"
+            name="csv"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+    </Panel.Section>
+    <Panel.Section>
+      <Button
+        disabled={true}
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Create
+         Recipient List
+      </Button>
+    </Panel.Section>
+  </Panel>
 </div>
 `;
 
 exports[`RecipientListForm renders correctly in create mode 1`] = `
 <div>
-  <form>
-    <Panel>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          label="Label"
-          name="name"
-          placeholder="My favorite recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          label="Identifier"
-          name="id"
-          placeholder="my-favorite-recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          label="Description"
-          name="description"
-          placeholder="All my favorite recipients"
-          validate={
-            Array [
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          fileType="csv"
-          helpText={
-            <span>
-              You can download a 
-              <DownloadLink
-                href="example-recipient-list.csv"
-              >
-                CSV template here
-              </DownloadLink>
-               to use when formatting your recipient list for upload.
-            </span>
-          }
-          label="Upload a CSV file of recipients"
-          name="csv"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          disabled={true}
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Create
-           Recipient List
-        </Button>
-      </Panel.Section>
-    </Panel>
-  </form>
+  <Panel>
+    <Panel.Section>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            label="Name"
+            name="name"
+            onChange={[Function]}
+            placeholder="My favorite recipients"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            disabled={false}
+            label="Identifier"
+            name="id"
+            placeholder="my-favorite-recipients"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            label="Description"
+            name="description"
+            placeholder="All my favorite recipients"
+            validate={
+              Array [
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            fileType="csv"
+            helpText={
+              <span>
+                You can download a 
+                <DownloadLink
+                  href="example-recipient-list.csv"
+                >
+                  CSV template here
+                </DownloadLink>
+                 to use when formatting your recipient list for upload.
+              </span>
+            }
+            label="Upload a CSV file of recipients"
+            name="csv"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+    </Panel.Section>
+    <Panel.Section>
+      <Button
+        disabled={true}
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Create
+         Recipient List
+      </Button>
+    </Panel.Section>
+  </Panel>
 </div>
 `;
 
-exports[`RecipientListForm renders correctly in edit mode 1`] = `
+exports[`RecipientListForm should disable form elements during submit 1`] = `
 <div>
-  <form>
-    <Panel>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          label="Label"
-          name="name"
-          placeholder="My favorite recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          label="Description"
-          name="description"
-          placeholder="All my favorite recipients"
-          validate={
-            Array [
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          fileType="csv"
-          helpText={
-            <span>
-              You can download a 
-              <DownloadLink
-                href="example-recipient-list.csv"
-              >
-                CSV template here
-              </DownloadLink>
-               to use when formatting your recipient list for upload.
-            </span>
-          }
-          label="Optional: Upload a CSV file of recipients to replace the existing recipients in this list"
-          name="csv"
-          required={true}
-          validate={
-            Array [
-              [Function],
-            ]
-          }
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          disabled={true}
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Update
-           Recipient List
-        </Button>
-      </Panel.Section>
-    </Panel>
-  </form>
+  <Panel>
+    <Panel.Section>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            disabled={true}
+            label="Name"
+            name="name"
+            onChange={[Function]}
+            placeholder="My favorite recipients"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            disabled={true}
+            label="Identifier"
+            name="id"
+            placeholder="my-favorite-recipients"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            disabled={true}
+            label="Description"
+            name="description"
+            placeholder="All my favorite recipients"
+            validate={
+              Array [
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+      <Grid
+        className="Spacer"
+      >
+        <Grid.Column>
+          <Field
+            component={[Function]}
+            disabled={true}
+            fileType="csv"
+            helpText={
+              <span>
+                You can download a 
+                <DownloadLink
+                  href="example-recipient-list.csv"
+                >
+                  CSV template here
+                </DownloadLink>
+                 to use when formatting your recipient list for upload.
+              </span>
+            }
+            label="Upload a CSV file of recipients"
+            name="csv"
+            required={true}
+            validate={
+              Array [
+                [Function],
+                [Function],
+              ]
+            }
+          />
+        </Grid.Column>
+      </Grid>
+    </Panel.Section>
+    <Panel.Section>
+      <Button
+        disabled={true}
+        primary={true}
+        size="default"
+        submit={true}
+      >
+        Create
+         Recipient List
+      </Button>
+    </Panel.Section>
+  </Panel>
 </div>
 `;
-
-exports[`RecipientListForm should disable form elements on submit 1`] = `
-<div>
-  <form>
-    <Panel>
-      <Panel.Section>
-        <Field
-          component={[Function]}
-          disabled={true}
-          label="Label"
-          name="name"
-          placeholder="My favorite recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          disabled={true}
-          label="Identifier"
-          name="id"
-          placeholder="my-favorite-recipients"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          disabled={true}
-          label="Description"
-          name="description"
-          placeholder="All my favorite recipients"
-          validate={
-            Array [
-              [Function],
-            ]
-          }
-        />
-        <Field
-          component={[Function]}
-          disabled={true}
-          fileType="csv"
-          helpText={
-            <span>
-              You can download a 
-              <DownloadLink
-                href="example-recipient-list.csv"
-              >
-                CSV template here
-              </DownloadLink>
-               to use when formatting your recipient list for upload.
-            </span>
-          }
-          label="Upload a CSV file of recipients"
-          name="csv"
-          required={true}
-          validate={
-            Array [
-              [Function],
-              [Function],
-            ]
-          }
-        />
-      </Panel.Section>
-      <Panel.Section>
-        <Button
-          disabled={true}
-          primary={true}
-          size="default"
-          submit={true}
-        >
-          Create
-           Recipient List
-        </Button>
-      </Panel.Section>
-    </Panel>
-  </form>
-</div>
-`;
-
-exports[`RecipientListForm should throw on submit if CSV parsing fails 1`] = `[SubmissionError: Submit Validation Failed]`;

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientsCollection.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientsCollection.test.js.snap
@@ -9,11 +9,11 @@ exports[`RecipientsCollection renders collection correctly 1`] = `
       Array [
         Object {
           "label": "Address",
-          "sortKey": "email",
+          "sortKey": "address.email",
         },
         Object {
           "label": "Name",
-          "sortKey": "name",
+          "sortKey": "address.name",
         },
       ]
     }
@@ -37,6 +37,7 @@ exports[`RecipientsCollection renders collection correctly 1`] = `
         },
       ]
     }
+    saveCsv={false}
   />
 </Panel>
 `;

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientsCollection.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientsCollection.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RecipientsCollection renders collection correctly 1`] = `
+<Panel
+  title="Preview Contacts"
+>
+  <TableCollection
+    columns={
+      Array [
+        Object {
+          "label": "Address",
+          "sortKey": "email",
+        },
+        Object {
+          "label": "Name",
+          "sortKey": "name",
+        },
+      ]
+    }
+    defaultSortColumn={null}
+    defaultSortDirection="asc"
+    getRowData={[Function]}
+    pagination={true}
+    rows={
+      Array [
+        Object {
+          "address": Object {
+            "email": "foo@domain.com",
+            "name": "foo",
+          },
+        },
+        Object {
+          "address": Object {
+            "email": "bar@domain.com",
+            "name": "bar",
+          },
+        },
+      ]
+    }
+  />
+</Panel>
+`;

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientsCollection.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientsCollection.test.js.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RecipientsCollection renders collection correctly 1`] = `
-<Panel
-  title="Preview Contacts"
->
+<Fragment>
+  <h1>
+    Preview Contacts
+  </h1>
   <TableCollection
     columns={
       Array [
@@ -39,5 +40,5 @@ exports[`RecipientsCollection renders collection correctly 1`] = `
     }
     saveCsv={false}
   />
-</Panel>
+</Fragment>
 `;

--- a/src/pages/recipientLists/tests/CreatePage.test.js
+++ b/src/pages/recipientLists/tests/CreatePage.test.js
@@ -27,6 +27,13 @@ describe('CreatePage', () => {
 
 
   describe('parseCsv', () => {
+    const csvErrors = [
+      'Line 73: Too many notes',
+      'Line 247: Vanilla is unacceptable'
+    ];
+
+    const recipients = [{ address: { name: 'foo', email: 'foo@domain.com' }}];
+
     it('parses CSV when CSV is uploaded', () => {
       parseRecipientListCsv.mockImplementationOnce(() => Promise.resolve());
       wrapper.setProps({ csv: 'fooCSV' });
@@ -34,21 +41,23 @@ describe('CreatePage', () => {
     });
 
     it('saves recipients when valid', async () => {
-      const recipients = [{ address: { name: 'foo', email: 'foo@domain.com' }}];
       parseRecipientListCsv.mockImplementationOnce(() => Promise.resolve(recipients));
       await wrapper.instance().parseCsv();
       expect(wrapper.state('recipients')).toEqual(recipients);
     });
 
     it('alerts errors on parsing error', async () => {
-      const csvErrors = [
-        'Line 73: Too many notes',
-        'Line 247: Vanilla is unacceptable'
-      ];
-
       parseRecipientListCsv.mockImplementationOnce(() => Promise.reject(csvErrors));
       await wrapper.instance().parseCsv();
       expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: csvErrors });
+    });
+
+    it('resets current recipients when new csv can not be parsed', async () => {
+      wrapper.setState({ recipients });
+      expect(wrapper.state('recipients')).toEqual(recipients);
+      parseRecipientListCsv.mockImplementationOnce(() => Promise.reject(csvErrors));
+      await wrapper.instance().parseCsv();
+      expect(wrapper.state('recipients')).toEqual([]);
     });
   });
 

--- a/src/pages/recipientLists/tests/CreatePage.test.js
+++ b/src/pages/recipientLists/tests/CreatePage.test.js
@@ -2,25 +2,55 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { CreatePage } from '../CreatePage';
+import parseRecipientListCsv from '../helpers/csv';
+
+jest.mock('../helpers/csv');
 
 describe('CreatePage', () => {
   let props;
+  let wrapper;
 
   beforeEach(() => {
     props = {
-      createRecipientList: jest.fn(() => Promise.resolve()),
+      createRecipientList: jest.fn((args) => Promise.resolve({ id: args.id })),
       showAlert: jest.fn(),
-      history: { push: jest.fn() }
+      history: { push: jest.fn() },
+      handleSubmit: jest.fn()
     };
+
+    wrapper = shallow(<CreatePage {...props} />);
   });
 
   it('should render correctly', () => {
-    expect(shallow(<CreatePage />)).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 
-  it('should create a recipient list', async() => {
-    const wrapper = shallow(<CreatePage {...props} />);
-    await wrapper.instance().createRecipientList();
-    expect(props.createRecipientList).toHaveBeenCalled();
+
+  describe('parseCsv', () => {
+    it('saves recipients when valid', async () => {
+      const recipients = [{ address: { name: 'foo', email: 'foo@domain.com' }}];
+      parseRecipientListCsv.mockImplementationOnce(() => Promise.resolve(recipients));
+      await wrapper.instance().parseCsv();
+      expect(wrapper.state('recipients')).toEqual(recipients);
+    });
+
+    it('alerts errors on parsing error', async () => {
+      const csvErrors = [
+        'Line 73: Too many notes',
+        'Line 247: Vanilla is unacceptable'
+      ];
+
+      parseRecipientListCsv.mockImplementationOnce(() => Promise.reject(csvErrors));
+      await wrapper.instance().parseCsv();
+      expect(props.showAlert).toHaveBeenCalledWith({ type: 'error', message: csvErrors });
+    });
+  });
+
+  describe('createRecipientsList', () => {
+    it('should POST with recipients & without csv prop', async () => {
+      const data = { name: 'Foo', id: 'foo', description: 'foo bar', csv: 'hello' };
+      await wrapper.instance().createRecipientsList(data);
+      expect(props.createRecipientList).toHaveBeenCalledWith({ name: 'Foo', id: 'foo', description: 'foo bar', recipients: []});
+    });
   });
 });

--- a/src/pages/recipientLists/tests/EditPage.test.js
+++ b/src/pages/recipientLists/tests/EditPage.test.js
@@ -11,6 +11,7 @@ describe('EditPage', () => {
   beforeEach(() => {
     id = 'fave-recipients';
     props = {
+      handleSubmit: jest.fn(),
       match: { params: { id }},
       list: [{
         id,
@@ -41,25 +42,13 @@ describe('EditPage', () => {
   });
 
   it('should load a recipient list', () => {
-    const propsLoading = {
-      ...props,
-      current: null,
-      loading: true
-    };
-
-    const wrapper = shallow(<EditPage {...propsLoading} />);
-    expect(wrapper).toMatchSnapshot();
+    wrapper.setProps({ current: null, loading: true });
     expect(props.getRecipientList).toHaveBeenCalled();
   });
 
-  it('should handle a missing list id', async() => {
+  it('should handle a missing list id', async () => {
     props.getRecipientList.mockImplementationOnce(() => Promise.reject());
-    const propsLoading = {
-      ...props,
-      current: null,
-      loading: true
-    };
-    const wrapper = shallow(<EditPage {...propsLoading} />);
+    wrapper.setProps({ current: null, loading: true });
     await wrapper.instance().componentDidMount();
     expect(props.history.push).toHaveBeenCalledWith('/lists/recipient-lists');
   });
@@ -67,27 +56,27 @@ describe('EditPage', () => {
   it('should show a delete modal', () => {
     wrapper.instance().toggleDelete();
     wrapper.update();
-    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('DeleteModal')).toMatchSnapshot();
   });
 
-  it('should delete a recipient list', async() => {
+  it('should delete a recipient list', async () => {
     await wrapper.instance().deleteRecipientList();
     expect(props.deleteRecipientList).toHaveBeenCalled();
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should redirect after delete', async() => {
+  it('should redirect after delete', async () => {
     await wrapper.instance().deleteRecipientList();
     expect(props.history.push).toHaveBeenCalled();
   });
 
-  it('should update a recipient list', async() => {
+  it('should update a recipient list', async () => {
     await wrapper.instance().updateRecipientList();
     expect(props.updateRecipientList).toHaveBeenCalled();
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should redirect after update', async() => {
+  it('should redirect after update', async () => {
     await wrapper.instance().updateRecipientList();
     expect(props.history.push).toHaveBeenCalled();
   });

--- a/src/pages/recipientLists/tests/__snapshots__/CreatePage.test.js.snap
+++ b/src/pages/recipientLists/tests/__snapshots__/CreatePage.test.js.snap
@@ -16,10 +16,6 @@ exports[`CreatePage should render correctly 1`] = `
     <RecipientsListForm
       formName="recipientListForm"
     />
-    <RecipientsCollection
-      hasCsv={false}
-      recipients={Array []}
-    />
   </form>
 </Page>
 `;

--- a/src/pages/recipientLists/tests/__snapshots__/CreatePage.test.js.snap
+++ b/src/pages/recipientLists/tests/__snapshots__/CreatePage.test.js.snap
@@ -12,8 +12,14 @@ exports[`CreatePage should render correctly 1`] = `
   empty={Object {}}
   title="Create Recipient List"
 >
-  <Connect(ReduxForm)
-    onSubmit={[Function]}
-  />
+  <form>
+    <RecipientsListForm
+      formName="recipientListForm"
+    />
+    <RecipientsCollection
+      hasCsv={false}
+      recipients={Array []}
+    />
+  </form>
 </Page>
 `;

--- a/src/pages/recipientLists/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/recipientLists/tests/__snapshots__/EditPage.test.js.snap
@@ -20,10 +20,12 @@ exports[`EditPage should delete a recipient list 1`] = `
   }
   title="Update Recipient List"
 >
-  <Connect(ReduxForm)
-    editMode={true}
-    onSubmit={[Function]}
-  />
+  <form>
+    <RecipientsListForm
+      editMode={true}
+      formName="recipientListForm"
+    />
+  </form>
   <DeleteModal
     content={
       <p>
@@ -37,8 +39,6 @@ exports[`EditPage should delete a recipient list 1`] = `
   />
 </Page>
 `;
-
-exports[`EditPage should load a recipient list 1`] = `<Loading />`;
 
 exports[`EditPage should render correctly 1`] = `
 <Page
@@ -60,10 +60,12 @@ exports[`EditPage should render correctly 1`] = `
   }
   title="Update Recipient List"
 >
-  <Connect(ReduxForm)
-    editMode={true}
-    onSubmit={[Function]}
-  />
+  <form>
+    <RecipientsListForm
+      editMode={true}
+      formName="recipientListForm"
+    />
+  </form>
   <DeleteModal
     content={
       <p>
@@ -79,41 +81,17 @@ exports[`EditPage should render correctly 1`] = `
 `;
 
 exports[`EditPage should show a delete modal 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "Recipient Lists",
-      "to": "/lists/recipient-lists",
-    }
+<DeleteModal
+  content={
+    <p>
+      The recipient list will be immediately and permanently removed. This cannot be undone.
+    </p>
   }
-  empty={Object {}}
-  secondaryActions={
-    Array [
-      Object {
-        "content": "Delete",
-        "onClick": [Function],
-      },
-    ]
-  }
-  title="Update Recipient List"
->
-  <Connect(ReduxForm)
-    editMode={true}
-    onSubmit={[Function]}
-  />
-  <DeleteModal
-    content={
-      <p>
-        The recipient list will be immediately and permanently removed. This cannot be undone.
-      </p>
-    }
-    onCancel={[Function]}
-    onDelete={[Function]}
-    open={true}
-    title="Are you sure you want to delete this recipient list?"
-  />
-</Page>
+  onCancel={[Function]}
+  onDelete={[Function]}
+  open={true}
+  title="Are you sure you want to delete this recipient list?"
+/>
 `;
 
 exports[`EditPage should update a recipient list 1`] = `
@@ -136,10 +114,12 @@ exports[`EditPage should update a recipient list 1`] = `
   }
   title="Update Recipient List"
 >
-  <Connect(ReduxForm)
-    editMode={true}
-    onSubmit={[Function]}
-  />
+  <form>
+    <RecipientsListForm
+      editMode={true}
+      formName="recipientListForm"
+    />
+  </form>
   <DeleteModal
     content={
       <p>


### PR DESCRIPTION

### What Changed
 - Moved redux form decoration to Create/Edit page (parent component) so after upload recipients can be managed from parent component
- Update create page according to mock
- Update edit page briefly (more to do on relevant ticket)
<img width="1000" alt="Screen Shot 2019-05-20 at 10 24 14 AM" src="https://user-images.githubusercontent.com/14877079/58028791-71662900-7ae9-11e9-90b3-fdefdb4af6b8.png">
- Unlike past, CSV will be uploaded as soon as file is selected

### How/What to test
- Create a new recipient list with upload
  -- Upon upload you should see the recipients preview below
- Edit list should work as usual 

### Notes
There are some improvements needed on Edit page, which i'll do in the relevant ticket that's coming next. 