### PR TITLE
EO-809: Fix filter issue in Signals Mailbox Provider

### DIFF
--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -13,7 +13,7 @@ const ORDER_BY_MAPPING = {
 
 const signalsActionCreator = ({ dimension, type }) => ({
   facet = '',
-  filter = '',
+  filter,
   from,
   limit,
   offset,

--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -13,7 +13,7 @@ const ORDER_BY_MAPPING = {
 
 const signalsActionCreator = ({ dimension, type }) => ({
   facet = '',
-  filter,
+  filter = '',
   from,
   limit,
   offset,
@@ -36,6 +36,10 @@ const signalsActionCreator = ({ dimension, type }) => ({
     facet = '';
     subaccount = filter;
     filter = '';
+  }
+
+  if (facet === 'mb_provider' && filter) {
+    filter = filter.toLowerCase().replace(' ', '_');
   }
 
   return sparkpostApiRequest({

--- a/src/actions/tests/__snapshots__/signals.test.js.snap
+++ b/src/actions/tests/__snapshots__/signals.test.js.snap
@@ -115,6 +115,29 @@ Array [
 ]
 `;
 
+exports[`Signals Actions .getHealthScore with a mailbox provider filter 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "headers": Object {},
+      "method": "GET",
+      "params": Object {
+        "filter": "google_ap",
+        "from": "2018-01-12",
+        "limit": undefined,
+        "offset": undefined,
+        "order": undefined,
+        "order_by": undefined,
+        "to": "2018-01-13",
+      },
+      "showErrorAlert": false,
+      "url": "/v1/signals/health-score/mb_provider",
+    },
+    "type": "GET_HEALTH_SCORE",
+  },
+]
+`;
+
 exports[`Signals Actions .getHealthScore with an order by subaccount 1`] = `
 Array [
   Object {

--- a/src/actions/tests/signals.test.js
+++ b/src/actions/tests/signals.test.js
@@ -74,6 +74,9 @@ describe('Signals Actions', () => {
     },
     'with an order by subaccount': {
       action: () => actions.getHealthScore({ ...requiredOptions, order: 'asc', orderBy: 'sid' })
+    },
+    'with a mailbox provider filter': {
+      action: () => actions.getHealthScore({ ...requiredOptions, facet: 'mb_provider', filter: 'Google Ap' })
     }
   });
 


### PR DESCRIPTION
### What Changed
 - Searching by Mailbox Provider now converts filter string to snake case to attempt to match key 

### How To Test
 - [Point openresty to prd](https://confluence.int.messagesystems.com/pages/viewpage.action?spaceKey=ENG&title=Configuring+Openresty+Upstreams)
 - Use appteam or 108 account
 - On Healthscore page or Engagement Recency, filter by Mailbox Provider
 - Try searching using human readable text (like`Verizon Med`)

### Notes
 - Searching `Other Providers` does not provide results since `other` is the used key

### To Do
- [ ] Address Feedback
