### PR TITLE
AC-888: Dashboard inaccurately reports daily usage for unrestricted accounts

### DIFF
--- a/src/components/usageReport/SendMoreCTA.js
+++ b/src/components/usageReport/SendMoreCTA.js
@@ -22,18 +22,9 @@ export class SendMoreCTA extends Component {
       }));
   }
 
-  renderVerifyEmailCTA() {
-    const { verifyingEmail } = this.props;
-
-    const resendVerificationLink = <UnstyledLink
-      onClick={this.resendVerification}>
-      Verify your email.
-    </UnstyledLink>;
-
-    return verifyingEmail ? <span>Resending a verification email... </span> : resendVerificationLink;
-  }
-
   render() {
+    const { hasSendingLimits, verifyingEmail } = this.props;
+
     return (
       <AccessControl condition={isAdmin}>
         <p>
@@ -42,7 +33,13 @@ export class SendMoreCTA extends Component {
           <ConditionSwitch>
 
             {/* email isn't verified */}
-            <Case condition={not(isEmailVerified)} children={this.renderVerifyEmailCTA()} />
+            <Case condition={not(isEmailVerified)}>
+              {verifyingEmail ? (
+                <span>Resending a verification email... </span>
+              ) : (
+                <UnstyledLink onClick={this.resendVerification}> Verify your email. </UnstyledLink>
+              )}
+            </Case>
 
             {/* on a deprecated plan */}
             <Case condition={onPlanWithStatus('deprecated')} children={<PageLink to="/account/billing">Switch to a new plan.</PageLink>} />
@@ -52,7 +49,11 @@ export class SendMoreCTA extends Component {
 
           </ConditionSwitch>
           {' '}
-          <UnstyledLink to={LINKS.DAILY_MONTHLY_QUOTA_LIMIT_DOC} external>Learn more about these limits.</UnstyledLink>
+          {hasSendingLimits && (
+            <UnstyledLink to={LINKS.DAILY_MONTHLY_QUOTA_LIMIT_DOC} external>
+              Learn more about these limits.
+            </UnstyledLink>
+          )}
         </p>
       </AccessControl>
     );

--- a/src/components/usageReport/UsageReport.js
+++ b/src/components/usageReport/UsageReport.js
@@ -52,10 +52,6 @@ export class UsageReport extends Component {
     const hasDailyLimit = usage.day.limit > 0;
     const hasMonthlyLimit = usage.month.limit > 0;
 
-    const overageMarkup = overage
-      ? <DisplayNumber label='Extra Emails Used' content={overage.toLocaleString()}/>
-      : null;
-
     return (
       <Panel title='Your Usage Report' actions={actions}>
         <Panel.Section>
@@ -81,8 +77,10 @@ export class UsageReport extends Component {
             <ProgressBar completed={getPercent(usage.month.used, usage.month.limit)} />
           )}
           <DisplayNumber label='Used' content={usage.month.used.toLocaleString()} orange />
-          <DisplayNumber label='Included' content={subscription.plan_volume.toLocaleString()}/>
-          {overageMarkup}
+          <DisplayNumber label='Included' content={subscription.plan_volume.toLocaleString()} />
+          {overage > 0 && (
+            <DisplayNumber label='Extra Emails Used' content={overage.toLocaleString()} />
+          )}
           {hasMonthlyLimit && (
             <DisplayNumber label='Monthly limit' content={usage.month.limit.toLocaleString()} />
           )}

--- a/src/components/usageReport/UsageReport.js
+++ b/src/components/usageReport/UsageReport.js
@@ -70,7 +70,7 @@ export class UsageReport extends Component {
           {hasDailyLimit && (
             <DisplayNumber label='Daily Limit' content={usage.day.limit.toLocaleString()} />
           )}
-          <SendMoreCTA />
+          <SendMoreCTA hasSendingLimits={hasDailyLimit || hasMonthlyLimit} />
         </Panel.Section>
         <Panel.Section>
           <ProgressLabel

--- a/src/components/usageReport/UsageReport.js
+++ b/src/components/usageReport/UsageReport.js
@@ -49,6 +49,8 @@ export class UsageReport extends Component {
 
     const remaining = subscription.plan_volume - usage.month.used;
     const overage = remaining < 0 ? Math.abs(remaining) : 0;
+    const hasDailyLimit = usage.day.limit > 0;
+    const hasMonthlyLimit = usage.month.limit > 0;
 
     const overageMarkup = overage
       ? <DisplayNumber label='Extra Emails Used' content={overage.toLocaleString()}/>
@@ -61,11 +63,11 @@ export class UsageReport extends Component {
             title='Today'
             secondaryTitle={`Since ${formatDateTime(usage.day.start)}`}
           />
-          {usage.day.limit && (
+          {hasDailyLimit && (
             <ProgressBar completed={getPercent(usage.day.used, usage.day.limit)} />
           )}
           <DisplayNumber label='Used' content={usage.day.used.toLocaleString()} orange />
-          {usage.day.limit && (
+          {hasDailyLimit && (
             <DisplayNumber label='Daily Limit' content={usage.day.limit.toLocaleString()} />
           )}
           <SendMoreCTA />
@@ -75,13 +77,13 @@ export class UsageReport extends Component {
             title='This Month'
             secondaryTitle={`Billing cycle: ${formatDate(usage.month.start)} - ${formatDate(usage.month.end)}`}
           />
-          {usage.month.limit && (
+          {hasMonthlyLimit && (
             <ProgressBar completed={getPercent(usage.month.used, usage.month.limit)} />
           )}
           <DisplayNumber label='Used' content={usage.month.used.toLocaleString()} orange />
           <DisplayNumber label='Included' content={subscription.plan_volume.toLocaleString()}/>
           {overageMarkup}
-          {usage.month.limit && (
+          {hasMonthlyLimit && (
             <DisplayNumber label='Monthly limit' content={usage.month.limit.toLocaleString()} />
           )}
         </Panel.Section>

--- a/src/components/usageReport/UsageReport.js
+++ b/src/components/usageReport/UsageReport.js
@@ -47,53 +47,43 @@ export class UsageReport extends Component {
       return <PanelLoading />;
     }
 
-
     const remaining = subscription.plan_volume - usage.month.used;
     const overage = remaining < 0 ? Math.abs(remaining) : 0;
-
-    const dailyUsage = getPercent(usage.day.used, usage.day.limit);
-
-    const monthlyLimit = usage.month.limit || subscription.plan_volume;
-    const monthlyUsage = getPercent(usage.month.used, monthlyLimit);
-
-    const dailyLimitMarkup = usage.day.limit
-      ? <DisplayNumber label='Daily Limit' content={usage.day.limit.toLocaleString()}/>
-      : null;
 
     const overageMarkup = overage
       ? <DisplayNumber label='Extra Emails Used' content={overage.toLocaleString()}/>
       : null;
 
-    const monthlyLimitMarkup = usage.month.limit && usage.month.limit !== subscription.plan_volume
-      ? <DisplayNumber label='Monthly limit' content={usage.month.limit.toLocaleString()} />
-      : null;
-
     return (
       <Panel title='Your Usage Report' actions={actions}>
         <Panel.Section>
-
           <ProgressLabel
             title='Today'
             secondaryTitle={`Since ${formatDateTime(usage.day.start)}`}
           />
-          <ProgressBar completed={dailyUsage} />
+          {usage.day.limit && (
+            <ProgressBar completed={getPercent(usage.day.used, usage.day.limit)} />
+          )}
           <DisplayNumber label='Used' content={usage.day.used.toLocaleString()} orange />
-          {dailyLimitMarkup}
-
+          {usage.day.limit && (
+            <DisplayNumber label='Daily Limit' content={usage.day.limit.toLocaleString()} />
+          )}
           <SendMoreCTA />
         </Panel.Section>
         <Panel.Section>
-
           <ProgressLabel
             title='This Month'
             secondaryTitle={`Billing cycle: ${formatDate(usage.month.start)} - ${formatDate(usage.month.end)}`}
           />
-          <ProgressBar completed={monthlyUsage} />
+          {usage.month.limit && (
+            <ProgressBar completed={getPercent(usage.month.used, usage.month.limit)} />
+          )}
           <DisplayNumber label='Used' content={usage.month.used.toLocaleString()} orange />
           <DisplayNumber label='Included' content={subscription.plan_volume.toLocaleString()}/>
           {overageMarkup}
-          {monthlyLimitMarkup}
-
+          {usage.month.limit && (
+            <DisplayNumber label='Monthly limit' content={usage.month.limit.toLocaleString()} />
+          )}
         </Panel.Section>
       </Panel>
     );

--- a/src/components/usageReport/tests/SendMoreCTA.test.js
+++ b/src/components/usageReport/tests/SendMoreCTA.test.js
@@ -23,6 +23,14 @@ describe('SendMoreCTA Component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders learn more about sending limits link', () => {
+    wrapper.setProps({ hasSendingLimits: true });
+
+    expect(
+      wrapper.findWhere((node) => node.text() === 'Learn more about these limits.')
+    ).toExist();
+  });
+
   describe('resendVerification', () => {
     it('renders verifying state', () => {
       wrapper.setProps({ verifyingEmail: true });

--- a/src/components/usageReport/tests/UsageReport.test.js
+++ b/src/components/usageReport/tests/UsageReport.test.js
@@ -55,4 +55,25 @@ describe('UsageReport Component', () => {
 
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should not render limits for unrestricted accounts', () => {
+    const usage = {
+      day: {
+        used: 1000,
+        limit: null,
+        start: '2017-08-30T00:00:00.000Z'
+      },
+      month: {
+        used: 1000,
+        limit: null,
+        start: '2017-08-01T08:00:00.000Z',
+        end: '2017-08-31T08:00:00.000Z'
+      }
+    };
+    const wrapper = shallow(<UsageReport {...props} usage={usage} />);
+
+    expect(wrapper.find('ProgressBar')).not.toExist();
+    expect(wrapper.find('DisplayNumber[label="Daily limit"]')).not.toExist();
+    expect(wrapper.find('DisplayNumber[label="Monthly limit"]')).not.toExist();
+  });
 });

--- a/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/SendMoreCTA.test.js.snap
@@ -14,7 +14,7 @@ exports[`SendMoreCTA Component renders correctly 1`] = `
         <UnstyledLink
           onClick={[Function]}
         >
-          Verify your email.
+           Verify your email. 
         </UnstyledLink>
       </Case>
       <Case
@@ -37,12 +37,6 @@ exports[`SendMoreCTA Component renders correctly 1`] = `
       </Case>
     </Connect(ConditionSwitch)>
      
-    <UnstyledLink
-      external={true}
-      to="https://support.sparkpost.com/customer/portal/articles/2030894"
-    >
-      Learn more about these limits.
-    </UnstyledLink>
   </p>
 </AccessControl>
 `;

--- a/src/components/usageReport/tests/__snapshots__/UsageReport.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/UsageReport.test.js.snap
@@ -38,7 +38,9 @@ exports[`UsageReport Component should render with overages 1`] = `
       content="2,000"
       label="Daily Limit"
     />
-    <Connect(SendMoreCTA) />
+    <Connect(SendMoreCTA)
+      hasSendingLimits={true}
+    />
   </Panel.Section>
   <Panel.Section>
     <ProgressLabel
@@ -102,7 +104,9 @@ exports[`UsageReport Component should render with regular usage 1`] = `
       content="2,000"
       label="Daily Limit"
     />
-    <Connect(SendMoreCTA) />
+    <Connect(SendMoreCTA)
+      hasSendingLimits={true}
+    />
   </Panel.Section>
   <Panel.Section>
     <ProgressLabel


### PR DESCRIPTION
Refer to [AC-888](https://jira.int.messagesystems.com/browse/AC-888)

### What Changed
 - Limits will not be shown unless present
 - Monthly limit will always be displayed when present (before it was hidden if same value as plan volume)

![Screen Shot 2019-07-16 at 12 07 16 PM](https://user-images.githubusercontent.com/1335605/61314516-c7460d00-a7ca-11e9-9c08-3c9fd74ce46e.png)

### How To Test
 - Create a new account
 - `PUT /account/control trust_level=unrestricted`
 - Open the dashboard and confirm limits are not displayed


