### PR TITLE
SE-100 Alerts Edit Page

### DIFF
--- a/src/actions/alertsV1.js
+++ b/src/actions/alertsV1.js
@@ -22,6 +22,17 @@ export function createAlert({ data }) {
   });
 }
 
+export function updateAlert({ data, id }) {
+  return sparkpostApiRequest({
+    type: 'UPDATE_ALERT_V1',
+    meta: {
+      method: 'PUT',
+      url: `/v1/alerts/${id}`,
+      data
+    }
+  });
+}
+
 export function setMutedStatus({ muted, id }) {
   return sparkpostApiRequest({
     type: 'SET_ALERT_V1_MUTED_STATUS',

--- a/src/actions/tests/__snapshots__/alertsV1.test.js.snap
+++ b/src/actions/tests/__snapshots__/alertsV1.test.js.snap
@@ -69,3 +69,18 @@ Array [
   },
 ]
 `;
+
+exports[`Action Creator: Alerts should dispatch an update action 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {
+        "name": "Updated Name",
+      },
+      "method": "PUT",
+      "url": "/v1/alerts/alert-id",
+    },
+    "type": "UPDATE_ALERT_V1",
+  },
+]
+`;

--- a/src/actions/tests/alertsV1.test.js
+++ b/src/actions/tests/alertsV1.test.js
@@ -25,6 +25,11 @@ describe('Action Creator: Alerts', () => {
     expect(mockStore.getActions()).toMatchSnapshot();
   });
 
+  it('should dispatch an update action', () => {
+    mockStore.dispatch(alerts.updateAlert({ id: 'alert-id', data: { name: 'Updated Name' }}));
+    expect(mockStore.getActions()).toMatchSnapshot();
+  });
+
   it('should dispatch a set muted status action', () => {
     mockStore.dispatch(alerts.setMutedStatus({ id: 'alert-id', muted: false }));
     expect(mockStore.getActions()).toMatchSnapshot();

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -684,7 +684,15 @@ const routes = [
     component: alerts.CreatePageNew,
     condition: isUserUiOptionSet('alerts'),
     layout: App,
-    title: 'Create Alerts',
+    title: 'Create Alert',
+    supportDocsSearch: 'Alerts'
+  },
+  {
+    path: '/alerts-new/edit/:id',
+    component: alerts.EditPageNew,
+    condition: isUserUiOptionSet('alerts'),
+    layout: App,
+    title: 'Edit Alert',
     supportDocsSearch: 'Alerts'
   },
   {

--- a/src/pages/alerts/CreatePageNew.js
+++ b/src/pages/alerts/CreatePageNew.js
@@ -50,7 +50,7 @@ export class CreatePageNew extends Component {
           submitting={loading}
           onSubmit={this.handleCreate}
           isDuplicate={Boolean(idToDuplicate)}
-          newAlert={true}
+          isNewAlert={true}
         />
       </Page>
     );

--- a/src/pages/alerts/CreatePageNew.js
+++ b/src/pages/alerts/CreatePageNew.js
@@ -16,10 +16,6 @@ export class CreatePageNew extends Component {
     }
   }
 
-  /*
-    Passed as onSubmit to AlertForm. Figures out what updates need to be passed
-    to the createAlert action.
-  */
   handleCreate = (values) => {
     const { createAlert, showUIAlert, history } = this.props;
     return createAlert({
@@ -50,7 +46,12 @@ export class CreatePageNew extends Component {
       <Page
         title='Create Alert'
         breadcrumbAction={{ content: 'Back to Alerts', to: '/alerts-new', component: Link }}>
-        <AlertFormNew submitting={loading} onSubmit={this.handleCreate} isDuplicate={Boolean(idToDuplicate)}/>
+        <AlertFormNew
+          submitting={loading}
+          onSubmit={this.handleCreate}
+          isDuplicate={Boolean(idToDuplicate)}
+          newAlert={true}
+        />
       </Page>
     );
   }

--- a/src/pages/alerts/EditPageNew.js
+++ b/src/pages/alerts/EditPageNew.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { Page } from '@sparkpost/matchbox';
 import withEditPage from './containers/EditPageNew.container';
 import AlertFormNew from './components/AlertFormNew';
-import { formatFromFormToApi, formatFromApiToForm } from './helpers/formatFormData';
+import formatFormValues from './helpers/formatFormValues';
 import { Loading } from 'src/components';
 import RedirectAndAlert from 'src/components/globalAlert/RedirectAndAlert';
 
@@ -18,7 +18,7 @@ export class EditPageNew extends Component {
     const { updateAlert, showUIAlert, history, id } = this.props;
     return updateAlert({
       id,
-      data: formatFromFormToApi(values)
+      data: formatFormValues(values)
     }).then(() => {
       showUIAlert({ type: 'success', message: 'Alert updated' });
       history.push('/alerts-new');
@@ -26,7 +26,7 @@ export class EditPageNew extends Component {
   };
 
   render() {
-    const { loading, getError, getLoading, alert } = this.props;
+    const { loading, getError, getLoading } = this.props;
 
     if (getLoading) {
       return <Loading/>;
@@ -40,7 +40,6 @@ export class EditPageNew extends Component {
         />
       );
     }
-    const initialValues = formatFromApiToForm(alert);
 
     return (
       <Page
@@ -49,8 +48,7 @@ export class EditPageNew extends Component {
         <AlertFormNew
           submitting={loading}
           onSubmit={this.handleUpdate}
-          intialValues={initialValues}
-          newAlert={false}
+          isNewAlert={false}
         />
       </Page>
     );

--- a/src/pages/alerts/EditPageNew.js
+++ b/src/pages/alerts/EditPageNew.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Page } from '@sparkpost/matchbox';
+import withEditPage from './containers/EditPageNew.container';
+import AlertFormNew from './components/AlertFormNew';
+import { formatFromFormToApi, formatFromApiToForm } from './helpers/formatFormData';
+import { Loading } from 'src/components';
+import RedirectAndAlert from 'src/components/globalAlert/RedirectAndAlert';
+
+export class EditPageNew extends Component {
+
+  componentDidMount() {
+    const { getAlert, id } = this.props;
+    getAlert({ id });
+  }
+
+  handleUpdate = (values) => {
+    const { updateAlert, showUIAlert, history, id } = this.props;
+    return updateAlert({
+      id,
+      data: formatFromFormToApi(values)
+    }).then(() => {
+      showUIAlert({ type: 'success', message: 'Alert updated' });
+      history.push('/alerts-new');
+    });
+  };
+
+  render() {
+    const { loading, getError, getLoading, alert } = this.props;
+
+    if (getLoading) {
+      return <Loading/>;
+    }
+
+    if (getError) {
+      return (
+        <RedirectAndAlert
+          to='/alerts-new'
+          alert={{ type: 'error', message: getError.message }}
+        />
+      );
+    }
+    const initialValues = formatFromApiToForm(alert);
+
+    return (
+      <Page
+        title='Edit Alert'
+        breadcrumbAction={{ content: 'Back to Alerts', to: '/alerts-new', component: Link }}>
+        <AlertFormNew
+          submitting={loading}
+          onSubmit={this.handleUpdate}
+          intialValues={initialValues}
+          newAlert={false}
+        />
+      </Page>
+    );
+  }
+}
+
+export default withEditPage(EditPageNew);

--- a/src/pages/alerts/components/AlertDetails.js
+++ b/src/pages/alerts/components/AlertDetails.js
@@ -5,6 +5,7 @@ import { MAILBOX_PROVIDERS } from 'src/constants';
 import styles from './AlertDetails.module.scss';
 import AlertToggle from './AlertToggleNew';
 import { Email } from '../constants/notificationChannelIcons';
+import { Link } from 'react-router-dom';
 
 export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
   const { metric, channels = {}, filters = [], subaccounts = [], threshold_evaluator = {}, any_subaccount, muted } = alert;
@@ -100,7 +101,7 @@ export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
       <Panel.Section className={styles.Panel}>
         <span className={styles.Subtitle}>Alert Details</span>
         <span className={styles.ButtonGroup}>
-          <Button className={styles.Button} primary>Edit</Button>
+          <Button component={Link} to={`/alerts-new/edit/${id}`} className={styles.Button} primary>Edit</Button>
         </span>
       </Panel.Section>
       {renderAlertDetails()}

--- a/src/pages/alerts/components/AlertDetails.module.scss
+++ b/src/pages/alerts/components/AlertDetails.module.scss
@@ -24,6 +24,7 @@
   .Button {
     margin: 0 rem(10);
     width: rem(100);
+    text-align: center;
   }
 }
 

--- a/src/pages/alerts/components/AlertFormNew.container.js
+++ b/src/pages/alerts/components/AlertFormNew.container.js
@@ -10,7 +10,7 @@ export default function withAlertForm(WrappedComponent) {
 
   const mapStateToProps = (state, props) => {
     const selector = formValueSelector(FORM_NAME);
-    const { isDuplicate } = props;
+    const { isDuplicate, isNewAlert } = props;
 
     return {
       formErrors: getFormSyncErrors(FORM_NAME)(state),
@@ -19,7 +19,7 @@ export default function withAlertForm(WrappedComponent) {
       metric: selector(state, 'metric'),
       single_filter: selector(state, 'single_filter'),
       muted: selector(state, 'muted'),
-      initialValues: isDuplicate ? selectAlertFormValues(state, props) : DEFAULT_FORM_VALUES
+      initialValues: (isDuplicate || !isNewAlert) ? selectAlertFormValues(state, props) : DEFAULT_FORM_VALUES
     };
   };
 

--- a/src/pages/alerts/components/AlertFormNew.js
+++ b/src/pages/alerts/components/AlertFormNew.js
@@ -51,10 +51,10 @@ export class AlertFormNew extends Component {
       hasSubaccounts,
       formErrors,
       formMeta,
-      newAlert
+      isNewAlert
     } = this.props;
 
-    const submitText = submitting ? 'Submitting...' : (newAlert ? 'Create Alert' : 'Update Alert');
+    const submitText = submitting ? 'Submitting...' : (isNewAlert ? 'Create Alert' : 'Update Alert');
     const formSpec = getFormSpec(metric);
     const channelsError = this.isNotificationChannelsEmpty(formMeta, formErrors);
 

--- a/src/pages/alerts/components/AlertFormNew.js
+++ b/src/pages/alerts/components/AlertFormNew.js
@@ -50,10 +50,11 @@ export class AlertFormNew extends Component {
       handleSubmit,
       hasSubaccounts,
       formErrors,
-      formMeta
+      formMeta,
+      newAlert
     } = this.props;
 
-    const submitText = submitting ? 'Submitting...' : 'Create Alert';
+    const submitText = submitting ? 'Submitting...' : (newAlert ? 'Create Alert' : 'Update Alert');
     const formSpec = getFormSpec(metric);
     const channelsError = this.isNotificationChannelsEmpty(formMeta, formErrors);
 
@@ -76,10 +77,8 @@ export class AlertFormNew extends Component {
                     name='metric'
                     component={SelectWrapper}
                     options={metricsOptions}
-                    helpText={'This assignment is permanent.'}
                     onChange={this.resetFormValues}
                     validate={required}
-
                   />
                 </div>
                 {formSpec.hasFilters &&

--- a/src/pages/alerts/components/tests/AlertFormNew.test.js
+++ b/src/pages/alerts/components/tests/AlertFormNew.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import cases from 'jest-in-case';
 import { AlertFormNew } from '../AlertFormNew';
 import { DEFAULT_FORM_VALUES } from '../../constants/formConstants';
 import * as alertFormHelper from '../../helpers/alertForm';
@@ -25,7 +24,8 @@ describe('Alert Form Component', () => {
       metric: 'health_score',
       change: jest.fn(),
       formMeta: {},
-      formErrors: {}
+      formErrors: {},
+      newAlert: true
     };
 
     wrapper = shallow(<AlertFormNew {...props} />);
@@ -83,22 +83,40 @@ describe('Alert Form Component', () => {
     expect(wrapper.find('Error')).toExist();
   });
 
-  describe('submit button props', () => {
+  describe('submit button', () => {
 
-    const formCases = {
-      'pristine': { pristine: true },
-      'submitting': { submitting: true }
-    };
     const defaultFormState = {
       pristine: false,
       submitting: false
     };
 
-    cases('should disable submit button when form is', (formState) => {
+    it('should disable submit button when form is pristine', () => {
       wrapper.setProps(defaultFormState);
       expect(wrapper.find('Button').props().disabled).toEqual(false);
-      wrapper.setProps({ ...defaultFormState, ...formState });
+      wrapper.setProps({ pristine: true });
       expect(wrapper.find('Button').props().disabled).toEqual(true);
-    }, formCases);
+    });
+
+    it('should disable submit button when form is submitting', () => {
+      wrapper.setProps(defaultFormState);
+      expect(wrapper.find('Button').props().disabled).toEqual(false);
+      wrapper.setProps({ pristine: true });
+      expect(wrapper.find('Button').props().disabled).toEqual(true);
+    });
+
+    it('should display Submitting when submitting ', () => {
+      wrapper.setProps({ submitting: true });
+      expect(wrapper.find('Button').props().children).toEqual('Submitting...');
+    });
+
+    it('should display Create Alert when it is new alert', () => {
+      wrapper.setProps({ ...defaultFormState, newAlert: true });
+      expect(wrapper.find('Button').props().children).toEqual('Create Alert');
+    });
+
+    it('should display Update Alert when it is editing alert', () => {
+      wrapper.setProps({ ...defaultFormState, newAlert: false });
+      expect(wrapper.find('Button').props().children).toEqual('Update Alert');
+    });
   });
 });

--- a/src/pages/alerts/components/tests/AlertFormNew.test.js
+++ b/src/pages/alerts/components/tests/AlertFormNew.test.js
@@ -92,16 +92,16 @@ describe('Alert Form Component', () => {
 
     it('should disable submit button when form is pristine', () => {
       wrapper.setProps(defaultFormState);
-      expect(wrapper.find('Button').props().disabled).toEqual(false);
+      expect(wrapper.find('Button')).toHaveProp('disabled', false);
       wrapper.setProps({ pristine: true });
-      expect(wrapper.find('Button').props().disabled).toEqual(true);
+      expect(wrapper.find('Button')).toHaveProp('disabled', true);
     });
 
     it('should disable submit button when form is submitting', () => {
       wrapper.setProps(defaultFormState);
-      expect(wrapper.find('Button').props().disabled).toEqual(false);
+      expect(wrapper.find('Button')).toHaveProp('disabled', false);
       wrapper.setProps({ pristine: true });
-      expect(wrapper.find('Button').props().disabled).toEqual(true);
+      expect(wrapper.find('Button')).toHaveProp('disabled', true);
     });
 
     it('should display Submitting when submitting ', () => {

--- a/src/pages/alerts/components/tests/AlertFormNew.test.js
+++ b/src/pages/alerts/components/tests/AlertFormNew.test.js
@@ -25,7 +25,7 @@ describe('Alert Form Component', () => {
       change: jest.fn(),
       formMeta: {},
       formErrors: {},
-      newAlert: true
+      isNewAlert: true
     };
 
     wrapper = shallow(<AlertFormNew {...props} />);
@@ -110,12 +110,12 @@ describe('Alert Form Component', () => {
     });
 
     it('should display Create Alert when it is new alert', () => {
-      wrapper.setProps({ ...defaultFormState, newAlert: true });
+      wrapper.setProps({ ...defaultFormState, isNewAlert: true });
       expect(wrapper.find('Button').props().children).toEqual('Create Alert');
     });
 
     it('should display Update Alert when it is editing alert', () => {
-      wrapper.setProps({ ...defaultFormState, newAlert: false });
+      wrapper.setProps({ ...defaultFormState, isNewAlert: false });
       expect(wrapper.find('Button').props().children).toEqual('Update Alert');
     });
   });

--- a/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
@@ -18,7 +18,7 @@ exports[`Alert Details Component should render the alert details component corre
         component={[Function]}
         primary={true}
         size="default"
