### PR TITLE
AC-919: Removed action from banner

### DIFF
--- a/src/pages/billing/components/ManuallyBilledBanner.js
+++ b/src/pages/billing/components/ManuallyBilledBanner.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Banner } from '@sparkpost/matchbox';
-import PageLink from 'src/components/pageLink/PageLink';
 import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 
 /**
@@ -42,31 +41,16 @@ const ManuallyBilledBanner = ({
     );
   }
 
-  const autoBillingAvailable = !custom && onZuoraPlan;
-  const action = autoBillingAvailable
-    ? {
-      Component: PageLink,
-      content: 'Enable Automatic Billing',
-      to: custom ? '/account/billing/enable-automatic' : '/account/billing/plan'
-    }
-    : null;
-
   return (
     <Banner
       status="info"
       title={title}
-      action={action}
     >
       <p>
         To make changes to your plan or billing information, please {
           <SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>
         }.
       </p>
-      {autoBillingAvailable && (
-        <p>
-          Enable automatic billing to self-manage your plan and add-ons.
-        </p>
-      )}
     </Banner>
   );
 };

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledBanner.test.js.snap
@@ -2,13 +2,6 @@
 
 exports[`ManuallyBilledBanner renders banner 1`] = `
 <Banner
-  action={
-    Object {
-      "Component": [Function],
-      "content": "Enable Automatic Billing",
-      "to": "/account/billing/plan",
-    }
-  }
   status="info"
   title="
     Your current Test plan includes 15,000 emails per month
@@ -23,15 +16,11 @@ exports[`ManuallyBilledBanner renders banner 1`] = `
     </Connect(SupportTicketLink)>
     .
   </p>
-  <p>
-    Enable automatic billing to self-manage your plan and add-ons.
-  </p>
 </Banner>
 `;
 
 exports[`ManuallyBilledBanner with custom subscription and plan in Zuora 1`] = `
 <Banner
-  action={null}
   status="info"
   title="
     Your current Custom plan includes 120,000 emails per year
@@ -51,7 +40,6 @@ exports[`ManuallyBilledBanner with custom subscription and plan in Zuora 1`] = `
 
 exports[`ManuallyBilledBanner with custom subscription, plan not in Zuora 1`] = `
 <Banner
-  action={null}
   status="info"
   title="
     Your current Custom plan includes 120,000 emails per year


### PR DESCRIPTION
### What Changed
- Action removed from manually billed banner to enable self serve billing (issues as we transition manually billed customers to zuora)

### How To Test
 - Get manually billed account with current plan code
 - Go to `/account/billing`
 - Action to enable self-serve billing removed (for now)

### To Do
- [ ] Address any feedback
