### PR TITLE
TR-1374 - Edit test data

### DIFF
--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { getDraft, getPreview, getPublished, update as updateDraft, publish as publishDraft, deleteTemplate } from 'src/actions/templates';
+import { getDraft, getPreview, getPublished, update as updateDraft, publish as publishDraft, deleteTemplate, getTestData, setTestData } from 'src/actions/templates';
 import { list as listDomains } from 'src/actions/sendingDomains';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 
@@ -8,7 +8,8 @@ import {
   selectDraftTemplate,
   selectDraftTemplatePreview,
   selectPreviewLineErrors,
-  selectPublishedTemplate
+  selectPublishedTemplate,
+  selectTemplateTestData
 } from 'src/selectors/templates';
 import { EditorContextProvider } from './context/EditorContext';
 import EditAndPreviewPage from './EditAndPreviewPage';
@@ -41,7 +42,8 @@ const mapStateToProps = (state, props) => {
     isDraftUpdating: Boolean(state.templates.updating),
     isDraftPublishing: Boolean(state.templates.publishPending),
     preview: selectDraftTemplatePreview(state, id, {}),
-    previewLineErrors: selectPreviewLineErrors(state)
+    previewLineErrors: selectPreviewLineErrors(state),
+    testData: selectTemplateTestData(state)
   };
 };
 
@@ -53,7 +55,9 @@ const mapDispatchToProps = {
   updateDraft,
   publishDraft,
   listDomains,
-  listSubaccounts
+  listSubaccounts,
+  getTestData,
+  setTestData
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditAndPreviewPageContainer);

--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -1,6 +1,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { getDraft, getPreview, getPublished, update as updateDraft, publish as publishDraft, deleteTemplate, getTestData, setTestData } from 'src/actions/templates';
+import {
+  deleteTemplate,
+  getDraft,
+  getPreview,
+  getPublished,
+  getTestData,
+  publish as publishDraft,
+  setTestData,
+  update as updateDraft
+} from 'src/actions/templates';
 import { list as listDomains } from 'src/actions/sendingDomains';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 
@@ -16,7 +25,7 @@ import EditAndPreviewPage from './EditAndPreviewPage';
 
 const EditAndPreviewPageContainer = (props) => (
   <EditorContextProvider value={props}>
-    <EditAndPreviewPage />
+    <EditAndPreviewPage/>
   </EditorContextProvider>
 );
 
@@ -43,7 +52,7 @@ const mapStateToProps = (state, props) => {
     isDraftPublishing: Boolean(state.templates.publishPending),
     preview: selectDraftTemplatePreview(state, id, {}),
     previewLineErrors: selectPreviewLineErrors(state),
-    testData: selectTemplateTestData(state)
+    templateTestData: selectTemplateTestData(state)
   };
 };
 
@@ -56,8 +65,8 @@ const mapDispatchToProps = {
   publishDraft,
   listDomains,
   listSubaccounts,
-  getTestData,
-  setTestData
+  getTestDataFromLocalStorage: getTestData,
+  setTestDataToLocalStorage: setTestData
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditAndPreviewPageContainer);

