### PR TITLE
AC-848: Added UI Options to hide terminated subaccounts

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -55,6 +55,23 @@ export function update(data) {
   });
 }
 
+export function setAccountOption(key, value) {
+  return sparkpostApiRequest({
+    type: 'SET_ACCOUNT_OPTION',
+    meta: {
+      method: 'PUT',
+      url: '/v1/account',
+      data: {
+        options: {
+          ui: {
+            [key]: value
+          }
+        }
+      }
+    }
+  });
+}
+
 
 export function register(data) {
 

--- a/src/components/typeahead/SubaccountTypeahead.js
+++ b/src/components/typeahead/SubaccountTypeahead.js
@@ -1,7 +1,7 @@
 
 import { connect } from 'react-redux';
 import { list as getSubaccountsList } from 'src/actions/subaccounts';
-import { hasSubaccounts, selectFilteredSubaccounts } from 'src/selectors/subaccounts';
+import { hasSubaccounts, selectSubaccounts } from 'src/selectors/subaccounts';
 import { Typeahead } from './Typeahead';
 import React, { Component } from 'react';
 import Item from './SubaccountTypeaheadItem';
@@ -38,7 +38,7 @@ export class SubaccountTypeahead extends Component {
 
 const mapStateToProps = (state) => ({
   hasSubaccounts: hasSubaccounts(state),
-  results: selectFilteredSubaccounts(state)
+  results: selectSubaccounts(state)
 });
 
 export default connect(mapStateToProps, { getSubaccountsList })(SubaccountTypeahead);

--- a/src/components/typeahead/SubaccountTypeahead.js
+++ b/src/components/typeahead/SubaccountTypeahead.js
@@ -1,7 +1,7 @@
 
 import { connect } from 'react-redux';
 import { list as getSubaccountsList } from 'src/actions/subaccounts';
-import { hasSubaccounts, selectSubaccounts } from 'src/selectors/subaccounts';
+import { hasSubaccounts, selectSubaccounts, getSubaccounts } from 'src/selectors/subaccounts';
 import { Typeahead } from './Typeahead';
 import React, { Component } from 'react';
 import Item from './SubaccountTypeaheadItem';
@@ -36,9 +36,9 @@ export class SubaccountTypeahead extends Component {
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, props) => ({
   hasSubaccounts: hasSubaccounts(state),
-  results: selectSubaccounts(state)
+  results: props.unfiltered ? getSubaccounts(state) : selectSubaccounts(state)
 });
 
 export default connect(mapStateToProps, { getSubaccountsList })(SubaccountTypeahead);

--- a/src/components/typeahead/SubaccountTypeahead.js
+++ b/src/components/typeahead/SubaccountTypeahead.js
@@ -1,7 +1,7 @@
 
 import { connect } from 'react-redux';
 import { list as getSubaccountsList } from 'src/actions/subaccounts';
-import { hasSubaccounts } from 'src/selectors/subaccounts';
+import { hasSubaccounts, selectFilteredSubaccounts } from 'src/selectors/subaccounts';
 import { Typeahead } from './Typeahead';
 import React, { Component } from 'react';
 import Item from './SubaccountTypeaheadItem';
@@ -20,7 +20,7 @@ export class SubaccountTypeahead extends Component {
 
     return (
       <Typeahead
-        renderItem={(item) => <Item name={item.name} id={item.id} /> }
+        renderItem={(item) => <Item name={item.name} id={item.id} />}
         itemToString={(item) => (item ? `${item.name} (${item.id})` : '')}
         label="Subaccount"
         {...this.props}
@@ -38,7 +38,7 @@ export class SubaccountTypeahead extends Component {
 
 const mapStateToProps = (state) => ({
   hasSubaccounts: hasSubaccounts(state),
-  results: state.subaccounts.list
+  results: selectFilteredSubaccounts(state)
 });
 
 export default connect(mapStateToProps, { getSubaccountsList })(SubaccountTypeahead);

--- a/src/pages/account/AccountSettingsPage.js
+++ b/src/pages/account/AccountSettingsPage.js
@@ -5,6 +5,7 @@ import LabelledValue from 'src/components/labelledValue/LabelledValue';
 import CancellationPanel from './components/CancellationPanel';
 import SingleSignOnPanel from './components/SingleSignOnPanel';
 import EnforceTfaPanel from './components/EnforceTfaPanel';
+import UIOptionsPanel from './components/UIOptionsPanel';
 
 export function AccountSettingsPage({ currentUser }) {
   return (
@@ -16,6 +17,7 @@ export function AccountSettingsPage({ currentUser }) {
       </Panel>
       <SingleSignOnPanel />
       <EnforceTfaPanel />
+      <UIOptionsPanel />
       <CancellationPanel />
     </Page>
   );

--- a/src/pages/account/components/UIOptionsPanel.js
+++ b/src/pages/account/components/UIOptionsPanel.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import { Panel, Toggle, Grid } from '@sparkpost/matchbox';
+import LabelledValue from 'src/components/labelledValue/LabelledValue';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { update as updateAccount } from 'src/actions/account';
+import { connect } from 'react-redux';
+
+export class UIOptionsPanel extends Component {
+
+
+  setUIOption = () => {
+    const { updateAccount, hideTermSubEnabled } = this.props;
+    const body = {
+      options: {
+        ui: {
+          hideTerminatedSubaccounts: Boolean(!hideTermSubEnabled)
+        }
+      }
+    };
+    updateAccount(body);
+  };
+
+  render() {
+    const { hideTermSubEnabled, loading } = this.props;
+
+    return (
+      <Panel title='UI Options'>
+        <Panel.Section>
+          <Grid>
+            <Grid.Column xs={11}>
+              <LabelledValue label='Hide Subacounts'>
+                <p>Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.</p>
+              </LabelledValue>
+            </Grid.Column>
+            <Grid.Column xs={1}>
+              <Toggle
+                id="hideTerminatedSubaccounts"
+                checked={hideTermSubEnabled}
+                disabled={loading}
+                onChange={this.setUIOption}
+              />
+            </Grid.Column>
+          </Grid>
+        </Panel.Section>
+      </Panel>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  hideTermSubEnabled: isAccountUiOptionSet('hideTerminatedSubaccounts')(state),
+  loading: state.account.updateLoading
+});
+
+export default connect(mapStateToProps, { updateAccount })(UIOptionsPanel);

--- a/src/pages/account/components/UIOptionsPanel.js
+++ b/src/pages/account/components/UIOptionsPanel.js
@@ -11,7 +11,7 @@ const OPTIONS = [
   {
     key: 'hideTerminatedSubaccounts',
     label: 'Hide Subaccounts',
-    description: 'Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.'
+    description: 'Hide terminated subaccounts. Resources associated with terminated subaccounts can still be accessed.'
   }
 ];
 

--- a/src/pages/account/components/UIOptionsPanel.js
+++ b/src/pages/account/components/UIOptionsPanel.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Panel, Toggle, Grid } from '@sparkpost/matchbox';
 import LabelledValue from 'src/components/labelledValue/LabelledValue';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { selectCondition } from 'src/selectors/accessConditionState';
 import { update as updateAccount } from 'src/actions/account';
 import { connect } from 'react-redux';
 
@@ -13,7 +14,7 @@ export class UIOptionsPanel extends Component {
     const body = {
       options: {
         ui: {
-          hideTerminatedSubaccounts: Boolean(!hideTermSubEnabled)
+          hideTerminatedSubaccounts: !hideTermSubEnabled
         }
       }
     };
@@ -24,7 +25,7 @@ export class UIOptionsPanel extends Component {
     const { hideTermSubEnabled, loading } = this.props;
 
     return (
-      <Panel title='UI Options'>
+      <Panel title='Account Options'>
         <Panel.Section>
           <Grid>
             <Grid.Column xs={11}>
@@ -48,7 +49,7 @@ export class UIOptionsPanel extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  hideTermSubEnabled: isAccountUiOptionSet('hideTerminatedSubaccounts')(state),
+  hideTermSubEnabled: selectCondition(isAccountUiOptionSet('hideTerminatedSubaccounts'))(state),
   loading: state.account.updateLoading
 });
 

--- a/src/pages/account/components/UIOptionsPanel.js
+++ b/src/pages/account/components/UIOptionsPanel.js
@@ -1,24 +1,17 @@
 import React, { Component } from 'react';
-import { Panel, Toggle, Grid } from '@sparkpost/matchbox';
+import { Panel, Toggle } from '@sparkpost/matchbox';
 import LabelledValue from 'src/components/labelledValue/LabelledValue';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import { selectCondition } from 'src/selectors/accessConditionState';
-import { update as updateAccount } from 'src/actions/account';
+import { setAccountOption } from 'src/actions/account';
 import { connect } from 'react-redux';
+import styles from './UIOptionsPanel.module.scss';
 
 export class UIOptionsPanel extends Component {
 
-
   setUIOption = () => {
-    const { updateAccount, hideTermSubEnabled } = this.props;
-    const body = {
-      options: {
-        ui: {
-          hideTerminatedSubaccounts: !hideTermSubEnabled
-        }
-      }
-    };
-    updateAccount(body);
+    const { setAccountOption, hideTermSubEnabled } = this.props;
+    setAccountOption('hideTerminatedSubaccounts', !hideTermSubEnabled);
   };
 
   render() {
@@ -27,21 +20,21 @@ export class UIOptionsPanel extends Component {
     return (
       <Panel title='Account Options'>
         <Panel.Section>
-          <Grid>
-            <Grid.Column xs={11}>
-              <LabelledValue label='Hide Subacounts'>
-                <p>Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.</p>
-              </LabelledValue>
-            </Grid.Column>
-            <Grid.Column xs={1}>
-              <Toggle
-                id="hideTerminatedSubaccounts"
-                checked={hideTermSubEnabled}
-                disabled={loading}
-                onChange={this.setUIOption}
-              />
-            </Grid.Column>
-          </Grid>
+          <LabelledValue label='Hide Subacounts'>
+            <div className={styles.ToggleRow}>
+              <div>
+                Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.
+              </div>
+              <div>
+                <Toggle
+                  id="hideTerminatedSubaccounts"
+                  checked={hideTermSubEnabled}
+                  disabled={loading}
+                  onChange={this.setUIOption}
+                />
+              </div>
+            </div>
+          </LabelledValue>
         </Panel.Section>
       </Panel>
     );
@@ -53,4 +46,4 @@ const mapStateToProps = (state) => ({
   loading: state.account.updateLoading
 });
 
-export default connect(mapStateToProps, { updateAccount })(UIOptionsPanel);
+export default connect(mapStateToProps, { setAccountOption })(UIOptionsPanel);

--- a/src/pages/account/components/UIOptionsPanel.js
+++ b/src/pages/account/components/UIOptionsPanel.js
@@ -7,43 +7,59 @@ import { setAccountOption } from 'src/actions/account';
 import { connect } from 'react-redux';
 import styles from './UIOptionsPanel.module.scss';
 
+const OPTIONS = [
+  {
+    key: 'hideTerminatedSubaccounts',
+    label: 'Hide Subaccounts',
+    description: 'Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.'
+  }
+];
+
+
 export class UIOptionsPanel extends Component {
 
-  setUIOption = () => {
-    const { setAccountOption, hideTermSubEnabled } = this.props;
-    setAccountOption('hideTerminatedSubaccounts', !hideTermSubEnabled);
+  setUIOption = (key, value) => {
+    this.props.setAccountOption(key, value);
   };
 
   render() {
-    const { hideTermSubEnabled, loading } = this.props;
+    const { loading, uiOptions } = this.props;
 
     return (
       <Panel title='Account Options'>
         <Panel.Section>
-          <LabelledValue label='Hide Subacounts'>
-            <div className={styles.ToggleRow}>
-              <div>
-                Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.
+          {uiOptions.map(({ label, description, value, key }) => (
+            <LabelledValue label={label} key={`ui-option-${key}`}>
+              <div className={styles.ToggleRow}>
+                <div>
+                  {description}
+                </div>
+                <div>
+                  <Toggle
+                    id={key}
+                    checked={value}
+                    disabled={loading}
+                    onChange={() => this.setUIOption(key, !value)}
+                  />
+                </div>
               </div>
-              <div>
-                <Toggle
-                  id="hideTerminatedSubaccounts"
-                  checked={hideTermSubEnabled}
-                  disabled={loading}
-                  onChange={this.setUIOption}
-                />
-              </div>
-            </div>
-          </LabelledValue>
+            </LabelledValue>
+          ))}
         </Panel.Section>
       </Panel>
     );
   }
 }
 
-const mapStateToProps = (state) => ({
-  hideTermSubEnabled: selectCondition(isAccountUiOptionSet('hideTerminatedSubaccounts'))(state),
-  loading: state.account.updateLoading
-});
+const mapStateToProps = (state) => {
+  const uiOptions = OPTIONS.map((option) => {
+    option.value = selectCondition(isAccountUiOptionSet(option.key))(state);
+    return option;
+  });
+  return {
+    uiOptions,
+    loading: state.account.updateLoading
+  };
+};
 
 export default connect(mapStateToProps, { setAccountOption })(UIOptionsPanel);

--- a/src/pages/account/components/UIOptionsPanel.module.scss
+++ b/src/pages/account/components/UIOptionsPanel.module.scss
@@ -4,7 +4,7 @@
   display: flex;
 
   :first-child {
-    flex-grow: 0;
+    flex-grow: 1;
     padding-right: spacing();
   }
 }

--- a/src/pages/account/components/UIOptionsPanel.module.scss
+++ b/src/pages/account/components/UIOptionsPanel.module.scss
@@ -1,0 +1,10 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.ToggleRow {
+  display: flex;
+
+  :first-child {
+    flex-grow: 0;
+    padding-right: spacing();
+  }
+}

--- a/src/pages/account/components/tests/UIOptionsPanel.test.js
+++ b/src/pages/account/components/tests/UIOptionsPanel.test.js
@@ -2,9 +2,18 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { UIOptionsPanel } from '../UIOptionsPanel';
 
+const uiOptions = [
+  {
+    key: 'hideTerminatedSubaccounts',
+    label: 'Hide Subaccounts',
+    description: 'Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.',
+    value: false
+  }
+];
+
 const subject = (props = {}) => shallow(
   <UIOptionsPanel
-    hideTermSubEnabled={false}
+    uiOptions={uiOptions}
     setAccountOption={() => {}}
     {...props}
   />
@@ -16,7 +25,8 @@ describe('UIOptionsPanel', () => {
   });
 
   it('renders toggle correctly if option enabled', () => {
-    const wrapper = subject({ hideTermSubEnabled: true });
+    const uiOption = uiOptions[0];
+    const wrapper = subject({ uiOptions: [{ ...uiOption, value: true }]});
     expect(wrapper.find('Toggle')).toHaveProp('checked', true);
   });
 

--- a/src/pages/account/components/tests/UIOptionsPanel.test.js
+++ b/src/pages/account/components/tests/UIOptionsPanel.test.js
@@ -2,30 +2,28 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { UIOptionsPanel } from '../UIOptionsPanel';
 
-let props;
-let wrapper;
+const subject = (props = {}) => shallow(
+  <UIOptionsPanel
+    hideTermSubEnabled={false}
+    updateAccount={() => {}}
+    {...props}
+  />
+);
 
 describe('UIOptionsPanel', () => {
-  beforeEach(() => {
-    props = {
-      hideTermSubEnabled: false,
-      updateAccount: jest.fn()
-    };
-    wrapper = shallow(<UIOptionsPanel {...props} />);
-  });
-
   it('renders', () => {
-    expect(wrapper).toMatchSnapshot();
+    expect(subject()).toMatchSnapshot();
   });
 
   it('renders toggle correctly if option enabled', () => {
-    props.hideTermSubEnabled = true;
-    wrapper = shallow(<UIOptionsPanel {...props} />);
-    expect(wrapper.find('Toggle').prop('checked')).toEqual(true);
+    const wrapper = subject({ hideTermSubEnabled: true });
+    expect(wrapper.find('Toggle')).toHaveProp('checked', true);
   });
 
   it('shoudld toggle', () => {
+    const updateAccount = jest.fn();
+    const wrapper = subject({ updateAccount });
     wrapper.find('Toggle').simulate('change');
-    expect(props.updateAccount).toHaveBeenCalledWith({ options: { ui: { hideTerminatedSubaccounts: true }}});
+    expect(updateAccount).toHaveBeenCalledWith({ options: { ui: { hideTerminatedSubaccounts: true }}});
   });
 });

--- a/src/pages/account/components/tests/UIOptionsPanel.test.js
+++ b/src/pages/account/components/tests/UIOptionsPanel.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { UIOptionsPanel } from '../UIOptionsPanel';
+
+let props;
+let wrapper;
+
+describe('UIOptionsPanel', () => {
+  beforeEach(() => {
+    props = {
+      hideTermSubEnabled: false,
+      updateAccount: jest.fn()
+    };
+    wrapper = shallow(<UIOptionsPanel {...props} />);
+  });
+
+  it('renders', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders toggle correctly if option enabled', () => {
+    props.hideTermSubEnabled = true;
+    wrapper = shallow(<UIOptionsPanel {...props} />);
+    expect(wrapper.find('Toggle').prop('checked')).toEqual(true);
+  });
+
+  it('shoudld toggle', () => {
+    wrapper.find('Toggle').simulate('change');
+    expect(props.updateAccount).toHaveBeenCalledWith({ options: { ui: { hideTerminatedSubaccounts: true }}});
+  });
+});

--- a/src/pages/account/components/tests/UIOptionsPanel.test.js
+++ b/src/pages/account/components/tests/UIOptionsPanel.test.js
@@ -5,7 +5,7 @@ import { UIOptionsPanel } from '../UIOptionsPanel';
 const subject = (props = {}) => shallow(
   <UIOptionsPanel
     hideTermSubEnabled={false}
-    updateAccount={() => {}}
+    setAccountOption={() => {}}
     {...props}
   />
 );
@@ -21,9 +21,9 @@ describe('UIOptionsPanel', () => {
   });
 
   it('shoudld toggle', () => {
-    const updateAccount = jest.fn();
-    const wrapper = subject({ updateAccount });
+    const setAccountOption = jest.fn();
+    const wrapper = subject({ setAccountOption });
     wrapper.find('Toggle').simulate('change');
-    expect(updateAccount).toHaveBeenCalledWith({ options: { ui: { hideTerminatedSubaccounts: true }}});
+    expect(setAccountOption).toHaveBeenCalledWith('hideTerminatedSubaccounts', true);
   });
 });

--- a/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
+++ b/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
@@ -10,7 +10,7 @@ exports[`UIOptionsPanel renders 1`] = `
         xs={11}
       >
         <LabelledValue
-          label="Hide Subacounts"
+          label="Hide Subaccounts"
         >
           <p>
             Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.

--- a/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
+++ b/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UIOptionsPanel renders 1`] = `
+<Panel
+  title="UI Options"
+>
+  <Panel.Section>
+    <Grid>
+      <Grid.Column
+        xs={11}
+      >
+        <LabelledValue
+          label="Hide Subacounts"
+        >
+          <p>
+            Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.
+          </p>
+        </LabelledValue>
+      </Grid.Column>
+      <Grid.Column
+        xs={1}
+      >
+        <Toggle
+          checked={false}
+          id="hideTerminatedSubaccounts"
+          onChange={[Function]}
+        />
+      </Grid.Column>
+    </Grid>
+  </Panel.Section>
+</Panel>
+`;

--- a/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
+++ b/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
@@ -2,31 +2,27 @@
 
 exports[`UIOptionsPanel renders 1`] = `
 <Panel
-  title="UI Options"
+  title="Account Options"
 >
   <Panel.Section>
-    <Grid>
-      <Grid.Column
-        xs={11}
+    <LabelledValue
+      label="Hide Subacounts"
+    >
+      <div
+        className="ToggleRow"
       >
-        <LabelledValue
-          label="Hide Subaccounts"
-        >
-          <p>
-            Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.
-          </p>
-        </LabelledValue>
-      </Grid.Column>
-      <Grid.Column
-        xs={1}
-      >
-        <Toggle
-          checked={false}
-          id="hideTerminatedSubaccounts"
-          onChange={[Function]}
-        />
-      </Grid.Column>
-    </Grid>
+        <div>
+          Hide terminated subacounts. Resources associated with terminated subaccounts can still be accessed.
+        </div>
+        <div>
+          <Toggle
+            checked={false}
+            id="hideTerminatedSubaccounts"
+            onChange={[Function]}
+          />
+        </div>
+      </div>
+    </LabelledValue>
   </Panel.Section>
 </Panel>
 `;

--- a/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
+++ b/src/pages/account/components/tests/__snapshots__/UIOptionsPanel.test.js.snap
@@ -6,7 +6,8 @@ exports[`UIOptionsPanel renders 1`] = `
 >
   <Panel.Section>
     <LabelledValue
-      label="Hide Subacounts"
+      key="ui-option-hideTerminatedSubaccounts"
+      label="Hide Subaccounts"
     >
       <div
         className="ToggleRow"

--- a/src/pages/account/tests/__snapshots__/AccountSettingsPage.test.js.snap
+++ b/src/pages/account/tests/__snapshots__/AccountSettingsPage.test.js.snap
@@ -16,6 +16,7 @@ exports[`AccountSettingsPage renders 1`] = `
   </Panel>
   <Connect(SingleSignOnPanel) />
   <Connect(EnforceTFAPanel) />
+  <Connect(UIOptionsPanel) />
   <Connect(CancellationPanel) />
 </Page>
 `;

--- a/src/pages/signals/components/filters/SubaccountFilter.js
+++ b/src/pages/signals/components/filters/SubaccountFilter.js
@@ -98,6 +98,7 @@ export class SubaccountFilter extends React.Component {
                     label=""
                     onChange={this.handleChange}
                     placeholder="Search here"
+                    unfiltered
                   />
                 </div>
               </div>

--- a/src/pages/signals/components/filters/tests/__snapshots__/SubaccountFilter.test.js.snap
+++ b/src/pages/signals/components/filters/tests/__snapshots__/SubaccountFilter.test.js.snap
@@ -53,6 +53,7 @@ exports[`SubaccountFilter Component renders open popover with options 1`] = `
           label=""
           onChange={[Function]}
           placeholder="Search here"
+          unfiltered={true}
         />
       </div>
     </div>
@@ -182,6 +183,7 @@ exports[`SubaccountFilter Component renders with subaccount 1`] = `
               label=""
               onChange={[Function]}
               placeholder="Search here"
+              unfiltered={true}
             />
           </div>
         </div>

--- a/src/pages/subaccounts/ListPage.js
+++ b/src/pages/subaccounts/ListPage.js
@@ -6,7 +6,7 @@ import { Page } from '@sparkpost/matchbox';
 import { Users } from 'src/components/images';
 import { Loading, TableCollection, ApiErrorBanner } from 'src/components';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
-import { selectSubaccounts } from 'src/selectors/subaccounts';
+import { selectFilteredSubaccounts } from 'src/selectors/subaccounts';
 import getRowData from './helpers/getRowData';
 import { LINKS } from 'src/constants';
 
@@ -83,14 +83,14 @@ export class ListPage extends Component {
             external: true
           }
         }}>
-        { error ? this.renderError() : this.renderCollection() }
+        {error ? this.renderError() : this.renderCollection()}
       </Page>
     );
   }
 }
 
 const mapStateToProps = (state) => ({
-  subaccounts: selectSubaccounts(state),
+  subaccounts: selectFilteredSubaccounts(state),
   loading: state.subaccounts.listLoading,
   error: state.subaccounts.listError
 });

--- a/src/pages/subaccounts/ListPage.js
+++ b/src/pages/subaccounts/ListPage.js
@@ -6,7 +6,7 @@ import { Page } from '@sparkpost/matchbox';
 import { Users } from 'src/components/images';
 import { Loading, TableCollection, ApiErrorBanner } from 'src/components';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
-import { selectFilteredSubaccounts } from 'src/selectors/subaccounts';
+import { selectSubaccounts } from 'src/selectors/subaccounts';
 import getRowData from './helpers/getRowData';
 import { LINKS } from 'src/constants';
 
@@ -90,7 +90,7 @@ export class ListPage extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  subaccounts: selectFilteredSubaccounts(state),
+  subaccounts: selectSubaccounts(state),
   loading: state.subaccounts.listLoading,
   error: state.subaccounts.listError
 });

--- a/src/reducers/account.js
+++ b/src/reducers/account.js
@@ -42,6 +42,18 @@ export default (state = initialState, { type, meta, payload }) => {
     case 'UPDATE_ACCOUNT_FAIL':
       return { ...state, updateError: payload, updateLoading: false };
 
+    case 'SET_ACCOUNT_OPTION_PENDING':
+      return { ...state, updateLoading: true, updateError: null };
+
+    case 'SET_ACCOUNT_OPTION_SUCCESS': {
+      const { options = {}} = state; //Spread other account options
+      const { ui = {}} = options; //Spread other account UI options
+      return { ...state, updateLoading: false, options: { ...options, ui: { ...ui, ...meta.data.options.ui }}};
+    }
+
+    case 'SET_ACCOUNT_OPTION_FAIL':
+      return { ...state, updateError: payload, updateLoading: false };
+
     case 'CREATE_ACCOUNT_PENDING':
       return { ...state, createLoading: true, createError: null };
 

--- a/src/reducers/tests/account.test.js
+++ b/src/reducers/tests/account.test.js
@@ -48,3 +48,16 @@ cases('Account reducer', (action) => {
 cases('Billing reducer', (action) => {
   expect(accountReducer(initialState, action)).toMatchSnapshot();
 }, BILLING_TEST_CASES);
+
+describe('setAccountOption', () => {
+  const initState = { ...initialState, options: { otherThing: false, ui: { exists: true }}};
+  const action = { type: 'SET_ACCOUNT_OPTION_SUCCESS', meta: { data: { options: { ui: { newThing: true }}}}};
+  expect(accountReducer(initState, action)).toEqual(
+    expect.objectContaining({
+      options: {
+        otherThing: false,
+        ui: { exists: true, newThing: true }
+      }
+    })
+  );
+});

--- a/src/selectors/subaccounts.js
+++ b/src/selectors/subaccounts.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import qs from 'query-string';
 import _ from 'lodash';
+import { isAccountUiOptionSet } from '../helpers/conditions/account';
 
 const formatSubaccount = ({ compliance_status = 'active', status = 'active', ...rest }) => {
   const compliance = compliance_status !== 'active';
@@ -32,6 +33,10 @@ export const selectSubaccountFromQuery = createSelector(
   [getSubaccounts, selectSubaccountIdFromQuery],
   (subaccounts, id) => _.find(subaccounts, { id: Number(id) })
 );
+
+export const selectFilteredSubaccounts = (state) => _.filter(state.subaccounts.list, ({ status }) =>
+  !isAccountUiOptionSet('hideTerminatedSubaccounts')(state) || status !== 'terminated');
+
 
 export const selectSubaccountIdFromProps = (state, props) => props.subaccountId;
 

--- a/src/selectors/subaccounts.js
+++ b/src/selectors/subaccounts.js
@@ -21,7 +21,7 @@ export const selectSubaccounts = createSelector(
   [getSubaccounts, selectCondition(isAccountUiOptionSet('hideTerminatedSubaccounts'))],
   (subaccounts, hideTerminatedSubaccounts) => {
     const visibleSubaccounts = hideTerminatedSubaccounts
-      ? subaccounts.filter(({ status }) => status !== 'terminated')
+      ? subaccounts.filter(({ status, compliance_status }) => status !== 'terminated' && compliance_status !== 'terminated')
       : subaccounts;
 
     return visibleSubaccounts.map((subaccount) => formatSubaccount(subaccount));

--- a/src/selectors/tests/subaccounts.test.js
+++ b/src/selectors/tests/subaccounts.test.js
@@ -31,7 +31,8 @@ describe('Subaccount selectors', () => {
               name: 'Subby 2'
             }
           ]
-        }
+        },
+        account: { options: {}}
       };
 
       expect(selector.selectSubaccounts(state)).toEqual([
@@ -52,6 +53,31 @@ describe('Subaccount selectors', () => {
       const state = { currentUser: { has_subaccounts: false }};
       expect(selector.hasSubaccounts(state)).toEqual(false);
     });
+
+    it('should return subaccounts without status "terminated" if account UI option "hideTerminatedSubaccounts" is true', () => {
+      const state = {
+        subaccounts: {
+          list: [
+            {
+              compliance_status: 'active',
+              status: 'valid',
+              name: 'Subby 1'
+            },
+            {
+              status: 'terminated',
+              name: 'Subby 2'
+            }
+          ]
+        },
+        account: { options: { ui: { 'hideTerminatedSubaccounts': true }}}
+      };
+      expect(selector.selectSubaccounts(state)).toEqual([{
+        compliance: false,
+        status: 'valid',
+        name: 'Subby 1'
+      }]);
+    });
+
   });
 
   describe('getSubaccountIdFromProps', () => {

--- a/src/selectors/tests/subaccounts.test.js
+++ b/src/selectors/tests/subaccounts.test.js
@@ -66,6 +66,11 @@ describe('Subaccount selectors', () => {
             {
               status: 'terminated',
               name: 'Subby 2'
+            },
+            {
+              compliance_status: 'terminated',
+              status: 'active',
+              name: 'Subby 3'
             }
           ]
         },


### PR DESCRIPTION
### What Changed
 - UI Option to filter subaccounts

### How To Test
 - Go to `/account/settings`
 - Toggle account option to hide terminated subaccounts
 - Check list page for subaccounts
 - Check typaheads don't show terminated subaccounts if enabled

### To Do
- [ ] Address feedback