### PR TITLE
AC-871: Allow promo code to be passed through URL parameters

### DIFF
--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -39,7 +39,7 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
           ? <span>
             {' at '}
             {hasDiscount && <s className={styles.DiscountedLabel}>${priceInfo.price}</s>}
-            <strong>{hasDiscount ? formatCurrency(discountAmount) : `$${discountAmount.toLocaleString()}`}</strong>
+            <strong>{hasDiscount ? formatCurrency(discountAmount) : `$${priceInfo.price}`}</strong>
             /{priceInfo.intervalShort}
           </span>
           : <span> FREE </span>}

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -36,10 +36,12 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
       <span className={styles.MainLabel} {...rest}>
         <strong>{plan.volume.toLocaleString()}</strong><span> emails/month </span>
         {priceInfo.price > 0
-          ? <span><span> at </span>
+          ? <span>
+            {' at '}
             {hasDiscount && <s className={styles.DiscountedLabel}>${priceInfo.price}</s>}
             <strong>{hasDiscount ? formatCurrency(discountAmount) : `$${discountAmount.toLocaleString()}`}</strong>
-            /{priceInfo.intervalShort}</span>
+            /{priceInfo.intervalShort}
+          </span>
           : <span> FREE </span>}
       </span>
       <span className={styles.SupportLabel}>

--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -2,6 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import { getPlanPrice } from 'src/helpers/billing';
 import styles from './PlanPrice.module.scss';
