### PR TITLE
EO-801 Switch over to Alerts v1 API for Alerts List page

### DIFF
--- a/src/actions/alertsV1.js
+++ b/src/actions/alertsV1.js
@@ -1,0 +1,34 @@
+import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
+
+export function listAlerts() {
+  return sparkpostApiRequest({
+    type: 'LIST_ALERTS_V1',
+    meta: {
+      method: 'GET',
+      url: '/v1/alerts',
+      showErrorAlert: false
+    }
+  });
+}
+
+export function setMutedStatus({ muted, id }) {
+  return sparkpostApiRequest({
+    type: 'SET_ALERT_V1_MUTED_STATUS',
+    meta: {
+      method: 'PUT',
+      url: `/v1/alerts/${id}`,
+      data: { muted }
+    }
+  });
+}
+
+export function deleteAlert({ id }) {
+  return sparkpostApiRequest({
+    type: 'DELETE_ALERT_V1',
+    meta: {
+      method: 'DELETE',
+      url: `/v1/alerts/${id}`,
+      id
+    }
+  });
+}

--- a/src/actions/alertsV1.js
+++ b/src/actions/alertsV1.js
@@ -17,7 +17,8 @@ export function setMutedStatus({ muted, id }) {
     meta: {
       method: 'PUT',
       url: `/v1/alerts/${id}`,
-      data: { muted }
+      data: { muted },
+      id
     }
   });
 }

--- a/src/actions/tests/__snapshots__/alertsV1.test.js.snap
+++ b/src/actions/tests/__snapshots__/alertsV1.test.js.snap
@@ -33,6 +33,7 @@ Array [
       "data": Object {
         "muted": false,
       },
+      "id": "alert-id",
       "method": "PUT",
       "url": "/v1/alerts/alert-id",
     },

