### PR TITLE
TR-1470 - Makes the second top panel fixed 

### DIFF
--- a/src/pages/templatesV2/EditAndPreview.module.scss
+++ b/src/pages/templatesV2/EditAndPreview.module.scss
@@ -1,0 +1,10 @@
+.EditorNav {
+  position: fixed;
+  width: 100%;
+  top: 50;
+  z-index: 100;
+}
+
+.MainContent {
+  margin-top: 60px;
+}

--- a/src/pages/templatesV2/EditAndPreviewPage.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.js
@@ -7,6 +7,7 @@ import links from './constants/editNavigationLinks';
 import useEditorContext from './hooks/useEditorContext';
 
 import { routeNamespace } from './constants/routes';
+import styles from './EditAndPreview.module.scss';
 
 const EditAndPreviewPage = () => {
   const { currentNavigationIndex, draft, hasDraftFailedToLoad, isDraftLoading } = useEditorContext();
@@ -31,8 +32,13 @@ const EditAndPreviewPage = () => {
       breadcrumbRedirectsTo={`/${routeNamespace}`}
       title={draft.name}
     >
-      <EditNavigation primaryArea={<PrimaryArea />} />
-      <Contents />
+      <div className={styles.EditorNav}>
+        <EditNavigation primaryArea={<PrimaryArea/>}/>
+      </div>
+
+      <div className={styles.MainContent}>
+        <Contents/>
+      </div>
     </FullPage>
   );
 };

--- a/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
+++ b/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
@@ -5,9 +5,17 @@ exports[`EditAndPreviewPage renders a page 1`] = `
   breadcrumbRedirectsTo="/templatesv2"
   title="Test Template"
 >
-  <EditNavigation
-    primaryArea={<EditContentsPrimaryArea />}
-  />
-  <EditContents />
+  <div
+    className="EditorNav"
+  >
+    <EditNavigation
+      primaryArea={<EditContentsPrimaryArea />}
+    />
+  </div>
+  <div
+    className="MainContent"
+  >
+    <EditContents />
+  </div>
 </FullPage>
 `;


### PR DESCRIPTION
Secondary panel in the top nav is made fixed so it's not lost in scroll as this section will contain crucial actions for the page. Please see the ticket if it's not clear which panel is being referred. 

### How to Test
- Campaigns -> Templates -> Open a template
- Scroll and you should see the section with items like `Content`, `Settings` is fixed. 
