### PR TITLE
EO-372: Added file type validation

### DIFF
--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -1,5 +1,5 @@
-export const toSentence = (array) => {
-  const conjunction = (array.length >= 3) ? ', and ' : ' and ';
+export const toSentence = (array, conjuctionTerm = 'and') => {
+  const conjunction = (array.length >= 3) ? `, ${conjuctionTerm} ` : ` ${conjuctionTerm} `;
   return array.slice(0, -2).join(', ') + //combines all elements except the last 2 into comma separated items.
     (array.slice(0, -2).length ? ', ' : '') + //appends comma before appending last 2 items unless there are <=2 item in the whole array
     (array.slice(-2).join(conjunction)); //joins the last 2 items using oxford comma for >=3 items and append to end of sentence.

--- a/src/helpers/tests/array.test.js
+++ b/src/helpers/tests/array.test.js
@@ -16,4 +16,12 @@ describe('.toSentence', () => {
   it('returns a sentence', () => {
     expect(toSentence(['first', 'second', 'third'])).toEqual('first, second, and third');
   });
+
+  it('returns both values with specified conjuction', () => {
+    expect(toSentence(['first', 'second'], 'or')).toEqual('first or second');
+  });
+
+  it('returns a sentence with specified conjunction', () => {
+    expect(toSentence(['first', 'second', 'third'], 'or')).toEqual('first, second, or third');
+  });
 });

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -104,15 +104,15 @@ export function nonEmptyFile(file) {
 }
 
 export const fileExtension = _.memoize(function fileExtension(...extensions) {
-  extensions = extensions.map((extension) => `.${extension.toLowerCase()}`);
+  const formattedExtensions = extensions.map((extension) => `.${extension.toLowerCase()}`);
+
   return (file) => {
     if (!file) {
       return;
     }
+    const hasValidExtension = formattedExtensions.some((extension) => file.name.toLowerCase().endsWith(extension));
 
-    const hasValidExtension = extensions.some((extension) => file.name.toLowerCase().endsWith(extension));
-
-    return hasValidExtension ? undefined : `Must be a ${toSentence(extensions, 'or')} file`;
+    return hasValidExtension ? undefined : `Must be a ${toSentence(formattedExtensions, 'or')} file`;
   };
 });
 

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -102,9 +102,14 @@ export function nonEmptyFile(file) {
   return !file || file.size > 0 ? undefined : 'File must be non-empty';
 }
 
-export const fileExtension = _.memoize(function fileExtension(extension) {
-  const regex = RegExp(`.${extension}$`);
-  return (file) => !file || regex.test(file.name) ? undefined : `Must be a .${extension} file`;
+export const fileExtension = _.memoize(function fileExtension(...extensions) {
+  return (file) => {
+    if (!file) {
+      return;
+    }
+    const extType = _.find(extensions, (extension) => RegExp(`.${extension}$`).test(file.name));
+    return extType ? undefined : `Must be a .${extensions.join(', .')} file`;
+  };
 });
 
 export const maxLength = _.memoize(function maxLength(length) {

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { formatBytes } from 'src/helpers/units';
 import { getDuration } from 'src/helpers/date';
+import { toSentence } from 'src/helpers/array';
 import { isEmailAddress, isEmailLocalPart, isRecipientEmailAddress } from 'src/helpers/email';
 import { domainRegex, slugRegex } from './regex';
 import isURL from 'validator/lib/isURL';
@@ -103,12 +104,15 @@ export function nonEmptyFile(file) {
 }
 
 export const fileExtension = _.memoize(function fileExtension(...extensions) {
+  extensions = extensions.map((extension) => `.${extension.toLowerCase()}`);
   return (file) => {
     if (!file) {
       return;
     }
-    const extType = _.find(extensions, (extension) => RegExp(`.${extension}$`).test(file.name));
-    return extType ? undefined : `Must be a .${extensions.join(', .')} file`;
+
+    const hasValidExtension = extensions.some((extension) => file.name.toLowerCase().endsWith(extension));
+
+    return hasValidExtension ? undefined : `Must be a ${toSentence(extensions, 'or')} file`;
   };
 });
 

--- a/src/pages/recipientValidation/components/ListForm.js
+++ b/src/pages/recipientValidation/components/ListForm.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Field, reduxForm, formValueSelector } from 'redux-form';
 import { Panel } from '@sparkpost/matchbox';
-import { maxFileSize } from 'src/helpers/validation';
+import { maxFileSize, fileExtension } from 'src/helpers/validation';
 import FileUploadWrapper from './FileUploadWrapper';
 import { uploadList, resetUploadError } from 'src/actions/recipientValidation';
 import { showAlert } from 'src/actions/globalAlert';
@@ -31,7 +31,7 @@ export class ListForm extends Component {
 
     // Redux form validation does not run in the same render cycle after Field's onChange,
     // thus checking props.valid would not work here *shakes fist*
-    const valid = !maxFileSize(config.maxRecipVerifUploadSizeBytes)(file);
+    const valid = !maxFileSize(config.maxRecipVerifUploadSizeBytes)(file) && !fileExtension('csv', 'txt')(file);
 
     if (file && valid && !listError) {
       handleSubmit(this.handleUpload)();
@@ -44,7 +44,7 @@ export class ListForm extends Component {
   }
 
   render() {
-    const uploadValidators = maxFileSize(config.maxRecipVerifUploadSizeBytes);
+    const uploadValidators = [maxFileSize(config.maxRecipVerifUploadSizeBytes), fileExtension('csv', 'txt')];
 
     return (
       <Panel.Section>

--- a/src/pages/recipientValidation/components/tests/ListForm.test.js
+++ b/src/pages/recipientValidation/components/tests/ListForm.test.js
@@ -31,7 +31,7 @@ describe('ListForm', () => {
   });
 
   it('should submit csv', async () => {
-    wrapper.setProps({ ...props, file: { size: 45 }});
+    wrapper.setProps({ ...props, file: { size: 45, name: 'test.csv' }});
 
     const csvUpload = props.uploadList.mock.calls[0][0];
     await expect(props.uploadList).toHaveBeenCalledTimes(1);
@@ -47,8 +47,13 @@ describe('ListForm', () => {
     expect(props.uploadList).not.toHaveBeenCalled();
   });
 
+  it('should not submit if not type csv or txt', () => {
+    wrapper.setProps({ ...props, file: { name: 'thing.doc' }});
+    expect(props.uploadList).not.toHaveBeenCalled();
+  });
+
   it('should not submit csv with an error', () => {
-    wrapper.setProps({ ...props, file: { size: 45 }, listError: 'error' });
+    wrapper.setProps({ ...props, file: { size: 45, name: 'test.csv' }, listError: 'error' });
     expect(props.uploadList).not.toHaveBeenCalled();
   });
 

--- a/src/pages/recipientValidation/components/tests/__snapshots__/ListForm.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/ListForm.test.js.snap
@@ -6,7 +6,12 @@ exports[`ListForm renders correctly 1`] = `
     <Field
       component={[Function]}
       name="csv"
-      validate={[Function]}
+      validate={
+        Array [
+          [Function],
+          [Function],
+        ]
+      }
     />
   </form>
 </Panel.Section>


### PR DESCRIPTION
### What Changed
 - Modified file extension validation to accept multiple parameters
 - Added validator to recipient-validation list upload page to accept only `.csv` and `.txt`

### How To Test
 - Navigate to `/recipient-validation/list`
 - Check that drag and drop only works for files of type `.csv` and `.txt`
 - Check that drag and drop does not submit for files of other types and shows error message

### To Do
- [ ] Address feedback