-        to="../edit/alert-id"
+        to="/alerts-new/edit/alert-id"
       >
         Edit
       </Button>

--- a/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
@@ -15,8 +15,10 @@ exports[`Alert Details Component should render the alert details component corre
     >
       <Button
         className="Button"
+        component={[Function]}
         primary={true}
         size="default"
+        to="../edit/alert-id"
       >
         Edit
       </Button>

--- a/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
@@ -36,7 +36,6 @@ exports[`Alert Form Component should render the alert form component correctly 1
             </label>
             <Field
               component={[Function]}
-              helpText="This assignment is permanent."
               name="metric"
               onChange={[Function]}
               options={

--- a/src/pages/alerts/containers/EditPageNew.container.js
+++ b/src/pages/alerts/containers/EditPageNew.container.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { updateAlert, getAlert } from 'src/actions/alertsV1';
+import { showAlert } from 'src/actions/globalAlert';
+
+function withAlertsUpdate(WrappedComponent) {
+  const mapDispatchToProps = { updateAlert, showUIAlert: showAlert, getAlert };
+
+  const mapStateToProps = (state, props) => ({
+    id: props.match.params.id,
+    getError: state.alertsV1.getError,
+    getLoading: state.alertsV1.getPending,
+    alert: state.alertsV1.alert || {},
+    loading: state.alertsV1.updatePending
+  });
+
+  return connect(mapStateToProps, mapDispatchToProps)(WrappedComponent);
+}
+
+export default withAlertsUpdate;

--- a/src/pages/alerts/helpers/formatFormValues.js
+++ b/src/pages/alerts/helpers/formatFormValues.js
@@ -56,8 +56,7 @@ export default function formatFormValues(values) {
     any_subaccount,
     filters,
     threshold_evaluator,
-    channels: { emails },
-    muted: false //Temporary until edit page is completed and muted Field is added to form.
+    channels: { emails }
   };
 
   return _.omit({ ...values, ...keysToChange }, keysToOmit);

--- a/src/pages/alerts/index.js
+++ b/src/pages/alerts/index.js
@@ -1,4 +1,5 @@
 import EditPage from './EditPage';
+import EditPageNew from './EditPageNew';
 import CreatePage from './CreatePage';
 import CreatePageNew from './CreatePageNew';
 import ListPage from './ListPage';
@@ -9,6 +10,7 @@ export default {
   CreatePage,
   CreatePageNew,
   EditPage,
+  EditPageNew,
   ListPage,
   ListPageNew,
   DetailsPage

--- a/src/pages/alerts/tests/EditPageNew.test.js
+++ b/src/pages/alerts/tests/EditPageNew.test.js
@@ -1,0 +1,57 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { EditPageNew } from '../EditPageNew';
+import { formatFromFormToApi } from '../helpers/formatFormData';
+import AlertFormNew from '../components/AlertFormNew';
+
+jest.mock('../helpers/formatFormData');
+
+describe('Page: Alerts Edit', () => {
+  const props = {
+    updateAlert: jest.fn(() => Promise.resolve({ id: 'mock-id' })),
+    showUIAlert: jest.fn(),
+    error: null,
+    history: {
+      push: jest.fn()
+    },
+    loading: false,
+    getAlert: jest.fn(),
+    getError: undefined,
+    getLoading: undefined,
+    id: 'alert-id-1',
+    alert: {}
+  };
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<EditPageNew {...props} />);
+  });
+
+  it('should render happy path', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render Loading when loading alert', () => {
+    wrapper.setProps({ getLoading: true });
+    expect(wrapper.find('Loading')).toExist();
+  });
+
+  it('should render Error when there is an error when getting alert', () => {
+    wrapper.setProps({ getError: true });
+    expect(wrapper.find('RedirectAndAlert')).toExist();
+  });
+
+  it('should get alert when component mounts', () => {
+    wrapper = shallow(<EditPageNew {...props} id={'alert-id-2'} />);
+    expect(props.getAlert).toHaveBeenCalledWith({ id: 'alert-id-2' });
+  });
+
+  it('should handle submit', async () => {
+    formatFromFormToApi.mockImplementationOnce((a) => a);
+    await wrapper.find(AlertFormNew).simulate('submit', { value: 'mock value' });
+    expect(props.updateAlert).toHaveBeenCalledWith({ data: { value: 'mock value' }, id: props.id });
+    expect(props.showUIAlert).toHaveBeenCalled();
+    expect(props.history.push).toHaveBeenCalledWith('/alerts-new');
+  });
+});

