### PR TITLE
TR-1605 Allow templatesV2 feature flag to be disabled

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -51,7 +51,7 @@ echo '{"options": {"ui": {"my-new-route": true}}}' | http put app.tst.sparkpost:
 For a user:
 
 ```sh
-echo '{"options": {"ui": {"my-new-route": true}}}' | http put app.tst.sparkpost:8888/api/v1/user/{username}/control
+echo '{"options": {"ui": {"my-new-route": true}}}' | http put app.tst.sparkpost:8888/api/v1/users/{username}/control
 x-msys-tenant:uat x-msys-customer:<CID>
 ```
 
@@ -66,5 +66,5 @@ echo '{"options": {"ui": {"my-new-route": false}}}' | http put app.tst.sparkpost
 
 For a user:
 ```sh
-echo '{"options": {"ui": {"my-new-route": false}}}' | http put app.tst.sparkpost:8888/api/v1/user/{username}/control x-msys-tenant:uat x-msys-customer:<CID>
+echo '{"options": {"ui": {"my-new-route": false}}}' | http put app.tst.sparkpost:8888/api/v1/users/{username}/control x-msys-tenant:uat x-msys-customer:<CID>
 ```

--- a/src/config/campaignNavItems.js
+++ b/src/config/campaignNavItems.js
@@ -1,5 +1,5 @@
-import { hasUiOption } from 'src/helpers/conditions/account';
 import { TemplateOutlineFill } from '@sparkpost/matchbox-icons';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 
 const campaignNavItems = [
   {
@@ -21,7 +21,6 @@ export default {
   label: 'Campaigns',
   to: '/campaigns',
   icon: TemplateOutlineFill,
-  condition: hasUiOption('templatesV2'),
+  condition: isAccountUiOptionSet('templatesV2'),
   children: campaignNavItems
 };
-


### PR DESCRIPTION
[TR-1605](https://jira.int.messagesystems.com/browse/TR-1605)

### What Changed
- Switched feature toggles from `hasUiOptions` to `isAccountUiOptionSet`

### How To Test
- Create a new account
- Confirm "Campaigns" navigation is not visible
- Follow feature-flag docs to set "templatesV2" feature flag to true
- Confirm "Campaigns" navigation is visible
- Set "templatesV2" feature flag to false
- Confirm "Campaigns" navigation is not visible