### PR TITLE
EO-836: Updated styling on Single address form

### DIFF
--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -11,7 +11,7 @@ import ConditionSwitch, { Case, defaultCase } from 'src/components/auth/Conditio
 
 const tabs = [
   { content: 'Validate A List' },
-  { content: 'Validate a Single Address' },
+  { content: 'Single Address' },
   { content: 'API Integration' }
 ];
 
@@ -42,7 +42,7 @@ export class RecipientValidationPage extends Component {
 
     return (
       <Page
-        title='Recipient Email Validation'>
+        title='Recipient Validation'>
         <Tabs
           selected={selectedTab}
           connectBelow={true}

--- a/src/pages/recipientValidation/components/ApiDetails.js
+++ b/src/pages/recipientValidation/components/ApiDetails.js
@@ -28,7 +28,7 @@ export const ApiIntegrationDocs = () => {
     <div className={styles.SampleRequest}>
       <small>
         <span className={styles.Method}>GET</span>
-        <code>/api/v1/recipient-validatioin/single/{'{'}address{'}'}</code>
+        <code>/api/v1/recipient-validation/single/{'{'}address{'}'}</code>
       </small>
     </div>
   );

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -6,6 +6,7 @@ import { TextFieldWrapper } from 'src/components';
 import { required, email, maxLength } from 'src/helpers/validation';
 import { singleAddress } from 'src/actions/recipientValidation';
 import SingleResult from './SingleResult';
+import styles from './SingleAddressForm.module.scss';
 
 const formName = 'singleAddressForm';
 export class SingleAddressForm extends Component {
@@ -21,16 +22,21 @@ export class SingleAddressForm extends Component {
       <Fragment>
         <Panel.Section>
           <form onSubmit={handleSubmit(this.singleAddressForm)}>
-            <p>Validate an email address to determine if it is a deliverable email address or a rejected, undeliverable email address.</p>
-            <Field
-              name='address'
-              component={TextFieldWrapper}
-              label='Email address'
-              placeholder={'eg. example@mail.com'}
-              validate={[required, email, maxLength(254)]}
-              normalize={(value = '') => value.trim()}
-              connectRight={<Button primary submit disabled={submitDisabled}>{buttonContent}</Button>}
-            />
+            <div className={styles.Header}>Validate a Single Address</div>
+            <p className={styles.Paragraph}>Enter the email address below you would like to validate.</p>
+            <div className={styles.Field}>
+              <Field
+                style={{ height: '3.2rem', paddingLeft: '1.5em', fontSize: '.9em' }}
+                name='address'
+                component={TextFieldWrapper}
+                placeholder={'harry.potter@hogwarts.edu'}
+                validate={[required, email, maxLength(254)]}
+                normalize={(value = '') => value.trim()}
+              />
+            </div>
+            <div className={styles.Submit}>
+              <Button size='large' fullWidth primary submit disabled={submitDisabled}>{buttonContent}</Button>
+            </div>
           </form>
         </Panel.Section>
         {singleResults && (

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -23,7 +23,7 @@ export class SingleAddressForm extends Component {
         <Panel.Section>
           <form onSubmit={handleSubmit(this.singleAddressForm)}>
             <div className={styles.Header}>Validate a Single Address</div>
-            <p className={styles.Paragraph}>Enter the email address below you would like to validate.</p>
+            <p className={styles.Subheader}>Enter the email address below you would like to validate.</p>
             <div className={styles.Field}>
               <Field
                 style={{ height: '3.2rem', paddingLeft: '1.5em', fontSize: '.9em' }}

--- a/src/pages/recipientValidation/components/SingleAddressForm.module.scss
+++ b/src/pages/recipientValidation/components/SingleAddressForm.module.scss
@@ -26,3 +26,25 @@
 .Validity {
   margin-bottom: 0;
 }
+
+.Header {
+  margin: spacing() 0;
+  font-size: rem(20);
+  font-weight: 600;
+  text-align: center;
+}
+
+.Paragraph {
+  text-align: center;
+}
+
+.Field {
+  max-width: 500px;
+  margin: 4rem auto 0;
+}
+
+.Submit {
+  max-width: 160px;
+  margin: 3em auto;
+}
+

--- a/src/pages/recipientValidation/components/SingleAddressForm.module.scss
+++ b/src/pages/recipientValidation/components/SingleAddressForm.module.scss
@@ -34,7 +34,7 @@
   text-align: center;
 }
 
-.Paragraph {
+.Subheader {
   text-align: center;
 }
 

--- a/src/pages/recipientValidation/components/tests/__snapshots__/ApiDetails.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/ApiDetails.test.js.snap
@@ -31,7 +31,7 @@ exports[`ApiDetails tab should render page correctly 1`] = `
             GET
           </span>
           <code>
-            /api/v1/recipient-validatioin/single/
+            /api/v1/recipient-validation/single/
             {
             address
             }

--- a/src/pages/recipientValidation/components/tests/__snapshots__/SingleAddressForm.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/SingleAddressForm.test.js.snap
@@ -12,7 +12,7 @@ exports[`SingleAddressForm renders correctly 1`] = `
         Validate a Single Address
       </div>
       <p
-        className="Paragraph"
+        className="Subheader"
       >
         Enter the email address below you would like to validate.
       </p>
@@ -27,8 +27,8 @@ exports[`SingleAddressForm renders correctly 1`] = `
           style={
             Object {
               "fontSize": ".9em",
-              "height": "3rem",
-              "padding": "4em initial",
+              "height": "3.2rem",
+              "paddingLeft": "1.5em",
             }
           }
           validate={
@@ -70,7 +70,7 @@ exports[`SingleAddressForm should disable form elements on submit 1`] = `
         Validate a Single Address
       </div>
       <p
-        className="Paragraph"
+        className="Subheader"
       >
         Enter the email address below you would like to validate.
       </p>
@@ -85,8 +85,8 @@ exports[`SingleAddressForm should disable form elements on submit 1`] = `
           style={
             Object {
               "fontSize": ".9em",
-              "height": "3rem",
-              "padding": "4em initial",
+              "height": "3.2rem",
+              "paddingLeft": "1.5em",
             }
           }
           validate={

--- a/src/pages/recipientValidation/components/tests/__snapshots__/SingleAddressForm.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/SingleAddressForm.test.js.snap
@@ -6,33 +6,53 @@ exports[`SingleAddressForm renders correctly 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <p>
-        Validate an email address to determine if it is a deliverable email address or a rejected, undeliverable email address.
+      <div
+        className="Header"
+      >
+        Validate a Single Address
+      </div>
+      <p
+        className="Paragraph"
+      >
+        Enter the email address below you would like to validate.
       </p>
-      <Field
-        component={[Function]}
-        connectRight={
-          <Button
-            disabled={true}
-            primary={true}
-            size="default"
-            submit={true}
-          >
-            Validate
-          </Button>
-        }
-        label="Email address"
-        name="address"
-        normalize={[Function]}
-        placeholder="eg. example@mail.com"
-        validate={
-          Array [
-            [Function],
-            [Function],
-            [Function],
-          ]
-        }
-      />
+      <div
+        className="Field"
+      >
+        <Field
+          component={[Function]}
+          name="address"
+          normalize={[Function]}
+          placeholder="harry.potter@hogwarts.edu"
+          style={
+            Object {
+              "fontSize": ".9em",
+              "height": "3rem",
+              "padding": "4em initial",
+            }
+          }
+          validate={
+            Array [
+              [Function],
+              [Function],
+              [Function],
+            ]
+          }
+        />
+      </div>
+      <div
+        className="Submit"
+      >
+        <Button
+          disabled={true}
+          fullWidth={true}
+          primary={true}
+          size="large"
+          submit={true}
+        >
+          Validate
+        </Button>
+      </div>
     </form>
   </Panel.Section>
 </Fragment>
@@ -44,33 +64,53 @@ exports[`SingleAddressForm should disable form elements on submit 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <p>
-        Validate an email address to determine if it is a deliverable email address or a rejected, undeliverable email address.
+      <div
+        className="Header"
+      >
+        Validate a Single Address
+      </div>
+      <p
+        className="Paragraph"
+      >
+        Enter the email address below you would like to validate.
       </p>
-      <Field
-        component={[Function]}
-        connectRight={
-          <Button
-            disabled={true}
-            primary={true}
-            size="default"
-            submit={true}
-          >
-            Validating...
-          </Button>
-        }
-        label="Email address"
-        name="address"
-        normalize={[Function]}
-        placeholder="eg. example@mail.com"
-        validate={
-          Array [
-            [Function],
-            [Function],
-            [Function],
-          ]
-        }
-      />
+      <div
+        className="Field"
+      >
+        <Field
+          component={[Function]}
+          name="address"
+          normalize={[Function]}
+          placeholder="harry.potter@hogwarts.edu"
+          style={
+            Object {
+              "fontSize": ".9em",
+              "height": "3rem",
+              "padding": "4em initial",
+            }
+          }
+          validate={
+            Array [
+              [Function],
+              [Function],
+              [Function],
+            ]
+          }
+        />
+      </div>
+      <div
+        className="Submit"
+      >
+        <Button
+          disabled={true}
+          fullWidth={true}
+          primary={true}
+          size="large"
+          submit={true}
+        >
+          Validating...
+        </Button>
+      </div>
     </form>
   </Panel.Section>
 </Fragment>


### PR DESCRIPTION
### What Changed
 - Updated styling on single address form

### How To Test
 - Navigate to `/recipient-validation`
 - Second tab should say `Single Address`
 - Click on tab
 - Form should be aligned with mock up
 - Check that form works

### To Do
- [ ] Address feedback