### PR TITLE
AC-873: Updated support hours

### DIFF
--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -80,7 +80,7 @@ export class Support extends Component {
           {currentSupportView === 'ticket' && <SupportForm onClose={closeSupportPanel} />}
           {currentSupportView === 'contact' && (
             <div className={styles.SupportContainer}>
-              <h6>We are available Monday through Friday, 9am to 8pm Eastern time.</h6>
+              <h6>We are available Monday through Friday, 9am to 7pm Eastern time.</h6>
               <UnstyledLink to='tel:1-415-751-0928'>+1 (415) 751-0928</UnstyledLink>
             </div>
           )}

--- a/src/components/support/tests/__snapshots__/Support.test.js.snap
+++ b/src/components/support/tests/__snapshots__/Support.test.js.snap
@@ -120,7 +120,7 @@ exports[`Support renders support contact panel 1`] = `
       className="SupportContainer"
     >
       <h6>
-        We are available Monday through Friday, 9am to 8pm Eastern time.
+        We are available Monday through Friday, 9am to 7pm Eastern time.
       </h6>
       <UnstyledLink
         to="tel:1-415-751-0928"


### PR DESCRIPTION
### What Changed
 - Changed support hours from `8pm` to `7pm`

### How To Test
 - Log into app team
 - Click support icon on top and go to `Contact Us` tab
 - Should say 7pm...

### To Do
- [ ] Address feedback
