### PR TITLE
TR-1539 Read only template settings for published template

### DIFF
--- a/src/config/routes/templates.js
+++ b/src/config/routes/templates.js
@@ -72,7 +72,7 @@ const v2Routes = [
     supportDocSearch: 'template'
   },
   {
-    path: '/templatesv2/edit/:id/:navKey?',
+    path: '/templatesv2/edit/:id/:version?/:navKey?',
     component: templatesV2.EditAndPreviewPage,
     condition: hasGrants('templates/view'),
     layout: Fullscreen,

--- a/src/pages/templatesV2/CreatePage.js
+++ b/src/pages/templatesV2/CreatePage.js
@@ -20,7 +20,7 @@ export default class CreatePage extends Component {
     return create(formData)
       .then(() => {
         showAlert({ type: 'success', message: 'Template Created.' });
-        history.push(`/${routeNamespace}/edit/${values.id}${setSubaccountQuery(subaccountId)}`);
+        history.push(`/${routeNamespace}/edit/${values.id}/draft/content${setSubaccountQuery(subaccountId)}`);
       });
   };
 

--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -23,9 +23,16 @@ const mapStateToProps = (state, props) => {
   const id = props.match.params.id;
   const draft = selectDraftTemplate(state, id);
   const published = selectPublishedTemplate(state, id);
+  const isPublishedMode = props.match.params.version === 'published';
+  const draftOrPublished = draft || published;
+  const hasDraft = draftOrPublished && draftOrPublished.has_draft;
+  const hasPublished = draftOrPublished && draftOrPublished.has_published;
 
   return {
     draft,
+    isPublishedMode,
+    hasDraft,
+    hasPublished,
     hasDraftFailedToLoad: Boolean(state.templates.getDraftError),
     hasFailedToPreview: Boolean(state.templates.contentPreview.error),
     isDraftLoading: !draft || Boolean(state.templates.getDraftLoading),

--- a/src/pages/templatesV2/components/ListComponents.js
+++ b/src/pages/templatesV2/components/ListComponents.js
@@ -9,13 +9,13 @@ import styles from './ListComponents.module.scss';
 import { routeNamespace } from '../constants/routes';
 
 export const Name = ({ name, id, subaccount_id, ...rowData }) => {
-  const isDraft = rowData.list_status === 'draft';
+  const version = rowData.list_status === 'draft' ? 'draft' : 'published';
 
   return (
     <>
       <p className={styles.Name}>
         <Link
-          to={`/${routeNamespace}/edit/${id}${isDraft ? '' : '/published'}${setSubaccountQuery(subaccount_id)}`}>
+          to={`/${routeNamespace}/edit/${id}/${version}/content${setSubaccountQuery(subaccount_id)}`}>
           <strong>{name}</strong>
         </Link>
       </p>

--- a/src/pages/templatesV2/components/settings/Form.js
+++ b/src/pages/templatesV2/components/settings/Form.js
@@ -30,7 +30,7 @@ export default class SettingsForm extends React.Component {
   };
 
   render() {
-    const { handleSubmit, domainsLoading, domains, subaccountId, submitting, pristine, valid, hasSubaccounts, canViewSubaccount } = this.props;
+    const { handleSubmit, domainsLoading, domains, subaccountId, submitting, pristine, valid, hasSubaccounts, canViewSubaccount, isPublishedMode } = this.props;
     const canViewSubaccountSection = hasSubaccounts && canViewSubaccount;
     const fromEmailHelpText = !domainsLoading && !domains.length ? (subaccountId ? 'The selected subaccount does not have any verified sending domains.' : 'You do not have any verified sending domains to use.') : null;
 
@@ -41,7 +41,7 @@ export default class SettingsForm extends React.Component {
             name='name'
             component={TextFieldWrapper}
             label='Template Name'
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
             validate={required}
           />
 
@@ -53,14 +53,14 @@ export default class SettingsForm extends React.Component {
             disabled={true}
           />
         </Panel.Section>
-        {canViewSubaccountSection && <SubaccountSection newTemplate={false} disabled={submitting}/>}
+        {canViewSubaccountSection && <SubaccountSection newTemplate={false} disabled={submitting || isPublishedMode}/>}
         <Panel.Section>
           <Field
             name='content.subject'
             component={TextFieldWrapper}
             label='Subject'
             validate={required}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -71,7 +71,7 @@ export default class SettingsForm extends React.Component {
             validate={[required, emailOrSubstitution]}
             domains={domains}
             helpText={fromEmailHelpText}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -79,6 +79,7 @@ export default class SettingsForm extends React.Component {
             component={TextFieldWrapper}
             label='From Name'
             helpText='A friendly from for your recipients.'
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -87,7 +88,7 @@ export default class SettingsForm extends React.Component {
             label='Reply To'
             helpText='An email address recipients can reply to.'
             validate={emailOrSubstitution}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -95,7 +96,7 @@ export default class SettingsForm extends React.Component {
             component={TextFieldWrapper}
             label='Description'
             helpText='Not visible to recipients.'
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
           />
         </Panel.Section>
         <Panel.Section>
@@ -105,8 +106,7 @@ export default class SettingsForm extends React.Component {
             label='Track Opens'
             type='checkbox'
             parse={this.parseToggle}
-            disabled={submitting}
-
+            disabled={submitting || isPublishedMode}
           />
 
           <Field
@@ -115,8 +115,7 @@ export default class SettingsForm extends React.Component {
             label='Track Clicks'
             type='checkbox'
             parse={this.parseToggle}
-            disabled={submitting}
-
+            disabled={submitting || isPublishedMode}
           />
           <Field
             name='options.transactional'
@@ -126,7 +125,7 @@ export default class SettingsForm extends React.Component {
             parse={this.parseToggle}
             helpText={<p className={styles.HelpText}>Transactional messages are triggered by a user’s actions on the
               website, like requesting a password reset, signing up, or making a purchase.</p>}
-            disabled={submitting}
+            disabled={submitting || isPublishedMode}
 
           />
         </Panel.Section>
@@ -134,7 +133,7 @@ export default class SettingsForm extends React.Component {
           <Button
             type='submit'
             primary
-            disabled={submitting || !valid || pristine}
+            disabled={submitting || !valid || pristine || isPublishedMode}
           >
             Update Settings
           </Button>

--- a/src/pages/templatesV2/components/settings/tests/Form.test.js
+++ b/src/pages/templatesV2/components/settings/tests/Form.test.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme';
 import React from 'react';
+import every from 'lodash/every';
 import SettingsForm from '../Form';
 
 jest.mock('../../DeleteTemplate');
@@ -14,6 +15,7 @@ describe('SettingsForm', () => {
       domainsLoading: false,
       hasSubaccounts: false,
       canViewSubaccount: false,
+      isPublishedMode: false,
       handleSubmit: jest.fn((func) => func),
       showAlert: jest.fn()
     };
@@ -29,6 +31,14 @@ describe('SettingsForm', () => {
 
   it('renders with subaccounts', () => {
     expect(subject({ hasSubaccounts: true, canViewSubaccount: true }).exists('SubaccountSection')).toBe(true);
+  });
+
+  it('renders with fields disabled in published mode', () => {
+    const wrapper = subject({ hasSubaccounts: true, canViewSubaccount: true, isPublishedMode: true });
+    const fieldProps = wrapper.find('Field').map((field) => field.prop('disabled'));
+    expect(fieldProps.length).toEqual(10);
+    expect(every(fieldProps)).toBe(true);
+    expect(wrapper.find('SubaccountSection').prop('disabled')).toBe(true);
   });
 
   it('renders From Email help text with no verified domains', () => {

--- a/src/pages/templatesV2/components/settings/tests/__snapshots__/Form.test.js.snap
+++ b/src/pages/templatesV2/components/settings/tests/__snapshots__/Form.test.js.snap
@@ -8,6 +8,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
     <Panel.Section>
       <Field
         component={[Function]}
+        disabled={false}
         label="Template Name"
         name="name"
         validate={[Function]}
@@ -23,12 +24,14 @@ exports[`SettingsForm renders without subaccounts 1`] = `
     <Panel.Section>
       <Field
         component={[Function]}
+        disabled={false}
         label="Subject"
         name="content.subject"
         validate={[Function]}
       />
       <Field
         component={[Function]}
+        disabled={false}
         domains={
           Array [
             Object {
@@ -52,12 +55,14 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText="A friendly from for your recipients."
         label="From Name"
         name="content.from.name"
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText="An email address recipients can reply to."
         label="Reply To"
         name="content.reply_to"
@@ -65,6 +70,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText="Not visible to recipients."
         label="Description"
         name="description"
@@ -73,6 +79,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
     <Panel.Section>
       <Field
         component={[Function]}
+        disabled={false}
         label="Track Opens"
         name="options.open_tracking"
         parse={[Function]}
@@ -80,6 +87,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         label="Track Clicks"
         name="options.click_tracking"
         parse={[Function]}
@@ -87,6 +95,7 @@ exports[`SettingsForm renders without subaccounts 1`] = `
       />
       <Field
         component={[Function]}
+        disabled={false}
         helpText={
           <p
             className="HelpText"

--- a/src/pages/templatesV2/components/tests/ListComponents.test.js
+++ b/src/pages/templatesV2/components/tests/ListComponents.test.js
@@ -17,7 +17,7 @@ describe('Template List Components', () => {
 
     it('should navigate to published page if template is published', () => {
       wrapper.setProps({ list_status: 'published' });
-      expect(wrapper.find('Link').props().to).toEqual('/templatesv2/edit/id-123/published?subaccount=123');
+      expect(wrapper.find('Link').props().to).toEqual('/templatesv2/edit/id-123/published/content?subaccount=123');
     });
   });
 

--- a/src/pages/templatesV2/components/tests/__snapshots__/ListComponents.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/ListComponents.test.js.snap
@@ -27,7 +27,7 @@ exports[`Template List Components Name should render 1`] = `
   >
     <Link
       replace={false}
-      to="/templatesv2/edit/id-123?subaccount=123"
+      to="/templatesv2/edit/id-123/draft/content?subaccount=123"
     >
       <strong>
         template name

--- a/src/pages/templatesV2/context/EditorContext.js
+++ b/src/pages/templatesV2/context/EditorContext.js
@@ -26,7 +26,7 @@ export const EditorContextProvider = ({ children, value: { getDraft, getPublishe
     getPublished(requestParams.id, requestParams.subaccount);
     listDomains();
     listSubaccounts();
-  }, [listSubaccounts, listDomains, getDraft, getPublished, requestParams.id, requestParams.subaccount]);
+  }, [listSubaccounts, listDomains, getDraft, getPublished, requestParams.id, requestParams.version, requestParams.subaccount]);
 
   return (
     <EditorContext.Provider value={pageValue}>

--- a/src/pages/templatesV2/hooks/tests/useEditorNavigation.test.js
+++ b/src/pages/templatesV2/hooks/tests/useEditorNavigation.test.js
@@ -13,8 +13,8 @@ describe('useEditorNavigation', () => {
       ...routerState
     });
 
-    const TestComponent = () => <div hooked={useEditorNavigation()} />;
-    return mount(<TestComponent />);
+    const TestComponent = () => <div hooked={useEditorNavigation()}/>;
+    return mount(<TestComponent/>);
   };
   const useHook = (wrapper) => wrapper.update().children().prop('hooked');
 
@@ -39,25 +39,46 @@ describe('useEditorNavigation', () => {
       .toEqual(expect.objectContaining({ currentNavigationIndex: 1, currentNavigationKey: 'settings' }));
   });
 
-  it('redirects when link is clicked', () => {
-    const historyPush = jest.fn();
-    const wrapper = useTestWrapper({ routerState: { history: { push: historyPush }}});
-
-    act(() => {
-      useHook(wrapper).setNavigation('settings');
+  describe('redirections', () => {
+    let historyPush;
+    beforeEach(() => {
+      historyPush = jest.fn();
     });
 
-    expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/settings');
-  });
-
-  it('redirects with subaccount id', () => {
-    const historyPush = jest.fn();
-    const wrapper = useTestWrapper({ routerState: { history: { push: historyPush }, requestParams: { id: 'test-template', subaccount: 102 }}});
-
-    act(() => {
-      useHook(wrapper).setNavigation('settings');
+    afterEach(() => {
+      historyPush.mockReset();
     });
 
-    expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/settings?subaccount=102');
+    const subject = (wrapper) => {
+      act(() => {
+        useHook(wrapper).setNavigation('settings');
+      });
+    };
+    const routeState = (overrides = {}) => ({
+      routerState: {
+        history: { push: historyPush },
+        requestParams: { id: 'test-template', ...overrides }
+      }
+    });
+
+    it('redirects when link is clicked (draft)', () => {
+      subject(useTestWrapper(routeState()));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/draft/settings');
+    });
+
+    it('redirects with subaccount id (draft)', () => {
+      subject(useTestWrapper(routeState({ subaccount: 102 })));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/draft/settings?subaccount=102');
+    });
+
+    it('redirects when link is clicked (published)', () => {
+      subject(useTestWrapper(routeState({ version: 'published' })));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/published/settings');
+    });
+
+    it('redirects with subaccount id (published)', () => {
+      subject(useTestWrapper(routeState({ version: 'published', subaccount: 102 })));
+      expect(historyPush).toHaveBeenCalledWith('/templatesv2/edit/test-template/published/settings?subaccount=102');
+    });
   });
 });

--- a/src/pages/templatesV2/hooks/useEditorNavigation.js
+++ b/src/pages/templatesV2/hooks/useEditorNavigation.js
@@ -5,9 +5,9 @@ import { routeNamespace } from '../constants/routes';
 import { setSubaccountQuery } from '../../../helpers/subaccounts';
 
 const useEditorNavigation = () => {
-  const { history, requestParams: { id, navKey = '', subaccount: subaccountId }} = useRouter();
+  const { history, requestParams: { id, version = 'draft', navKey = '', subaccount: subaccountId }} = useRouter();
   const setNavigation = (nextNavigationKey) => {
-    history.push(`/${routeNamespace}/edit/${id}/${nextNavigationKey}${setSubaccountQuery(subaccountId)}`);
+    history.push(`/${routeNamespace}/edit/${id}/${version}/${nextNavigationKey}${setSubaccountQuery(subaccountId)}`);
   };
 
   return useMemo(() => {

--- a/src/pages/templatesV2/tests/CreatePage.test.js
+++ b/src/pages/templatesV2/tests/CreatePage.test.js
@@ -56,7 +56,7 @@ describe('CreatePage', () => {
       const mockAlert = jest.fn();
       const wrapper = subject({ create: jest.fn(() => Promise.resolve()), history: { push: mockPush }, showAlert: mockAlert });
       await wrapper.find('form').simulate('submit', { id: 'foo', content: {}});
-      expect(mockPush).toHaveBeenCalledWith('/templatesv2/edit/foo');
+      expect(mockPush).toHaveBeenCalledWith('/templatesv2/edit/foo/draft/content');
       expect(mockAlert).toHaveBeenCalledWith({ type: 'success', message: 'Template Created.' });
     });
   });


### PR DESCRIPTION
Disables settings fields when viewing published template

### What Changed
 - Fields in `Template Settings` tab are disabled when viewing published template
   - Delete button should be active
 - To distinguish (and deep link), modified route to add version
 - List and create pages are updated to take to new routes 

### How To Test
 - From List page, click on draft template -> Template Settings. It should be editable as usual
 - From List page, click on published template -> Template Settings. It should not be editable
 - Create a template. After template creation, it should take you to `/edit/<id>/draft/content`

### Notes:
- Editors are made read only in #1068 
- Navigation between draft and published mode is handled in #1060 

### To Do
- [ ] Address review feedback
