### PR TITLE
EO-795 Surface new Health Score components in the UI

### DIFF
--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -190,6 +190,7 @@ export class HealthScorePage extends Component {
             )}
             {(!panelContent && !selectedWeightsAreEmpty) && (
               <DivergingBar
+                barHeight={23}
                 data={selectedWeights}
                 xKey='weight'
                 yKey='weight_type'

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -190,7 +190,7 @@ export class HealthScorePage extends Component {
             )}
             {(!panelContent && !selectedWeightsAreEmpty) && (
               <DivergingBar
-                barHeight={23}
+                barHeight={280 / (selectedWeights.length || 1)}
                 data={selectedWeights}
                 xKey='weight'
                 yKey='weight_type'

--- a/src/pages/signals/constants/info.js
+++ b/src/pages/signals/constants/info.js
@@ -36,10 +36,10 @@ export const HEALTH_SCORE_COMPONENTS = {
     `
   },
   'List Quality': {
-    label: 'List Quality',
-    chartTitle: 'Percent of List Quality Issues',
+    label: 'Subscriber Quality',
+    chartTitle: 'Percent of Subscriber Quality Issues',
     info: `
-      List Quality is determined by the share of attempted email injections that match address
+      Subscriber Quality is determined by the share of attempted email injections that match address
       patterns associated with problematic list procurement and hygiene practices.
     `
   },
@@ -55,8 +55,36 @@ export const HEALTH_SCORE_COMPONENTS = {
     label: 'Transient Failures',
     chartTitle: 'Transient Failure Percent',
     info: `
-      Transient Failures are calcuated as the share of attempted email injections that exhibit
+      Transient Failures are calculated as the share of attempted email injections that exhibit
       temporary delivery problems.
+    `
+  },
+  'Spam Trap Hits': {
+    label: 'Spam Trap Hits',
+    chartTitle: 'Spam Trap Hits Percent',
+    info: `
+      Spam traps hits are calculated as the percent of your injections that are sent to spam traps. 
+    `
+  },
+  'Suppression Hits': {
+    label: 'Suppression Hits',
+    chartTitle: 'Suppression Hits Percent',
+    info: `
+      Percent of the injections that were sent to addresses on your suppression list.
+    `
+  },
+  'Historical Engagement': {
+    label: 'Historical Engagement',
+    chartTitle: 'Historical Engagement Percent',
+    info: `
+      The engagement rate calculated for the previous 3 days of emails sent.
+    `
+  },
+  'Unsubscribes': {
+    label: 'Unsubscribes',
+    chartTitle: 'Unsubscribes Percent',
+    info: `
+      Unsubscribes are the share of emails injected that led to the recipient unsubscribing.
     `
   },
   'eng cohorts: unengaged': {

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -77,6 +77,23 @@ describe('Signals Health Score Page', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders component weights bar height dynamically', () => {
+    expect(wrapper.find('DivergingBar').at(0).prop('barHeight')).toEqual(140);
+    const newData = [
+      {
+        date: '2017-01-01',
+        weights: [
+          { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
+          { weight_type: 'eng cohorts: new, 14-day', weight: -0.5, weight_value: 0.25 },
+          { weight_type: 'List Quality', weight: 0.8, weight_value: 0.25 },
+          { weight_type: 'Other bounces', weight: -0.8, weight_value: 0.25 }
+        ]
+      }
+    ];
+    wrapper.setProps({ data: newData });
+    expect(wrapper.find('DivergingBar').at(0).prop('barHeight')).toEqual(70);
+  });
+
   describe('local state', () => {
     it('handles component select', () => {
       wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'eng cohorts: new, 14-day' }});

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -341,7 +341,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
 "
         />
         <DivergingBar
-          barHeight={35}
+          barHeight={23}
           data={
             Array [
               Object {

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -341,7 +341,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
 "
         />
         <DivergingBar
-          barHeight={23}
+          barHeight={140}
           data={
             Array [
               Object {


### PR DESCRIPTION
### What Changed
 - Added new components to the diverging chart in the health score page

### How To Test
 -If V2 data is available, just navigate to the health score page. If not, you can mock fake data through the `GET_HEATH_SCORE_SUCCESS` reducer.
Add these lines 
``` 
       const testData = [
        { weight_type: 'Unsubscribes', weight: '0.0348689072', weight_value: '0.0220773366' },
        { weight_type: 'Suppression Hits', weight: '-0.0318396464', weight_value: '0.0363057569' },
        { weight_type: 'Historical Engagement', weight: '-0.0051612244', weight_value: '0.0000714738' },
        { weight_type: 'Spam Trap Hits', weight: '0.0073121670', weight_value: '0.2504608377' }
      ];
      data[0].history[0].weights.push(testData[0],testData[1],testData[2],testData[3]);
```
 - Navigate to the health score components page by clicking a facet in `/signals/health-score`
 - Click on the first bar from the left in the health score chart. You should see the new components. 

### To Do
- [ ] Address review feedback