--- a/src/pages/templatesV2/components/TestDataSection.js
+++ b/src/pages/templatesV2/components/TestDataSection.js
@@ -14,9 +14,7 @@ const TestDataSection = () => {
       mode="json"
       name="test-data-editor"
       onChange={(val) => {
-        try {
-          setTestData(JSON.parse(val));
-        } catch (err) {} /* eslint no-empty: ["error", { "allowEmptyCatch": true }] */
+        setTestData(val);
       }}
       value={testData}
     />

--- a/src/pages/templatesV2/components/TestDataSection.js
+++ b/src/pages/templatesV2/components/TestDataSection.js
@@ -1,41 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import useEditorContext from '../hooks/useEditorContext';
 import Editor from './Editor';
 
 const TestDataSection = () => {
-  const { draft, isPublishedMode, testData, getTestData, setTestData } = useEditorContext();
-  const mode = isPublishedMode ? 'published' : 'draft';
-
-  const [data, setData] = useState('');
-
-  //on mount, trigger fetching data from store
-  useEffect(() => {
-    getTestData({ id: draft.id, mode });
-  }, [draft.id, getTestData, mode]);
-
-
-  //Hydrate when testData is updated (completed loading from store)
-  useEffect(() => {
-    setData(testData);
-  }, [testData]);
-
-
-  //whenever data is changed locally, save it in store.
-  useEffect(() => {
-    setTestData({ id: draft.id, data: data, mode });
-  }, [data, draft.id, mode, setTestData]);
+  const { syncTestData, stringTestData } = useEditorContext();
 
   return (
     <Editor
       mode="json"
       name="test-data-editor"
       onChange={(val) => {
-        setData(val);
+        syncTestData(val);
       }}
-      value={data}
+      value={stringTestData}
     />
   );
-
 };
 
 export default TestDataSection;

--- a/src/pages/templatesV2/components/TestDataSection.js
+++ b/src/pages/templatesV2/components/TestDataSection.js
@@ -3,16 +3,16 @@ import useEditorContext from '../hooks/useEditorContext';
 import Editor from './Editor';
 
 const TestDataSection = () => {
-  const { syncTestData, stringTestData } = useEditorContext();
+  const { setTestData, testData } = useEditorContext();
 
   return (
     <Editor
       mode="json"
       name="test-data-editor"
       onChange={(val) => {
-        syncTestData(val);
+        setTestData(val);
       }}
-      value={stringTestData}
+      value={testData}
     />
   );
 };

--- a/src/pages/templatesV2/components/TestDataSection.js
+++ b/src/pages/templatesV2/components/TestDataSection.js
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import useEditorContext from '../hooks/useEditorContext';
 import Editor from './Editor';
 
 const TestDataSection = () => {
-  const { setTestData, testData } = useEditorContext();
+  const { setTestData, syncTestDataInStorage, testData } = useEditorContext();
+
+  useEffect(() => //sync with storage during unmount
+    syncTestDataInStorage
+  , [syncTestDataInStorage]);
 
   return (
     <Editor
       mode="json"
       name="test-data-editor"
       onChange={(val) => {
-        setTestData(val);
+        try {
+          setTestData(JSON.parse(val));
+        } catch (err) {} /* eslint no-empty: ["error", { "allowEmptyCatch": true }] */
       }}
       value={testData}
     />

--- a/src/pages/templatesV2/components/TestDataSection.js
+++ b/src/pages/templatesV2/components/TestDataSection.js
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import useEditorContext from '../hooks/useEditorContext';
+import Editor from './Editor';
+
+const TestDataSection = () => {
+  const { draft, isPublishedMode, testData, getTestData, setTestData } = useEditorContext();
+  const mode = isPublishedMode ? 'published' : 'draft';
+
+  const [data, setData] = useState('');
+
+  //on mount, trigger fetching data from store
+  useEffect(() => {
+    getTestData({ id: draft.id, mode });
+  }, [draft.id, getTestData, mode]);
+
+
+  //Hydrate when testData is updated (completed loading from store)
+  useEffect(() => {
+    setData(testData);
+  }, [testData]);
+
+
+  //whenever data is changed locally, save it in store.
+  useEffect(() => {
+    setTestData({ id: draft.id, data: data, mode });
+  }, [data, draft.id, mode, setTestData]);
+
+  return (
+    <Editor
+      mode="json"
+      name="test-data-editor"
+      onChange={(val) => {
+        setData(val);
+      }}
+      value={data}
+    />
+  );
+
+};
+
+export default TestDataSection;
+

--- a/src/pages/templatesV2/components/tests/TestDataSection.test.js
+++ b/src/pages/templatesV2/components/tests/TestDataSection.test.js
@@ -6,7 +6,7 @@ import TestDataSection from '../TestDataSection';
 jest.mock('../../hooks/useEditorContext');
 
 describe('TestDataSection', () => {
-  const subject = ({ stateOverride } = {}) => {
+  const subject = (...stateOverride) => {
     useEditorContext.mockReturnValue({
       testData: JSON.stringify({
         subject: 'Example Subject'
@@ -21,4 +21,11 @@ describe('TestDataSection', () => {
   it('renders test data editor', () => {
     expect(subject()).toMatchSnapshot();
   });
+
+  it.skip('updates state on change', () => {
+  });
+
+  it.skip('syncs data in local storage upon unmount', () => {
+  });
+
 });

--- a/src/pages/templatesV2/components/tests/TestDataSection.test.js
+++ b/src/pages/templatesV2/components/tests/TestDataSection.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import useEditorContext from '../../hooks/useEditorContext';
+import TestDataSection from '../TestDataSection';
+
+jest.mock('../../hooks/useEditorContext');
+
+describe('TestDataSection', () => {
+  const subject = ({ stateOverride } = {}) => {
+    useEditorContext.mockReturnValue({
+      testData: JSON.stringify({
+        subject: 'Example Subject'
+      }),
+      setTestData: jest.fn(),
+      ...stateOverride
+    });
+
+    return shallow(<TestDataSection/>);
+  };
+
+  it('renders test data editor', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+});

--- a/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
@@ -26,6 +26,10 @@ exports[`EditSection renders tabs and section 1`] = `
             "content": "Text",
             "key": "text",
           },
+          Object {
+            "content": "Test Data",
+            "key": "test_data",
+          },
         ]
       }
     />

--- a/src/pages/templatesV2/components/tests/__snapshots__/TestDataSection.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/TestDataSection.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TestDataSection renders test data editor 1`] = `
+<Editor
+  mode="json"
+  name="test-data-editor"
+  onChange={[Function]}
+  value="{\\"subject\\":\\"Example Subject\\"}"
+/>
+`;

--- a/src/pages/templatesV2/constants/editTabs.js
+++ b/src/pages/templatesV2/constants/editTabs.js
@@ -1,6 +1,7 @@
 import EditAmpSection from '../components/EditAmpSection';
 import EditHtmlSection from '../components/EditHtmlSection';
 import EditTextSection from '../components/EditTextSection';
+import TestDataSection from '../components/TestDataSection';
 
 const editTabs = [
   {
@@ -17,6 +18,11 @@ const editTabs = [
     content: 'Text',
     key: 'text',
     render: EditTextSection
+  },
+  {
+    content: 'Test Data',
+    key: 'test_data',
+    render: TestDataSection
   }
 ];
 

--- a/src/pages/templatesV2/context/EditorContext.js
+++ b/src/pages/templatesV2/context/EditorContext.js
@@ -5,6 +5,7 @@ import useEditorContent from '../hooks/useEditorContent';
 import useEditorNavigation from '../hooks/useEditorNavigation';
 import useEditorPreview from '../hooks/useEditorPreview';
 import useEditorTabs from '../hooks/useEditorTabs';
+import useTestData from '../hooks/useTestData';
 
 const EditorContext = createContext();
 
@@ -17,6 +18,7 @@ export const EditorContextProvider = ({ children, value: { getDraft, getPublishe
   const pageValue = chainHooks(
     () => value,
     useEditorContent,
+    useTestData, //must come before Preview
     useEditorNavigation,
     useEditorPreview, // must follow useEditorContent
     useEditorAnnotations, // must follow useEditorContent

--- a/src/pages/templatesV2/context/tests/EditorContext.test.js
+++ b/src/pages/templatesV2/context/tests/EditorContext.test.js
@@ -36,7 +36,7 @@ describe('EditorContext', () => {
 
       subject({
         render: mount, // for useEffect
-        value: { getDraft, getPublished }
+        value: { getDraft, getPublished, getTestDataFromLocalStorage: jest.fn() }
       });
 
       expect(getDraft).toHaveBeenCalledWith('test-template', '123');

--- a/src/pages/templatesV2/context/tests/__snapshots__/EditorContext.test.js.snap
+++ b/src/pages/templatesV2/context/tests/__snapshots__/EditorContext.test.js.snap
@@ -14,11 +14,15 @@ exports[`EditorContext EditorContextProvider renders children wrapped by a conte
       "currentNavigationKey": "content",
       "currentTabIndex": 0,
       "currentTabKey": "html",
+      "formattedTestData": Object {},
       "previewDevice": "desktop",
       "setContent": [Function],
       "setNavigation": [Function],
       "setPreviewDevice": [Function],
       "setTab": [Function],
+      "setTestData": [Function],
+      "syncTestDataInStorage": [Function],
+      "testData": undefined,
     }
   }
 >

--- a/src/pages/templatesV2/hooks/tests/useEditorPreview.test.js
+++ b/src/pages/templatesV2/hooks/tests/useEditorPreview.test.js
@@ -5,7 +5,7 @@ import useEditorPreview from '../useEditorPreview';
 
 describe('useEditorPreview', () => {
   const useTestWrapper = (value = {}) => {
-    const TestComponent = () => <div hooked={useEditorPreview(value)} />;
+    const TestComponent = () => <div hooked={useEditorPreview({ formattedTestData: {}, ...value })} />;
     return mount(<TestComponent />);
   };
   const useHook = (wrapper) => wrapper.update().children().prop('hooked');
@@ -24,14 +24,14 @@ describe('useEditorPreview', () => {
     const content = { html: '<h1>Test Example</h1>' };
     const draft = { id: 'test-template', subaccount_id: 123 };
 
-    useTestWrapper({ content, debounceAction, draft, getPreview });
+    useTestWrapper({ content, debounceAction, draft, getPreview, formattedTestData: { substitution_data: { foo: 'bar' }}});
 
     expect(getPreview).toHaveBeenCalledWith({
       id: draft.id,
       content,
       mode: 'draft',
       subaccountId: draft.subaccount_id,
-      substitution_data: {}
+      substitution_data: { foo: 'bar' }
     });
   });
 

--- a/src/pages/templatesV2/hooks/tests/useTestData.test.js
+++ b/src/pages/templatesV2/hooks/tests/useTestData.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import useTestData from '../useTestData';
+
+describe('useEditorTabs', () => {
+  let getTestDataFromLocalStorage;
+  let setTestDataToLocalStorage;
+
+  beforeEach(() => {
+    getTestDataFromLocalStorage = jest.fn();
+    setTestDataToLocalStorage = jest.fn();
+  });
+
+  const useTestWrapper = (value = {}) => {
+    const TestComponent = () => <div hooked={useTestData({
+      getTestDataFromLocalStorage,
+      setTestDataToLocalStorage,
+      draft: { id: 'foo' },
+      ...value
+    })}/>;
+    return mount(<TestComponent/>);
+  };
+
+  const useHook = (wrapper) => wrapper.update().children().prop('hooked');
+
+  it('fetches test data from storage on mount', () => {
+    useHook(useTestWrapper());
+    expect(getTestDataFromLocalStorage).toHaveBeenCalledWith({ id: 'foo', mode: 'draft' });
+  });
+
+  it('fetches testdata when mode change', () => {
+    useHook(useTestWrapper({ isPublishedMode: true }));
+    expect(getTestDataFromLocalStorage).toHaveBeenCalledWith({ id: 'foo', mode: 'published' });
+  });
+
+  it('fetches testdata when template ID change', () => {
+    useHook(useTestWrapper({ draft: { id: 'foo2' }}));
+    expect(getTestDataFromLocalStorage).toHaveBeenCalledWith({ id: 'foo2', mode: 'draft' });
+  });
+
+  it('updates local state when test data changes externally', () => {
+    const templateTestData = { substitution_data: { name: 'foo' }};
+    const { testData } = useHook(useTestWrapper({ templateTestData }));
+    expect(testData).toEqual(templateTestData);
+  });
+
+  describe('syncTestDataInStorage', () => {
+    it('updates local storage when local state is different', () => {
+      const wrapper = useTestWrapper({ templateTestData: 'foo' });
+      act(() => {
+        useHook(wrapper).setTestData('bar');
+      });
+      const context = useHook(wrapper);
+      context.syncTestDataInStorage();
+      expect(setTestDataToLocalStorage).toHaveBeenCalled();
+    });
+
+    it('does not updates local storage when local state is unchanged', () => {
+      const wrapper = useTestWrapper({ templateTestData: 'foo' });
+      act(() => {
+        useHook(wrapper).setTestData('foo');
+      });
+      const context = useHook(wrapper);
+      context.syncTestDataInStorage();
+      expect(setTestDataToLocalStorage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('formattedTestData', () => {
+    it('return parsed json', () => {
+      const json = { foo: 'bar' };
+      const { formattedTestData } = useHook(useTestWrapper({ templateTestData: JSON.stringify(json) }));
+      expect(formattedTestData).toEqual(json);
+    });
+  });
+});

--- a/src/pages/templatesV2/hooks/useEditorPreview.js
+++ b/src/pages/templatesV2/hooks/useEditorPreview.js
@@ -7,7 +7,7 @@ import isEmpty from 'lodash/isEmpty';
 const debouncer = debounce((fn) => fn(), 1000);
 
 // tracks changes to content and requests preview update
-const useEditorPreview = ({ content, draft = {}, getPreview, getTestData, testData, debounceAction = debouncer, formattedTestData }) => {
+const useEditorPreview = ({ content, draft = {}, getPreview, debounceAction = debouncer, formattedTestData }) => {
   const [previewDevice, setPreviewDevice] = useState('desktop');
 
   useEffect(() => {
@@ -22,7 +22,7 @@ const useEditorPreview = ({ content, draft = {}, getPreview, getTestData, testDa
         });
       });
     }
-  }, [content, debounceAction, draft.id, draft.subaccount_id, getPreview, formattedTestData]);
+  }, [content, debounceAction, draft.id, draft.subaccount_id, getPreview, formattedTestData.substitution_data]);
 
   // clean-up debounced state when unmounted
   useEffect(() => () => {

--- a/src/pages/templatesV2/hooks/useEditorPreview.js
+++ b/src/pages/templatesV2/hooks/useEditorPreview.js
@@ -7,12 +7,7 @@ import isEmpty from 'lodash/isEmpty';
 const debouncer = debounce((fn) => fn(), 1000);
 
 // tracks changes to content and requests preview update
-const useEditorPreview = ({
-  content,
-  draft = {},
-  getPreview,
-  debounceAction = debouncer
-}) => {
+const useEditorPreview = ({ content, draft = {}, getPreview, getTestData, testData, debounceAction = debouncer, formattedTestData }) => {
   const [previewDevice, setPreviewDevice] = useState('desktop');
 
   useEffect(() => {
@@ -23,14 +18,16 @@ const useEditorPreview = ({
           content,
           mode: 'draft',
           subaccountId: draft.subaccount_id,
-          substitution_data: {}
+          substitution_data: formattedTestData.substitution_data
         });
       });
     }
-  }, [getPreview, content, debounceAction, draft.id, draft.subaccount_id]);
+  }, [content, debounceAction, draft.id, draft.subaccount_id, getPreview, formattedTestData]);
 
   // clean-up debounced state when unmounted
-  useEffect(() => () => { debounceAction.cancel(); }, [debounceAction]);
+  useEffect(() => () => {
+    debounceAction.cancel();
+  }, [debounceAction]);
 
   return {
     previewDevice,

--- a/src/pages/templatesV2/hooks/useTestData.js
+++ b/src/pages/templatesV2/hooks/useTestData.js
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import isEqual from 'lodash/isEqual';
 
 const useTestData = ({ draft = {}, templateTestData, version: mode, getTestDataFromLocalStorage, setTestDataToLocalStorage, isPublishedMode }) => {
   const [state, setState] = useState(templateTestData);
-  const [formattedData, setFormattedData] = useState({});
 
   //on mount, trigger fetching data from store
   useEffect(() => {
@@ -11,14 +11,17 @@ const useTestData = ({ draft = {}, templateTestData, version: mode, getTestDataF
 
   //update local state when testData is externally updated (e.g. completed loading from store)
   useEffect(() => {
-    setState(templateTestData);
-    setFormattedData(JSON.parse(templateTestData));
-  }, [setState, setFormattedData, templateTestData]);
+    if (!isEqual(state, templateTestData)) {
+      setState(templateTestData);
+    }
+  }, [setState, state, templateTestData]);
 
   //whenever data is changed locally, save it in localstorage.
   useEffect(() => {
     setTestDataToLocalStorage({ id: draft.id, data: state, mode });
   }, [state, draft.id, mode, setTestDataToLocalStorage]);
+
+  const formattedData = useMemo(() => JSON.parse(state), [state]);
 
   return {
     formattedTestData: formattedData,

--- a/src/pages/templatesV2/hooks/useTestData.js
+++ b/src/pages/templatesV2/hooks/useTestData.js
@@ -1,0 +1,42 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const useTestData = ({ draft = {}, testData, getTestData, setTestData, isPublishedMode }) => {
+  const [subData, setSubData] = useState(testData);
+  const mode = isPublishedMode ? 'published' : 'draft';
+
+  const syncTestData = (data) => {
+    setSubData(data);
+  };
+
+  const formatSubData = useMemo(() => {
+    try {
+      return JSON.parse(subData, null, 2);
+    } catch (err) {
+      // console.warn(err);
+      return {};
+    }
+  }, [subData]);
+
+  //on mount, trigger fetching data from store
+  useEffect(() => {
+    getTestData({ id: draft.id, mode });
+  }, [draft.id, getTestData, mode]);
+
+  //update local state when testData is externally updated (e.g. completed loading from store)
+  useEffect(() => {
+    syncTestData(testData);
+  }, [syncTestData, testData]);
+
+  //whenever data is changed locally, save it in localstorage.
+  useEffect(() => {
+    setTestData({ id: draft.id, data: subData, mode });
+  }, [subData, draft.id, mode, setTestData]);
+
+  return {
+    formattedTestData: formatSubData,
+    stringTestData: subData,
+    syncTestData
+  };
+};
+
+export default useTestData;

--- a/src/pages/templatesV2/hooks/useTestData.js
+++ b/src/pages/templatesV2/hooks/useTestData.js
@@ -1,41 +1,29 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-const useTestData = ({ draft = {}, testData, getTestData, setTestData, isPublishedMode }) => {
-  const [subData, setSubData] = useState(testData);
-  const mode = isPublishedMode ? 'published' : 'draft';
-
-  const syncTestData = (data) => {
-    setSubData(data);
-  };
-
-  const formatSubData = useMemo(() => {
-    try {
-      return JSON.parse(subData, null, 2);
-    } catch (err) {
-      // console.warn(err);
-      return {};
-    }
-  }, [subData]);
+const useTestData = ({ draft = {}, templateTestData, version: mode, getTestDataFromLocalStorage, setTestDataToLocalStorage, isPublishedMode }) => {
+  const [state, setState] = useState(templateTestData);
+  const [formattedData, setFormattedData] = useState({});
 
   //on mount, trigger fetching data from store
   useEffect(() => {
-    getTestData({ id: draft.id, mode });
-  }, [draft.id, getTestData, mode]);
+    getTestDataFromLocalStorage({ id: draft.id, mode });
+  }, [draft.id, getTestDataFromLocalStorage, mode]);
 
   //update local state when testData is externally updated (e.g. completed loading from store)
   useEffect(() => {
-    syncTestData(testData);
-  }, [syncTestData, testData]);
+    setState(templateTestData);
+    setFormattedData(JSON.parse(templateTestData));
+  }, [setState, setFormattedData, templateTestData]);
 
   //whenever data is changed locally, save it in localstorage.
   useEffect(() => {
-    setTestData({ id: draft.id, data: subData, mode });
-  }, [subData, draft.id, mode, setTestData]);
+    setTestDataToLocalStorage({ id: draft.id, data: state, mode });
+  }, [state, draft.id, mode, setTestDataToLocalStorage]);
 
   return {
-    formattedTestData: formatSubData,
-    stringTestData: subData,
-    syncTestData
+    formattedTestData: formattedData,
+    testData: state,
+    setTestData: setState
   };
 };
 

--- a/src/pages/templatesV2/hooks/useTestData.js
+++ b/src/pages/templatesV2/hooks/useTestData.js
@@ -1,32 +1,40 @@
 import { useEffect, useMemo, useState } from 'react';
 import isEqual from 'lodash/isEqual';
 
-const useTestData = ({ draft = {}, templateTestData, version: mode, getTestDataFromLocalStorage, setTestDataToLocalStorage, isPublishedMode }) => {
+const useTestData = ({ draft = {}, templateTestData, getTestDataFromLocalStorage, setTestDataToLocalStorage, isPublishedMode }) => {
   const [state, setState] = useState(templateTestData);
+  const templateId = draft.id;
+  const mode = isPublishedMode ? 'published' : 'draft';
 
-  //on mount, trigger fetching data from store
+  //trigger fetching data from store.
   useEffect(() => {
-    getTestDataFromLocalStorage({ id: draft.id, mode });
-  }, [draft.id, getTestDataFromLocalStorage, mode]);
+    getTestDataFromLocalStorage({ id: templateId, mode });
+  }, [getTestDataFromLocalStorage, mode, templateId]);
 
   //update local state when testData is externally updated (e.g. completed loading from store)
   useEffect(() => {
-    if (!isEqual(state, templateTestData)) {
-      setState(templateTestData);
+    setState(templateTestData);
+  }, [templateTestData, mode]);
+
+  const formattedData = useMemo(() => {
+    try {
+      return JSON.parse(state);
+    } catch (err) {
+      return {};
     }
-  }, [setState, state, templateTestData]);
+  }, [state]);
 
-  //whenever data is changed locally, save it in localstorage.
-  useEffect(() => {
-    setTestDataToLocalStorage({ id: draft.id, data: state, mode });
-  }, [state, draft.id, mode, setTestDataToLocalStorage]);
-
-  const formattedData = useMemo(() => JSON.parse(state), [state]);
+  const syncTestDataInStorage = () => {
+    if (!isEqual(templateTestData, state)) {
+      setTestDataToLocalStorage({ id: templateId, data: state, mode });
+    }
+  };
 
   return {
     formattedTestData: formattedData,
     testData: state,
-    setTestData: setState
+    setTestData: setState,
+    syncTestDataInStorage
   };
 };
 


### PR DESCRIPTION
Allows user to edit tests data

### What Changed
 - Syncs test data with local storage
 - Uses test data in preview generation

### How To Test
 - Edit Template (v2)
 - Go to `Test Data` tab and add substitution_data (other prop might not be in use now)
 - Go to HTML/Text/AMP and use those subs tag 
 - Preview should render with substituted data
 
 - Separate test data for published and draft template

Notes: 
 - Probably we can enable annotation for test data
 - Currently preview is not re-generated upon changing test data. Should we auto preview as soon as test data is changed? 


### To Do
- [ ] Finish pending tests