### PR TITLE
EO-813 Move divider line to between June 6/7

### DIFF
--- a/src/pages/signals/constants/healthScoreV2.js
+++ b/src/pages/signals/constants/healthScoreV2.js
@@ -1,6 +1,6 @@
 import styles from 'src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.module.scss';
 
-const V2Date = '2019-06-08';
+const V2Date = '2019-06-07';
 
 export const newModelLine = [
   {

--- a/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
@@ -89,7 +89,7 @@ exports[`Signals Health Score Chart renders happy path correctly 1`] = `
             },
             "stroke": "#d2d2d7",
             "strokeWidth": 1,
-            "x": "2019-06-08",
+            "x": "2019-06-07",
           },
           Object {
             "label": Object {
@@ -98,7 +98,7 @@ exports[`Signals Health Score Chart renders happy path correctly 1`] = `
               "value": "Model",
             },
             "strokeWidth": 0,
-            "x": "2019-06-08",
+            "x": "2019-06-07",
           },
         ]
       }

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -145,7 +145,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
                 },
                 "stroke": "#d2d2d7",
                 "strokeWidth": 1,
-                "x": "2019-06-08",
+                "x": "2019-06-07",
               },
               Object {
                 "label": Object {
@@ -154,7 +154,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
                   "value": "Model",
                 },
                 "strokeWidth": 0,
-                "x": "2019-06-08",
+                "x": "2019-06-07",
               },
             ]
           }
@@ -518,7 +518,7 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
                 },
                 "stroke": "#d2d2d7",
                 "strokeWidth": 1,
-                "x": "2019-06-08",
+                "x": "2019-06-07",
               },
               Object {
                 "label": Object {
@@ -527,7 +527,7 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
                   "value": "Model",
                 },
                 "strokeWidth": 0,
-                "x": "2019-06-08",
+                "x": "2019-06-07",
               },
             ]
           }


### PR DESCRIPTION
Note: Give your PR a short title. Something like "_TICKET NUMBER: feature description_" is good.

### What Changed
 - Moved divider line to between June 6 and June 7

### How To Test
 - [Point openresty to prd](https://confluence.int.messagesystems.com/pages/viewpage.action?spaceKey=ENG&title=Configuring+Openresty+Upstreams)
 - Use appteam or 108 account
 - Go to Signals main page and verify that the divider line is between 6/6 and 6/7
 - Go to Signals health score page by clicking a facet on the main page and verify that the divider line is between 6/6 and 6/7