### PR TITLE
TR-1533 Fix content editing modes

### DIFF
--- a/src/config/routes/templates.js
+++ b/src/config/routes/templates.js
@@ -72,7 +72,7 @@ const v2Routes = [
     supportDocSearch: 'template'
   },
   {
-    path: '/templatesv2/edit/:id/:navKey?',
+    path: '/templatesv2/edit/:id/:version?/:navKey?',
     component: templatesV2.EditAndPreviewPage,
     condition: hasGrants('templates/view'),
     layout: Fullscreen,

--- a/src/pages/templatesV2/CreatePage.js
+++ b/src/pages/templatesV2/CreatePage.js
@@ -20,7 +20,7 @@ export default class CreatePage extends Component {
     return create(formData)
       .then(() => {
         showAlert({ type: 'success', message: 'Template Created.' });
-        history.push(`/${routeNamespace}/edit/${values.id}${setSubaccountQuery(subaccountId)}`);
+        history.push(`/${routeNamespace}/edit/${values.id}/draft/content${setSubaccountQuery(subaccountId)}`);
       });
   };
 

--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -4,7 +4,6 @@ import { getDraft, getPreview, getPublished, update as updateDraft, publish as p
 import { list as listDomains } from 'src/actions/sendingDomains';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 
-
 import {
   selectDraftTemplate,
   selectDraftTemplatePreview,
@@ -24,12 +23,17 @@ const mapStateToProps = (state, props) => {
   const id = props.match.params.id;
   const draft = selectDraftTemplate(state, id);
   const published = selectPublishedTemplate(state, id);
-  const isPublishedMode = props.match.params.navKey === 'published';
+  const isPublishedMode = props.match.params.version === 'published';
+  const draftOrPublished = draft || published;
+  const hasDraft = draftOrPublished && draftOrPublished.has_draft;
+  const hasPublished = draftOrPublished && draftOrPublished.has_published;
 
   return {
     draft,
     published,
     isPublishedMode,
+    hasDraft,
+    hasPublished,
     hasDraftFailedToLoad: Boolean(state.templates.getDraftError),
     hasFailedToPreview: Boolean(state.templates.contentPreview.error),
     isDraftLoading: !draft || Boolean(state.templates.getDraftLoading),

--- a/src/pages/templatesV2/EditAndPreviewPage.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.js
@@ -1,16 +1,17 @@
 import React from 'react';
+import { FileEdit, CheckCircle } from '@sparkpost/matchbox-icons';
+
 import { RedirectAndAlert } from 'src/components/globalAlert';
 import FullPage from 'src/components/fullPage';
 import Loading from 'src/components/loading';
 import EditNavigation from './components/EditNavigation';
 import links from './constants/editNavigationLinks';
 import useEditorContext from './hooks/useEditorContext';
-
-import { routeNamespace } from './constants/routes';
 import styles from './EditAndPreviewPage.module.scss';
+import { routeNamespace } from './constants/routes';
 
 const EditAndPreviewPage = () => {
-  const { currentNavigationIndex, draft, hasDraftFailedToLoad, isDraftLoading } = useEditorContext();
+  const { currentNavigationIndex, draft, hasDraftFailedToLoad, isDraftLoading, isPublishedMode } = useEditorContext();
   const Contents = links[currentNavigationIndex].render;
   const PrimaryArea = links[currentNavigationIndex].renderPrimaryArea;
 
@@ -27,10 +28,13 @@ const EditAndPreviewPage = () => {
     return <Loading />;
   }
 
+  const primaryArea = isPublishedMode ? <span>PUBLISHED <CheckCircle className={styles.GreenColor} /> </span> : <span>DRAFT <FileEdit /></span>;
+
   return (
     <FullPage
       breadcrumbRedirectsTo={`/${routeNamespace}`}
       title={draft.name}
+      primaryArea={primaryArea}
     >
       <div className={styles.EditorNav}>
         <EditNavigation primaryArea={<PrimaryArea/>}/>

--- a/src/pages/templatesV2/EditAndPreviewPage.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.js
@@ -28,7 +28,7 @@ const EditAndPreviewPage = () => {
     return <Loading />;
   }
 
-  const primaryArea = isPublishedMode ? <div>PUBLISHED <CheckCircle size={17} className={styles.GreenColor} /> </div> : <div>DRAFT <FileEdit size={17} /></div>;
+  const primaryArea = isPublishedMode ? <div className={styles.Status}><span>Published</span><CheckCircle size={17} className={styles.GreenColor} /></div> : <div className={styles.Status}><span>Draft</span><FileEdit size={17} /></div>;
 
   return (
     <FullPage

--- a/src/pages/templatesV2/EditAndPreviewPage.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.js
@@ -28,7 +28,7 @@ const EditAndPreviewPage = () => {
     return <Loading />;
   }
 
-  const primaryArea = isPublishedMode ? <span>PUBLISHED <CheckCircle className={styles.GreenColor} /> </span> : <span>DRAFT <FileEdit /></span>;
+  const primaryArea = isPublishedMode ? <div>PUBLISHED <CheckCircle size={17} className={styles.GreenColor} /> </div> : <div>DRAFT <FileEdit size={17} /></div>;
 
   return (
     <FullPage

--- a/src/pages/templatesV2/EditAndPreviewPage.module.scss
+++ b/src/pages/templatesV2/EditAndPreviewPage.module.scss
@@ -8,3 +8,7 @@
 .MainContent {
   margin-top: 60px;
 }
+
+.GreenColor {
+  color: #44D09E;
+}

--- a/src/pages/templatesV2/EditAndPreviewPage.module.scss
+++ b/src/pages/templatesV2/EditAndPreviewPage.module.scss
@@ -1,3 +1,5 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
 .EditorNav {
   position: fixed;
   width: 100%;
@@ -11,4 +13,21 @@
 
 .GreenColor {
   color: #44D09E;
+}
+
+.Status {
+  display: flex;
+  align-items: center;
+
+  * {
+    line-height: 100%;
+  }
+
+  svg {
+    margin-left: spacing(small);
+  }
+
+  span {
+    text-transform: uppercase;
+  }
 }

--- a/src/pages/templatesV2/ListPage.js
+++ b/src/pages/templatesV2/ListPage.js
@@ -42,10 +42,10 @@ export default class ListPage extends Component {
         component: Name,
         header: {
           label: 'Template Name',
-          sortKey: 'name'
+          sortKey: 'list_name'
         },
         visible: true,
-        key: 'name'
+        key: 'list_name'
       },
       {
         component: Status,

--- a/src/pages/templatesV2/components/EditAmpSection.js
+++ b/src/pages/templatesV2/components/EditAmpSection.js
@@ -4,7 +4,7 @@ import Editor from './Editor';
 import 'brace/mode/html';
 
 const EditAmpSection = () => {
-  const { content, setContent } = useEditorContext();
+  const { content, setContent, isPublishedMode } = useEditorContext();
 
   return (
     <Editor
@@ -12,6 +12,7 @@ const EditAmpSection = () => {
       name="amp-html-content-editor"
       onChange={(value) => { setContent({ amp_html: value }); }}
       value={content.amp_html}
+      readOnly={isPublishedMode}
     />
   );
 };

--- a/src/pages/templatesV2/components/EditHtmlSection.js
+++ b/src/pages/templatesV2/components/EditHtmlSection.js
@@ -4,7 +4,7 @@ import Editor from './Editor';
 import 'brace/mode/html';
 
 const EditHtmlSection = () => {
-  const { content, setContent } = useEditorContext();
+  const { content, setContent, isPublishedMode } = useEditorContext();
 
   return (
     <Editor
@@ -12,6 +12,7 @@ const EditHtmlSection = () => {
       name="html-content-editor"
       onChange={(value) => { setContent({ html: value }); }}
       value={content.html}
+      readOnly={isPublishedMode}
     />
   );
 };

--- a/src/pages/templatesV2/components/EditTextSection.js
+++ b/src/pages/templatesV2/components/EditTextSection.js
@@ -3,13 +3,14 @@ import useEditorContext from '../hooks/useEditorContext';
 import Editor from './Editor';
 
 const EditTextSection = () => {
-  const { content, setContent } = useEditorContext();
+  const { content, setContent, isPublishedMode } = useEditorContext();
 
   return (
     <Editor
       name="text-content-editor"
       onChange={(value) => { setContent({ text: value }); }}
       value={content.text}
+      readOnly={isPublishedMode}
     />
   );
 };

--- a/src/pages/templatesV2/components/ListComponents.js
+++ b/src/pages/templatesV2/components/ListComponents.js
@@ -9,13 +9,13 @@ import styles from './ListComponents.module.scss';
 import { routeNamespace } from '../constants/routes';
 
 export const Name = ({ name, id, subaccount_id, ...rowData }) => {
-  const isDraft = rowData.list_status === 'draft';
+  const version = rowData.list_status === 'draft' ? 'draft' : 'published';
 
   return (
     <>
       <p className={styles.Name}>
         <Link
-          to={`/${routeNamespace}/edit/${id}${isDraft ? '' : '/published'}${setSubaccountQuery(subaccount_id)}`}>
+          to={`/${routeNamespace}/edit/${id}/${version}/content${setSubaccountQuery(subaccount_id)}`}>
           <strong>{name}</strong>
         </Link>
       </p>

--- a/src/pages/templatesV2/components/ListComponents.js
+++ b/src/pages/templatesV2/components/ListComponents.js
@@ -8,7 +8,7 @@ import styles from './ListComponents.module.scss';
 
 import { routeNamespace } from '../constants/routes';
 
-export const Name = ({ name, id, subaccount_id, ...rowData }) => {
+export const Name = ({ list_name: name, id, subaccount_id, ...rowData }) => {
   const version = rowData.list_status === 'draft' ? 'draft' : 'published';
 
   return (

--- a/src/pages/templatesV2/components/editorActions/Actions.module.scss
+++ b/src/pages/templatesV2/components/editorActions/Actions.module.scss
@@ -2,23 +2,30 @@
 
 .ActionItem {
   a {
-    color: color(gray, 4);
     font-weight: 400;
     display: block;
     padding: rem(9) spacing();
     color: color(gray, 4);
     transition: 0.15s;
     cursor: pointer;
+    font-size: rem(15);
 
     &:hover {
       background: color(gray, 9);
       color: color(gray, 1);
+    }
+    svg {
+      margin-right: spacing(small) * 1.5;
     }
   }
 }
 
 .Actions {
   display: inline-block;
+}
+
+.ActionsBody {
+  margin-top: 3px;
 }
 
 .Divider {

--- a/src/pages/templatesV2/components/editorActions/Actions.module.scss
+++ b/src/pages/templatesV2/components/editorActions/Actions.module.scss
@@ -1,27 +1,24 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 .ActionItem {
-  display: block;
-  padding: rem(9) spacing();
-  color: color(gray, 4);
-  transition: 0.15s;
-  cursor: pointer;
-
-  &:hover {
-    background: color(gray, 9);
-    color: color(gray, 1);
-  }
-
   a {
     color: color(gray, 4);
     font-weight: 400;
+    display: block;
+    padding: rem(9) spacing();
+    color: color(gray, 4);
+    transition: 0.15s;
+    cursor: pointer;
+
+    &:hover {
+      background: color(gray, 9);
+      color: color(gray, 1);
+    }
   }
 }
 
 .Actions {
   display: inline-block;
-
-
 }
 
 .Divider {

--- a/src/pages/templatesV2/components/editorActions/DraftModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/DraftModeActions.js
@@ -5,8 +5,10 @@ import SaveAndPublish from './SaveAndPublish';
 import ViewPublished from './ViewPublished';
 import SaveDraft from './SaveDraft';
 import styles from './Actions.module.scss';
+import useEditorContext from '../../hooks/useEditorContext';
 
 export default () => {
+  const { hasPublished } = useEditorContext();
   const [open, setOpen] = useState(false);
 
   return (<Button.Group>
@@ -20,11 +22,15 @@ export default () => {
         onClose={() => setOpen(false)}
         trigger={<Button onClick={() => setOpen(true)}><ArrowDropDown/></Button>}
       >
-        <div>
+        <div className={styles.ActionsBody}>
           <SaveAndPublish className={styles.ActionItem} onClick={() => setOpen(false)}/>
           <SaveDraft className={styles.ActionItem} onClick={() => setOpen(false)}/>
-          <hr className={styles.Divider}/>
-          <ViewPublished className={styles.ActionItem}/>
+          {hasPublished &&
+            <>
+              <hr className={styles.Divider}/>
+              <ViewPublished className={styles.ActionItem}/>
+            </>
+          }
         </div>
       </Popover>
     </div>

--- a/src/pages/templatesV2/components/editorActions/EditDraft.js
+++ b/src/pages/templatesV2/components/editorActions/EditDraft.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FileEdit } from '@sparkpost/matchbox-icons';
 import useEditorContext from '../../hooks/useEditorContext';
 import { routeNamespace } from '../../constants/routes';
 import { UnstyledLink } from '@sparkpost/matchbox';
@@ -14,8 +13,7 @@ export default ({ className, children }) => {
   };
 
   return (<div className={className}>
-    {children && <UnstyledLink onClick={onClick}>{children}</UnstyledLink>}
-    {!children && <UnstyledLink onClick={onClick}><FileEdit/>&nbsp;&nbsp;Edit Draft</UnstyledLink>}
+    <UnstyledLink onClick={onClick}>{children}</UnstyledLink>
   </div>);
 
 };

--- a/src/pages/templatesV2/components/editorActions/EditDraft.js
+++ b/src/pages/templatesV2/components/editorActions/EditDraft.js
@@ -10,7 +10,7 @@ export default ({ className, children }) => {
   const { draft, history } = useEditorContext();
 
   const onClick = () => {
-    history.push(`/${routeNamespace}/edit/${draft.id}${setSubaccountQuery(draft.subaccount_id)}`);
+    history.push(`/${routeNamespace}/edit/${draft.id}/draft/content${setSubaccountQuery(draft.subaccount_id)}`);
   };
 
   return (<div className={className}>

--- a/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import { Button, Popover } from '@sparkpost/matchbox';
-import { ArrowDropDown } from '@sparkpost/matchbox-icons';
+import { ArrowDropDown, FileEdit } from '@sparkpost/matchbox-icons';
 import styles from './Actions.module.scss';
 import EditDraft from './EditDraft';
+import useEditorContext from '../../hooks/useEditorContext';
 
-const PublishedModeActions = () => (
-  <Button.Group>
+const PublishedModeActions = () => {
+  const { hasDraft } = useEditorContext();
+  const draftText = hasDraft ? 'Edit Draft' : 'Save as Draft';
+
+  return (<Button.Group>
     <EditDraft className={styles.Actions}>
-      <Button><strong>Edit Draft</strong></Button>
+      <Button><strong>{draftText}</strong></Button>
     </EditDraft>
 
     <div className={styles.Actions}>
@@ -15,12 +19,14 @@ const PublishedModeActions = () => (
         left={true}
         trigger={<Button><ArrowDropDown/></Button>}
       >
-        <div>
-          <EditDraft className={styles.ActionItem}/>
+        <div className={styles.ActionsBody}>
+          <EditDraft className={styles.ActionItem}>
+            <FileEdit/>{draftText}
+          </EditDraft>
         </div>
       </Popover>
     </div>
-  </Button.Group>
-);
+  </Button.Group>);
+};
 PublishedModeActions.displayName = 'PublishedModeActions';
 export default PublishedModeActions;

--- a/src/pages/templatesV2/components/editorActions/SaveAndPublish.js
+++ b/src/pages/templatesV2/components/editorActions/SaveAndPublish.js
@@ -10,12 +10,12 @@ import { CheckCircleOutline } from '@sparkpost/matchbox-icons';
 
 export default ({ className, onClick = noop, children, ...props }) => {
   const [open, setOpen] = useState(false);
-  const { draft, content, publishDraft, isDraftPublishing, history } = useEditorContext();
+  const { draft, publishDraft, isDraftPublishing, history } = useEditorContext();
 
-  const onConfirm = useCallback(() => publishDraft({ id: draft.id, content }, draft.subaccount_id)
+  const onConfirm = useCallback(() => publishDraft(draft, draft.subaccount_id)
     .then(() => {
       history.push(`/${routeNamespace}/edit/${draft.id}/published/content${setSubaccountQuery(draft.subaccount_id)}`);
-    }), [content, draft.id, draft.subaccount_id, history, publishDraft]);
+    }), [draft, history, publishDraft]);
 
   /*
   hiding popover makes modal hidden too, so it's invoking onClick when modal is being closed.
@@ -31,7 +31,7 @@ export default ({ className, onClick = noop, children, ...props }) => {
 
   return <div className={className}>
     {children && <UnstyledLink onClick={showModal}>{children}</UnstyledLink>}
-    {!children && <UnstyledLink onClick={showModal}><CheckCircleOutline/>&nbsp;&nbsp;Save and Publish</UnstyledLink>}
+    {!children && <UnstyledLink onClick={showModal}><CheckCircleOutline/>Save and Publish</UnstyledLink>}
     <ConfirmationModal
       title='Are you sure you want to publish your template?'
       content={<p>Once published, your template will be available for use in email campaigns and A/B tests.</p>}

--- a/src/pages/templatesV2/components/editorActions/SaveAndPublish.js
+++ b/src/pages/templatesV2/components/editorActions/SaveAndPublish.js
@@ -14,7 +14,7 @@ export default ({ className, onClick = noop, children, ...props }) => {
 
   const onConfirm = useCallback(() => publishDraft({ id: draft.id, content }, draft.subaccount_id)
     .then(() => {
-      history.push(`/${routeNamespace}/edit/${draft.id}/published${setSubaccountQuery(draft.subaccount_id)}`);
+      history.push(`/${routeNamespace}/edit/${draft.id}/published/content${setSubaccountQuery(draft.subaccount_id)}`);
     }), [content, draft.id, draft.subaccount_id, history, publishDraft]);
 
   /*

--- a/src/pages/templatesV2/components/editorActions/SaveDraft.js
+++ b/src/pages/templatesV2/components/editorActions/SaveDraft.js
@@ -17,7 +17,7 @@ export default ({ className, onClick }) => {
 
   return (<div className={className}>
     <UnstyledLink onClick={handleClick}>
-      <FileEdit/>&nbsp;&nbsp;Save Draft
+      <FileEdit/>Save Draft
     </UnstyledLink>
   </div>);
 

--- a/src/pages/templatesV2/components/editorActions/ViewPublished.js
+++ b/src/pages/templatesV2/components/editorActions/ViewPublished.js
@@ -9,7 +9,7 @@ import { setSubaccountQuery } from 'src/helpers/subaccounts';
 export default ({ className }) => {
   const { draft, history } = useEditorContext();
 
-  const publishedPath = `/${routeNamespace}/edit/${draft.id}/published${setSubaccountQuery(draft.subaccount_id)}`;
+  const publishedPath = `/${routeNamespace}/edit/${draft.id}/published/content${setSubaccountQuery(draft.subaccount_id)}`;
 
   return (<div className={className}>
     <UnstyledLink onClick={() => history.push(publishedPath)}>

--- a/src/pages/templatesV2/components/editorActions/ViewPublished.js
+++ b/src/pages/templatesV2/components/editorActions/ViewPublished.js
@@ -5,7 +5,6 @@ import { routeNamespace } from '../../constants/routes';
 import { UnstyledLink } from '@sparkpost/matchbox';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 
-
 export default ({ className }) => {
   const { draft, history } = useEditorContext();
 
@@ -13,7 +12,7 @@ export default ({ className }) => {
 
   return (<div className={className}>
     <UnstyledLink onClick={() => history.push(publishedPath)}>
-      <RemoveRedEye/>&nbsp;&nbsp;View Published
+      <RemoveRedEye/>View Published
     </UnstyledLink>
   </div>);
 

--- a/src/pages/templatesV2/components/editorActions/tests/DraftModeActions.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/DraftModeActions.test.js
@@ -1,9 +1,25 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import useEditorContext from '../../../hooks/useEditorContext';
 import DraftModeActions from '../DraftModeActions';
 
+jest.mock('../../../hooks/useEditorContext');
+
 describe('DraftModeActions', () => {
+  const subject = (editorState) => {
+    useEditorContext.mockReturnValue({
+      hasPublished: true,
+      ...editorState
+    });
+
+    return shallow(<DraftModeActions />);
+  };
+
   it('renders draft actions', () => {
-    expect(shallow(<DraftModeActions/>)).toMatchSnapshot();
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('does not render ViewPublished when hasPublished is false ', () => {
+    expect(subject({ hasPublished: false }).find('ViewPublished')).not.toExist();
   });
 });

--- a/src/pages/templatesV2/components/editorActions/tests/EditDraft.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/EditDraft.test.js
@@ -29,13 +29,13 @@ describe('EditDraft', () => {
     const push = jest.fn();
     const wrapper = subject({ history: { push }});
     wrapper.find('UnstyledLink').simulate('click');
-    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo');
+    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/draft/content');
   });
 
   it('routes to draft path with subaccount on click', () => {
     const push = jest.fn();
     const wrapper = subject({ history: { push }, draft: { id: 'foo', subaccount_id: 101 }});
     wrapper.find('UnstyledLink').simulate('click');
-    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo?subaccount=101');
+    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/draft/content?subaccount=101');
   });
 });

--- a/src/pages/templatesV2/components/editorActions/tests/PublishedModeActions.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/PublishedModeActions.test.js
@@ -1,9 +1,21 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import useEditorContext from '../../../hooks/useEditorContext';
 import PublishedModeActions from '../PublishedModeActions';
 
+jest.mock('../../../hooks/useEditorContext');
+
 describe('PublishedModeActions', () => {
+  const subject = (editorState) => {
+    useEditorContext.mockReturnValue({
+      hasDraft: true,
+      ...editorState
+    });
+
+    return shallow(<PublishedModeActions />);
+  };
+
   it('renders published actions', () => {
-    expect(shallow(<PublishedModeActions/>)).toMatchSnapshot();
+    expect(subject()).toMatchSnapshot();
   });
 });

--- a/src/pages/templatesV2/components/editorActions/tests/SaveAndPublish.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/SaveAndPublish.test.js
@@ -34,18 +34,18 @@ describe('SaveAndPublish', () => {
 
   it('publishes content upon confirmation', () => {
     const publishDraft = jest.fn(() => Promise.resolve());
-    const content = { text: 'foo text', html: '<h1>foo html</h1>' };
-    const wrapper = subject({ publishDraft, content });
+    const draft = { id: 'foo', content: { text: 'foo text', html: '<h1>foo html</h1>' }};
+    const wrapper = subject({ publishDraft, draft });
     wrapper.find('ConfirmationModal').prop('onConfirm')(); //invoke attached func
-    expect(publishDraft).toHaveBeenCalledWith({ id: 'foo', content }, undefined);
+    expect(publishDraft).toHaveBeenCalledWith(draft, undefined);
   });
 
   it('publishes content with subaccount upon confirmation', () => {
     const publishDraft = jest.fn(() => Promise.resolve());
-    const content = { text: 'foo text', html: '<h1>foo html</h1>' };
-    const wrapper = subject({ publishDraft, content, draft: { id: 'foo', subaccount_id: 101 }});
+    const draft = { id: 'foo', content: { text: 'foo text', html: '<h1>foo html</h1>' }, subaccount_id: 101 };
+    const wrapper = subject({ publishDraft, draft });
     wrapper.find('ConfirmationModal').prop('onConfirm')(); //invoke attached func
-    expect(publishDraft).toHaveBeenCalledWith({ id: 'foo', content }, 101);
+    expect(publishDraft).toHaveBeenCalledWith(draft, 101);
   });
 
   it('redirects to published path upon publishing', async () => {

--- a/src/pages/templatesV2/components/editorActions/tests/SaveAndPublish.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/SaveAndPublish.test.js
@@ -54,7 +54,7 @@ describe('SaveAndPublish', () => {
     const wrapper = subject({ history: { push }, publishDraft });
     await wrapper.find('ConfirmationModal').prop('onConfirm')(); //invoke attached func
     expect(publishDraft).toHaveBeenCalled();
-    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published');
+    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published/content');
   });
 
   it('redirects to published path with subaccount upon publishing', async () => {
@@ -63,7 +63,7 @@ describe('SaveAndPublish', () => {
     const wrapper = subject({ history: { push }, publishDraft, draft: { id: 'foo', subaccount_id: 101 }});
     await wrapper.find('ConfirmationModal').prop('onConfirm')(); //invoke attached func
     expect(publishDraft).toHaveBeenCalled();
-    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published?subaccount=101');
+    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published/content?subaccount=101');
   });
 
 });

--- a/src/pages/templatesV2/components/editorActions/tests/ViewPublished.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/ViewPublished.test.js
@@ -24,13 +24,13 @@ describe('ViewPublished', () => {
     const push = jest.fn();
     const wrapper = subject({ history: { push }});
     wrapper.find('UnstyledLink').simulate('click');
-    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published');
+    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published/content');
   });
 
   it('redirects to published path (with subaccount) upon click', () => {
     const push = jest.fn();
     const wrapper = subject({ history: { push }, draft: { id: 'foo', subaccount_id: 1001 }});
     wrapper.find('UnstyledLink').simulate('click');
-    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published?subaccount=1001');
+    expect(push).toHaveBeenCalledWith('/templatesv2/edit/foo/published/content?subaccount=1001');
   });
 });

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DraftModeActions.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DraftModeActions.test.js.snap
@@ -31,7 +31,9 @@ exports[`DraftModeActions renders draft actions 1`] = `
         </Button>
       }
     >
-      <div>
+      <div
+        className="ActionsBody"
+      >
         <_default
           className="ActionItem"
           onClick={[Function]}

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/EditDraft.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/EditDraft.test.js.snap
@@ -6,9 +6,6 @@ exports[`EditDraft renders edit draft action 1`] = `
 >
   <UnstyledLink
     onClick={[Function]}
-  >
-    <FileEdit />
-      Edit Draft
-  </UnstyledLink>
+  />
 </div>
 `;

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
@@ -28,10 +28,15 @@ exports[`PublishedModeActions renders published actions 1`] = `
         </Button>
       }
     >
-      <div>
+      <div
+        className="ActionsBody"
+      >
         <_default
           className="ActionItem"
-        />
+        >
+          <FileEdit />
+          Edit Draft
+        </_default>
       </div>
     </Popover>
   </div>

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveAndPublish.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveAndPublish.test.js.snap
@@ -8,7 +8,7 @@ exports[`SaveAndPublish renders SaveAndPublish action 1`] = `
     onClick={[Function]}
   >
     <CheckCircleOutline />
-      Save and Publish
+    Save and Publish
   </UnstyledLink>
   <ConfirmationModal
     confirmVerb="Save and Publish"

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveDraft.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveDraft.test.js.snap
@@ -8,7 +8,7 @@ exports[`SaveDraft renders save draft action 1`] = `
     onClick={[Function]}
   >
     <FileEdit />
-      Save Draft
+    Save Draft
   </UnstyledLink>
 </div>
 `;

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/ViewPublished.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/ViewPublished.test.js.snap
@@ -8,7 +8,7 @@ exports[`ViewPublished renders ViewPublished action 1`] = `
     onClick={[Function]}
   >
     <RemoveRedEye />
-      View Published
+    View Published
   </UnstyledLink>
 </div>
 `;

--- a/src/pages/templatesV2/components/settings/Form.Container.js
+++ b/src/pages/templatesV2/components/settings/Form.Container.js
@@ -11,6 +11,7 @@ import { withRouter } from 'react-router-dom';
 import { update as updateTemplate } from 'src/actions/templates';
 import { reduxForm } from 'redux-form';
 import { showAlert } from 'src/actions/globalAlert';
+import { selectSubaccountFromQuery } from '../../../../selectors/subaccounts';
 
 const formName = 'templateSettings';
 
@@ -19,7 +20,10 @@ const mapStateToProps = (state, props) => ({
   domainsLoading: state.sendingDomains.listLoading,
   hasSubaccounts: hasSubaccounts(state),
   canViewSubaccount: selectCondition(not(isSubaccountUser))(state),
-  initialValues: props.draft
+  initialValues: {
+    ...props.draft,
+    subaccount: selectSubaccountFromQuery(state, props)
+  }
 });
 
 const formOptions = {

--- a/src/pages/templatesV2/components/settings/Form.Container.js
+++ b/src/pages/templatesV2/components/settings/Form.Container.js
@@ -15,16 +15,20 @@ import { selectSubaccountFromQuery } from '../../../../selectors/subaccounts';
 
 const formName = 'templateSettings';
 
-const mapStateToProps = (state, props) => ({
-  domains: selectDomainsBySubaccount(state, props),
-  domainsLoading: state.sendingDomains.listLoading,
-  hasSubaccounts: hasSubaccounts(state),
-  canViewSubaccount: selectCondition(not(isSubaccountUser))(state),
-  initialValues: {
-    ...props.draft,
-    subaccount: selectSubaccountFromQuery(state, props)
-  }
-});
+const mapStateToProps = (state, props) => {
+  const activeVersion = props.isPublishedMode ? props.published : props.draft;
+
+  return {
+    domains: selectDomainsBySubaccount(state, props),
+    domainsLoading: state.sendingDomains.listLoading,
+    hasSubaccounts: hasSubaccounts(state),
+    canViewSubaccount: selectCondition(not(isSubaccountUser))(state),
+    initialValues: {
+      ...activeVersion,
+      subaccount: selectSubaccountFromQuery(state, props)
+    }
+  };
+};
 
 const formOptions = {
   form: formName,

--- a/src/pages/templatesV2/components/settings/Form.js
+++ b/src/pages/templatesV2/components/settings/Form.js
@@ -30,7 +30,7 @@ export default class SettingsForm extends React.Component {
   };
 
   render() {
-    const { handleSubmit, domainsLoading, domains, subaccountId, submitting, pristine, valid, hasSubaccounts, canViewSubaccount } = this.props;
+    const { handleSubmit, domainsLoading, domains, subaccountId, submitting, pristine, valid, hasSubaccounts, canViewSubaccount, isPublishedMode } = this.props;
     const canViewSubaccountSection = hasSubaccounts && canViewSubaccount;
     const fromEmailHelpText = !domainsLoading && !domains.length ? (subaccountId ? 'The selected subaccount does not have any verified sending domains.' : 'You do not have any verified sending domains to use.') : null;
 
@@ -41,7 +41,7 @@ export default class SettingsForm extends React.Component {
             name='name'
             component={TextFieldWrapper}
             label='Template Name'
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
             validate={required}
           />
 
@@ -53,14 +53,14 @@ export default class SettingsForm extends React.Component {
             disabled={true}
           />
         </Panel.Section>
-        {canViewSubaccountSection && <SubaccountSection newTemplate={false} disabled={submitting}/>}
+        {canViewSubaccountSection && <SubaccountSection newTemplate={false} disabled={submitting || isPublishedMode}/>}
         <Panel.Section>
           <Field
             name='content.subject'
             component={TextFieldWrapper}
             label='Subject'
             validate={required}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -71,7 +71,7 @@ export default class SettingsForm extends React.Component {
             validate={[required, emailOrSubstitution]}
             domains={domains}
             helpText={fromEmailHelpText}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -79,6 +79,7 @@ export default class SettingsForm extends React.Component {
             component={TextFieldWrapper}
             label='From Name'
             helpText='A friendly from for your recipients.'
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -87,7 +88,7 @@ export default class SettingsForm extends React.Component {
             label='Reply To'
             helpText='An email address recipients can reply to.'
             validate={emailOrSubstitution}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -95,7 +96,7 @@ export default class SettingsForm extends React.Component {
             component={TextFieldWrapper}
             label='Description'
             helpText='Not visible to recipients.'
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
         </Panel.Section>
         <Panel.Section>
@@ -105,8 +106,7 @@ export default class SettingsForm extends React.Component {
             label='Track Opens'
             type='checkbox'
             parse={this.parseToggle}
-            disabled={submitting}
-
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -115,8 +115,7 @@ export default class SettingsForm extends React.Component {
             label='Track Clicks'
             type='checkbox'
             parse={this.parseToggle}
-            disabled={submitting}
-
+            disabled={submitting || isPublishedMode}
           />
           <Field
             name='options.transactional'
@@ -126,7 +125,7 @@ export default class SettingsForm extends React.Component {
             parse={this.parseToggle}
             helpText={<p className={styles.HelpText}>Transactional messages are triggered by a user’s actions on the
               website, like requesting a password reset, signing up, or making a purchase.</p>}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
 
           />
         </Panel.Section>
@@ -134,7 +133,7 @@ export default class SettingsForm extends React.Component {
           <Button
             type='submit'
             primary
-            disabled={submitting || !valid || pristine}
+            disabled={submitting || !valid || pristine || isPublishedMode}
           >
             Update Settings
           </Button>

--- a/src/pages/templatesV2/components/settings/Form.js
+++ b/src/pages/templatesV2/components/settings/Form.js
@@ -29,12 +29,19 @@ export default class SettingsForm extends React.Component {
     showAlert({ message: 'Template deleted.', type: 'success' });
   };
 
+  renderPublishedIntro = () => {
+    const { hasDraft } = this.props;
+    return (<Panel.Section>
+      <p className={styles.SettingsIntro}>{`Template settings can only be changed in drafts. Simply select '${hasDraft ? 'Edit Draft' : 'Save as Draft'}' in the top right to access the draft version, and adjust settings as needed.`}</p>
+    </Panel.Section>);
+  }
   render() {
     const { handleSubmit, domainsLoading, domains, subaccountId, submitting, pristine, valid, hasSubaccounts, canViewSubaccount, isPublishedMode } = this.props;
     const canViewSubaccountSection = hasSubaccounts && canViewSubaccount;
     const fromEmailHelpText = !domainsLoading && !domains.length ? (subaccountId ? 'The selected subaccount does not have any verified sending domains.' : 'You do not have any verified sending domains to use.') : null;
 
     return (<>
+      {isPublishedMode && this.renderPublishedIntro()}
       <form onSubmit={handleSubmit(this.updateSettings)}>
         <Panel.Section>
           <Field

--- a/src/pages/templatesV2/components/settings/Form.module.scss
+++ b/src/pages/templatesV2/components/settings/Form.module.scss
@@ -5,3 +5,6 @@
 .DeleteButton {
   margin-left: 20px;
 }
+.SettingsIntro {
+  max-width: 80%;
+}

--- a/src/pages/templatesV2/components/settings/tests/Form.test.js
+++ b/src/pages/templatesV2/components/settings/tests/Form.test.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme';
 import React from 'react';
+import every from 'lodash/every';
 import SettingsForm from '../Form';
 
 jest.mock('../../DeleteTemplate');
@@ -14,6 +15,7 @@ describe('SettingsForm', () => {
       domainsLoading: false,
       hasSubaccounts: false,
       canViewSubaccount: false,
+      isPublishedMode: false,
       handleSubmit: jest.fn((func) => func),
       showAlert: jest.fn()
     };
@@ -29,6 +31,14 @@ describe('SettingsForm', () => {
 
   it('renders with subaccounts', () => {
     expect(subject({ hasSubaccounts: true, canViewSubaccount: true }).exists('SubaccountSection')).toBe(true);
+  });
+
+  it('renders with fields disabled in published mode', () => {
+    const wrapper = subject({ hasSubaccounts: true, canViewSubaccount: true, isPublishedMode: true });
+    const fieldProps = wrapper.find('Field').map((field) => field.prop('disabled'));
+    expect(fieldProps.length).toEqual(10);
+    expect(every(fieldProps)).toBe(true);
+    expect(wrapper.find('SubaccountSection').prop('disabled')).toBe(true);
   });
 
   it('renders From Email help text with no verified domains', () => {

--- a/src/pages/templatesV2/components/settings/tests/Form.test.js
+++ b/src/pages/templatesV2/components/settings/tests/Form.test.js
@@ -33,14 +33,6 @@ describe('SettingsForm', () => {
     expect(subject({ hasSubaccounts: true, canViewSubaccount: true }).exists('SubaccountSection')).toBe(true);
   });
 
-  it('renders with fields disabled in published mode', () => {
-    const wrapper = subject({ hasSubaccounts: true, canViewSubaccount: true, isPublishedMode: true });
-    const fieldProps = wrapper.find('Field').map((field) => field.prop('disabled'));
-    expect(fieldProps.length).toEqual(10);
-    expect(every(fieldProps)).toBe(true);
-    expect(wrapper.find('SubaccountSection').prop('disabled')).toBe(true);
-  });
-
   it('renders From Email help text with no verified domains', () => {
     const wrapper = subject({ domains: []});
     expect(wrapper.find('[name="content.from.email"]').prop('helpText'))
@@ -55,6 +47,24 @@ describe('SettingsForm', () => {
 
   it('renders id field disabled', () => {
     expect(subject().find('[name="id"]').prop('disabled')).toBe(true);
+  });
+
+  describe('Published version', () => {
+    it('renders with fields disabled', () => {
+      const wrapper = subject({ hasSubaccounts: true, canViewSubaccount: true, isPublishedMode: true });
+      const fieldProps = wrapper.find('Field').map((field) => field.prop('disabled'));
+      expect(fieldProps.length).toEqual(10);
+      expect(every(fieldProps)).toBe(true);
+      expect(wrapper.find('SubaccountSection').prop('disabled')).toBe(true);
+    });
+
+    it('renders settings intro when draft does not exist', () => {
+      expect(subject({ hasDraft: false, isPublishedMode: true }).find('[className="SettingsIntro"]')).toMatchSnapshot();
+    });
+
+    it('renders settings intro when draft exists', () => {
+      expect(subject({ hasDraft: true, isPublishedMode: true }).find('[className="SettingsIntro"]')).toMatchSnapshot();
+    });
   });
 
   describe('parseToggle', () => {

--- a/src/pages/templatesV2/components/settings/tests/__snapshots__/Form.test.js.snap
+++ b/src/pages/templatesV2/components/settings/tests/__snapshots__/Form.test.js.snap
@@ -8,6 +8,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
     <Panel.Section>
       <Field
         component={[Function]}
+        disabled={false}
         label="Template Name"
         name="name"
         validate={[Function]}
@@ -23,12 +24,14 @@ exports[`SettingsForm renders without subaccounts 1`] = `
     <Panel.Section>
       <Field
         component={[Function]}
+        disabled={false}
         label="Subject"
         name="content.subject"
         validate={[Function]}
       />
       <Field
         component={[Function]}
+        disabled={false}
         domains={
           Array [
             Object {
@@ -52,12 +55,14 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText="A friendly from for your recipients."
         label="From Name"
         name="content.from.name"
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText="An email address recipients can reply to."
         label="Reply To"
         name="content.reply_to"
@@ -65,6 +70,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText="Not visible to recipients."
         label="Description"
         name="description"
@@ -73,6 +79,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
     <Panel.Section>
       <Field
         component={[Function]}
+        disabled={false}
         label="Track Opens"
         name="options.open_tracking"
         parse={[Function]}
@@ -80,6 +87,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         label="Track Clicks"
         name="options.click_tracking"
         parse={[Function]}
@@ -87,6 +95,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText={
           <p
             className="HelpText"

--- a/src/pages/templatesV2/components/settings/tests/__snapshots__/Form.test.js.snap
+++ b/src/pages/templatesV2/components/settings/tests/__snapshots__/Form.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SettingsForm Published version renders settings intro when draft does not exist 1`] = `
+<p
+  className="SettingsIntro"
+>
+  Template settings can only be changed in drafts. Simply select 'Save as Draft' in the top right to access the draft version, and adjust settings as needed.
+</p>
+`;
+
+exports[`SettingsForm Published version renders settings intro when draft exists 1`] = `
+<p
+  className="SettingsIntro"
+>
+  Template settings can only be changed in drafts. Simply select 'Edit Draft' in the top right to access the draft version, and adjust settings as needed.
+</p>
+`;
+
 exports[`SettingsForm renders without subaccounts 1`] = `
 <Fragment>
   <form

--- a/src/pages/templatesV2/components/tests/EditAmpSection.test.js
+++ b/src/pages/templatesV2/components/tests/EditAmpSection.test.js
@@ -20,6 +20,10 @@ describe('EditAmpSection', () => {
     expect(subject()).toMatchSnapshot();
   });
 
+  it('renders correctly in readOnly mode', () => {
+    expect(subject({ editorState: { isPublishedMode: true }}).prop('readOnly')).toBe(true);
+  });
+
   it('sets content on change', () => {
     const setContent = jest.fn();
     const wrapper = subject({ editorState: { setContent }});

--- a/src/pages/templatesV2/components/tests/EditHtmlSection.test.js
+++ b/src/pages/templatesV2/components/tests/EditHtmlSection.test.js
@@ -20,6 +20,10 @@ describe('EditHtmlSection', () => {
     expect(subject()).toMatchSnapshot();
   });
 
+  it('renders correctly in readOnly mode', () => {
+    expect(subject({ editorState: { isPublishedMode: true }}).prop('readOnly')).toBe(true);
+  });
+
   it('sets content on change', () => {
     const setContent = jest.fn();
     const wrapper = subject({ editorState: { setContent }});

--- a/src/pages/templatesV2/components/tests/EditTextSection.test.js
+++ b/src/pages/templatesV2/components/tests/EditTextSection.test.js
@@ -20,6 +20,10 @@ describe('EditTextSection', () => {
     expect(subject()).toMatchSnapshot();
   });
 
+  it('renders correctly in readOnly mode', () => {
+    expect(subject({ editorState: { isPublishedMode: true }}).prop('readOnly')).toBe(true);
+  });
+
   it('sets content on change', () => {
     const setContent = jest.fn();
     const wrapper = subject({ editorState: { setContent }});

--- a/src/pages/templatesV2/components/tests/ListComponents.test.js
+++ b/src/pages/templatesV2/components/tests/ListComponents.test.js
@@ -17,7 +17,7 @@ describe('Template List Components', () => {
 
     it('should navigate to published page if template is published', () => {
       wrapper.setProps({ list_status: 'published' });
-      expect(wrapper.find('Link').props().to).toEqual('/templatesv2/edit/id-123/published?subaccount=123');
+      expect(wrapper.find('Link').props().to).toEqual('/templatesv2/edit/id-123/published/content?subaccount=123');
     });
   });
 

--- a/src/pages/templatesV2/components/tests/ListComponents.test.js
+++ b/src/pages/templatesV2/components/tests/ListComponents.test.js
@@ -7,7 +7,7 @@ describe('Template List Components', () => {
 
   describe('Name', () => {
     beforeEach(() => {
-      const props = { name: 'template name', id: 'id-123', subaccount_id: 123, list_status: 'draft' };
+      const props = { name: 'template name', list_name: 'template name', id: 'id-123', subaccount_id: 123, list_status: 'draft' };
       wrapper = shallow(<Name {...props} />);
     });
 

--- a/src/pages/templatesV2/components/tests/__snapshots__/ListComponents.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/ListComponents.test.js.snap
@@ -27,7 +27,7 @@ exports[`Template List Components Name should render 1`] = `
   >
     <Link
       replace={false}
-      to="/templatesv2/edit/id-123?subaccount=123"
+      to="/templatesv2/edit/id-123/draft/content?subaccount=123"
     >
       <strong>
         template name

--- a/src/pages/templatesV2/context/EditorContext.js
+++ b/src/pages/templatesV2/context/EditorContext.js
@@ -26,7 +26,7 @@ export const EditorContextProvider = ({ children, value: { getDraft, getPublishe
     getPublished(requestParams.id, requestParams.subaccount);
     listDomains();
     listSubaccounts();
-  }, [listSubaccounts, listDomains, getDraft, getPublished, requestParams.id, requestParams.subaccount, requestParams.navKey]);
+  }, [listSubaccounts, listDomains, getDraft, getPublished, requestParams.id, requestParams.version, requestParams.navKey, requestParams.subaccount]);
 
   return (
     <EditorContext.Provider value={pageValue}>

--- a/src/pages/templatesV2/context/EditorContext.js
+++ b/src/pages/templatesV2/context/EditorContext.js
@@ -26,7 +26,7 @@ export const EditorContextProvider = ({ children, value: { getDraft, getPublishe
     getPublished(requestParams.id, requestParams.subaccount);
     listDomains();
     listSubaccounts();
-  }, [listSubaccounts, listDomains, getDraft, getPublished, requestParams.id, requestParams.version, requestParams.navKey, requestParams.subaccount]);
+  }, [listSubaccounts, listDomains, getDraft, getPublished, requestParams.id, requestParams.version, requestParams.subaccount]);
 
   return (
     <EditorContext.Provider value={pageValue}>

--- a/src/pages/templatesV2/hooks/tests/useEditorContent.test.js
+++ b/src/pages/templatesV2/hooks/tests/useEditorContent.test.js
@@ -28,19 +28,54 @@ describe('useEditorContent', () => {
     expect(content).toEqual({ html: '<h1>Test</h1>', text: 'Test' });
   });
 
-  it('merges updated content', () => {
-    const wrapper = useTestWrapper({
-      draft: {
-        content: { html: '<h1>Test</h1>', text: 'Test' }
-      }
+  describe('setContent', () => {
+    let draft;
+    let published;
+    beforeEach(() => {
+      draft = {
+        content: {
+          html: '<h1>Draft HTML</h1>',
+          text: 'Draft Text'
+        }
+      };
+
+      published = {
+        content: {
+          html: '<h1>Published HTML</h1>',
+          text: 'Published Text'
+        }
+      };
     });
 
-    act(() => {
-      useHook(wrapper).setContent({ html: '<h1>Updated!</h1>' });
+    it('merges draft content', () => {
+      const wrapper = useTestWrapper({
+        isPublishedMode: false,
+        draft,
+        published
+      });
+
+      act(() => {
+        useHook(wrapper).setContent({ html: '<h1>Draft HTML Updated!</h1>' });
+      });
+
+      const { content } = useHook(wrapper);
+      expect(content).toEqual({ html: '<h1>Draft HTML Updated!</h1>', text: 'Draft Text' });
     });
 
-    const { content } = useHook(wrapper);
+    it('does not allow merging published content', () => {
+      const wrapper = useTestWrapper({
+        isPublishedMode: true,
+        draft,
+        published
+      });
 
-    expect(content).toEqual({ html: '<h1>Updated!</h1>', text: 'Test' });
+      act(() => {
+        useHook(wrapper).setContent({ html: '<h1>Published HTML Updated!</h1>' });
+      });
+
+      const { content } = useHook(wrapper);
+      expect(content).toEqual({ html: '<h1>Published HTML</h1>', text: 'Published Text' });
+    });
   });
+
 });

--- a/src/pages/templatesV2/hooks/tests/useEditorContent.test.js
+++ b/src/pages/templatesV2/hooks/tests/useEditorContent.test.js
@@ -5,8 +5,8 @@ import useEditorContent from '../useEditorContent';
 
 describe('useEditorContent', () => {
   const useTestWrapper = (value = {}) => {
-    const TestComponent = () => <div hooked={useEditorContent(value)}/>;
-    return mount(<TestComponent/>);
+    const TestComponent = () => <div hooked={useEditorContent(value)} />;
+    return mount(<TestComponent />);
   };
   const useHook = (wrapper) => wrapper.update().children().prop('hooked');
 
@@ -28,54 +28,19 @@ describe('useEditorContent', () => {
     expect(content).toEqual({ html: '<h1>Test</h1>', text: 'Test' });
   });
 
-  describe('setContent', () => {
-    let draft;
-    let published;
-    beforeEach(() => {
-      draft = {
-        content: {
-          html: '<h1>Draft HTML</h1>',
-          text: 'Draft Text'
-        }
-      };
-
-      published = {
-        content: {
-          html: '<h1>Published HTML</h1>',
-          text: 'Published Text'
-        }
-      };
+  it('merges updated content', () => {
+    const wrapper = useTestWrapper({
+      draft: {
+        content: { html: '<h1>Test</h1>', text: 'Test' }
+      }
     });
 
-    it('merges draft content', () => {
-      const wrapper = useTestWrapper({
-        isPublishedMode: false,
-        draft,
-        published
-      });
-
-      act(() => {
-        useHook(wrapper).setContent({ html: '<h1>Draft HTML Updated!</h1>' });
-      });
-
-      const { content } = useHook(wrapper);
-      expect(content).toEqual({ html: '<h1>Draft HTML Updated!</h1>', text: 'Draft Text' });
+    act(() => {
+      useHook(wrapper).setContent({ html: '<h1>Updated!</h1>' });
     });
 
-    it('merges published content', () => {
-      const wrapper = useTestWrapper({
-        isPublishedMode: true,
-        draft,
-        published
-      });
+    const { content } = useHook(wrapper);
 
-      act(() => {
-        useHook(wrapper).setContent({ html: '<h1>Published HTML Updated!</h1>' });
-      });
-
-      const { content } = useHook(wrapper);
-      expect(content).toEqual({ html: '<h1>Published HTML Updated!</h1>', text: 'Published Text' });
-    });
+    expect(content).toEqual({ html: '<h1>Updated!</h1>', text: 'Test' });
   });
-
 });

--- a/src/pages/templatesV2/hooks/tests/useEditorContent.test.js
+++ b/src/pages/templatesV2/hooks/tests/useEditorContent.test.js
@@ -5,8 +5,8 @@ import useEditorContent from '../useEditorContent';
 
 describe('useEditorContent', () => {
   const useTestWrapper = (value = {}) => {
-    const TestComponent = () => <div hooked={useEditorContent(value)} />;
-    return mount(<TestComponent />);
+    const TestComponent = () => <div hooked={useEditorContent(value)}/>;
+    return mount(<TestComponent/>);
   };
   const useHook = (wrapper) => wrapper.update().children().prop('hooked');
 
@@ -28,19 +28,54 @@ describe('useEditorContent', () => {
     expect(content).toEqual({ html: '<h1>Test</h1>', text: 'Test' });
   });
 
-  it('merges updated content', () => {
-    const wrapper = useTestWrapper({
-      draft: {
-        content: { html: '<h1>Test</h1>', text: 'Test' }
-      }
+  describe('setContent', () => {
+    let draft;
+    let published;
+    beforeEach(() => {
+      draft = {
+        content: {
+          html: '<h1>Draft HTML</h1>',
+          text: 'Draft Text'
+        }
+      };
+
+      published = {
+        content: {
+          html: '<h1>Published HTML</h1>',
+          text: 'Published Text'
+        }
+      };
     });
 
-    act(() => {
-      useHook(wrapper).setContent({ html: '<h1>Updated!</h1>' });
+    it('merges draft content', () => {
+      const wrapper = useTestWrapper({
+        isPublishedMode: false,
+        draft,
+        published
+      });
+
+      act(() => {
+        useHook(wrapper).setContent({ html: '<h1>Draft HTML Updated!</h1>' });
+      });
+
+      const { content } = useHook(wrapper);
+      expect(content).toEqual({ html: '<h1>Draft HTML Updated!</h1>', text: 'Draft Text' });
     });
 
-    const { content } = useHook(wrapper);
+    it('merges published content', () => {
+      const wrapper = useTestWrapper({
+        isPublishedMode: true,
+        draft,
+        published
+      });
 
-    expect(content).toEqual({ html: '<h1>Updated!</h1>', text: 'Test' });
+      act(() => {
+        useHook(wrapper).setContent({ html: '<h1>Published HTML Updated!</h1>' });
+      });
+
+      const { content } = useHook(wrapper);
+      expect(content).toEqual({ html: '<h1>Published HTML Updated!</h1>', text: 'Published Text' });
+    });
   });
+
 });

--- a/src/pages/templatesV2/hooks/tests/useEditorNavigation.test.js
+++ b/src/pages/templatesV2/hooks/tests/useEditorNavigation.test.js
@@ -13,8 +13,8 @@ describe('useEditorNavigation', () => {
       ...routerState
     });
 
-    const TestComponent = () => <div hooked={useEditorNavigation()} />;
-    return mount(<TestComponent />);
+    const TestComponent = () => <div hooked={useEditorNavigation()}/>;
+    return mount(<TestComponent/>);
   };
   const useHook = (wrapper) => wrapper.update().children().prop('hooked');
 
@@ -39,25 +39,46 @@ describe('useEditorNavigation', () => {
       .toEqual(expect.objectContaining({ currentNavigationIndex: 1, currentNavigationKey: 'settings' }));
   });
 
-  it('redirects when link is clicked', () => {
-    const historyPush = jest.fn();
-    const wrapper = useTestWrapper({ routerState: { history: { push: historyPush }}});
-
-    act(() => {
-      useHook(wrapper).setNavigation('settings');
+  describe('redirections', () => {
+    let historyPush;
+    beforeEach(() => {
+      historyPush = jest.fn();
     });
 
-    expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/settings');
-  });
-
-  it('redirects with subaccount id', () => {
-    const historyPush = jest.fn();
-    const wrapper = useTestWrapper({ routerState: { history: { push: historyPush }, requestParams: { id: 'test-template', subaccount: 102 }}});
-
-    act(() => {
-      useHook(wrapper).setNavigation('settings');
+    afterEach(() => {
+      historyPush.mockReset();
     });
 
-    expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/settings?subaccount=102');
+    const subject = (wrapper) => {
+      act(() => {
+        useHook(wrapper).setNavigation('settings');
+      });
+    };
+    const routeState = (overrides = {}) => ({
+      routerState: {
+        history: { push: historyPush },
+        requestParams: { id: 'test-template', ...overrides }
+      }
+    });
+
+    it('redirects when link is clicked (draft)', () => {
+      subject(useTestWrapper(routeState()));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/draft/settings');
+    });
+
+    it('redirects with subaccount id (draft)', () => {
+      subject(useTestWrapper(routeState({ subaccount: 102 })));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/draft/settings?subaccount=102');
+    });
+
+    it('redirects when link is clicked (published)', () => {
+      subject(useTestWrapper(routeState({ version: 'published' })));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/published/settings');
+    });
+
+    it('redirects with subaccount id (published)', () => {
+      subject(useTestWrapper(routeState({ version: 'published', subaccount: 102 })));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/published/settings?subaccount=102');
+    });
   });
 });

--- a/src/pages/templatesV2/hooks/useEditorContent.js
+++ b/src/pages/templatesV2/hooks/useEditorContent.js
@@ -1,18 +1,22 @@
 import { useEffect, useState } from 'react';
 
 // the store for in progress content changes
-const useEditorContent = ({ draft = {}}) => {
+const useEditorContent = ({ draft = {}, published = {}, isPublishedMode }) => {
   const [state, setState] = useState({});
   const setContent = (nextState) => {
+    if (isPublishedMode) {
+      return; //do not allow updating published content
+    }
     setState({ ...state, ...nextState }); // merge-in
   };
 
   // hydrate when loaded
   useEffect(() => {
-    if (draft.content) {
-      setState(draft.content);
+    const activeContent = isPublishedMode ? published : draft;
+    if (activeContent.content) {
+      setState(activeContent.content);
     }
-  }, [draft.content]);
+  }, [draft, isPublishedMode, published]);
 
   return {
     content: state,

--- a/src/pages/templatesV2/hooks/useEditorNavigation.js
+++ b/src/pages/templatesV2/hooks/useEditorNavigation.js
@@ -5,9 +5,9 @@ import { routeNamespace } from '../constants/routes';
 import { setSubaccountQuery } from '../../../helpers/subaccounts';
 
 const useEditorNavigation = () => {
-  const { history, requestParams: { id, navKey = '', subaccount: subaccountId }} = useRouter();
+  const { history, requestParams: { id, version = 'draft', navKey = '', subaccount: subaccountId }} = useRouter();
   const setNavigation = (nextNavigationKey) => {
-    history.push(`/${routeNamespace}/edit/${id}/${nextNavigationKey}${setSubaccountQuery(subaccountId)}`);
+    history.push(`/${routeNamespace}/edit/${id}/${version}/${nextNavigationKey}${setSubaccountQuery(subaccountId)}`);
   };
 
   return useMemo(() => {

--- a/src/pages/templatesV2/tests/CreatePage.test.js
+++ b/src/pages/templatesV2/tests/CreatePage.test.js
@@ -56,7 +56,7 @@ describe('CreatePage', () => {
       const mockAlert = jest.fn();
       const wrapper = subject({ create: jest.fn(() => Promise.resolve()), history: { push: mockPush }, showAlert: mockAlert });
       await wrapper.find('form').simulate('submit', { id: 'foo', content: {}});
-      expect(mockPush).toHaveBeenCalledWith('/templatesv2/edit/foo');
+      expect(mockPush).toHaveBeenCalledWith('/templatesv2/edit/foo/draft/content');
       expect(mockAlert).toHaveBeenCalledWith({ type: 'success', message: 'Template Created.' });
     });
   });

--- a/src/pages/templatesV2/tests/EditAndPreviewPage.test.js
+++ b/src/pages/templatesV2/tests/EditAndPreviewPage.test.js
@@ -22,6 +22,10 @@ describe('EditAndPreviewPage', () => {
     expect(subject()).toMatchSnapshot();
   });
 
+  it('renders a page in published mode', () => {
+    expect(subject({ editorState: { isPublishedMode: true }}).prop('primaryArea')).toMatchSnapshot();
+  });
+
   it('renders loading', () => {
     const wrapper = subject({ editorState: { isDraftLoading: true }});
     expect(wrapper.find('Loading')).toExist();

--- a/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
+++ b/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
@@ -3,6 +3,12 @@
 exports[`EditAndPreviewPage renders a page 1`] = `
 <FullPage
   breadcrumbRedirectsTo="/templatesv2"
+  primaryArea={
+    <span>
+      DRAFT 
+      <FileEdit />
+    </span>
+  }
   title="Test Template"
 >
   <div
@@ -18,4 +24,14 @@ exports[`EditAndPreviewPage renders a page 1`] = `
     <EditContents />
   </div>
 </FullPage>
+`;
+
+exports[`EditAndPreviewPage renders a page in published mode 1`] = `
+<span>
+  PUBLISHED 
+  <CheckCircle
+    className="GreenColor"
+  />
+   
+</span>
 `;

--- a/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
+++ b/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
@@ -4,8 +4,12 @@ exports[`EditAndPreviewPage renders a page 1`] = `
 <FullPage
   breadcrumbRedirectsTo="/templatesv2"
   primaryArea={
-    <div>
-      DRAFT 
+    <div
+      className="Status"
+    >
+      <span>
+        Draft
+      </span>
       <FileEdit
         size={17}
       />
@@ -29,12 +33,15 @@ exports[`EditAndPreviewPage renders a page 1`] = `
 `;
 
 exports[`EditAndPreviewPage renders a page in published mode 1`] = `
-<div>
-  PUBLISHED 
+<div
+  className="Status"
+>
+  <span>
+    Published
+  </span>
   <CheckCircle
     className="GreenColor"
     size={17}
   />
-   
 </div>
 `;

--- a/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
+++ b/src/pages/templatesV2/tests/__snapshots__/EditAndPreviewPage.test.js.snap
@@ -4,10 +4,12 @@ exports[`EditAndPreviewPage renders a page 1`] = `
 <FullPage
   breadcrumbRedirectsTo="/templatesv2"
   primaryArea={
-    <span>
+    <div>
       DRAFT 
-      <FileEdit />
-    </span>
+      <FileEdit
+        size={17}
+      />
+    </div>
   }
   title="Test Template"
 >
@@ -27,11 +29,12 @@ exports[`EditAndPreviewPage renders a page 1`] = `
 `;
 
 exports[`EditAndPreviewPage renders a page in published mode 1`] = `
-<span>
+<div>
   PUBLISHED 
   <CheckCircle
     className="GreenColor"
+    size={17}
   />
    
-</span>
+</div>
 `;

--- a/src/pages/templatesV2/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templatesV2/tests/__snapshots__/ListPage.test.js.snap
@@ -30,9 +30,9 @@ exports[`ListPage renders correctly 1`] = `
     columns={
       Array [
         Object {
-          "key": "name",
+          "key": "list_name",
           "label": "Template Name",
-          "sortKey": "name",
+          "sortKey": "list_name",
         },
         Object {
           "key": "status",

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -90,10 +90,10 @@ export const selectTemplatesForListTable = createSelector(
       const hasDraft = template.has_draft;
 
       if (hasPublished) {
-        templatesForListing.push({ ...template, list_status: hasDraft ? 'published_with_draft' : 'published' });
+        templatesForListing.push({ ...template, list_name: template.name, list_status: hasDraft ? 'published_with_draft' : 'published' });
       }
       if (hasDraft) {
-        templatesForListing.push({ ...template, name: hasPublished ? `${template.name} (DRAFT)` : template.name, list_status: 'draft' });
+        templatesForListing.push({ ...template, list_name: hasPublished ? `${template.name} (DRAFT)` : template.name, list_status: 'draft' });
       }
     });
     return templatesForListing;

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -255,6 +255,7 @@ exports[`Templates selectors selectTemplatesForListTable returns template(s) cor
 Array [
   Object {
     "has_published": true,
+    "list_name": "publishedSubaccount",
     "list_status": "published",
     "name": "publishedSubaccount",
     "shared_with_subaccounts": false,
@@ -263,6 +264,7 @@ Array [
   Object {
     "has_draft": true,
     "has_published": true,
+    "list_name": "publishedMaster",
     "list_status": "published_with_draft",
     "name": "publishedMaster",
     "published": true,
@@ -272,14 +274,16 @@ Array [
   Object {
     "has_draft": true,
     "has_published": true,
+    "list_name": "publishedMaster (DRAFT)",
     "list_status": "draft",
-    "name": "publishedMaster (DRAFT)",
+    "name": "publishedMaster",
     "published": true,
     "shared_with_subaccounts": false,
     "subaccount_id": 0,
   },
   Object {
     "has_published": true,
+    "list_name": "publishedShared",
     "list_status": "published",
     "name": "publishedShared",
     "shared_with_subaccounts": true,
@@ -293,6 +297,7 @@ Array [
   Object {
     "has_draft": true,
     "has_published": false,
+    "list_name": "publishedSubaccount",
     "list_status": "draft",
     "name": "publishedSubaccount",
     "shared_with_subaccounts": false,
@@ -305,6 +310,7 @@ exports[`Templates selectors selectTemplatesForListTable returns template(s) wit
 Array [
   Object {
     "has_published": true,
+    "list_name": "publishedSubaccount",
     "list_status": "published",
     "name": "publishedSubaccount",
     "shared_with_subaccounts": false,
@@ -312,6 +318,7 @@ Array [
   },
   Object {
     "has_published": true,
+    "list_name": "publishedMaster",
     "list_status": "published",
     "name": "publishedMaster",
     "published": true,
@@ -320,6 +327,7 @@ Array [
   },
   Object {
     "has_published": true,
+    "list_name": "publishedShared",
     "list_status": "published",
     "name": "publishedShared",
     "shared_with_subaccounts": true,


### PR DESCRIPTION
Renders editor in read only mode when viewing a published template; editable when viewing a draft. 

### What Changed
 - Render editors based on template status. Draft is editable, locked in published version
 - Add draft/published indicate at top bar
 - Fields in `Template Settings` tab are disabled when viewing published template
   - Delete button should be active
 - To distinguish (and deep link), modified route to add version
 - List and create pages are updated to take to new routes
 - Updated List page to use `list_name` to preserve original name in order to show correct messaging after delete. 

### How To Test
From Campaigns -> Templates
 - Open a draft template. You should be able to edit and top indicator should show draft
- Open a published template. Editing areas should be read only and indicated it's a published template like the image below. Template Settings should also be in read only mode
<img width="245" alt="Screen Shot 2019-06-18 at 6 51 29 PM" src="https://user-images.githubusercontent.com/14877079/59725029-1adc2f80-91fa-11e9-9a8b-bb3a2f03fa6f.png">
-  Create a template. After template creation, it should take you to `/edit/<id>/draft/content`
- Modify a draft (w/o publish) and see the two versions are rendered correctly 

