### PR TITLE
AC-830: Updated Email Role to templates

### DIFF
--- a/src/constants/users.js
+++ b/src/constants/users.js
@@ -1,19 +1,19 @@
 export const ROLES = {
   ADMIN: 'admin',
   DEVELOPER: 'developer',
-  TEMPLATES: 'email', //Email role renamed to templates. TODO: Update after API access_level changes
+  TEMPLATES: 'templates',
   REPORTING: 'reporting',
   SUBACCOUNT_REPORTING: 'subaccount_reporting',
   SUPERUSER: 'superuser'
 };
 
 export const ROLE_LABELS = {
-  email: 'Templates',//Email role renamed to templates. TODO: Update after API access_level changes
-  admin: 'Admin',
-  developer: 'Developer',
-  reporting: 'Reporting',
-  subaccount_reporting: 'Reporting',
-  superuser: 'Super User',
+  [ROLES.TEMPLATES]: 'Templates',
+  [ROLES.ADMIN]: 'Admin',
+  [ROLES.DEVELOPER]: 'Developer',
+  [ROLES.REPORTING]: 'Reporting',
+  [ROLES.SUBACCOUNT_REPORTING]: 'Reporting',
+  [ROLES.SUPERUSER]: 'Super User',
   heroku: 'Heroku'
 };
 export const SUBACCOUNT_ROLES = [ROLES.SUBACCOUNT_REPORTING];

--- a/src/pages/users/components/tests/__snapshots__/RoleRadioGroup.test.js.snap
+++ b/src/pages/users/components/tests/__snapshots__/RoleRadioGroup.test.js.snap
@@ -40,7 +40,7 @@ exports[`Component: RoleRadioGroup should render the RadioGroup 1`] = `
         "label": <strong>
           Templates
         </strong>,
-        "value": "email",
+        "value": "templates",
       },
       Object {
         "children": false,

--- a/src/selectors/tests/__snapshots__/users.test.js.snap
+++ b/src/selectors/tests/__snapshots__/users.test.js.snap
@@ -10,7 +10,7 @@ Array [
     "username": "ape",
   },
   Object {
-    "access": "email",
+    "access": "templates",
     "isCurrentUser": true,
     "name": "Zebra",
     "roleLabel": "Templates",

--- a/src/selectors/tests/users.test.js
+++ b/src/selectors/tests/users.test.js
@@ -6,7 +6,7 @@ describe('Users Selectors', () => {
     users: {
       entities: {
         ape: { name: 'Ape', username: 'ape', access: 'access' },
-        zebra: { name: 'Zebra', username: 'zebra', access: 'email' }
+        zebra: { name: 'Zebra', username: 'zebra', access: 'templates' }
       },
       sortKey: 'name'
     }


### PR DESCRIPTION
### What Changed
 - Renamed role `email` to `Templates`

### How To Test
 - Check that Role is renamed from `email` to `Templates` on manage users page
 - Check that invite user is working correctly
 - Check that modify user role is working correctly
### Notes
 - Should roll out soon after AC-714 so that invites and user modifying isn't broken

### To Do
- [ ] Address any feedback