+import { formatCurrency } from 'src/helpers/units';
 
 const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false, selectedPromo = {}, ...rest }) => {
   if (_.isEmpty(plan)) {
@@ -28,12 +29,17 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
     discountAmount = discountAmount * ((100 - selectedPromo.discount_percentage) / 100);
   }
 
+  const hasDiscount = discountAmount !== priceInfo.price;
+
   return (
     <span className='notranslate'>
       <span className={styles.MainLabel} {...rest}>
         <strong>{plan.volume.toLocaleString()}</strong><span> emails/month </span>
         {priceInfo.price > 0
-          ? <span> at {discountAmount !== priceInfo.price && (<s className={styles.DiscountedLabel}>${priceInfo.price}</s>)}<strong>${discountAmount.toLocaleString()}</strong>/{priceInfo.intervalShort}</span>
+          ? <span><span> at </span>
+            {hasDiscount && <s className={styles.DiscountedLabel}>${priceInfo.price}</s>}
+            <strong>{hasDiscount ? formatCurrency(discountAmount) : `$${discountAmount.toLocaleString()}`}</strong>
+            /{priceInfo.intervalShort}</span>
           : <span> FREE </span>}
       </span>
       <span className={styles.SupportLabel}>

--- a/src/components/billing/PromoCode.js
+++ b/src/components/billing/PromoCode.js
@@ -11,12 +11,13 @@ const Loading = ({ loading }) => loading ? <LoadingSVG size="XSmall" /> : null;
 export class PromoCode extends React.Component {
 
   render() {
-    const { selectedPromo = {}, promoPending = false } = this.props;
+    const { selectedPromo = {}, promoPending = false, promoError = {}} = this.props;
     return (
       <span>
         <Field
           label='Promo Code'
           name="promoCode"
+          error={promoError.message}
           errorInLabel
           component={TextFieldWrapper}
           suffix={<Loading loading={promoPending} />}
@@ -30,7 +31,8 @@ export class PromoCode extends React.Component {
 }
 
 const mapStateToProps = (state) => ({
-  promoPending: state.billing.promoPending
+  promoPending: state.billing.promoPending,
+  promoError: state.billing.promoError
 });
 
 export default connect(mapStateToProps)(PromoCode);

--- a/src/components/billing/tests/PromoCode.test.js
+++ b/src/components/billing/tests/PromoCode.test.js
@@ -30,4 +30,10 @@ describe('promoCode', () => {
     wrapper.setProps(props);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should render with error', () => {
+    props.promoError = { message: 'Oh no!' };
+    wrapper.setProps(props);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -14,10 +14,11 @@ exports[`PlanPrice allows class name overriding 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <strong>
-        $
-        9
+        $9
       </strong>
       /
       mo
@@ -43,7 +44,9 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <s
         className="DiscountedLabel"
       >
@@ -51,8 +54,7 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
         9
       </s>
       <strong>
-        $
-        0
+        $0.00
       </strong>
       /
       mo
@@ -78,10 +80,11 @@ exports[`PlanPrice renders correctly 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <strong>
-        $
-        9
+        $9
       </strong>
       /
       mo
@@ -130,10 +133,11 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <strong>
-        $
-        9
+        $9
       </strong>
       /
       mo
@@ -187,10 +191,11 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <strong>
-        $
-        0.012
+        $0.012
       </strong>
       /
       hr
@@ -216,7 +221,9 @@ exports[`PlanPrice renders flat discount 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <s
         className="DiscountedLabel"
       >
@@ -224,8 +231,7 @@ exports[`PlanPrice renders flat discount 1`] = `
         9
       </s>
       <strong>
-        $
-        4
+        $4.00
       </strong>
       /
       mo
@@ -251,10 +257,11 @@ exports[`PlanPrice renders free ip 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <strong>
-        $
-        9
+        $9
       </strong>
       /
       mo
@@ -282,10 +289,11 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <strong>
-        $
-        9
+        $9
       </strong>
       /
       mo
@@ -316,7 +324,9 @@ exports[`PlanPrice renders percent discount 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <s
         className="DiscountedLabel"
       >
@@ -324,8 +334,7 @@ exports[`PlanPrice renders percent discount 1`] = `
         9
       </s>
       <strong>
-        $
-        6.75
+        $6.75
       </strong>
       /
       mo
@@ -351,10 +360,11 @@ exports[`PlanPrice renders with overage 1`] = `
        emails/month 
     </span>
     <span>
-       at 
+      <span>
+         at 
+      </span>
       <strong>
-        $
-        9
+        $9
       </strong>
       /
       mo

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -14,9 +14,7 @@ exports[`PlanPrice allows class name overriding 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <strong>
         $9
       </strong>
@@ -44,9 +42,7 @@ exports[`PlanPrice renders as 0 if flat discount is greater than price 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <s
         className="DiscountedLabel"
       >
@@ -80,9 +76,7 @@ exports[`PlanPrice renders correctly 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <strong>
         $9
       </strong>
@@ -133,9 +127,7 @@ exports[`PlanPrice renders correctly for CSM inclusion 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <strong>
         $9
       </strong>
@@ -191,9 +183,7 @@ exports[`PlanPrice renders correctly with hourly plans 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <strong>
         $0.012
       </strong>
@@ -221,9 +211,7 @@ exports[`PlanPrice renders flat discount 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <s
         className="DiscountedLabel"
       >
@@ -257,9 +245,7 @@ exports[`PlanPrice renders free ip 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <strong>
         $9
       </strong>
@@ -289,9 +275,7 @@ exports[`PlanPrice renders free ip and overage correct 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <strong>
         $9
       </strong>
@@ -324,9 +308,7 @@ exports[`PlanPrice renders percent discount 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <s
         className="DiscountedLabel"
       >
@@ -360,9 +342,7 @@ exports[`PlanPrice renders with overage 1`] = `
        emails/month 
     </span>
     <span>
-      <span>
-         at 
-      </span>
+       at 
       <strong>
         $9
       </strong>

--- a/src/components/billing/tests/__snapshots__/PromoCode.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PromoCode.test.js.snap
@@ -37,6 +37,23 @@ exports[`promoCode should render with description 1`] = `
 </span>
 `;
 
+exports[`promoCode should render with error 1`] = `
+<span>
+  <Field
+    component={[Function]}
+    error="Oh no!"
+    errorInLabel={true}
+    label="Promo Code"
+    name="promoCode"
+    suffix={
+      <Loading
+        loading={false}
+      />
+    }
+  />
+</span>
+`;
+
 exports[`promoCode should render with loading spinner 1`] = `
 <span>
   <Field

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -35,7 +35,16 @@ export class ChangePlanForm extends Component {
   };
 
   componentDidMount() {
-    this.props.getPlans();
+    this.props.getPlans().then(() => {
+      const { initialValues, selectedPlan } = this.props;
+      if (initialValues.promoCode && !_.isEmpty(selectedPlan)) {
+        return this.props.verifyPromoCode({
+          promoCode: initialValues.promoCode,
+          billingId: selectedPlan.billingId,
+          meta: { promoCode: initialValues.promoCode, showErrorAlert: false }
+        });
+      }
+    });
     this.props.getBillingCountries();
     this.props.fetchAccount();
     this.props.getBillingInfo();
@@ -158,10 +167,9 @@ export class ChangePlanForm extends Component {
 
 const mapStateToProps = (state, props) => {
   const selector = formValueSelector(FORMNAME);
-  const { code: planCode } = qs.parse(props.location.search);
+  const { code: planCode, promo: promoCode } = qs.parse(props.location.search);
   const plans = selectTieredVisiblePlans(state);
   const { account, loading } = selectAccountBilling(state);
-
   return {
     loading: (!account.created && loading) || (_.isEmpty(plans) && state.billing.plansLoading),
     isAws: selectCondition(isAws)(state),
@@ -172,7 +180,7 @@ const mapStateToProps = (state, props) => {
     plans,
     currentPlan: currentPlanSelector(state),
     selectedPlan: selector(state, 'planpicker') || {},
-    initialValues: changePlanInitialValues(state, { planCode })
+    initialValues: changePlanInitialValues(state, { planCode, promoCode })
   };
 };
 

--- a/src/pages/billing/forms/ChangePlanForm.js
+++ b/src/pages/billing/forms/ChangePlanForm.js
@@ -37,6 +37,9 @@ export class ChangePlanForm extends Component {
   componentDidMount() {
     this.props.getPlans().then(() => {
       const { initialValues, selectedPlan } = this.props;
+
+      //After loading plans, verifies query promo against plan and applies UI discount
+      //TODO: Move to componentDidUpdate
       if (initialValues.promoCode && !_.isEmpty(selectedPlan)) {
         return this.props.verifyPromoCode({
           promoCode: initialValues.promoCode,

--- a/src/pages/billing/forms/tests/ChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/ChangePlanForm.test.js
@@ -35,7 +35,7 @@ describe('Form Container: Change Plan', () => {
       },
       isSelfServeBilling: true,
       billing: { countries: [], plans, selectedPromo: {}},
-      getPlans: jest.fn(),
+      getPlans: jest.fn(() => Promise.resolve()),
       getBillingCountries: jest.fn(),
       verifyPromoCode: jest.fn(() => Promise.resolve({ discount_id: 'test-discount' })),
       getBillingInfo: jest.fn(),
@@ -48,6 +48,9 @@ describe('Form Container: Change Plan', () => {
       location: {
         pathname: '/account/billing/plan',
         search: 'immediatePlanChange=free-0817&pass=through'
+      },
+      initialValues: {
+        promoCode: undefined
       },
       handleSubmit: jest.fn(),
       showAlert: jest.fn(),
@@ -124,6 +127,18 @@ describe('Form Container: Change Plan', () => {
       expect(props.billingCreate).toHaveBeenCalledWith(values);
       expect(props.history.push).toHaveBeenCalledWith('/account/billing');
       expect(props.showAlert).toHaveBeenCalledWith({ type: 'success', message: 'Subscription Updated' });
+    });
+
+    it('should verify promo code if passed in as initial value', async () => {
+      props.initialValues = { promoCode: 'initial-promo-code' };
+      props.selectedPlan = { billingId: 'test-id' };
+      wrapper = await shallow(<ChangePlanForm {...props} />);
+      expect(props.getPlans).toHaveBeenCalled();
+      expect(props.verifyPromoCode).toHaveBeenCalledWith({
+        promoCode: 'initial-promo-code',
+        billingId: 'test-id',
+        meta: { promoCode: 'initial-promo-code', showErrorAlert: false }
+      });
     });
 
     it('should call verify if promo code is attached and update subscription', async () => {

--- a/src/selectors/accountBillingForms.js
+++ b/src/selectors/accountBillingForms.js
@@ -14,7 +14,7 @@ export const getFirstStateForCountry = createSelector(
 /**
  * Selects initial values for all the forms on account/billing/plan
  */
-export function changePlanInitialValues(state, { planCode } = {}) {
+export function changePlanInitialValues(state, { planCode, promoCode } = {}) {
   const overridePlan = _.find(selectAvailablePlans(state), { code: planCode }); // typically from query string
   const currentPlan = currentPlanSelector(state);
   const firstVisiblePlan = _.first(selectVisiblePlans(state));
@@ -29,7 +29,8 @@ export function changePlanInitialValues(state, { planCode } = {}) {
       lastName: state.currentUser.last_name,
       country: firstCountry,
       state: firstState
-    }
+    },
+    promoCode
   };
 }
 

--- a/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
+++ b/src/selectors/tests/__snapshots__/accountBillingForms.test.js.snap
@@ -1,23 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Selector: Account billing form changePlanInitialValues when NOT self serve should find and return secret plan 1`] = `
-Object {
-  "billingAddress": Object {
-    "country": "US",
-    "firstName": "ann",
-    "lastName": "perkins",
-    "state": "AL",
-  },
-  "email": "ann@perkins.com",
-  "planpicker": Object {
-    "billingId": "ias",
-    "code": "im a secret",
-    "isFree": false,
-    "status": "secret",
-  },
-}
-`;
-
 exports[`Selector: Account billing form changePlanInitialValues when NOT self serve should return change plan values: with a billing id 1`] = `
 Object {
   "billingAddress": Object {
@@ -31,6 +13,7 @@ Object {
     "billingId": "1",
     "code": "abc",
   },
+  "promoCode": undefined,
 }
 `;
 
@@ -46,6 +29,7 @@ Object {
   "planpicker": Object {
     "code": "abc",
   },
+  "promoCode": undefined,
 }
 `;
 

--- a/src/selectors/tests/accountBillingForms.test.js
+++ b/src/selectors/tests/accountBillingForms.test.js
@@ -52,8 +52,17 @@ describe('Selector: Account billing form', () => {
       expect(changePlanInitialValues(store)).toMatchSnapshot();
     });
 
+    it('should return promo code', () => {
+      expect(changePlanInitialValues(store, { promoCode: 'promo' })).toEqual(expect.objectContaining({ promoCode: 'promo' }));
+    });
+
     it('should find and return secret plan', () => {
-      expect(changePlanInitialValues(store, { planCode: 'im a secret' })).toMatchSnapshot();
+      expect(changePlanInitialValues(store, { planCode: 'im a secret' }))
+        .toEqual(
+          expect.objectContaining({
+            planpicker: { billingId: 'ias', code: 'im a secret', isFree: false, status: 'secret' }
+          })
+        );
     });
   });
 


### PR DESCRIPTION
[AC-871](https://jira.int.messagesystems.com/browse/AC-871)
### What Changed
 - Added the `promo` query string to `/account/billing/plan`

### How To Test
 - Go to `/account/billing/plan?code=100K-starter-0519&promo=THXFISH2` (works on staging, not sure about uat)
 - Check that verification runs on mount
 - Check that page refresh is good
 - Check that submission works
 - Check that page works without param
 - Check that invalid promo renders error

### To Do
- [ ] Address feedback
- [ ] Possibly add promo to `/account/billing` like plan query

### Notes
 - Didn't add it to `/account/billing` since there is one specific intended URL for this.
