### PR TITLE
AC-838: Updated loading condition

### DIFF
--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -163,7 +163,7 @@ const mapStateToProps = (state, props) => {
   const { account, loading } = selectAccountBilling(state);
 
   return {
-    loading: (!account.created && loading) || (_.isEmpty(plans) && state.billing.plansLoading),
+    loading: loading || (_.isEmpty(plans) && state.billing.plansLoading),
     isAws: selectCondition(isAws)(state),
     account,
     billing: state.billing,


### PR DESCRIPTION
[AC-838](https://jira.int.messagesystems.com/browse/AC-838)
### What Changed
 - Updated loading condition which could be causing bug of rendering page before getting billing info

### How To Test
 - On new account, go to `/account/billing`
 - Check that submitting new plan w/ card goes through
 - Check that loading state stays loading until new page

### To Do
- [ ] Address feedback

### Notes
 I think that account should always have created, so then it should be looking at the loading condition regardless.
