### PR TITLE
AC-746 : Logout invalidates both access and refresh token

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -177,7 +177,9 @@ export function logout() {
       return;
     }
     dispatch(invalidateAuthToken(token));
-    dispatch(invalidateAuthToken(refreshToken));
+    if (refreshToken) {
+      dispatch(invalidateAuthToken(refreshToken));
+    }
     dispatch(websiteAuth.logout());
 
     removeHerokuToolbar();

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -145,6 +145,21 @@ export function ssoCheck(username) {
   });
 }
 
+export function invalidateAuthToken(token) {
+  return sparkpostApiRequest({
+    type: 'LOGOUT',
+    meta: {
+      method: 'POST',
+      url: '/v1/authenticate/logout',
+      data: `token=${token}`,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': `${token}`
+      }
+    }
+  });
+}
+
 export function refresh(token, refreshToken) {
   return (dispatch) => {
     const newCookie = authCookie.merge({ access_token: token, refresh_token: refreshToken });
@@ -156,11 +171,13 @@ export function refresh(token, refreshToken) {
 export function logout() {
   return (dispatch, getState) => {
     const { auth } = getState();
+    const { token, refreshToken } = auth;
     // only log out if currently logged in
     if (!auth.loggedIn) {
       return;
     }
-
+    dispatch(invalidateAuthToken(token));
+    dispatch(invalidateAuthToken(refreshToken));
     dispatch(websiteAuth.logout());
 
     removeHerokuToolbar();

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -149,7 +149,7 @@ Array [
 ]
 `;
 
-exports[`Action Creator: Auth logout should dispatch a logout when user is logged in 2`] = `
+exports[`Action Creator: Auth logout should skip invalidating the refreshToken if one does not exist 1`] = `
 Array [
   Array [
     [Function],

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -133,10 +133,32 @@ Array [
 exports[`Action Creator: Auth logout should dispatch a logout when user is logged in 1`] = `
 Array [
   Array [
-    [Function],
+    Object {
+      "meta": Object {
+        "data": "token=245234523423",
+        "headers": Object {
+          "Authorization": "245234523423",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        "method": "POST",
+        "url": "/v1/authenticate/logout",
+      },
+      "type": "LOGOUT",
+    },
   ],
   Array [
-    [Function],
+    Object {
+      "meta": Object {
+        "data": "token=adfa012342342",
+        "headers": Object {
+          "Authorization": "adfa012342342",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        "method": "POST",
+        "url": "/v1/authenticate/logout",
+      },
+      "type": "LOGOUT",
+    },
   ],
   Array [
     undefined,
@@ -152,7 +174,18 @@ Array [
 exports[`Action Creator: Auth logout should skip invalidating the refreshToken if one does not exist 1`] = `
 Array [
   Array [
-    [Function],
+    Object {
+      "meta": Object {
+        "data": "token=245234523423",
+        "headers": Object {
+          "Authorization": "245234523423",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        "method": "POST",
+        "url": "/v1/authenticate/logout",
+      },
+      "type": "LOGOUT",
+    },
   ],
   Array [
     undefined,

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -136,9 +136,6 @@ Array [
     [Function],
   ],
   Array [
-    [Function],
-  ],
-  Array [
     undefined,
   ],
   Array [

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -136,6 +136,25 @@ Array [
     [Function],
   ],
   Array [
+    [Function],
+  ],
+  Array [
+    undefined,
+  ],
+  Array [
+    Object {
+      "type": "LOGOUT",
+    },
+  ],
+]
+`;
+
+exports[`Action Creator: Auth logout should dispatch a logout when user is logged in 2`] = `
+Array [
+  Array [
+    [Function],
+  ],
+  Array [
     undefined,
   ],
   Array [

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -133,6 +133,12 @@ Array [
 exports[`Action Creator: Auth logout should dispatch a logout when user is logged in 1`] = `
 Array [
   Array [
+    [Function],
+  ],
+  Array [
+    [Function],
+  ],
+  Array [
     undefined,
   ],
   Array [

--- a/src/actions/tests/auth.test.js
+++ b/src/actions/tests/auth.test.js
@@ -10,6 +10,7 @@ jest.mock('src/actions/websiteAuth');
 jest.mock('src/actions/accessControl');
 jest.mock('src/helpers/http');
 jest.mock('src/actions/tfa');
+jest.mock('src/actions/helpers/sparkpostApiRequest', () => jest.fn((a) => a));
 
 describe('Action Creator: Auth', () => {
   let dispatchMock;

--- a/src/actions/tests/auth.test.js
+++ b/src/actions/tests/auth.test.js
@@ -15,12 +15,7 @@ describe('Action Creator: Auth', () => {
   let dispatchMock;
   let getStateMock;
   let stateMock;
-
-  const authData = {
-    username: 'ron-burgundy',
-    token: '245234523423',
-    refreshToken: 'adfa012342342'
-  };
+  let authData;
 
   function mockGetTfaStatus(enabled, required) {
     getTfaStatusBeforeLoggedIn.mockResolvedValue({
@@ -34,12 +29,20 @@ describe('Action Creator: Auth', () => {
   }
 
   beforeEach(() => {
-    dispatchMock = jest.fn((a) => Promise.resolve(a));
+    authData = {
+      username: 'ron-burgundy',
+      token: '245234523423',
+      refreshToken: 'adfa012342342'
+    };
 
+    dispatchMock = jest.fn((a) => Promise.resolve(a));
     stateMock = {
       auth: {
-        loggedIn: false
-      }
+        loggedIn: false,
+        token: '245234523423',
+        refreshToken: 'adfa012342342'
+      },
+      token: 'superToken'
     };
 
     getStateMock = jest.fn(() => stateMock);
@@ -206,6 +209,7 @@ describe('Action Creator: Auth', () => {
       const thunk = authActions.logout();
       await thunk(dispatchMock, getStateMock);
       expect(authCookie.remove).toHaveBeenCalledTimes(1);
+      expect(dispatchMock).toHaveBeenCalledTimes(4);
       expect(dispatchMock.mock.calls).toMatchSnapshot();
     });
 
@@ -215,6 +219,16 @@ describe('Action Creator: Auth', () => {
       await thunk(dispatchMock, getStateMock);
       expect(authCookie.remove).not.toHaveBeenCalled();
       expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    it('should skip invalidating the refreshToken if one does not exist', async () => {
+      stateMock.auth.refreshToken = null;
+      stateMock.auth.loggedIn = true;
+      const thunk = authActions.logout();
+      await thunk(dispatchMock, getStateMock);
+      expect(authCookie.remove).toHaveBeenCalledTimes(1);
+      expect(dispatchMock).toHaveBeenCalledTimes(3);
+      expect(dispatchMock.mock.calls).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Note: Give your PR a short title. Something like "_TICKET NUMBER: feature description_" is good.

### What Changed
 - Access and Refresh tokens are invalidated when the user clicks the logout button

### How To Test
 - Login on the development webpage
 - Gather access/refresh key from DynamoDB
 - Logout
 - Confirm the keys are removed from Dynamo and can't be used to access api/v1/account
