### PR TITLE
AC-922: Added link for manually billed customers

### DIFF
--- a/src/pages/recipientValidation/components/RVDisabledPage.js
+++ b/src/pages/recipientValidation/components/RVDisabledPage.js
@@ -16,7 +16,7 @@ export class RVDisabledPage extends Component {
   renderActionButton = () => {
     const { isSelfServeBilling, isFree } = this.props;
     if (!isSelfServeBilling) {
-      return null;
+      return (<Button external primary to='https://www.sparkpost.com/recipient-validation/#recipient-validation-form'>Contact Sales</Button>);
     }
     return (isFree)
       ? (<Button primary component={Link} to={'/account/billing'}>Upgrade your plan</Button>)

--- a/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
+++ b/src/pages/recipientValidation/components/tests/RVDisabledPage.test.js
@@ -23,9 +23,11 @@ describe('Recipient Validation Disabled Page', () => {
     wrapper.setProps({ ...props, accountUpdateLoading: true });
     expect(wrapper).toMatchSnapshot();
   });
-  it('should show no button when customer is manually billed' , () => {
+  it('should render link to website form when customer is manually billed' , () => {
     wrapper.setProps({ ...props, isSelfServeBilling: false });
-    expect(wrapper.find('Button')).not.toExist();
+    expect(wrapper.find('Button')).toHaveLength(1);
+    expect(wrapper.find('Button').prop('to')).toEqual('https://www.sparkpost.com/recipient-validation/#recipient-validation-form');
+    expect(wrapper.find('Button').prop('children')).toEqual('Contact Sales');
   });
 
   it('should redirect to billing page when customer is self serve and on free plan' , () => {


### PR DESCRIPTION
### What Changed
 - Added link to RVDisabled account page

### How To Test
 - Have account without account option `recipient_validation`
    - Have account as manually billed (PUT on /account/control with `plan`)
 - Check that link exists

### To Do
- [ ] Address any feedback
