### PR TITLE
EO-780 - Replace with RV "request access" page with the "add RV" page

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -156,14 +156,14 @@ export const PLAN_TIERS = {
 };
 
 export const RECIPIENT_VALIDATION_TIERS = [
-  { volumeMin: 0, volumeMax: 5000, cost: 0.01 },
-  { volumeMin: 5000, volumeMax: 10000, cost: 0.008 },
-  { volumeMin: 10000, volumeMax: 50000, cost: 0.006 },
-  { volumeMin: 50000, volumeMax: 100000, cost: 0.004 },
-  { volumeMin: 100000, volumeMax: 250000, cost: 0.003 },
-  { volumeMin: 250000, volumeMax: 750000, cost: 0.0015 },
-  { volumeMin: 750000, volumeMax: 1000000, cost: 0.001 },
-  { volumeMin: 1000000, volumeMax: Infinity, cost: 0.00075 }
+  { volumeMin: 0, volumeMax: 5000, cost: 0.01, displayedCost: '$0.010' },
+  { volumeMin: 5000, volumeMax: 10000, cost: 0.008, displayedCost: '$0.008' },
+  { volumeMin: 10000, volumeMax: 50000, cost: 0.006, displayedCost: '$0.006' },
+  { volumeMin: 50000, volumeMax: 100000, cost: 0.004, displayedCost: '$0.004' },
+  { volumeMin: 100000, volumeMax: 250000, cost: 0.003, displayedCost: '$0.003' },
+  { volumeMin: 250000, volumeMax: 750000, cost: 0.0015, displayedCost: '$0.0015' },
+  { volumeMin: 750000, volumeMax: 1000000, cost: 0.001, displayedCost: '$0.0010' },
+  { volumeMin: 1000000, volumeMax: Infinity, cost: 0.00075, displayedCost: '$0.00075' }
 ];
 
 export { ROLES, SUBACCOUNT_ROLES, ROLE_LABELS } from './users';

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -23,7 +23,6 @@ export class RecipientValidationPage extends Component {
   }
 
   renderRecipientValidation = () => {
-
     const { selectedTab } = this.state;
 
     return (
@@ -40,9 +39,9 @@ export class RecipientValidationPage extends Component {
         {selectedTab === 0 && <ListResults/>}
       </Page>
     );
-  }
-  render() {
+  };
 
+  render() {
     return (
       <ConditionSwitch>
         <Case condition={hasAccountOptionEnabled('recipient_validation')}>

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { Page, Panel, Table, Button, UnstyledLink } from '@sparkpost/matchbox';
+import { Page, Panel, Table, Button } from '@sparkpost/matchbox';
 import React from 'react';
 import styles from './RVDisabledPage.module.scss';
 import { currentPlanSelector } from 'src/selectors/accountBillingInfo';
@@ -66,13 +66,13 @@ export class RVDisabledPage extends Component {
     return rows;
   };
 
-  getActionButton = () => {
+  renderActionButton = () => {
     const { isSelfServeBilling, isFree } = this.props;
     if (!isSelfServeBilling) {
       return null;
     }
     return (isFree)
-      ? (<UnstyledLink component={Button} to={'/account/billing'} primary>Upgrade your plan</UnstyledLink>)
+      ? (<Button primary to={'/account/billing'}>Upgrade your plan</Button>)
       : (<Button primary onClick={this.enableRV}>Enable Recipient Validation</Button>);
   };
 
@@ -108,7 +108,7 @@ export class RVDisabledPage extends Component {
             </tbody>
           </Table>
         </Panel>
-        {this.getActionButton()}
+        {this.renderActionButton()}
       </Page>
     );
   }

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -37,13 +37,13 @@ export class RVDisabledPage extends Component {
     const firstRow = RECIPIENT_VALIDATION_TIERS[0];
     rows.unshift(
       <Table.Row key = {firstRow.volumeMin}>
-        <Table.Cell >
+        <Table.Cell>
           <strong className = {styles.Header}>
             Number of Emails
           </strong>
           <strong>{formatFullNumber(firstRow.volumeMin)}</strong> to <strong>{formatFullNumber(firstRow.volumeMax)}</strong>
         </Table.Cell>
-        <Table.Cell >
+        <Table.Cell>
           <strong className = {styles.Header}>
             Cost
           </strong>
@@ -91,8 +91,8 @@ export class RVDisabledPage extends Component {
           </p>
         </div>
         <Panel className = {styles.Table}>
-          <Table >
-            <tbody className={styles.Table}>
+          <Table>
+            <tbody>
               {this.getRows()}
             </tbody>
           </Table>

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -7,7 +7,7 @@ import { selectCondition } from 'src/selectors/accessConditionState';
 import { isSelfServeBilling } from 'src/helpers/conditions/account';
 import { connect } from 'react-redux';
 import { update as updateAccount } from 'src/actions/account';
-
+import { Loading } from 'src/components';
 
 const priceData = [
   ['5,000', '10,000', '$0.008'],
@@ -86,6 +86,9 @@ export class RVDisabledPage extends Component {
   };
 
   render() {
+    if (this.props.accountUpdateLoading) {
+      return <Loading/>;
+    }
     return (
       <Page title='Recipient Validation'>
         <div className={styles.Description}>
@@ -104,7 +107,6 @@ export class RVDisabledPage extends Component {
               {this.getRows()}
             </tbody>
           </Table>
-
         </Panel>
         {this.getActionButton()}
       </Page>
@@ -114,7 +116,8 @@ export class RVDisabledPage extends Component {
 
 const mapStateToProps = (state) => ({
   isSelfServeBilling: selectCondition(isSelfServeBilling)(state),
-  isFree: currentPlanSelector(state).isFree
+  isFree: currentPlanSelector(state).isFree,
+  accountUpdateLoading: state.account.updateLoading
 });
 
 export default (connect(mapStateToProps, { updateAccount })(RVDisabledPage));

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -10,18 +10,7 @@ import { connect } from 'react-redux';
 import { update as updateAccount } from 'src/actions/account';
 import { Loading } from 'src/components';
 import { formatFullNumber } from 'src/helpers/units';
-
-//TODO Use from constants
-const RECIPIENT_VALIDATION_TIERS = [
-  { volumeMin: 0, volumeMax: 5000, cost: 0.01 },
-  { volumeMin: 5000, volumeMax: 10000, cost: 0.008 },
-  { volumeMin: 10000, volumeMax: 50000, cost: 0.006 },
-  { volumeMin: 50000, volumeMax: 100000, cost: 0.004 },
-  { volumeMin: 100000, volumeMax: 250000, cost: 0.003 },
-  { volumeMin: 250000, volumeMax: 750000, cost: 0.0015 },
-  { volumeMin: 750000, volumeMax: 1000000, cost: 0.001 },
-  { volumeMin: 1000000, volumeMax: Infinity, cost: 0.00075 }
-];
+import { RECIPIENT_VALIDATION_TIERS } from 'src/constants';
 
 export class RVDisabledPage extends Component {
   getRows = () => {
@@ -35,29 +24,30 @@ export class RVDisabledPage extends Component {
           <Table.Cell width = {'40%'}>
             <strong>{formatFullNumber(row.volumeMin)}</strong>
             {row.volumeMax < Infinity //Last row with volumeMax of Infinity has different wording
-              ? <span> to <strong>{formatFullNumber(row.volumeMax)}</strong></span>
+              ? <> to <strong>{formatFullNumber(row.volumeMax)}</strong></>
               : <>+</>}
           </Table.Cell>
           <Table.Cell>
-            <strong>${row.cost}</strong> per email
+            <strong>{row.displayedCost}</strong> per email
           </Table.Cell>
         </Table.Row>);
     });
 
     //Adds the header & first row (includes both in same cell)
+    const firstRow = RECIPIENT_VALIDATION_TIERS[0];
     rows.unshift(
-      <Table.Row key = {RECIPIENT_VALIDATION_TIERS[0].volumeMin}>
+      <Table.Row key = {firstRow.volumeMin}>
         <Table.Cell >
           <strong className = {styles.Header}>
             Number of Emails
           </strong>
-          <strong>{RECIPIENT_VALIDATION_TIERS[0].volumeMin}</strong> to <strong>{RECIPIENT_VALIDATION_TIERS[0].volumeMax}</strong>
+          <strong>{formatFullNumber(firstRow.volumeMin)}</strong> to <strong>{formatFullNumber(firstRow.volumeMax)}</strong>
         </Table.Cell>
         <Table.Cell >
           <strong className = {styles.Header}>
             Cost
           </strong>
-          <strong>${RECIPIENT_VALIDATION_TIERS[0].cost}</strong> per email
+          <strong>{firstRow.displayedCost}</strong> per email
         </Table.Cell>
       </Table.Row>
     );

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -89,8 +89,8 @@ export class RVDisabledPage extends Component {
         message: 'RV enabled.'
       }));
   }
-  render() {
 
+  render() {
     return (
       <Page title='Recipient Validation'>
         <div className={styles.Description}>
@@ -100,7 +100,7 @@ export class RVDisabledPage extends Component {
           to catch many common problems, including syntax errors and non-existent mailboxes.
           </p>
           <p>
-          We have a monthly pay-as-you-go plan using tiered pricing, The more you validate, the less you pay per message.
+          We have a monthly pay-as-you-go plan using tiered pricing. The more you validate, the less you pay per message.
           </p>
         </div>
         <Panel className = {styles.Table}>

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -7,7 +7,6 @@ import { selectCondition } from 'src/selectors/accessConditionState';
 import { isSelfServeBilling } from 'src/helpers/conditions/account';
 import { connect } from 'react-redux';
 import { update as updateAccount } from 'src/actions/account';
-import { showAlert } from 'src/actions/globalAlert';
 
 
 const priceData = [
@@ -83,11 +82,7 @@ export class RVDisabledPage extends Component {
         recipient_validation: true
       }
     };
-    return this.props.updateAccount(body)
-      .then(() => showAlert({
-        type: 'success',
-        message: 'RV enabled.'
-      }));
+    this.props.updateAccount(body);
   }
 
   render() {

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -24,7 +24,7 @@ const priceDataEdge = [
 
 export class RVDisabledPage extends Component {
   getRows = () => {
-    const rows = priceData.map((row, i) => (
+    const rows = priceData.map((row) => (
       <Table.Row key = {row[0]}>
         <Table.Cell width = {'40%'}>
           <strong>{row[0]}</strong> to <strong>{row[1]}</strong>
@@ -34,25 +34,25 @@ export class RVDisabledPage extends Component {
         </Table.Cell>
       </Table.Row>));
 
+    //Adds the header & first row (includes both in same cell)
     rows.unshift(
       <Table.Row key = {priceDataEdge[0][0]}>
         <Table.Cell >
           <strong className = {styles.Header}>
             Number of Emails
           </strong>
-          <br className={styles.HeaderSpace}/>
           <strong>{priceDataEdge[0][0]}</strong> to <strong>{priceDataEdge[0][1]}</strong>
         </Table.Cell>
         <Table.Cell >
           <strong className = {styles.Header}>
             Cost
           </strong>
-          <br className={styles.HeaderSpace}/>
           <strong>{priceDataEdge[0][2]}</strong> per email
         </Table.Cell>
       </Table.Row>
     );
 
+    //Adds the last row (has slightly different wording)
     rows.push(
       <Table.Row key = {priceDataEdge[1][0]}>
         <Table.Cell>
@@ -64,7 +64,7 @@ export class RVDisabledPage extends Component {
       </Table.Row>
     );
     return rows;
-  }
+  };
 
   getActionButton = () => {
     const { isSelfServeBilling, isFree } = this.props;
@@ -74,7 +74,7 @@ export class RVDisabledPage extends Component {
     return (isFree)
       ? (<UnstyledLink component={Button} to={'/account/billing'} primary>Upgrade your plan</UnstyledLink>)
       : (<Button primary onClick={this.enableRV}>Enable Recipient Validation</Button>);
-  }
+  };
 
   enableRV = () => {
     const body = {
@@ -83,7 +83,7 @@ export class RVDisabledPage extends Component {
       }
     };
     this.props.updateAccount(body);
-  }
+  };
 
   render() {
     return (
@@ -111,6 +111,7 @@ export class RVDisabledPage extends Component {
     );
   }
 }
+
 const mapStateToProps = (state) => ({
   isSelfServeBilling: selectCondition(isSelfServeBilling)(state),
   isFree: currentPlanSelector(state).isFree

--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -1,23 +1,124 @@
 import { Component } from 'react';
-import { EmptyState } from '@sparkpost/matchbox';
-import { Generic } from 'src/components/images';
-import { LINKS } from 'src/constants';
+import { Page, Panel, Table, Button, UnstyledLink } from '@sparkpost/matchbox';
 import React from 'react';
+import styles from './RVDisabledPage.module.scss';
+import { currentPlanSelector } from 'src/selectors/accountBillingInfo';
+import { selectCondition } from 'src/selectors/accessConditionState';
+import { isSelfServeBilling } from 'src/helpers/conditions/account';
+import { connect } from 'react-redux';
+import { update as updateAccount } from 'src/actions/account';
+import { showAlert } from 'src/actions/globalAlert';
 
+
+const priceData = [
+  ['5,000', '10,000', '$0.008'],
+  ['10,000', '50,000', '$0.006'],
+  ['50,000', '100,000', '$0.004'],
+  ['100,000', '250,000', '$0.003'],
+  ['250,000', '750,000', '$0.0015'],
+  ['750,000', '1,000,000', '$0.00100']
+];
+const priceDataEdge = [
+  ['0', '5,000', '$0.010'],
+  ['1,000,000+', '$0.00075']
+];
 
 export class RVDisabledPage extends Component {
+  getRows = () => {
+    const rows = priceData.map((row, i) => (
+      <Table.Row key = {row[0]}>
+        <Table.Cell width = {'40%'}>
+          <strong>{row[0]}</strong> to <strong>{row[1]}</strong>
+        </Table.Cell>
+        <Table.Cell>
+          <strong>{row[2]}</strong> per email
+        </Table.Cell>
+      </Table.Row>));
+
+    rows.unshift(
+      <Table.Row key = {priceDataEdge[0][0]}>
+        <Table.Cell >
+          <strong className = {styles.Header}>
+            Number of Emails
+          </strong>
+          <br className={styles.HeaderSpace}/>
+          <strong>{priceDataEdge[0][0]}</strong> to <strong>{priceDataEdge[0][1]}</strong>
+        </Table.Cell>
+        <Table.Cell >
+          <strong className = {styles.Header}>
+            Cost
+          </strong>
+          <br className={styles.HeaderSpace}/>
+          <strong>{priceDataEdge[0][2]}</strong> per email
+        </Table.Cell>
+      </Table.Row>
+    );
+
+    rows.push(
+      <Table.Row key = {priceDataEdge[1][0]}>
+        <Table.Cell>
+          <strong>{priceDataEdge[1][0]}</strong>
+        </Table.Cell>
+        <Table.Cell>
+          <strong>{priceDataEdge[1][1]}</strong> per email
+        </Table.Cell>
+      </Table.Row>
+    );
+    return rows;
+  }
+
+  getActionButton = () => {
+    const { isSelfServeBilling, isFree } = this.props;
+    if (!isSelfServeBilling) {
+      return null;
+    }
+    return (isFree)
+      ? (<UnstyledLink component={Button} to={'/account/billing'} primary>Upgrade your plan</UnstyledLink>)
+      : (<Button primary onClick={this.enableRV}>Enable Recipient Validation</Button>);
+  }
+
+  enableRV = () => {
+    const body = {
+      options: {
+        recipient_validation: true
+      }
+    };
+    return this.props.updateAccount(body)
+      .then(() => showAlert({
+        type: 'success',
+        message: 'RV enabled.'
+      }));
+  }
   render() {
+
     return (
-      <EmptyState
-        title="Recipient Validation"
-        image={Generic}
-        primaryAction={{ content: 'Request Access', to: LINKS.RECIPIENT_VALIDATION_ACCESS, external: true }}
-      >
-        <p>Protect your sender reputation by guarding against bounces, errors, and even fraud.
-          SparkPost Recipient Validation is an easy, efficient way to verify that addresses are valid before you send.</p>
-      </EmptyState>
+      <Page title='Recipient Validation'>
+        <div className={styles.Description}>
+          <p>
+          Protect your reputation by guarding against bounces, errors, and even fraud. Recipient Validation is an easy,
+          efficient way to verify that addresses are valid before you send. We run emails through a series of checks
+          to catch many common problems, including syntax errors and non-existent mailboxes.
+          </p>
+          <p>
+          We have a monthly pay-as-you-go plan using tiered pricing, The more you validate, the less you pay per message.
+          </p>
+        </div>
+        <Panel className = {styles.Table}>
+          <Table >
+            <tbody className={styles.Table}>
+              {this.getRows()}
+            </tbody>
+          </Table>
+
+        </Panel>
+        {this.getActionButton()}
+      </Page>
     );
   }
 }
+const mapStateToProps = (state) => ({
+  isSelfServeBilling: selectCondition(isSelfServeBilling)(state),
+  isFree: currentPlanSelector(state).isFree
+});
 
-export default RVDisabledPage;
+export default (connect(mapStateToProps, { updateAccount })(RVDisabledPage));

--- a/src/pages/recipientValidation/components/RVDisabledPage.module.scss
+++ b/src/pages/recipientValidation/components/RVDisabledPage.module.scss
@@ -8,7 +8,7 @@
 }
 
 .Table {
-  padding: rem(30) rem(45);
+  padding: rem(30) rem(45) rem(15);
   font-size: rem(17);
 }
 
@@ -18,5 +18,3 @@
     @media screen and (min-width: breakpoint(large)) { margin-right: 25%; }
   }
 }
-
-

--- a/src/pages/recipientValidation/components/RVDisabledPage.module.scss
+++ b/src/pages/recipientValidation/components/RVDisabledPage.module.scss
@@ -3,8 +3,8 @@
 .Header {
   color: color(orange);
   font-size: rem(15);
-  margin-bottom: rem(100);
-
+  display: block;
+  margin-bottom: rem(25);
 }
 
 .Table {
@@ -17,10 +17,6 @@
   p {
     @media screen and (min-width: breakpoint(large)) { margin-right: 25%; }
   }
-}
-
-.HeaderSpace {
-  line-height: rem(50);
 }
 
 

--- a/src/pages/recipientValidation/components/RVDisabledPage.module.scss
+++ b/src/pages/recipientValidation/components/RVDisabledPage.module.scss
@@ -1,0 +1,26 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.Header {
+  color: color(orange);
+  font-size: rem(15);
+  margin-bottom: rem(100);
+
+}
+
+.Table {
+  padding: rem(30) rem(45);
+  font-size: rem(17);
+}
+
+.Description {
+  margin-bottom: rem(60);
+  p {
+    @media screen and (min-width: breakpoint(large)) { margin-right: 25%; }
+  }
+}
+
+.HeaderSpace {
+  line-height: rem(50);
+}
+
+

--- a/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
+++ b/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { RVDisabledPage } from '../RVDisabledPage';
+
+describe('Recipient Validation Disabled Page', () => {
+  let wrapper; let props;
+  beforeEach(() => {
+    props = {
+      isSelfServeBilling: true,
+      isFree: false,
+      updateAccount: jest.fn(() => Promise.resolve())
+    };
+
+    wrapper = shallow(<RVDisabledPage {...props} />);
+  });
+
+  it('should render' , () => {
+    wrapper.setProps(props);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should show no button when customer is manually billed' , () => {
+    wrapper.setProps({ ...props, isSelfServeBilling: false });
+    expect(wrapper.find('Button')).not.toExist();
+    expect(wrapper.find('UnstyledLink')).not.toExist();
+  });
+
+  it('should redirect to billing page when customer is self serve and on free plan' , () => {
+    wrapper.setProps({ isSelfServeBilling: true, isFree: true });
+    expect(wrapper.find('UnstyledLink')).toExist();
+    expect(wrapper.find('UnstyledLink').prop('to')).toEqual('/account/billing');
+    expect(wrapper.find('UnstyledLink').prop('children')).toEqual('Upgrade your plan');
+
+  });
+
+  it('should show enable RV button when customer is self serve and on paid plan' , () => {
+    wrapper.setProps(props);
+    expect(wrapper.find('Button')).toExist();
+    expect(wrapper.find('Button').prop('children')).toEqual('Enable Recipient Validation');
+  });
+
+  it('should make API call to enable RV when button is clicked.' , () => {
+    wrapper.setProps(props);
+    wrapper.find('Button').simulate('click');
+    expect(props.updateAccount).toHaveBeenCalledWith({ options: { recipient_validation: true }});
+  });
+});

--- a/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
+++ b/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
@@ -19,6 +19,10 @@ describe('Recipient Validation Disabled Page', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render Loading page when updating account' , () => {
+    wrapper.setProps({ ...props, accountUpdateLoading: true });
+    expect(wrapper).toMatchSnapshot();
+  });
   it('should show no button when customer is manually billed' , () => {
     wrapper.setProps({ ...props, isSelfServeBilling: false });
     expect(wrapper.find('Button')).not.toExist();

--- a/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
+++ b/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
@@ -26,20 +26,19 @@ describe('Recipient Validation Disabled Page', () => {
   it('should show no button when customer is manually billed' , () => {
     wrapper.setProps({ ...props, isSelfServeBilling: false });
     expect(wrapper.find('Button')).not.toExist();
-    expect(wrapper.find('UnstyledLink')).not.toExist();
   });
 
   it('should redirect to billing page when customer is self serve and on free plan' , () => {
     wrapper.setProps({ isSelfServeBilling: true, isFree: true });
-    expect(wrapper.find('UnstyledLink')).toExist();
-    expect(wrapper.find('UnstyledLink').prop('to')).toEqual('/account/billing');
-    expect(wrapper.find('UnstyledLink').prop('children')).toEqual('Upgrade your plan');
+    expect(wrapper.find('Button')).toHaveLength(1);
+    expect(wrapper.find('Button').prop('to')).toEqual('/account/billing');
+    expect(wrapper.find('Button').prop('children')).toEqual('Upgrade your plan');
 
   });
 
   it('should show enable RV button when customer is self serve and on paid plan' , () => {
     wrapper.setProps(props);
-    expect(wrapper.find('Button')).toExist();
+    expect(wrapper.find('Button')).toHaveLength(1);
     expect(wrapper.find('Button').prop('children')).toEqual('Enable Recipient Validation');
   });
 

--- a/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
@@ -31,9 +31,6 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
             >
               Number of Emails
             </strong>
-            <br
-              className="HeaderSpace"
-            />
             <strong>
               0
             </strong>
@@ -48,9 +45,6 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
             >
               Cost
             </strong>
-            <br
-              className="HeaderSpace"
-            />
             <strong>
               $0.010
             </strong>
@@ -210,3 +204,5 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
   </Button>
 </Page>
 `;
+
+exports[`Recipient Validation Disabled Page should render Loading page when updating account 1`] = `<Loading />`;

--- a/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
@@ -12,7 +12,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
       Protect your reputation by guarding against bounces, errors, and even fraud. Recipient Validation is an easy, efficient way to verify that addresses are valid before you send. We run emails through a series of checks to catch many common problems, including syntax errors and non-existent mailboxes.
     </p>
     <p>
-      We have a monthly pay-as-you-go plan using tiered pricing, The more you validate, the less you pay per message.
+      We have a monthly pay-as-you-go plan using tiered pricing. The more you validate, the less you pay per message.
     </p>
   </div>
   <Panel

--- a/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Recipient Validation Disabled Page should render 1`] = `
+<Page
+  empty={Object {}}
+  title="Recipient Validation"
+>
+  <div
+    className="Description"
+  >
+    <p>
+      Protect your reputation by guarding against bounces, errors, and even fraud. Recipient Validation is an easy, efficient way to verify that addresses are valid before you send. We run emails through a series of checks to catch many common problems, including syntax errors and non-existent mailboxes.
+    </p>
+    <p>
+      We have a monthly pay-as-you-go plan using tiered pricing, The more you validate, the less you pay per message.
+    </p>
+  </div>
+  <Panel
+    className="Table"
+  >
+    <Table>
+      <tbody
+        className="Table"
+      >
+        <Table.Row
+          key="0"
+        >
+          <Table.Cell>
+            <strong
+              className="Header"
+            >
+              Number of Emails
+            </strong>
+            <br
+              className="HeaderSpace"
+            />
+            <strong>
+              0
+            </strong>
+             to 
+            <strong>
+              5,000
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong
+              className="Header"
+            >
+              Cost
+            </strong>
+            <br
+              className="HeaderSpace"
+            />
+            <strong>
+              $0.010
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="5,000"
+        >
+          <Table.Cell
+            width="40%"
+          >
+            <strong>
+              5,000
+            </strong>
+             to 
+            <strong>
+              10,000
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong>
+              $0.008
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="10,000"
+        >
+          <Table.Cell
+            width="40%"
+          >
+            <strong>
+              10,000
+            </strong>
+             to 
+            <strong>
+              50,000
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong>
+              $0.006
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="50,000"
+        >
+          <Table.Cell
+            width="40%"
+          >
+            <strong>
+              50,000
+            </strong>
+             to 
+            <strong>
+              100,000
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong>
+              $0.004
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="100,000"
+        >
+          <Table.Cell
+            width="40%"
+          >
+            <strong>
+              100,000
+            </strong>
+             to 
+            <strong>
+              250,000
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong>
+              $0.003
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="250,000"
+        >
+          <Table.Cell
+            width="40%"
+          >
+            <strong>
+              250,000
+            </strong>
+             to 
+            <strong>
+              750,000
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong>
+              $0.0015
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="750,000"
+        >
+          <Table.Cell
+            width="40%"
+          >
+            <strong>
+              750,000
+            </strong>
+             to 
+            <strong>
+              1,000,000
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong>
+              $0.00100
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row
+          key="1,000,000+"
+        >
+          <Table.Cell>
+            <strong>
+              1,000,000+
+            </strong>
+          </Table.Cell>
+          <Table.Cell>
+            <strong>
+              $0.00075
+            </strong>
+             per email
+          </Table.Cell>
+        </Table.Row>
+      </tbody>
+    </Table>
+  </Panel>
+  <Button
+    onClick={[Function]}
+    primary={true}
+    size="default"
+  >
+    Enable Recipient Validation
+  </Button>
+</Page>
+`;

--- a/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
@@ -52,7 +52,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
           </Table.Cell>
         </Table.Row>
         <Table.Row
-          key="5,000"
+          key="5000"
         >
           <Table.Cell
             width="40%"
@@ -73,7 +73,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
           </Table.Cell>
         </Table.Row>
         <Table.Row
-          key="10,000"
+          key="10000"
         >
           <Table.Cell
             width="40%"
@@ -94,7 +94,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
           </Table.Cell>
         </Table.Row>
         <Table.Row
-          key="50,000"
+          key="50000"
         >
           <Table.Cell
             width="40%"
@@ -115,7 +115,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
           </Table.Cell>
         </Table.Row>
         <Table.Row
-          key="100,000"
+          key="100000"
         >
           <Table.Cell
             width="40%"
@@ -136,7 +136,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
           </Table.Cell>
         </Table.Row>
         <Table.Row
-          key="250,000"
+          key="250000"
         >
           <Table.Cell
             width="40%"
@@ -157,7 +157,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
           </Table.Cell>
         </Table.Row>
         <Table.Row
-          key="750,000"
+          key="750000"
         >
           <Table.Cell
             width="40%"
@@ -172,18 +172,21 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
           </Table.Cell>
           <Table.Cell>
             <strong>
-              $0.00100
+              $0.0010
             </strong>
              per email
           </Table.Cell>
         </Table.Row>
         <Table.Row
-          key="1,000,000+"
+          key="1000000"
         >
-          <Table.Cell>
+          <Table.Cell
+            width="40%"
+          >
             <strong>
-              1,000,000+
+              1,000,000
             </strong>
+            +
           </Table.Cell>
           <Table.Cell>
             <strong>

--- a/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/RVDisabledPage.test.js.snap
@@ -19,9 +19,7 @@ exports[`Recipient Validation Disabled Page should render 1`] = `
     className="Table"
   >
     <Table>
-      <tbody
-        className="Table"
-      >
+      <tbody>
         <Table.Row
           key="0"
         >

--- a/src/pages/recipientValidation/tests/__snapshots__/RecipientVerificationPage.test.js.snap
+++ b/src/pages/recipientValidation/tests/__snapshots__/RecipientVerificationPage.test.js.snap
@@ -34,7 +34,7 @@ exports[`Page: Recipient Email Verification renders single email verification ta
   <Case
     condition={[Function]}
   >
-    <RVDisabledPage />
+    <Connect(RVDisabledPage) />
   </Case>
 </Connect(ConditionSwitch)>
 `;
@@ -74,7 +74,7 @@ exports[`Page: Recipient Email Verification should render Recipient Validation p
   <Case
     condition={[Function]}
   >
-    <RVDisabledPage />
+    <Connect(RVDisabledPage) />
   </Case>
 </Connect(ConditionSwitch)>
 `;


### PR DESCRIPTION
### What Changed
 - Changed the page to self-request adding Recipient Validation. 
 - Changed the flag from UI option to account option
 - There are 3 possible outcomes: 
   1. Self-Service and on paid plan: Can click a button to enable RV.
   2. Self-Service and on free plan: Can click a button to redirect to billing page
   3. Manually-Billed: No button at all. 

### How To Test
 - Test the 3 situations above. 
   1. Self-Service and on paid plan: Click the enable RV button and it should reload to unlocked RV page. 
   2. Self-Service and on free plan: Click the upgrade plan button and get redirected to billing page. 
   3. Manually-Billed: No button exists at all. 

### To Do
- [x] Double check the upgrade account put endpoint with RV as an option. Will get implemented by the Accounts team.
- [x] Rebase after AC-770 to use existing RV_tier constant.