--- a/src/actions/tests/__snapshots__/alertsV1.test.js.snap
+++ b/src/actions/tests/__snapshots__/alertsV1.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Action Creator: Alerts should dispatch a delete action 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "id": "alert-id",
+      "method": "DELETE",
+      "url": "/v1/alerts/alert-id",
+    },
+    "type": "DELETE_ALERT_V1",
+  },
+]
+`;
+
+exports[`Action Creator: Alerts should dispatch a list action 1`] = `
+Array [
+  Object {
+    "type": "LIST_ALERTS_V1_SUCCESS",
+  },
+]
+`;
+
+exports[`Action Creator: Alerts should dispatch a set muted status action 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "muted": false,
+      },
+      "method": "PUT",
+      "url": "/v1/alerts/alert-id",
+    },
+    "type": "SET_ALERT_V1_MUTED_STATUS",
+  },
+]
+`;

--- a/src/actions/tests/__snapshots__/alertsV1.test.js.snap
+++ b/src/actions/tests/__snapshots__/alertsV1.test.js.snap
@@ -16,7 +16,12 @@ Array [
 exports[`Action Creator: Alerts should dispatch a list action 1`] = `
 Array [
   Object {
-    "type": "LIST_ALERTS_V1_SUCCESS",
+    "meta": Object {
+      "method": "GET",
+      "showErrorAlert": false,
+      "url": "/v1/alerts",
+    },
+    "type": "LIST_ALERTS_V1",
   },
 ]
 `;

--- a/src/actions/tests/alertsV1.test.js
+++ b/src/actions/tests/alertsV1.test.js
@@ -1,0 +1,27 @@
+import { createMockStore } from 'src/__testHelpers__/mockStore';
+import * as alerts from '../alertsV1';
+
+jest.mock('../helpers/sparkpostApiRequest', () => jest.fn((a) => a));
+
+describe('Action Creator: Alerts', () => {
+  let mockStore;
+
+  beforeEach(() => {
+    mockStore = createMockStore({});
+  });
+
+  it('should dispatch a list action', () => {
+    mockStore.dispatch(alerts.listAlerts());
+    expect(mockStore.getActions()).toMatchSnapshot();
+  });
+
+  it('should dispatch a set muted status action', () => {
+    mockStore.dispatch(alerts.setMutedStatus({ id: 'alert-id', muted: false }));
+    expect(mockStore.getActions()).toMatchSnapshot();
+  });
+
+  it('should dispatch a delete action', () => {
+    mockStore.dispatch(alerts.deleteAlert({ id: 'alert-id' }));
+    expect(mockStore.getActions()).toMatchSnapshot();
+  });
+});

--- a/src/pages/alerts/ListPageNew.js
+++ b/src/pages/alerts/ListPageNew.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Grid, Page, Panel } from '@sparkpost/matchbox';
 import { RemoveRedEye } from '@sparkpost/matchbox-icons';
-import { ApiErrorBanner, DeleteModal, Loading } from 'src/components';
+import { ApiErrorBanner, DeleteModal, Loading, DisplayDate } from 'src/components';
 import { Templates } from 'src/components/images';
 import AlertCollectionNew from './components/AlertCollectionNew';
 import withAlertsList from './containers/ListPage.container';
 import styles from './ListPage.module.scss';
 import { formatDateTime } from 'src/helpers/date';
 import _ from 'lodash';
-import DisplayDate from 'src/components/displayDate/DisplayDate.js';
 
 export class ListPageNew extends Component {
   state = {

--- a/src/pages/alerts/ListPageNew.js
+++ b/src/pages/alerts/ListPageNew.js
@@ -30,14 +30,6 @@ export class ListPageNew extends Component {
     });
   };
 
-  getRecentlyTriggeredAlerts = () => {
-    const { alerts } = this.props;
-    return alerts
-      .filter((alert) => alert.last_triggered !== null) //Remove any alert that has never triggered
-      .sort((a, b) => (a.last_triggered.timestamp > b.last_triggered.timestamp)) //Sorts by last triggered date, descending
-      .slice(0,4);
-  }
-
   handleDelete = () => {
     const { id } = this.state.alertToDelete;
 
@@ -58,38 +50,33 @@ export class ListPageNew extends Component {
 
   renderRecentlyTriggered() {
 
-    const orderedAlerts = this.getRecentlyTriggeredAlerts();
-
-    if (orderedAlerts.length === 0) {
+    const { recentlyTriggeredAlerts } = this.props;
+    if (recentlyTriggeredAlerts.length === 0) {
       return;
     }
 
-    const recentlyTriggered = orderedAlerts.map((alert) => (
-      <Grid.Column
-        xs={12}
-        md={6}
-        lg={3}
-        key = {alert.id}>
-        <Panel
-          accent
-        >
-          <Panel.Section className = {styles.LastTriggeredCard}>
-            <div className = {styles.LastTriggeredTime} >
-              <DisplayDate timestamp={alert.last_triggered_timestamp} formattedDate={alert.last_triggered_formatted} />
-            </div>
-            <h3>{alert.name}</h3>
-          </Panel.Section>
-
-          <Panel.Section className = {styles.Footer}>
-            <Button flat to = {'/alerts-new'/*TODO replace this link*/}><RemoveRedEye className = {styles.Icon}/></Button>
-          </Panel.Section>
-        </Panel>
-      </Grid.Column>));
     return (
       <>
         <h3>Recently Triggered Alerts</h3>
         <Grid>
-          {recentlyTriggered}
+          {recentlyTriggeredAlerts.map((alert) => (
+            <Grid.Column
+              xs={12}
+              md={6}
+              lg={3}
+              key = {alert.id}>
+              <Panel accent>
+                <Panel.Section className = {styles.LastTriggeredCard}>
+                  <div className = {styles.LastTriggeredTime} >
+                    <DisplayDate timestamp={alert.last_triggered_timestamp} formattedDate={alert.last_triggered_formatted} />
+                  </div>
+                  <h3>{alert.name}</h3>
+                </Panel.Section>
+                <Panel.Section className = {styles.Footer}>
+                  <Button flat to = {'/alerts-new'/*TODO replace this link*/}><RemoveRedEye className = {styles.Icon}/></Button>
+                </Panel.Section>
+              </Panel>
+            </Grid.Column>))};
         </Grid>
         </>);
   }

--- a/src/pages/alerts/ListPageNew.js
+++ b/src/pages/alerts/ListPageNew.js
@@ -5,7 +5,7 @@ import { RemoveRedEye } from '@sparkpost/matchbox-icons';
 import { ApiErrorBanner, DeleteModal, Loading, DisplayDate } from 'src/components';
 import { Templates } from 'src/components/images';
 import AlertCollectionNew from './components/AlertCollectionNew';
-import withAlertsList from './containers/ListPage.container';
+import withAlertsList from './containers/ListPageNew.container';
 import styles from './ListPage.module.scss';
 import _ from 'lodash';
 

--- a/src/pages/alerts/ListPageNew.js
+++ b/src/pages/alerts/ListPageNew.js
@@ -32,11 +32,10 @@ export class ListPageNew extends Component {
 
   getRecentlyTriggeredAlerts = () => {
     const { alerts } = this.props;
-    const orderedArray = alerts
+    return alerts
       .filter((alert) => alert.last_triggered !== null) //Remove any alert that has never triggered
-      .sort((a, b) => (a.last_triggered > b.last_triggered) ? -1 : 1) //Sorts by last triggered date, descending
+      .sort((a, b) => (a.last_triggered.timestamp > b.last_triggered.timestamp)) //Sorts by last triggered date, descending
       .slice(0,4);
-    return orderedArray;
   }
 
   handleDelete = () => {
@@ -75,7 +74,9 @@ export class ListPageNew extends Component {
           accent
         >
           <Panel.Section className = {styles.LastTriggeredCard}>
-            <div className = {styles.LastTriggeredTime} ><DisplayDate timestamp={alert.last_triggered} formattedDate={alert.formattedDate} /></div>
+            <div className = {styles.LastTriggeredTime} >
+              <DisplayDate timestamp={alert.last_triggered_timestamp} formattedDate={alert.last_triggered_formatted} />
+            </div>
             <h3>{alert.name}</h3>
           </Panel.Section>
 

--- a/src/pages/alerts/ListPageNew.js
+++ b/src/pages/alerts/ListPageNew.js
@@ -73,10 +73,10 @@ export class ListPageNew extends Component {
                   <h3>{alert.name}</h3>
                 </Panel.Section>
                 <Panel.Section className = {styles.Footer}>
-                  <Button flat to = {'/alerts-new'/*TODO replace this link*/}><RemoveRedEye className = {styles.Icon}/></Button>
+                  <Button flat to = {'/alerts-new'}><RemoveRedEye className = {styles.Icon}/></Button>
                 </Panel.Section>
               </Panel>
-            </Grid.Column>))};
+            </Grid.Column>))}
         </Grid>
         </>);
   }

--- a/src/pages/alerts/ListPageNew.js
+++ b/src/pages/alerts/ListPageNew.js
@@ -80,7 +80,7 @@ export class ListPageNew extends Component {
           </Panel.Section>
 
           <Panel.Section className = {styles.Footer}>
-            <Button flat to = {'/alerts-new'}><RemoveRedEye className = {styles.Icon}/></Button>
+            <Button flat to = {'/alerts-new'/*TODO replace this link*/}><RemoveRedEye className = {styles.Icon}/></Button>
           </Panel.Section>
         </Panel>
       </Grid.Column>));

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -25,7 +25,7 @@ class AlertCollectionNew extends Component {
     const columns = [
       { label: 'Alert Name', sortKey: 'name', width: '40%', className: styles.TabbedCellHeader },
       { label: 'Metric', sortKey: 'metric' },
-      { label: 'Last Triggered', sortKey: 'sortKey' },
+      { label: 'Last Triggered', sortKey: 'last_triggered_timestamp' },
       { label: 'Status', sortKey: 'muted' },
       null
     ];
@@ -33,14 +33,14 @@ class AlertCollectionNew extends Component {
     return columns;
   }
 
-  getRowData = ({ metric, muted, id, name, last_triggered, formattedDate }) => {
+  getRowData = ({ metric, muted, id, name, last_triggered_timestamp, last_triggered_formatted }) => {
     const deleteFn = () => this.props.handleDelete({ id, name });
     return [
       <div className = {styles.TabbedCellBody}>
         <PageLink to={this.getDetailsLink({ id })}>{name}</PageLink>
       </div>,
       <Tag>{_.get(METRICS, metric, metric)}</Tag>,
-      <DisplayDate timestamp={last_triggered} formattedDate={formattedDate} />,
+      <DisplayDate timestamp={last_triggered_timestamp} formattedDate={last_triggered_formatted || 'Never Triggered'} />,
       <AlertToggle muted={muted} id={id} />,
       <Button flat onClick = {deleteFn}><Delete className = {styles.Icon}/></Button>
     ];
@@ -65,7 +65,7 @@ class AlertCollectionNew extends Component {
         getRowData={this.getRowData}
         pagination={true}
         filterBox={filterBoxConfig}
-        defaultSortColumn='sortKey'
+        defaultSortColumn='last_triggered_timestamp'
         defaultSortDirection='desc'
       >
         {

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -41,7 +41,7 @@ class AlertCollectionNew extends Component {
       </div>,
       <Tag>{_.get(METRICS, metric, metric)}</Tag>,
       <DisplayDate timestamp={last_triggered} formattedDate={formattedDate} />,
-      <AlertToggle muted={muted} id={id} />,
+      <AlertToggle muted={muted} id={id.toString()} />,
       <Button flat onClick = {deleteFn}><Delete className = {styles.Icon}/></Button>
     ];
   }

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { Button, Table, Tag, Panel } from '@sparkpost/matchbox';
-import { TableCollection, PageLink } from 'src/components';
+import { TableCollection, PageLink, DisplayDate } from 'src/components';
 import AlertToggle from './AlertToggle';
 import { Delete } from '@sparkpost/matchbox-icons';
 import { METRICS } from '../constants/metrics';
 import styles from './AlertCollection.module.scss';
 import { formatDateTime } from 'src/helpers/date';
 import _ from 'lodash';
-import DisplayDate from 'src/components/displayDate/DisplayDate.js';
 
 const filterBoxConfig = {
   show: true,

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -41,7 +41,7 @@ class AlertCollectionNew extends Component {
       </div>,
       <Tag>{_.get(METRICS, metric, metric)}</Tag>,
       <DisplayDate timestamp={last_triggered} formattedDate={formattedDate} />,
-      <AlertToggle muted={muted} id={id.toString()} />,
+      <AlertToggle muted={muted} id={id} />,
       <Button flat onClick = {deleteFn}><Delete className = {styles.Icon}/></Button>
     ];
   }

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -5,7 +5,6 @@ import AlertToggle from './AlertToggleNew';
 import { Delete } from '@sparkpost/matchbox-icons';
 import { METRICS } from '../constants/metricsV1';
 import styles from './AlertCollection.module.scss';
-import _ from 'lodash';
 
 const filterBoxConfig = {
   show: true,
@@ -18,7 +17,7 @@ const filterBoxConfig = {
 };
 
 class AlertCollectionNew extends Component {
-  //TODO replace link
+
   getDetailsLink = ({ id }) => `/alerts/edit/${id}`;
 
   getColumns() {
@@ -39,7 +38,7 @@ class AlertCollectionNew extends Component {
       <div className = {styles.TabbedCellBody}>
         <PageLink to={this.getDetailsLink({ id })}>{name}</PageLink>
       </div>,
-      <Tag>{_.get(METRICS, metric, metric)}</Tag>,
+      <Tag>{METRICS[metric]}</Tag>,
       <DisplayDate timestamp={last_triggered_timestamp} formattedDate={last_triggered_formatted || 'Never Triggered'} />,
       <AlertToggle muted={muted} id={id} />,
       <Button flat onClick = {deleteFn}><Delete className = {styles.Icon}/></Button>
@@ -75,7 +74,6 @@ class AlertCollectionNew extends Component {
               <Panel.Section className = {styles.Title}>
                 <h3>All Alerts</h3>
               </Panel.Section>
-
               {filterBox}
               {collection}
             </Panel>

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
-import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { Button, Table, Tag, Panel } from '@sparkpost/matchbox';
 import { TableCollection, PageLink, DisplayDate } from 'src/components';
-import AlertToggle from './AlertToggle';
+import AlertToggle from './AlertToggleNew';
 import { Delete } from '@sparkpost/matchbox-icons';
-import { METRICS } from '../constants/metrics';
+import { METRICS } from '../constants/metricsV1';
 import styles from './AlertCollection.module.scss';
-import { formatDateTime } from 'src/helpers/date';
 import _ from 'lodash';
 
 const filterBoxConfig = {
@@ -20,34 +18,30 @@ const filterBoxConfig = {
 };
 
 class AlertCollectionNew extends Component {
-  //TODO Add last triggered date and replace link
-  getDetailsLink = ({ id, subaccount_id }) => `/alerts/edit/${id}${setSubaccountQuery(subaccount_id)}`
+  //TODO replace link
+  getDetailsLink = ({ id }) => `/alerts/edit/${id}`;
 
   getColumns() {
     const columns = [
       { label: 'Alert Name', sortKey: 'name', width: '40%', className: styles.TabbedCellHeader },
-      { label: 'Metric', sortKey: 'alert_metric' },
-      { label: 'Last Triggered', sortKey: '' },
-      { label: 'Status', sortKey: 'enabled' },
+      { label: 'Metric', sortKey: 'metric' },
+      { label: 'Last Triggered', sortKey: 'sortKey' },
+      { label: 'Status', sortKey: 'muted' },
       null
     ];
 
     return columns;
   }
 
-  getRowData = ({ alert_metric, enabled, id, name, subaccount_id }) => {
-
-    const deleteFn = () => this.props.handleDelete({ id, name, subaccount_id });
-    //TODO remove when real data is available through API
-    const timestamp = '2019-06-05T20:29:59.000Z';
-    const lastTriggeredDate = formatDateTime(timestamp);
+  getRowData = ({ metric, muted, id, name, last_triggered, formattedDate }) => {
+    const deleteFn = () => this.props.handleDelete({ id, name });
     return [
       <div className = {styles.TabbedCellBody}>
-        <PageLink to={this.getDetailsLink({ id, subaccount_id })}>{name}</PageLink>
+        <PageLink to={this.getDetailsLink({ id })}>{name}</PageLink>
       </div>,
-      <Tag>{_.get(METRICS, alert_metric, alert_metric)}</Tag>,
-      <DisplayDate timestamp={timestamp} formattedDate={lastTriggeredDate} />,
-      <AlertToggle enabled={enabled} id={id} subaccountId={subaccount_id} />,
+      <Tag>{_.get(METRICS, metric, metric)}</Tag>,
+      <DisplayDate timestamp={last_triggered} formattedDate={formattedDate} />,
+      <AlertToggle muted={muted} id={id} />,
       <Button flat onClick = {deleteFn}><Delete className = {styles.Icon}/></Button>
     ];
   }
@@ -71,7 +65,7 @@ class AlertCollectionNew extends Component {
         getRowData={this.getRowData}
         pagination={true}
         filterBox={filterBoxConfig}
-        defaultSortColumn='name'
+        defaultSortColumn='sortKey'
         defaultSortDirection='desc'
       >
         {

--- a/src/pages/alerts/components/AlertToggleNew.js
+++ b/src/pages/alerts/components/AlertToggleNew.js
@@ -7,11 +7,7 @@ import styles from './AlertToggle.module.scss';
 
 export class AlertToggle extends Component {
   state = {
-    muted: false
-  }
-
-  componentDidMount() {
-    this.setState({ muted: this.props.muted });
+    muted: this.props.muted
   }
 
   handleToggle = () => {
@@ -34,7 +30,7 @@ export class AlertToggle extends Component {
     return (
       <div className={styles.Wrapper}>
         <Toggle
-          id={id}
+          id={id.toString()}
           compact
           checked={!muted}
           disabled={pending}

--- a/src/pages/alerts/components/AlertToggleNew.js
+++ b/src/pages/alerts/components/AlertToggleNew.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Toggle } from '@sparkpost/matchbox';
+import { setMutedStatus } from 'src/actions/alertsV1';
+import { showAlert } from 'src/actions/globalAlert';
+import styles from './AlertToggle.module.scss';
+
+export class AlertToggle extends Component {
+  state = {
+    muted: false
+  }
+
+  componentDidMount() {
+    this.setState({ muted: this.props.muted });
+  }
+
+  handleToggle = () => {
+    const { id, setMutedStatus, showAlert } = this.props;
+    const { muted } = this.state;
+
+    this.setState({ muted: !muted });
+
+    return setMutedStatus({ id, muted: !muted }).then(() => {
+      showAlert({ type: 'success', message: 'Alert updated' });
+    }).catch(() => {
+      this.setState({ muted: this.props.muted }); // Revert to initial value
+    });
+  }
+
+  render() {
+    const { muted } = this.state;
+    const { id, pending } = this.props;
+
+    return (
+      <div className={styles.Wrapper}>
+        <Toggle
+          id={id}
+          compact
+          checked={!muted}
+          disabled={pending}
+          onChange={this.handleToggle}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  pending: state.alertsV1.setMutedStatusPending
+});
+
+export default connect(mapStateToProps, { setMutedStatus, showAlert })(AlertToggle);

--- a/src/pages/alerts/components/tests/AlertCollectionNew.test.js
+++ b/src/pages/alerts/components/tests/AlertCollectionNew.test.js
@@ -11,8 +11,8 @@ describe('TestCollection Component', () => {
         name: 'my alert 1',
         metric: 'monthly_sending_limit',
         last_triggered: null,
-        formattedDate: 'Never Triggered',
-        sortKey: '0'
+        last_triggered_formatted: null,
+        last_triggered_timestamp: 0
       },
       {
         id: 'id-2',
@@ -20,8 +20,8 @@ describe('TestCollection Component', () => {
         name: 'my alert 2',
         metric: 'monthly_sending_limit',
         last_triggered: '2019-06-05T14:48:00.000Z',
-        formattedDate: 'Jun 5 2019, 10:48am',
-        sortKey: '2019-06-05T14:48:00.000Z'
+        last_triggered_formatted: 'Jun 5 2019, 10:48am',
+        last_triggered_timestamp: 1559746080000
       },
       {
         id: 'id-3',
@@ -29,8 +29,8 @@ describe('TestCollection Component', () => {
         name: 'my alert 3',
         metric: 'health_score',
         last_triggered: '2019-06-015T14:48:00.000Z',
-        formattedDate: 'Jun 15 2019, 10:48am',
-        sortKey: '2019-06-15T14:48:00.000Z'
+        last_triggered_formatted: 'Jun 15 2019, 10:48am',
+        last_triggered_timestamp: 1560610080000
       }
     ],
     handleDelete: jest.fn()

--- a/src/pages/alerts/components/tests/AlertCollectionNew.test.js
+++ b/src/pages/alerts/components/tests/AlertCollectionNew.test.js
@@ -1,0 +1,61 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import AlertCollectionNew from '../AlertCollectionNew';
+
+describe('TestCollection Component', () => {
+  const props = {
+    alerts: [
+      {
+        id: 'id-1',
+        muted: true,
+        name: 'my alert 1',
+        metric: 'monthly_sending_limit',
+        last_triggered: null,
+        formattedDate: 'Never Triggered',
+        sortKey: '0'
+      },
+      {
+        id: 'id-2',
+        muted: false,
+        name: 'my alert 2',
+        metric: 'monthly_sending_limit',
+        last_triggered: '2019-06-05T14:48:00.000Z',
+        formattedDate: 'Jun 5 2019, 10:48am',
+        sortKey: '2019-06-05T14:48:00.000Z'
+      },
+      {
+        id: 'id-3',
+        muted: true,
+        name: 'my alert 3',
+        metric: 'health_score',
+        last_triggered: '2019-06-015T14:48:00.000Z',
+        formattedDate: 'Jun 15 2019, 10:48am',
+        sortKey: '2019-06-15T14:48:00.000Z'
+      }
+    ],
+    handleDelete: jest.fn()
+  };
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<AlertCollectionNew {...props} />);
+  });
+
+  it('should render', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render row data properly', () => {
+    props.alerts.forEach((alert) => {
+      const row = wrapper.instance().getRowData(alert);
+      expect(row).toMatchSnapshot();
+    });
+  });
+
+  it('should handleDelete', () => {
+    const actionCol = shallow(wrapper.instance().getRowData(props.alerts[0]).pop());
+    actionCol.find('button').simulate('click');
+    expect(props.handleDelete).toHaveBeenCalledWith({ id: 'id-1', name: 'my alert 1' });
+  });
+});

--- a/src/pages/alerts/components/tests/AlertToggleNew.test.js
+++ b/src/pages/alerts/components/tests/AlertToggleNew.test.js
@@ -1,0 +1,59 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { AlertToggle } from '../AlertToggleNew';
+
+describe('AlertToggle Component', () => {
+  const props = {
+    id: 'mock-id',
+    muted: false,
+    pending: false,
+    setMutedStatus: jest.fn(),
+    showAlert: jest.fn()
+  };
+
+  const subject = (options) => shallow(<AlertToggle {...props} {...options} />);
+
+  it('should render initial state', () => {
+    const wrapper = subject();
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Toggle')).toBeChecked();
+  });
+
+  it('should render pending state', () => {
+    const wrapper = subject({ pending: true });
+    expect(wrapper.find('Toggle')).toBeDisabled();
+  });
+
+  it('should handle a successful toggle', async () => {
+    const setMutedStatus = jest.fn(() => Promise.resolve());
+    const wrapper = subject({ setMutedStatus });
+
+    await wrapper.find('Toggle').prop('onChange')();
+
+    expect(setMutedStatus).toHaveBeenCalledWith({
+      muted: true,
+      id: 'mock-id'
+    });
+
+    expect(props.showAlert).toHaveBeenCalledWith({
+      message: 'Alert updated',
+      type: 'success'
+    });
+
+    expect(wrapper.find('Toggle')).not.toBeChecked();
+  });
+
+  it('should handle a failed toggle', async () => {
+    const setMutedStatus = jest.fn(() => Promise.reject());
+    const wrapper = subject({ setMutedStatus, muted: true });
+
+    await wrapper.find('Toggle').prop('onChange')();
+
+    expect(setMutedStatus).toHaveBeenCalledWith({
+      muted: false,
+      id: 'mock-id'
+    });
+
+    expect(wrapper.find('Toggle')).not.toBeChecked();
+  });
+});

--- a/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
@@ -16,7 +16,7 @@ exports[`TestCollection Component should render 1`] = `
       },
       Object {
         "label": "Last Triggered",
-        "sortKey": "sortKey",
+        "sortKey": "last_triggered_timestamp",
       },
       Object {
         "label": "Status",
@@ -25,7 +25,7 @@ exports[`TestCollection Component should render 1`] = `
       null,
     ]
   }
-  defaultSortColumn="sortKey"
+  defaultSortColumn="last_triggered_timestamp"
   defaultSortDirection="desc"
   filterBox={
     Object {
@@ -42,31 +42,31 @@ exports[`TestCollection Component should render 1`] = `
   rows={
     Array [
       Object {
-        "formattedDate": "Never Triggered",
         "id": "id-1",
         "last_triggered": null,
+        "last_triggered_formatted": null,
+        "last_triggered_timestamp": 0,
         "metric": "monthly_sending_limit",
         "muted": true,
         "name": "my alert 1",
-        "sortKey": "0",
       },
       Object {
-        "formattedDate": "Jun 5 2019, 10:48am",
         "id": "id-2",
         "last_triggered": "2019-06-05T14:48:00.000Z",
+        "last_triggered_formatted": "Jun 5 2019, 10:48am",
+        "last_triggered_timestamp": 1559746080000,
         "metric": "monthly_sending_limit",
         "muted": false,
         "name": "my alert 2",
-        "sortKey": "2019-06-05T14:48:00.000Z",
       },
       Object {
-        "formattedDate": "Jun 15 2019, 10:48am",
         "id": "id-3",
         "last_triggered": "2019-06-015T14:48:00.000Z",
+        "last_triggered_formatted": "Jun 15 2019, 10:48am",
+        "last_triggered_timestamp": 1560610080000,
         "metric": "health_score",
         "muted": true,
         "name": "my alert 3",
-        "sortKey": "2019-06-15T14:48:00.000Z",
       },
     ]
   }
@@ -92,7 +92,7 @@ Array [
   </Tag>,
   <DisplayDate
     formattedDate="Never Triggered"
-    timestamp={null}
+    timestamp={0}
   />,
   <Connect(AlertToggle)
     id="id-1"
@@ -126,7 +126,7 @@ Array [
   </Tag>,
   <DisplayDate
     formattedDate="Jun 5 2019, 10:48am"
-    timestamp="2019-06-05T14:48:00.000Z"
+    timestamp={1559746080000}
   />,
   <Connect(AlertToggle)
     id="id-2"
@@ -160,7 +160,7 @@ Array [
   </Tag>,
   <DisplayDate
     formattedDate="Jun 15 2019, 10:48am"
-    timestamp="2019-06-015T14:48:00.000Z"
+    timestamp={1560610080000}
   />,
   <Connect(AlertToggle)
     id="id-3"

--- a/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
@@ -1,0 +1,179 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TestCollection Component should render 1`] = `
+<TableCollection
+  columns={
+    Array [
+      Object {
+        "className": "TabbedCellHeader",
+        "label": "Alert Name",
+        "sortKey": "name",
+        "width": "40%",
+      },
+      Object {
+        "label": "Metric",
+        "sortKey": "metric",
+      },
+      Object {
+        "label": "Last Triggered",
+        "sortKey": "sortKey",
+      },
+      Object {
+        "label": "Status",
+        "sortKey": "muted",
+      },
+      null,
+    ]
+  }
+  defaultSortColumn="sortKey"
+  defaultSortDirection="desc"
+  filterBox={
+    Object {
+      "itemToStringKeys": Array [
+        "name",
+      ],
+      "placeholder": "Search...",
+      "show": true,
+      "wrapper": [Function],
+    }
+  }
+  getRowData={[Function]}
+  pagination={true}
+  rows={
+    Array [
+      Object {
+        "formattedDate": "Never Triggered",
+        "id": "id-1",
+        "last_triggered": null,
+        "metric": "monthly_sending_limit",
+        "muted": true,
+        "name": "my alert 1",
+        "sortKey": "0",
+      },
+      Object {
+        "formattedDate": "Jun 5 2019, 10:48am",
+        "id": "id-2",
+        "last_triggered": "2019-06-05T14:48:00.000Z",
+        "metric": "monthly_sending_limit",
+        "muted": false,
+        "name": "my alert 2",
+        "sortKey": "2019-06-05T14:48:00.000Z",
+      },
+      Object {
+        "formattedDate": "Jun 15 2019, 10:48am",
+        "id": "id-3",
+        "last_triggered": "2019-06-015T14:48:00.000Z",
+        "metric": "health_score",
+        "muted": true,
+        "name": "my alert 3",
+        "sortKey": "2019-06-15T14:48:00.000Z",
+      },
+    ]
+  }
+  wrapperComponent={[Function]}
+>
+  <Component />
+</TableCollection>
+`;
+
+exports[`TestCollection Component should render row data properly 1`] = `
+Array [
+  <div
+    className="TabbedCellBody"
+  >
+    <PageLink
+      to="/alerts/edit/id-1"
+    >
+      my alert 1
+    </PageLink>
+  </div>,
+  <Tag>
+    Monthly Sending Limit
+  </Tag>,
+  <DisplayDate
+    formattedDate="Never Triggered"
+    timestamp={null}
+  />,
+  <Connect(AlertToggle)
+    id="id-1"
+    muted={true}
+  />,
+  <Button
+    flat={true}
+    onClick={[Function]}
+    size="default"
+  >
+    <Delete
+      className="Icon"
+    />
+  </Button>,
+]
+`;
+
+exports[`TestCollection Component should render row data properly 2`] = `
+Array [
+  <div
+    className="TabbedCellBody"
+  >
+    <PageLink
+      to="/alerts/edit/id-2"
+    >
+      my alert 2
+    </PageLink>
+  </div>,
+  <Tag>
+    Monthly Sending Limit
+  </Tag>,
+  <DisplayDate
+    formattedDate="Jun 5 2019, 10:48am"
+    timestamp="2019-06-05T14:48:00.000Z"
+  />,
+  <Connect(AlertToggle)
+    id="id-2"
+    muted={false}
+  />,
+  <Button
+    flat={true}
+    onClick={[Function]}
+    size="default"
+  >
+    <Delete
+      className="Icon"
+    />
+  </Button>,
+]
+`;
+
+exports[`TestCollection Component should render row data properly 3`] = `
+Array [
+  <div
+    className="TabbedCellBody"
+  >
+    <PageLink
+      to="/alerts/edit/id-3"
+    >
+      my alert 3
+    </PageLink>
+  </div>,
+  <Tag>
+    Health Score
+  </Tag>,
+  <DisplayDate
+    formattedDate="Jun 15 2019, 10:48am"
+    timestamp="2019-06-015T14:48:00.000Z"
+  />,
+  <Connect(AlertToggle)
+    id="id-3"
+    muted={true}
+  />,
+  <Button
+    flat={true}
+    onClick={[Function]}
+    size="default"
+  >
+    <Delete
+      className="Icon"
+    />
+  </Button>,
+]
+`;

--- a/src/pages/alerts/components/tests/__snapshots__/AlertToggleNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertToggleNew.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertToggle Component should render initial state 1`] = `
+<div
+  className="Wrapper"
+>
+  <Toggle
+    checked={true}
+    compact={true}
+    disabled={false}
+    id="mock-id"
+    onChange={[Function]}
+  />
+</div>
+`;

--- a/src/pages/alerts/constants/metricsV1.js
+++ b/src/pages/alerts/constants/metricsV1.js
@@ -1,0 +1,5 @@
+export const METRICS = {
+  monthly_sending_limit: 'Monthly Sending Limit',
+  health_score: 'Health Score',
+  block_bounce_rate: 'Block Bounce Rate'
+};

--- a/src/pages/alerts/containers/ListPage.container.js
+++ b/src/pages/alerts/containers/ListPage.container.js
@@ -1,16 +1,17 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { deleteAlert, listAlerts } from 'src/actions/alerts';
+import { deleteAlert, listAlerts } from 'src/actions/alertsV1';
+import { selectAlertsList } from 'src/selectors/alertsV1';
 import { showAlert } from 'src/actions/globalAlert';
 
 function withAlertsList(WrappedComponent) {
   const mapDispatchToProps = { deleteAlert, listAlerts, showAlert };
 
   const mapStateToProps = (state, props) => ({
-    alerts: state.alerts.list,
-    error: state.alerts.listError,
-    loading: state.alerts.listPending,
-    deletePending: state.alerts.deletePending
+    alerts: selectAlertsList(state),
+    error: state.alertsV1.listError,
+    loading: state.alertsV1.listPending,
+    deletePending: state.alertsV1.deletePending
   });
 
   return withRouter(connect(mapStateToProps, mapDispatchToProps)(WrappedComponent));

--- a/src/pages/alerts/containers/ListPageNew.container.js
+++ b/src/pages/alerts/containers/ListPageNew.container.js
@@ -1,16 +1,17 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { deleteAlert, listAlerts } from 'src/actions/alerts';
+import { deleteAlert, listAlerts } from 'src/actions/alertsV1';
+import { selectAlertsList } from 'src/selectors/alertsV1';
 import { showAlert } from 'src/actions/globalAlert';
 
 function withAlertsList(WrappedComponent) {
   const mapDispatchToProps = { deleteAlert, listAlerts, showAlert };
 
   const mapStateToProps = (state, props) => ({
-    alerts: state.alerts.list,
-    error: state.alerts.listError,
-    loading: state.alerts.listPending,
-    deletePending: state.alerts.deletePending
+    alerts: selectAlertsList(state),
+    error: state.alertsV1.listError,
+    loading: state.alertsV1.listPending,
+    deletePending: state.alertsV1.deletePending
   });
 
   return withRouter(connect(mapStateToProps, mapDispatchToProps)(WrappedComponent));

--- a/src/pages/alerts/containers/ListPageNew.container.js
+++ b/src/pages/alerts/containers/ListPageNew.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { deleteAlert, listAlerts } from 'src/actions/alertsV1';
-import { selectAlertsList } from 'src/selectors/alertsV1';
+import { selectAlertsList, selectRecentlyTriggeredAlerts } from 'src/selectors/alertsV1';
 import { showAlert } from 'src/actions/globalAlert';
 
 function withAlertsList(WrappedComponent) {
@@ -9,6 +9,7 @@ function withAlertsList(WrappedComponent) {
 
   const mapStateToProps = (state, props) => ({
     alerts: selectAlertsList(state),
+    recentlyTriggeredAlerts: selectRecentlyTriggeredAlerts(state),
     error: state.alertsV1.listError,
     loading: state.alertsV1.listPending,
     deletePending: state.alertsV1.deletePending

--- a/src/pages/alerts/tests/ListPageNew.test.js
+++ b/src/pages/alerts/tests/ListPageNew.test.js
@@ -1,0 +1,89 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { ListPageNew } from '../ListPageNew';
+
+describe('Page: Alerts List', () => {
+  const props = {
+    listAlerts: jest.fn(),
+    deleteAlert: jest.fn(() => Promise.resolve()),
+    showAlert: jest.fn(),
+    error: null,
+    alerts: [
+      {
+        id: 'id-1',
+        name: 'my alert 1',
+        metric: 'health_score',
+        last_triggered: '2019-06-15T14:48:00.000Z'
+      },
+      {
+        id: 'id-2',
+        name: 'my alert 2',
+        metric: 'health_score',
+        last_triggered: null
+      },
+      {
+        id: 'id-3',
+        name: 'my alert 3',
+        metric: 'monthly_sending_limit',
+        last_triggered: '2019-06-05T05:48:00.000Z'
+      }
+    ],
+    loading: false
+  };
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<ListPageNew {...props} />);
+  });
+
+  it('should render happy path', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render loading component when loading data', () => {
+    wrapper.setProps({ loading: true });
+    expect(wrapper.find('Loading')).toHaveLength(1);
+  });
+
+  it('should render error when list fails to load', () => {
+    wrapper.setProps({ error: { message: 'this failed' }});
+    expect(wrapper.find('ApiErrorBanner')).toMatchSnapshot();
+  });
+
+  it('should render delete modal', () => {
+    wrapper.setState({ alertToDelete: { id: 1, name: 'foo' }});
+    expect(wrapper.find('DeleteModal')).toMatchSnapshot();
+  });
+
+  it('should render last triggered cards correctly in order', () => {
+    const { alerts } = props;
+    const panel = wrapper.find('Panel');
+    expect(panel).toHaveLength(2);
+    expect(panel.first().find('h3').prop('children')).toEqual(alerts[0].name);
+    expect(panel.last().find('h3').prop('children')).toEqual(alerts[2].name);
+  });
+
+  it('should render a maximum of 4 panels', () => {
+    const alertsLong = [ ...props.alerts,
+      { id: 4, last_triggered: '2019-06-05T05:48:00.000Z' },
+      { id: 5, last_triggered: '2019-06-05T05:48:00.000Z' },
+      { id: 6, last_triggered: '2019-06-05T05:48:00.000Z' }];
+    wrapper.setProps({ alerts: alertsLong });
+    expect(wrapper.find('Panel')).toHaveLength(4);
+  });
+
+  it('should toggle delete modal', () => {
+    expect(wrapper).toHaveState('alertToDelete', {});
+    wrapper.instance().openDeleteModal({ id: 'test-id', name: 'mock name' });
+    expect(wrapper).toHaveState('alertToDelete', { id: 'test-id', name: 'mock name' });
+    expect(wrapper.find('DeleteModal').prop('open')).toEqual(true);
+  });
+
+  it('should handle delete', async () => {
+    wrapper.setState({ 'alertToDelete': { id: 'alert-id' }});
+    await wrapper.instance().handleDelete();
+    expect(props.deleteAlert).toHaveBeenCalledWith({ id: 'alert-id' });
+    expect(props.showAlert).toHaveBeenCalled();
+  });
+});

--- a/src/pages/alerts/tests/ListPageNew.test.js
+++ b/src/pages/alerts/tests/ListPageNew.test.js
@@ -28,6 +28,24 @@ describe('Page: Alerts List', () => {
         last_triggered: '2019-06-05T05:48:00.000Z'
       }
     ],
+    recentlyTriggeredAlerts: [
+      {
+        id: 'id-1',
+        name: 'my alert 1',
+        metric: 'health_score',
+        last_triggered: '2019-06-15T14:48:00.000Z',
+        last_triggered_formatted: 'Jun 15 2019, 10:48am',
+        last_triggered_timestamp: 1560610080000
+      },
+      {
+        id: 'id-3',
+        name: 'my alert 3',
+        metric: 'monthly_sending_limit',
+        last_triggered: '2019-06-05T05:48:00.000Z',
+        last_triggered_formatted: 'Jun 5 2019, 10:48am',
+        last_triggered_timestamp: 1559746080000
+      }
+    ],
     loading: false
   };
 
@@ -57,20 +75,11 @@ describe('Page: Alerts List', () => {
   });
 
   it('should render last triggered cards correctly in order', () => {
-    const { alerts } = props;
+    const { recentlyTriggeredAlerts } = props;
     const panel = wrapper.find('Panel');
     expect(panel).toHaveLength(2);
-    expect(panel.first().find('h3').prop('children')).toEqual(alerts[0].name);
-    expect(panel.last().find('h3').prop('children')).toEqual(alerts[2].name);
-  });
-
-  it('should render a maximum of 4 panels', () => {
-    const alertsLong = [ ...props.alerts,
-      { id: 4, last_triggered: '2019-06-05T05:48:00.000Z' },
-      { id: 5, last_triggered: '2019-06-05T05:48:00.000Z' },
-      { id: 6, last_triggered: '2019-06-05T05:48:00.000Z' }];
-    wrapper.setProps({ alerts: alertsLong });
-    expect(wrapper.find('Panel')).toHaveLength(4);
+    expect(panel.first().find('h3').prop('children')).toEqual(recentlyTriggeredAlerts[0].name);
+    expect(panel.last().find('h3').prop('children')).toEqual(recentlyTriggeredAlerts[1].name);
   });
 
   it('should toggle delete modal', () => {

--- a/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
@@ -1,0 +1,182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page: Alerts List should render delete modal 1`] = `
+<DeleteModal
+  content={
+    <p>
+      The alert "
+      <strong>
+        foo
+      </strong>
+      " will be permanently removed. This cannot be undone.
+    </p>
+  }
+  onCancel={[Function]}
+  onDelete={[Function]}
+  open={true}
+  title="Are you sure you want to delete this alert?"
+/>
+`;
+
+exports[`Page: Alerts List should render error when list fails to load 1`] = `
+<ApiErrorBanner
+  errorDetails="this failed"
+  message="Sorry, we seem to have had some trouble loading your alerts."
+  reload={
+    [MockFunction] {
+      "calls": Array [
+        Array [],
+      ],
+      "results": undefined,
+    }
+  }
+/>
+`;
+
+exports[`Page: Alerts List should render happy path 1`] = `
+<Page
+  empty={
+    Object {
+      "content": <p>
+        Manage notifications that alert you of performance problems.
+      </p>,
+      "image": [Function],
+      "show": false,
+      "title": "Create an Alert",
+    }
+  }
+  primaryAction={
+    Object {
+      "component": [Function],
+      "content": "Create an Alert",
+      "to": "/alerts/create",
+    }
+  }
+  title="Alerts"
+>
+  <p
+    className="Description"
+  >
+    Use alerts to be notified when important changes occur in your Health Score, bounce rates, and email usage.
+  </p>
+  <h3>
+    Recently Triggered Alerts
+  </h3>
+  <Grid>
+    <Grid.Column
+      key="id-1"
+      lg={3}
+      md={6}
+      xs={12}
+    >
+      <Panel
+        accent={true}
+      >
+        <Panel.Section
+          className="LastTriggeredCard"
+        >
+          <div
+            className="LastTriggeredTime"
+          >
+            <DisplayDate
+              timestamp="2019-06-15T14:48:00.000Z"
+            />
+          </div>
+          <h3>
+            my alert 1
+          </h3>
+        </Panel.Section>
+        <Panel.Section
+          className="Footer"
+        >
+          <Button
+            flat={true}
+            size="default"
+            to="/alerts-new"
+          >
+            <RemoveRedEye
+              className="Icon"
+            />
+          </Button>
+        </Panel.Section>
+      </Panel>
+    </Grid.Column>
+    <Grid.Column
+      key="id-3"
+      lg={3}
+      md={6}
+      xs={12}
+    >
+      <Panel
+        accent={true}
+      >
+        <Panel.Section
+          className="LastTriggeredCard"
+        >
+          <div
+            className="LastTriggeredTime"
+          >
+            <DisplayDate
+              timestamp="2019-06-05T05:48:00.000Z"
+            />
+          </div>
+          <h3>
+            my alert 3
+          </h3>
+        </Panel.Section>
+        <Panel.Section
+          className="Footer"
+        >
+          <Button
+            flat={true}
+            size="default"
+            to="/alerts-new"
+          >
+            <RemoveRedEye
+              className="Icon"
+            />
+          </Button>
+        </Panel.Section>
+      </Panel>
+    </Grid.Column>
+  </Grid>
+  <AlertCollectionNew
+    alerts={
+      Array [
+        Object {
+          "id": "id-1",
+          "last_triggered": "2019-06-15T14:48:00.000Z",
+          "metric": "health_score",
+          "name": "my alert 1",
+        },
+        Object {
+          "id": "id-2",
+          "last_triggered": null,
+          "metric": "health_score",
+          "name": "my alert 2",
+        },
+        Object {
+          "id": "id-3",
+          "last_triggered": "2019-06-05T05:48:00.000Z",
+          "metric": "monthly_sending_limit",
+          "name": "my alert 3",
+        },
+      ]
+    }
+    handleDelete={[Function]}
+  />
+  <DeleteModal
+    content={
+      <p>
+        The alert "
+        <strong />
+        " will be permanently removed. This cannot be undone.
+      </p>
+    }
+    onCancel={[Function]}
+    onDelete={[Function]}
+    open={false}
+    title="Are you sure you want to delete this alert?"
+  />
+</Page>
+`;

--- a/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
@@ -141,7 +141,6 @@ exports[`Page: Alerts List should render happy path 1`] = `
         </Panel.Section>
       </Panel>
     </Grid.Column>
-    ;
   </Grid>
   <AlertCollectionNew
     alerts={

--- a/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
@@ -79,7 +79,8 @@ exports[`Page: Alerts List should render happy path 1`] = `
             className="LastTriggeredTime"
           >
             <DisplayDate
-              timestamp="2019-06-15T14:48:00.000Z"
+              formattedDate="Jun 15 2019, 10:48am"
+              timestamp={1560610080000}
             />
           </div>
           <h3>
@@ -117,7 +118,8 @@ exports[`Page: Alerts List should render happy path 1`] = `
             className="LastTriggeredTime"
           >
             <DisplayDate
-              timestamp="2019-06-05T05:48:00.000Z"
+              formattedDate="Jun 5 2019, 10:48am"
+              timestamp={1559746080000}
             />
           </div>
           <h3>
@@ -139,6 +141,7 @@ exports[`Page: Alerts List should render happy path 1`] = `
         </Panel.Section>
       </Panel>
     </Grid.Column>
+    ;
   </Grid>
   <AlertCollectionNew
     alerts={

--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { snakeToFriendly } from 'src/helpers/string';
 import { Button, Page } from '@sparkpost/matchbox';
 import { PanelLoading, TableCollection, ApiErrorBanner, Empty } from 'src/components';
-import DisplayDate from 'src/components/displayDate/DisplayDate.js';
+import { DisplayDate } from 'src/components';
 import MessageEventsSearch from './components/MessageEventsSearch';
 import ViewDetailsButton from './components/ViewDetailsButton';
 import { getMessageEvents, changePage, getMessageEventsCSV, clearCSV } from 'src/actions/messageEvents';

--- a/src/pages/reports/messageEvents/components/TableElements.js
+++ b/src/pages/reports/messageEvents/components/TableElements.js
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { snakeToFriendly } from 'src/helpers/string';
 
 import { Table } from '@sparkpost/matchbox';
-import DisplayDate from 'src/components/displayDate/DisplayDate.js';
+import { DisplayDate } from 'src/components';
 
 import styles from './HistoryTable.module.scss';
 

--- a/src/reducers/alertsV1.js
+++ b/src/reducers/alertsV1.js
@@ -24,9 +24,8 @@ export default (state = initialState, { type, payload, meta }) => {
 
     case 'SET_ALERT_V1_MUTED_STATUS_SUCCESS': {
       const { list } = state;
-      const { id } = meta;
       const updatedAlertList = list.map((alert) => {
-        if (alert.id === id) {
+        if (alert.id === meta.id) {
           alert.muted = payload.muted;
         }
         return alert;
@@ -45,7 +44,6 @@ export default (state = initialState, { type, payload, meta }) => {
       return {
         ...state,
         deletePending: false,
-        // TODO will need to match subaccount id
         list: state.list.filter((a) => a.id !== meta.id)
       };
 

--- a/src/reducers/alertsV1.js
+++ b/src/reducers/alertsV1.js
@@ -19,11 +19,21 @@ export default (state = initialState, { type, payload, meta }) => {
       return { ...state, list: payload, listPending: false };
 
     // UPDATE single list row Muted status
-    case 'SET_ALERT_MUTED_V1_STATUS_PENDING':
+    case 'SET_ALERT_V1_MUTED_STATUS_PENDING':
       return { ...state, setMutedStatusPending: true };
 
-    case 'SET_ALERT_MUTED_V1_STATUS_SUCCESS':
-    case 'SET_ALERT_MUTED_V1_STATUS_FAIL':
+    case 'SET_ALERT_V1_MUTED_STATUS_SUCCESS': {
+      const { list } = state;
+      const { id } = meta;
+      const updatedAlertList = list.map((alert) => {
+        if (alert.id === id) {
+          alert.muted = payload.muted;
+        }
+        return alert;
+      });
+      return { ...state, list: updatedAlertList, setMutedStatusPending: false };
+    }
+    case 'SET_ALERT_V1_MUTED_STATUS_FAIL':
       return { ...state, setMutedStatusPending: false };
 
       /* DELETE */

--- a/src/reducers/alertsV1.js
+++ b/src/reducers/alertsV1.js
@@ -1,0 +1,48 @@
+const initialState = {
+  list: [],
+  listPending: true,
+  listError: null,
+  deletePending: false
+};
+
+export default (state = initialState, { type, payload, meta }) => {
+  switch (type) {
+    /* LIST */
+
+    case 'LIST_ALERTS_V1_PENDING':
+      return { ...state, listPending: true, listError: null };
+
+    case 'LIST_ALERTS_V1_FAIL':
+      return { ...state, listError: payload, listPending: false };
+
+    case 'LIST_ALERTS_V1_SUCCESS':
+      return { ...state, list: payload, listPending: false };
+
+    // UPDATE single list row Muted status
+    case 'SET_ALERT_MUTED_V1_STATUS_PENDING':
+      return { ...state, setMutedStatusPending: true };
+
+    case 'SET_ALERT_MUTED_V1_STATUS_SUCCESS':
+    case 'SET_ALERT_MUTED_V1_STATUS_FAIL':
+      return { ...state, setMutedStatusPending: false };
+
+      /* DELETE */
+
+    case 'DELETE_ALERT_V1_PENDING':
+      return { ...state, deletePending: true };
+
+    case 'DELETE_ALERT_V1_SUCCESS':
+      return {
+        ...state,
+        deletePending: false,
+        // TODO will need to match subaccount id
+        list: state.list.filter((a) => a.id !== meta.id)
+      };
+
+    case 'DELETE_ALERT_V1_FAIL':
+      return { ...state, deletePending: false };
+
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,6 +7,7 @@ import account from './account';
 import accountSingleSignOn from './accountSingleSignOn';
 import abTesting from './abTesting';
 import alerts from './alerts';
+import alertsV1 from './alertsV1';
 import apiKeys from './api-keys';
 import auth from './auth';
 import billing from './billing';
@@ -52,6 +53,7 @@ const appReducer = combineReducers({
   account,
   accountSingleSignOn,
   alerts,
+  alertsV1,
   auth,
   billing,
   bounceReport,

--- a/src/selectors/alertsV1.js
+++ b/src/selectors/alertsV1.js
@@ -14,3 +14,12 @@ export const selectAlertsList = createSelector(
   )
 );
 
+export const selectRecentlyTriggeredAlerts = createSelector(
+  [ selectAlertsList ],
+  (alerts) => alerts
+    .filter((alert) => alert.last_triggered !== null) //Remove any alert that has never triggered
+    .sort((a, b) => (b.last_triggered_timestamp - a.last_triggered_timestamp)) //Sorts by last triggered date, descending
+    .slice(0,4)
+);
+
+

--- a/src/selectors/alertsV1.js
+++ b/src/selectors/alertsV1.js
@@ -1,0 +1,17 @@
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+import { formatDateTime } from '../helpers/date';
+
+const getAlertsList = (state) => state.alertsV1.list;
+
+const appendFormattedDate = (alert) => ({
+  ...alert,
+  sortKey: (alert.last_triggered) ? alert.last_triggered : '0',
+  formattedDate: (alert.last_triggered) ? formatDateTime(alert.last_triggered) : 'Never Triggered'
+});
+
+export const selectAlertsList = createSelector(
+  [ getAlertsList ],
+  (alerts) => _.map(alerts, appendFormattedDate)
+);
+

--- a/src/selectors/alertsV1.js
+++ b/src/selectors/alertsV1.js
@@ -1,17 +1,16 @@
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { formatDateTime } from '../helpers/date';
 
 const getAlertsList = (state) => state.alertsV1.list;
 
-const appendFormattedDate = (alert) => ({
-  ...alert,
-  sortKey: (alert.last_triggered) ? alert.last_triggered : '0',
-  formattedDate: (alert.last_triggered) ? formatDateTime(alert.last_triggered) : 'Never Triggered'
-});
-
 export const selectAlertsList = createSelector(
   [ getAlertsList ],
-  (alerts) => _.map(alerts, appendFormattedDate)
+  (alerts) => alerts.map((alert) =>
+    ({
+      ...alert,
+      last_triggered_timestamp: (alert.last_triggered) ? Date.parse(alert.last_triggered) : 0,
+      last_triggered_formatted: (alert.last_triggered) ? formatDateTime(alert.last_triggered) : null
+    })
+  )
 );
 

--- a/src/selectors/tests/alertsV1.test.js
+++ b/src/selectors/tests/alertsV1.test.js
@@ -1,0 +1,59 @@
+import * as alertsSelectors from '../alertsV1';
+
+
+
+describe('Alerts Selectors: ', () => {
+  let alertsV1; let formattedAlerts;
+
+  beforeEach(() => {
+    const list = [
+      {
+        id: 'id-1',
+        muted: true,
+        name: 'my alert 1',
+        metric: 'monthly_sending_limit',
+        last_triggered: null
+      },
+      {
+        id: 'id-2',
+        muted: false,
+        name: 'my alert 2',
+        metric: 'monthly_sending_limit',
+        last_triggered: '2019-06-05T14:48:00.000Z'
+      },
+      {
+        id: 'id-3',
+        muted: true,
+        name: 'my alert 3',
+        metric: 'health_score',
+        last_triggered: '2019-06-15T14:48:00.000Z'
+      }
+    ];
+
+    formattedAlerts = [
+      {
+        ...list[0],
+        formattedDate: 'Never Triggered',
+        sortKey: '0'
+      },
+      {
+        ...list[1],
+        formattedDate: 'Jun 5 2019, 10:48am',
+        sortKey: '2019-06-05T14:48:00.000Z'
+      },
+      {
+        ...list[2],
+        formattedDate: 'Jun 15 2019, 10:48am',
+        sortKey: '2019-06-15T14:48:00.000Z'
+      }
+    ];
+
+    alertsV1 = { list };
+  });
+
+  describe('Alerts List', () => {
+    it('returns formatted alerts data', () => {
+      expect(alertsSelectors.selectAlertsList({ alertsV1 })).toEqual(formattedAlerts);
+    });
+  });
+});

--- a/src/selectors/tests/alertsV1.test.js
+++ b/src/selectors/tests/alertsV1.test.js
@@ -3,7 +3,8 @@ import * as alertsSelectors from '../alertsV1';
 
 
 describe('Alerts Selectors: ', () => {
-  let alertsV1; let formattedAlerts;
+  let alertsV1;
+  let formattedAlerts;
 
   beforeEach(() => {
     const list = [
@@ -33,27 +34,30 @@ describe('Alerts Selectors: ', () => {
     formattedAlerts = [
       {
         ...list[0],
-        formattedDate: 'Never Triggered',
-        sortKey: '0'
+        last_triggered_formatted: null,
+        last_triggered_timestamp: 0
       },
       {
         ...list[1],
-        formattedDate: 'Jun 5 2019, 10:48am',
-        sortKey: '2019-06-05T14:48:00.000Z'
+        last_triggered_formatted: 'Jun 5 2019, 10:48am',
+        last_triggered_timestamp: 1559746080000
       },
       {
         ...list[2],
-        formattedDate: 'Jun 15 2019, 10:48am',
-        sortKey: '2019-06-15T14:48:00.000Z'
+        last_triggered_formatted: 'Jun 15 2019, 10:48am',
+        last_triggered_timestamp: 1560610080000
       }
     ];
 
     alertsV1 = { list };
   });
 
-  describe('Alerts List', () => {
-    it('returns formatted alerts data', () => {
-      expect(alertsSelectors.selectAlertsList({ alertsV1 })).toEqual(formattedAlerts);
-    });
+  it('selectAlertsList returns formatted alerts data', () => {
+    expect(alertsSelectors.selectAlertsList({ alertsV1 })).toEqual(formattedAlerts);
   });
+
+  it('selectRecentlyTriggeredAlerts returns triggered alerts in order descending ', () => {
+    expect(alertsSelectors.selectRecentlyTriggeredAlerts({ alertsV1 })).toEqual([formattedAlerts[2],formattedAlerts[1]]);
+  });
+
 });


### PR DESCRIPTION
### What Changed
 - Created action/reducer/selector for alerts v1.
 - Added a formatted date and sort key in the selector to modify the list of alerts. 
 - Changed response params from labs/alerts -> v1.  EX:  'alert_metric'->'metric', 'enabled'->'muted'
 - Sorted by last trigger by using a sort key. Also added logic to only show last 4 triggered alerts in the cards panel.

### How To Test
 - Enable user account option `alerts`. This is already enabled in appteam staging.
 - See [here](https://github.com/SparkPost/2web2ui/blob/master/docs/feature-flags.md) to enable user options. Alternatively, [point your local upstreams to staging](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams) and login to our appteam, CID 107 account
 - Edit your openresty configs to contain 
```
    location /api/v1/alerts {
      proxy_pass http://sp-alerts-api;
      include cors;
    }
```
under `server:80`,   `location /api/v1`
 - Navigate to `/alerts-new`.
 - Make sure everything works and that alerts can be toggled and deleted. 

### To Do
- [ ] Possible fix the toggle button bug here.
