### PR TITLE
FE-685: Use account option instead of UI option

### DIFF
--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -4,7 +4,7 @@ import { Page, Tabs, Panel } from '@sparkpost/matchbox';
 import ListForm from './components/ListForm';
 import SingleAddressForm from './components/SingleAddressForm';
 import ListResults from './components/ListResults';
-import { hasUiOption } from 'src/helpers/conditions/account';
+import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
 import RVDisabledPage from './components/RVDisabledPage';
 import ConditionSwitch, { Case, defaultCase } from 'src/components/auth/ConditionSwitch';
 
@@ -45,7 +45,7 @@ export class RecipientValidationPage extends Component {
 
     return (
       <ConditionSwitch>
-        <Case condition={hasUiOption('recipient_validation')}>
+        <Case condition={hasAccountOptionEnabled('recipient_validation')}>
           {this.renderRecipientValidation()}
         </Case>
         <Case condition={defaultCase}>


### PR DESCRIPTION
### What Changed
 - Account option controls rendering of RV rather than UI option

### How To Test
 - Modify account option through PUT on /account/control
 - Check that page shows with `{ options: { recipient_validation: true } }`
 - Check that page does't show if above condition is not true and `{ options: { ui: { recipient_validation: true } } }`

### To Do
- [ ] Address feedback
- [ ] Tag new routes in Pendo
