### PR TITLE
AC-885: Frontend login support via access token (issued via the /authenticate API)

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -40,23 +40,28 @@ export function login({ authData = {}, saveCookie = false }) {
  * within redux store
  *
  */
-export function authenticate(username, password, rememberMe = false) {
+export function authenticate(username, password, rememberMe = false, access_token) {
   // return a thunk
   return (dispatch, getState) => {
     const { loggedIn } = getState().auth;
-
+    const isTokenLogin = !!access_token;
     if (loggedIn) {
       return;
     }
 
     dispatch({ type: 'LOGIN_PENDING' });
 
-    return sparkpostLogin(username, password, rememberMe)
+    const maybeLogin = isTokenLogin ? Promise.resolve({ data: { access_token }}) : sparkpostLogin(username, password, rememberMe);
+
+    return maybeLogin
       .then(({ data = {}} = {}) => {
         const authData = { ...data, username };
 
+        //Skips website login if token login
+        if (!isTokenLogin) {
+          dispatch(websiteAuth.authenticate(username, password, rememberMe));
+        }
         // Start website auth token cookie setup process
-        dispatch(websiteAuth.authenticate(username, password, rememberMe));
 
         return Promise.all([authData, getTfaStatusBeforeLoggedIn({ username, token: authData.access_token })]);
       })
@@ -89,6 +94,7 @@ export function authenticate(username, password, rememberMe = false) {
       });
   };
 }
+
 
 function actOnTfaStatus(tfaEnabled, tfaRequired, authData) {
   if (tfaEnabled) {

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -58,6 +58,7 @@ export function authenticate(username, password, rememberMe = false, access_toke
         const authData = { ...data, username };
 
         //Skips website login if token login
+        //Token login is used for internal use, so won't need website auth
         if (!isTokenLogin) {
           dispatch(websiteAuth.authenticate(username, password, rememberMe));
         }

--- a/src/actions/tests/auth.test.js
+++ b/src/actions/tests/auth.test.js
@@ -99,6 +99,14 @@ describe('Action Creator: Auth', () => {
       expect(dispatchMock.mock.calls).toMatchSnapshot();
     });
 
+    it('should skip the default sparkpostLogin step if token is available', async () => {
+      const thunk = authActions.authenticate('bar', null, false, 'myToken');
+      await thunk(dispatchMock, getStateMock);
+      expect(sparkpostLogin).not.toHaveBeenCalled();
+      expect(getTfaStatusBeforeLoggedIn).toHaveBeenCalled();
+      expect(websiteAuth.authenticate).not.toHaveBeenCalled();
+    });
+
     it('should return auth status on login success', async () => {
       const thunk = authActions.authenticate('bar', 'pw', true);
       const result = await thunk(dispatchMock, getStateMock);

--- a/src/pages/auth/AuthPage.js
+++ b/src/pages/auth/AuthPage.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { authenticate } from 'src/actions/auth';
 import { PageLink, CenteredLogo } from 'src/components';
 import { Panel } from '@sparkpost/matchbox';
+import qs from 'query-string';
 
 import config from 'src/config';
 import LoginForm from './components/LoginForm';
@@ -11,6 +12,15 @@ import RedirectAfterLogin from './components/RedirectAfterLogin';
 import { TFA_ROUTE, ENABLE_TFA_AUTH_ROUTE, SSO_AUTH_ROUTE } from 'src/constants';
 
 export class AuthPage extends React.Component {
+
+  componentDidMount() {
+    const { username, access_token, authenticate } = this.props;
+    // username required as we don't have context for who's token
+    if (username && access_token) {
+      authenticate(username, null, false, access_token);
+    }
+  }
+
   loginSubmit = ({ username, password, rememberMe }) => {
     this.props.authenticate(username, password, rememberMe);
   }
@@ -45,10 +55,16 @@ export class AuthPage extends React.Component {
   }
 }
 
-const mapStateToProps = ({ auth, tfa }) => ({
-  loggedIn: auth.loggedIn,
-  tfaEnabled: tfa.enabled,
-  tfaRequired: tfa.required
-});
+const mapStateToProps = ({ auth, tfa }, { location }) => {
+  const { token: access_token, username } = qs.parse(location.search);
+
+  return {
+    loggedIn: auth.loggedIn,
+    tfaEnabled: tfa.enabled,
+    tfaRequired: tfa.required,
+    access_token,
+    username
+  };
+};
 
 export default connect(mapStateToProps, { authenticate })(AuthPage);

--- a/src/pages/auth/components/RedirectAfterLogin.js
+++ b/src/pages/auth/components/RedirectAfterLogin.js
@@ -6,9 +6,8 @@ import { DEFAULT_REDIRECT_ROUTE } from 'src/constants';
  * Redirect to the default route.
  * This is meant for use immediately after authentication completes.
  */
-export const RedirectAfterLogin = (props) => {
-  const route = { ...props.location, pathname: DEFAULT_REDIRECT_ROUTE };
-
+export const RedirectAfterLogin = ({ location: { state } = {}}) => {
+  const route = { state, pathname: DEFAULT_REDIRECT_ROUTE };
   return <Redirect to={route} />;
 };
 

--- a/src/pages/auth/components/tests/RedirectAfterLogin.test.js
+++ b/src/pages/auth/components/tests/RedirectAfterLogin.test.js
@@ -6,7 +6,7 @@ import { DEFAULT_REDIRECT_ROUTE } from 'src/constants';
 
 describe('Component: RedirectAfterLogin', () => {
   const baseProps = {
-    location: { search: '?test=one' }
+    location: { state: { testkey: 'test-value' }}
   };
 
   function subject(props) {
@@ -22,7 +22,7 @@ describe('Component: RedirectAfterLogin', () => {
     ).toEqual(
       expect.objectContaining({
         pathname: DEFAULT_REDIRECT_ROUTE,
-        search: baseProps.location.search
+        state: { testkey: 'test-value' }
       })
     );
   });

--- a/src/pages/auth/tests/AuthPage.test.js
+++ b/src/pages/auth/tests/AuthPage.test.js
@@ -9,7 +9,8 @@ describe('AuthPage tests', () => {
     loggedIn: false,
     tfaEnabled: false,
     tfaRequired: false,
-    authenticate: jest.fn()
+    authenticate: jest.fn(),
+    redirectAuthenticate: jest.fn()
   };
 
   function subject(props) {
@@ -42,5 +43,10 @@ describe('AuthPage tests', () => {
 
   it('should redirect to enable-tfa iff required', () => {
     expect(subject({ tfaRequired: true })).toMatchSnapshot();
+  });
+
+  it('should process authenticate if username/token passed in', () => {
+    const wrapper = subject({ username: 'its-me', access_token: 'bigTOKEN' });
+    expect(wrapper.instance().props.redirectAuthenticate).toHaveBeenCalledWith('its-me', 'bigTOKEN');
   });
 });

--- a/src/pages/auth/tests/AuthPage.test.js
+++ b/src/pages/auth/tests/AuthPage.test.js
@@ -9,8 +9,7 @@ describe('AuthPage tests', () => {
     loggedIn: false,
     tfaEnabled: false,
     tfaRequired: false,
-    authenticate: jest.fn(),
-    redirectAuthenticate: jest.fn()
+    authenticate: jest.fn()
   };
 
   function subject(props) {
@@ -47,6 +46,6 @@ describe('AuthPage tests', () => {
 
   it('should process authenticate if username/token passed in', () => {
     const wrapper = subject({ username: 'its-me', access_token: 'bigTOKEN' });
-    expect(wrapper.instance().props.redirectAuthenticate).toHaveBeenCalledWith('its-me', 'bigTOKEN');
+    expect(wrapper.instance().props.authenticate).toHaveBeenCalledWith('its-me', null, false, 'bigTOKEN');
   });
 });


### PR DESCRIPTION
[AC-885](https://jira.int.messagesystems.com/browse/AC-885)

### What Changed
 - Added a way to login to the web app with the url `/auth?token={token}&username={username}`

### How To Test
 - Open network tools and inspect first `/authenticate` request and grab token
 - Clear cookies/store
 - Go to url `/auth?token={token}&username={username}`
    - If it has a plus symbol in the username, replace with `%2B`
 - Verify that it authenticates and goes through
 - Verify on account where TFA is enabled
 - Verify on account where TFA is required but not enabled on user

### Notes
  - I removed the search params on RedirectAfterLogin as I don't see how it's being used right now and it clears up token/username in url after login. **Please let me know if this isn't the case** or if you think it doesn't need to be removed.

### To Do
- [ ] Address feedback
