### PR TITLE
EO-893 - Add soft and hard bounce metrics as options

### DIFF
--- a/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
@@ -58,6 +58,14 @@ exports[`Alert Form Component should render the alert form component correctly 1
                     "label": "Block Bounce Rate",
                     "value": "block_bounce_rate",
                   },
+                  Object {
+                    "label": "Hard Bounce Rate",
+                    "value": "hard_bounce_rate",
+                  },
+                  Object {
+                    "label": "Soft Bounce Rate",
+                    "value": "soft_bounce_rate",
+                  },
                 ]
               }
               validate={[Function]}

--- a/src/pages/alerts/constants/formConstants.js
+++ b/src/pages/alerts/constants/formConstants.js
@@ -3,7 +3,9 @@ export const FORM_NAME = 'alertForm';
 export const METRICS = {
   monthly_sending_limit: 'Monthly Sending Limit',
   health_score: 'Health Score',
-  block_bounce_rate: 'Block Bounce Rate'
+  block_bounce_rate: 'Block Bounce Rate',
+  hard_bounce_rate: 'Hard Bounce Rate',
+  soft_bounce_rate: 'Soft Bounce Rate'
 };
 
 export const FILTERS_FRIENDLY_NAMES = {

--- a/src/pages/alerts/helpers/alertForm.js
+++ b/src/pages/alerts/helpers/alertForm.js
@@ -9,6 +9,17 @@ import {
 
 export const getOptionsFromMap = (items, friendlyNameMap) => items.map((item) => ({ label: friendlyNameMap[item], value: item }));
 
+const realtimeMetricsSpec = {
+  hasFilters: true,
+  filterType: 'multi',
+  filterOptions: getOptionsFromMap(REALTIME_FILTERS, FILTERS_FRIENDLY_NAMES),
+  sourceOptions: getOptionsFromMap(['raw'], SOURCE_FRIENDLY_NAMES),
+  defaultFieldValues: [
+    { fieldName: 'source', fieldValue: 'raw' },
+    { fieldName: 'operator', fieldValue: 'gt' }
+  ]
+};
+
 const metricToFormSpecMap = {
   monthly_sending_limit: {
     hasFilters: false,
@@ -21,16 +32,9 @@ const metricToFormSpecMap = {
       { fieldName: 'operator', fieldValue: 'gt' }
     ]
   },
-  block_bounce_rate: {
-    hasFilters: true,
-    filterType: 'multi',
-    filterOptions: getOptionsFromMap(REALTIME_FILTERS, FILTERS_FRIENDLY_NAMES),
-    sourceOptions: getOptionsFromMap(['raw'], SOURCE_FRIENDLY_NAMES),
-    defaultFieldValues: [
-      { fieldName: 'source', fieldValue: 'raw' },
-      { fieldName: 'operator', fieldValue: 'gt' }
-    ]
-  },
+  block_bounce_rate: realtimeMetricsSpec,
+  hard_bounce_rate: realtimeMetricsSpec,
+  soft_bounce_rate: realtimeMetricsSpec,
   health_score: {
     hasFilters: true,
     filterType: 'single',
@@ -66,6 +70,8 @@ export const getEvaluatorOptions = (metric, source) => {
         case 'monthly_sending_limit':
           return 'Percent Used';
         case 'block_bounce_rate':
+        case 'hard_bounce_rate':
+        case 'soft_bounce_rate':
           return 'Bounce Percentage';
       }
     }

--- a/src/pages/alerts/helpers/tests/alertForm.test.js
+++ b/src/pages/alerts/helpers/tests/alertForm.test.js
@@ -28,6 +28,11 @@ describe('Alert form helper: ', () => {
     expect(alertFormHelper.getFormSpec(metric)).toEqual({});
   });
 
+  const expectedRealtimeMetric = {
+    suffix: '%',
+    operatorOptions: [{ label: 'Below', value: 'lt' }, { label: 'Above', value: 'gt' }],
+    sliderLabel: 'Bounce Percentage'
+  };
   const testCases =
     {
       'Monthly Sending Limit': {
@@ -41,10 +46,17 @@ describe('Alert form helper: ', () => {
       'Block Bounce Rate': {
         metric: 'block_bounce_rate',
         source: 'raw',
-        expected: {
-          suffix: '%',
-          operatorOptions: [{ label: 'Below', value: 'lt' }, { label: 'Above', value: 'gt' }],
-          sliderLabel: 'Bounce Percentage' }
+        expected: expectedRealtimeMetric
+      },
+      'Soft Bounce Rate': {
+        metric: 'soft_bounce_rate',
+        source: 'raw',
+        expected: expectedRealtimeMetric
+      },
+      'Hard Bounce Rate': {
+        metric: 'hard_bounce_rate',
+        source: 'raw',
+        expected: expectedRealtimeMetric
       },
       'Raw Health Score': {
         metric: 'health_score',


### PR DESCRIPTION
Added Soft and hard bounce rate as a selectable metric. 

### What Changed
- Added hard and soft bounces to to constants file and added them  

### How To Test
- Enable user account option `alerts`. This is already enabled in appteam staging.
 - See [here](https://github.com/SparkPost/2web2ui/blob/master/docs/feature-flags.md) to enable user options. Alternatively, [point your local upstreams to staging](https://confluence.int.messagesystems.com/display/ENG/Configuring+Openresty+Upstreams) and login to our appteam, CID 107 account
 - Edit your openresty configs to contain 
```
    location /api/v1/alerts {
      proxy_pass http://sp-alerts-api;
      include cors;
    }
```
under `server:80`,   `location /api/v1`
 - Create an alert. Verify that soft and hard bounces are options in the alert metric dropdown.
 - Also verify that the evaluator has the correct suffix and options.
 - In the table, the new alert should have the tag with a friendly name. 
 - Click on the alert, the alert should show the correct details.
