### PR TITLE
TR-1452: Preview subject and from for prototype fullscreen code editor

### DIFF
--- a/src/pages/templates/components/PreviewHeader.js
+++ b/src/pages/templates/components/PreviewHeader.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import isEmpty from 'lodash/isEmpty';
+import { Person } from '@sparkpost/matchbox-icons';
+import useEditorContext from '../hooks/useEditorContext';
+import styles from './PreviewHeader.module.scss';
+
+const PreviewHeader = () => {
+  const { preview } = useEditorContext();
+
+  if (isEmpty(preview)) {
+    return null;
+  }
+
+  return (
+    <div className={styles.PreviewHeader}>
+      <div className={styles.PreviewHeaderSubject}>
+        {preview.subject}
+      </div>
+      <div className={styles.PreviewHeaderContact}>
+        <div className={styles.PreviewHeaderAvatar}>
+          <Person color="white" size={50} />
+        </div>
+        <div className={styles.PreviewHeaderAddresses}>
+          <div className={styles.PreviewHeaderFrom}>
+            {!preview.from.name ? (
+              <strong>{preview.from.email}</strong>
+            ) : (
+              <>
+                <strong>{preview.from.name}</strong>
+                <span>{' '}</span>
+                <span>{`<${preview.from.email}>`}</span>
+              </>
+            )}
+          </div>
+          <div className={styles.PreviewHeaderTo}>
+            to me
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PreviewHeader;

--- a/src/pages/templates/components/PreviewHeader.module.scss
+++ b/src/pages/templates/components/PreviewHeader.module.scss
@@ -1,0 +1,34 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.PreviewHeader {
+  border-bottom: 1px solid color(grey, 8); // must match PreviewContainers
+  padding: spacing();
+}
+
+.PreviewHeaderSubject {
+  border-bottom: 1px solid color(grey, 8);
+  font-size: rem(18);
+  padding-bottom: spacing();
+}
+
+.PreviewHeaderContact {
+  display: flex;
+  padding-top: spacing();
+}
+
+.PreviewHeaderAvatar {
+  background: color(grey, 8);
+  border-radius: 2px;
+}
+
+.PreviewHeaderAddresses {
+  min-width: 0;
+  padding-left: spacing();
+  position: relative;
+}
+
+.PreviewHeaderFrom {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/pages/templates/components/PreviewHeader.module.scss
+++ b/src/pages/templates/components/PreviewHeader.module.scss
@@ -1,7 +1,6 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 .PreviewHeader {
-  border-bottom: 1px solid color(grey, 8); // must match PreviewContainers
   padding: spacing();
 }
 

--- a/src/pages/templates/components/PreviewSection.js
+++ b/src/pages/templates/components/PreviewSection.js
@@ -4,6 +4,7 @@ import useEditorContext from '../hooks/useEditorContext';
 import PreviewErrorFrame from './PreviewErrorFrame';
 import PreviewControlBar from './PreviewControlBar';
 import PreviewFrame from './PreviewFrame';
+import PreviewHeader from './PreviewHeader';
 import PreviewContainer from './PreviewContainer';
 import styles from './PreviewSection.module.scss';
 
@@ -23,11 +24,14 @@ const PreviewSection = () => {
           // only show full error frame if never able to generate a preview
           <PreviewErrorFrame errors={previewLineErrors} />
         ) : (
-          <PreviewFrame
-            content={content || ''}
-            key={currentTabKey} // unmount for each content part
-            strict={currentTabKey !== 'amp_html'}
-          />
+          <>
+            <PreviewHeader />
+            <PreviewFrame
+              content={content || ''}
+              key={currentTabKey} // unmount for each content part
+              strict={currentTabKey !== 'amp_html'}
+            />
+          </>
         )}
       </PreviewContainer>
     </Panel>

--- a/src/pages/templates/components/tests/PreviewHeader.test.js
+++ b/src/pages/templates/components/tests/PreviewHeader.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import useEditorContext from '../../hooks/useEditorContext';
+import PreviewHeader from '../PreviewHeader';
+
+jest.mock('../../hooks/useEditorContext');
+
+describe('PreviewHeader', () => {
+  const subject = ({ editorState } = {}) => {
+    useEditorContext.mockReturnValue({
+      preview: {
+        subject: 'Example Subject',
+        from: {
+          email: 'test@example.com',
+          name: 'Test Name'
+        }
+      },
+      ...editorState
+    });
+
+    return shallow(<PreviewHeader />);
+  };
+
+  it('renders preview header', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('renders nothings without a preview', () => {
+    const wrapper = subject({ editorState: { preview: {}}});
+    expect(wrapper).toBeEmptyRender();
+  });
+
+  it('renders only email address when no name is provided', () => {
+    const wrapper = subject({
+      editorState: {
+        preview: {
+          subject: 'Example Subject',
+          from: { email: 'test@example.com' }
+        }
+      }
+    });
+
+    expect(wrapper.find('strong')).toHaveText('test@example.com');
+  });
+});

--- a/src/pages/templates/components/tests/__snapshots__/PreviewHeader.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewHeader.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewHeader renders preview header 1`] = `
+<div
+  className="PreviewHeader"
+>
+  <div
+    className="PreviewHeaderSubject"
+  >
+    Example Subject
+  </div>
+  <div
+    className="PreviewHeaderContact"
+  >
+    <div
+      className="PreviewHeaderAvatar"
+    >
+      <Person
+        color="white"
+        size={50}
+      />
+    </div>
+    <div
+      className="PreviewHeaderAddresses"
+    >
+      <div
+        className="PreviewHeaderFrom"
+      >
+        <strong>
+          Test Name
+        </strong>
+        <span>
+           
+        </span>
+        <span>
+          &lt;test@example.com&gt;
+        </span>
+      </div>
+      <div
+        className="PreviewHeaderTo"
+      >
+        to me
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/PreviewSection.test.js.snap
@@ -6,6 +6,7 @@ exports[`PreviewSection renders preview frame 1`] = `
 >
   <PreviewControlBar />
   <PreviewContainer>
+    <PreviewHeader />
     <PreviewFrame
       content="<h1>Test Example</h1>"
       key="html"


### PR DESCRIPTION
This is a subtask [TR-1452](https://jira.int.messagesystems.com/browse/TR-1452).

### What Changed

- Preview subject and from address in desktop preview

<img width="1392" alt="Screen Shot 2019-05-25 at 12 28 27 PM" src="https://user-images.githubusercontent.com/1335605/58372397-90e6c280-7eea-11e9-8f94-06245685540b.png">

- Preview subject and from address in mobile preview

<img width="1391" alt="Screen Shot 2019-05-25 at 12 28 17 PM" src="https://user-images.githubusercontent.com/1335605/58372401-96dca380-7eea-11e9-9895-cc47f8a9281b.png">

### How To Test

- Confirm subject renders
- Confirm long a from address truncates