### PR TITLE
FE-680: Ad blocker message

### DIFF
--- a/src/actions/helpers/sparkpostApiError.js
+++ b/src/actions/helpers/sparkpostApiError.js
@@ -4,12 +4,10 @@ import _ from 'lodash';
 function SparkpostApiError(error) {
   const apiError = _.get(error, 'response.data.errors[0]', {});
 
-  if (!error.response) {
-    error.message = 'You may be having network issues or an adblocker may be blocking part of the app.';
-  }
   this.name = 'SparkpostApiError';
-  this.message = apiError.description || apiError.message || error.message;
   this.stack = error.stack; // must manually assign prototype value
+  this.message = apiError.description || apiError.message ||
+    (error.response ? error.message : 'You may be having network issues or an adblocker may be blocking part of the app.');
 
   // Intentionally assigning additional properties
   Object.assign(this, error);

--- a/src/actions/helpers/sparkpostApiError.js
+++ b/src/actions/helpers/sparkpostApiError.js
@@ -4,6 +4,9 @@ import _ from 'lodash';
 function SparkpostApiError(error) {
   const apiError = _.get(error, 'response.data.errors[0]', {});
 
+  if (!error.response) {
+    error.message = 'You may be having network issues or an adblocker may be blocking part of the app.';
+  }
   this.name = 'SparkpostApiError';
   this.message = apiError.description || apiError.message || error.message;
   this.stack = error.stack; // must manually assign prototype value

--- a/src/actions/helpers/tests/sparkpostApiError.test.js
+++ b/src/actions/helpers/tests/sparkpostApiError.test.js
@@ -1,7 +1,7 @@
 import SparkpostApiError from '../sparkpostApiError';
 
 function createTestError(sugar = {}) {
-  const error = new Error('Oh no!');
+  const error = new Error();
   return new SparkpostApiError(Object.assign(error, sugar));
 }
 
@@ -23,7 +23,7 @@ describe('SparkpostApiError', () => {
 
   it('returns error message', () => {
     const error = createTestError();
-    expect(error).toHaveProperty('message', 'Oh no!');
+    expect(error).toHaveProperty('message', 'You may be having network issues or an adblocker may be blocking part of the app.');
   });
 
   it('returns api error message', () => {

--- a/src/actions/helpers/tests/sparkpostApiError.test.js
+++ b/src/actions/helpers/tests/sparkpostApiError.test.js
@@ -1,7 +1,7 @@
 import SparkpostApiError from '../sparkpostApiError';
 
 function createTestError(sugar = {}) {
-  const error = new Error();
+  const error = new Error('Oh No!');
   return new SparkpostApiError(Object.assign(error, sugar));
 }
 
@@ -22,6 +22,11 @@ describe('SparkpostApiError', () => {
   });
 
   it('returns error message', () => {
+    const error = createTestError({ response: { status: 400 }});
+    expect(error).toHaveProperty('message', 'Oh No!');
+  });
+
+  it('returns a network error if no axios response', () => {
     const error = createTestError();
     expect(error).toHaveProperty('message', 'You may be having network issues or an adblocker may be blocking part of the app.');
   });


### PR DESCRIPTION
### What Changed
 - If SparkpostAPIError is missing response (when blocked request), show new message

### How To Test
 - Block request or go to `/reports/summary` w/ ad blocker
 - Error message should address adblock or network issue
 
### To Do
- [ ] Address feedback
