### PR TITLE
TR-1207: Mobile previewing of prototype fullscreen code editor

### DIFF
--- a/src/pages/templates/components/EditSection.js
+++ b/src/pages/templates/components/EditSection.js
@@ -10,6 +10,7 @@ const EditSection = () => {
   return (
     <Panel>
       <Tabs
+        color="blue"
         selected={currentTabIndex}
         onSelect={(nextTabIndex) => { setTab(nextTabIndex); }}
         tabs={tabs.map(({ render, routeKey, ...tab }) => tab)}

--- a/src/pages/templates/components/PreviewContainer.js
+++ b/src/pages/templates/components/PreviewContainer.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import classNames from 'classnames';
+import useEditorContext from '../hooks/useEditorContext';
+import styles from './PreviewContainer.module.scss';
+// <div className={classNames(styles.PreviewFrameWrapper, 'notranslate')}>
+
+const PreviewContainer = ({ children }) => {
+  const { previewDevice } = useEditorContext();
+
+  if (previewDevice === 'mobile') {
+    return (
+      <div className={classNames(styles.PreviewMobileContainer, 'notranslate')}>
+        <div className={styles.PreviewMobilePhone}>
+          <div className={styles.PreviewMobilePhoneScreen}>
+            {children}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classNames(styles.PreviewContainer, 'notranslate')}>
+      {children}
+    </div>
+  );
+};
+
+export default PreviewContainer;

--- a/src/pages/templates/components/PreviewContainer.module.scss
+++ b/src/pages/templates/components/PreviewContainer.module.scss
@@ -1,0 +1,32 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.PreviewContainer {
+  height: 550px;
+  min-height: 50vh;
+  overflow-y: scroll;
+  position: relative;
+}
+
+.PreviewMobileContainer {
+  padding: spacing(larger) 0;
+}
+
+.PreviewMobilePhone {
+  background: color(grey, 9);
+  border: 1px solid color(grey, 8);
+  border-radius: 20px;
+  height: 736px + 40px + 80px + 2px;
+  margin: 0 auto;
+  padding: 40px 10px 80px 10px;
+  width: 414px + 10px + 10px + 2px;
+}
+
+.PreviewMobilePhoneScreen {
+  background: white;
+  border: 1px solid color(grey, 8);
+  border-radius: 2px;
+  height: 100%;
+  overflow-y: scroll;
+  position: relative;
+  width: 100%;
+}

--- a/src/pages/templates/components/PreviewControlBar.js
+++ b/src/pages/templates/components/PreviewControlBar.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import classNames from 'classnames';
+import { UnstyledLink } from '@sparkpost/matchbox';
+import { DesktopWindows, PhoneAndroid } from '@sparkpost/matchbox-icons';
+import useEditorContext from '../hooks/useEditorContext';
+import styles from './PreviewControlBar.module.scss';
+
+const PreviewControlBar = () => {
+  const { previewDevice, setPreviewDevice } = useEditorContext();
+
+  return (
+    <div className={styles.PreviewControlBar}>
+      <div className={styles.PreviewDeviceToggle}>
+        <UnstyledLink
+          children={<DesktopWindows size={24} />}
+          className={classNames(styles.PreviewDeviceButton, previewDevice === 'desktop' && styles.active)}
+          id="preview-content-desktop-button"
+          onClick={() => { setPreviewDevice('desktop'); }}
+        />
+        <UnstyledLink
+          children={<PhoneAndroid size={24} />}
+          className={classNames(styles.PreviewDeviceButton, previewDevice === 'mobile' && styles.active)}
+          id="preview-content-mobile-button"
+          onClick={() => { setPreviewDevice('mobile'); }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PreviewControlBar;

--- a/src/pages/templates/components/PreviewControlBar.module.scss
+++ b/src/pages/templates/components/PreviewControlBar.module.scss
@@ -1,0 +1,22 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.PreviewControlBar {
+  border-bottom: 1px solid color(gray, 8);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 50px; // must match height of left panel
+}
+
+.PreviewDeviceToggle {
+  margin-left: spacing();
+}
+
+.PreviewDeviceButton {
+  color: color(gray, 4); // to match default text
+  margin-right: spacing();
+
+  &.active {
+    color: color(blue);
+  }
+}

--- a/src/pages/templates/components/PreviewSection.js
+++ b/src/pages/templates/components/PreviewSection.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Panel } from '@sparkpost/matchbox';
-import classNames from 'classnames';
 import useEditorContext from '../hooks/useEditorContext';
 import PreviewErrorFrame from './PreviewErrorFrame';
 import PreviewControlBar from './PreviewControlBar';
 import PreviewFrame from './PreviewFrame';
-import styles from './PreviewSection.module.scss';
+import PreviewContainer from './PreviewContainer';
 
 const PreviewSection = () => {
   const { currentTabKey, hasFailedToPreview, preview, previewLineErrors } = useEditorContext();
@@ -18,7 +17,7 @@ const PreviewSection = () => {
   return (
     <Panel>
       <PreviewControlBar />
-      <div className={classNames(styles.PreviewFrameWrapper, 'notranslate')}>
+      <PreviewContainer>
         {hasFailedToPreview ? (
           // only show full error frame if never able to generate a preview
           <PreviewErrorFrame errors={previewLineErrors} />
@@ -29,7 +28,7 @@ const PreviewSection = () => {
             strict={currentTabKey !== 'amp_html'}
           />
         )}
-      </div>
+      </PreviewContainer>
     </Panel>
   );
 };

--- a/src/pages/templates/components/PreviewSection.js
+++ b/src/pages/templates/components/PreviewSection.js
@@ -3,6 +3,7 @@ import { Panel } from '@sparkpost/matchbox';
 import classNames from 'classnames';
 import useEditorContext from '../hooks/useEditorContext';
 import PreviewErrorFrame from './PreviewErrorFrame';
+import PreviewControlBar from './PreviewControlBar';
 import PreviewFrame from './PreviewFrame';
 import styles from './PreviewSection.module.scss';
 
@@ -16,6 +17,7 @@ const PreviewSection = () => {
 
   return (
     <Panel>
+      <PreviewControlBar />
       <div className={classNames(styles.PreviewFrameWrapper, 'notranslate')}>
         {hasFailedToPreview ? (
           // only show full error frame if never able to generate a preview

--- a/src/pages/templates/components/PreviewSection.module.scss
+++ b/src/pages/templates/components/PreviewSection.module.scss
@@ -1,6 +1,0 @@
-.PreviewFrameWrapper {
-  height: 550px;
-  min-height: 50vh;
-  overflow-y: scroll;
-  position: relative;
-}

--- a/src/pages/templates/components/tests/PreviewContainer.test.js
+++ b/src/pages/templates/components/tests/PreviewContainer.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import useEditorContext from '../../hooks/useEditorContext';
+import PreviewContainer from '../PreviewContainer';
+
+jest.mock('../../hooks/useEditorContext');
+
+describe('PreviewContainer', () => {
+  const subject = ({ editorState } = {}) => {
+    useEditorContext.mockReturnValue({ previewDevice: 'desktop', ...editorState });
+    return shallow(<PreviewContainer children={<div>Example</div>} />);
+  };
+
+  it('renders desktop container', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('renders mobile container', () => {
+    expect(subject({ editorState: { previewDevice: 'mobile' }})).toMatchSnapshot();
+  });
+});

--- a/src/pages/templates/components/tests/PreviewControlBar.test.js
+++ b/src/pages/templates/components/tests/PreviewControlBar.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import useEditorContext from '../../hooks/useEditorContext';
+import PreviewControlBar from '../PreviewControlBar';
+
+jest.mock('../../hooks/useEditorContext');
+
+describe('PreviewControlBar', () => {
+  const subject = ({ editorState } = {}) => {
+    useEditorContext.mockReturnValue({
+      previewDevice: 'desktop',
+      ...editorState
+    });
+    return shallow(<PreviewControlBar />);
+  };
+
+  it('renders control bar', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('calls setPreviewDevice when desktop button is clicked', () => {
+    const setPreviewDevice = jest.fn();
+    const wrapper = subject({ editorState: { setPreviewDevice }});
+
+    wrapper.find('#preview-content-desktop-button').simulate('click');
+
+    expect(setPreviewDevice).toHaveBeenCalledWith('desktop');
+  });
+
+  it('calls setPreviewDevice when mobile button is clicked', () => {
+    const setPreviewDevice = jest.fn();
+    const wrapper = subject({ editorState: { setPreviewDevice }});
+
+    wrapper.find('#preview-content-mobile-button').simulate('click');
+
+    expect(setPreviewDevice).toHaveBeenCalledWith('mobile');
+  });
+});

--- a/src/pages/templates/components/tests/__snapshots__/EditSection.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/EditSection.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EditSection renders tabs and section 1`] = `
 <Panel>
   <Tabs
-    color="orange"
+    color="blue"
     connectBelow={true}
     onSelect={[Function]}
     selected={0}

--- a/src/pages/templates/components/tests/__snapshots__/PreviewContainer.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewContainer.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewContainer renders desktop container 1`] = `
+<div
+  className="PreviewContainer notranslate"
+>
+  <div>
+    Example
+  </div>
+</div>
+`;
+
+exports[`PreviewContainer renders mobile container 1`] = `
+<div
+  className="PreviewMobileContainer notranslate"
+>
+  <div
+    className="PreviewMobilePhone"
+  >
+    <div
+      className="PreviewMobilePhoneScreen"
+    >
+      <div>
+        Example
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/templates/components/tests/__snapshots__/PreviewControlBar.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewControlBar.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewControlBar renders control bar 1`] = `
+<div
+  className="PreviewControlBar"
+>
+  <div
+    className="PreviewDeviceToggle"
+  >
+    <UnstyledLink
+      className="PreviewDeviceButton active"
+      id="preview-content-desktop-button"
+      onClick={[Function]}
+    >
+      <DesktopWindows
+        size={24}
+      />
+    </UnstyledLink>
+    <UnstyledLink
+      className="PreviewDeviceButton"
+      id="preview-content-mobile-button"
+      onClick={[Function]}
+    >
+      <PhoneAndroid
+        size={24}
+      />
+    </UnstyledLink>
+  </div>
+</div>
+`;

--- a/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`PreviewSection renders preview frame 1`] = `
 <Panel>
+  <PreviewControlBar />
   <div
     className="PreviewFrameWrapper notranslate"
   >

--- a/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
@@ -3,14 +3,12 @@
 exports[`PreviewSection renders preview frame 1`] = `
 <Panel>
   <PreviewControlBar />
-  <div
-    className="PreviewFrameWrapper notranslate"
-  >
+  <PreviewContainer>
     <PreviewFrame
       content="<h1>Test Example</h1>"
       key="html"
       strict={true}
     />
-  </div>
+  </PreviewContainer>
 </Panel>
 `;

--- a/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
+++ b/src/pages/templates/context/tests/__snapshots__/EditorContext.test.js.snap
@@ -7,7 +7,9 @@ exports[`EditorContext EditorContextProvider renders children wrapped by a conte
       "content": Object {},
       "currentTabIndex": 0,
       "currentTabKey": "html",
+      "previewDevice": "desktop",
       "setContent": [Function],
+      "setPreviewDevice": [Function],
       "setTab": [Function],
     }
   }

--- a/src/pages/templates/hooks/tests/useEditorPreview.test.js
+++ b/src/pages/templates/hooks/tests/useEditorPreview.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import useEditorPreview from '../useEditorPreview';
 
@@ -11,7 +12,10 @@ describe('useEditorPreview', () => {
 
   it('returns empty object by default', () => {
     const wrapper = useTestWrapper();
-    expect(useHook(wrapper)).toEqual({});
+    expect(useHook(wrapper)).toEqual({
+      previewDevice: 'desktop',
+      setPreviewDevice: expect.any(Function)
+    });
   });
 
   it('calls getPreview when content changes', () => {
@@ -44,5 +48,15 @@ describe('useEditorPreview', () => {
     wrapper.unmount();
 
     expect(debounceAction.cancel).toHaveBeenCalled();
+  });
+
+  it('sets previewDevice', () => {
+    const wrapper = useTestWrapper();
+
+    act(() => {
+      useHook(wrapper).setPreviewDevice('mobile');
+    });
+
+    expect(useHook(wrapper)).toHaveProperty('previewDevice', 'mobile');
   });
 });

--- a/src/pages/templates/hooks/useEditorPreview.js
+++ b/src/pages/templates/hooks/useEditorPreview.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
 
@@ -13,6 +13,8 @@ const useEditorPreview = ({
   getPreview,
   debounceAction = debouncer
 }) => {
+  const [previewDevice, setPreviewDevice] = useState('desktop');
+
   useEffect(() => {
     if (!isEmpty(content)) {
       debounceAction(() => {
@@ -30,7 +32,10 @@ const useEditorPreview = ({
   // clean-up debounced state when unmounted
   useEffect(() => () => { debounceAction.cancel(); }, [debounceAction]);
 
-  return {};
+  return {
+    previewDevice,
+    setPreviewDevice
+  };
 };
 
 export default useEditorPreview;


### PR DESCRIPTION
This is subtask [TR-1207](https://jira.int.messagesystems.com/browse/TR-1207) of [TR-1204](https://jira.int.messagesystems.com/browse/TR-1204).

### What Changed

- Toggle between desktop and mobile device view

<img width="1392" alt="Screen Shot 2019-05-20 at 3 09 15 PM" src="https://user-images.githubusercontent.com/1335605/58046166-8c00c800-7b12-11e9-86ac-fcbfa2bc9873.png">

*** The height and pixel ratio of the PreviewFrame will be fixed in TR-1452.

### How To Test

- Open a template and click between device buttons