--- a/src/pages/alerts/tests/EditPageNew.test.js
+++ b/src/pages/alerts/tests/EditPageNew.test.js
@@ -1,10 +1,10 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import { EditPageNew } from '../EditPageNew';
-import { formatFromFormToApi } from '../helpers/formatFormData';
+import formatFormValues from '../helpers/formatFormValues';
 import AlertFormNew from '../components/AlertFormNew';
 
-jest.mock('../helpers/formatFormData');
+jest.mock('../helpers/formatFormValues');
 
 describe('Page: Alerts Edit', () => {
   const props = {
@@ -48,7 +48,7 @@ describe('Page: Alerts Edit', () => {
   });
 
   it('should handle submit', async () => {
-    formatFromFormToApi.mockImplementationOnce((a) => a);
+    formatFormValues.mockImplementationOnce((a) => a);
     await wrapper.find(AlertFormNew).simulate('submit', { value: 'mock value' });
     expect(props.updateAlert).toHaveBeenCalledWith({ data: { value: 'mock value' }, id: props.id });
     expect(props.showUIAlert).toHaveBeenCalled();

--- a/src/pages/alerts/tests/__snapshots__/CreatePageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/CreatePageNew.test.js.snap
@@ -14,7 +14,7 @@ exports[`Page: Alerts Create should render happy path 1`] = `
 >
   <withRouter(Connect(ReduxForm))
     isDuplicate={false}
-    newAlert={true}
+    isNewAlert={true}
     onSubmit={[Function]}
     submitting={false}
   />

--- a/src/pages/alerts/tests/__snapshots__/CreatePageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/CreatePageNew.test.js.snap
@@ -14,6 +14,7 @@ exports[`Page: Alerts Create should render happy path 1`] = `
 >
   <withRouter(Connect(ReduxForm))
     isDuplicate={false}
+    newAlert={true}
     onSubmit={[Function]}
     submitting={false}
   />

--- a/src/pages/alerts/tests/__snapshots__/EditPageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/EditPageNew.test.js.snap
@@ -13,7 +13,7 @@ exports[`Page: Alerts Edit should render happy path 1`] = `
   title="Edit Alert"
 >
   <withRouter(Connect(ReduxForm))
-    newAlert={false}
+    isNewAlert={false}
     onSubmit={[Function]}
     submitting={false}
   />

--- a/src/pages/alerts/tests/__snapshots__/EditPageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/EditPageNew.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page: Alerts Edit should render happy path 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "component": [Function],
+      "content": "Back to Alerts",
+      "to": "/alerts-new",
+    }
+  }
+  empty={Object {}}
+  title="Edit Alert"
+>
+  <withRouter(Connect(ReduxForm))
+    newAlert={false}
+    onSubmit={[Function]}
+    submitting={false}
+  />
+</Page>
+`;

--- a/src/reducers/alertsV1.js
+++ b/src/reducers/alertsV1.js
@@ -3,6 +3,7 @@ const initialState = {
   listPending: true,
   listError: null,
   createPending: false,
+  updatePending: false,
   deletePending: false,
   getPending: false
 };
@@ -28,6 +29,15 @@ export default (state = initialState, { type, payload, meta }) => {
     case 'CREATE_ALERT_V1_SUCCESS':
     case 'CREATE_ALERT_V1_FAIL':
       return { ...state, createPending: false };
+
+      /* UPDATE */
+
+    case 'UPDATE_ALERT_V1_PENDING':
+      return { ...state, updatePending: true };
+
+    case 'UPDATE_ALERT_V1_SUCCESS':
+    case 'UPDATE_ALERT_V1_FAIL':
+      return { ...state, updatePending: false };
 
       /* GET */
 


### PR DESCRIPTION
### What Changed
 - Added the new Edit page
 - Changed the muted status in the form data transformer to use the form value.

### How To Test
 - Enable user account option `alerts`. This is already enabled in appteam staging.
 - See [here](https://github.com/SparkPost/2web2ui/blob/master/docs/feature-flags.md) to enable user options. Alternatively, [point your local upstreams to staging](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams) and login to our appteam, CID 107 account
 - Edit your openresty configs to contain 
```
    location /api/v1/alerts {
      proxy_pass http://sp-alerts-api;
      include cors;
    }
```
under `server:80`,   `location /api/v1`
 - Navigate to `/alerts-new`.
 - Click any alert name in the table to open details page.
 - Click on the Edit button in the top right.
 - Verify that the edit page contains all of the alert's values 
 - Verify that clicking update successfully updates the alert.