### PR TITLE
TR-1643: Unable to filter by and delete suppressions with special characters in recipient email

### DIFF
--- a/src/actions/suppressions.js
+++ b/src/actions/suppressions.js
@@ -28,7 +28,7 @@ export function searchRecipient({ email, subaccountId } = {}) {
     type: 'SEARCH_SUPPRESSIONS_RECIPIENT',
     meta: {
       method: 'GET',
-      url: `/v1/suppression-list/${email}`,
+      url: `/v1/suppression-list/${encodeURIComponent(email)}`,
       headers: setSubaccountHeader(subaccountId)
     }
   });
@@ -73,7 +73,7 @@ export function deleteSuppression(suppression) {
     type: 'DELETE_SUPPRESSION',
     meta: {
       method: 'DELETE',
-      url: `/v1/suppression-list/${recipient}`,
+      url: `/v1/suppression-list/${encodeURIComponent(recipient)}`,
       headers: setSubaccountHeader(subaccountId),
       data: { type },
       suppression

--- a/src/actions/tests/suppressions.test.js
+++ b/src/actions/tests/suppressions.test.js
@@ -14,7 +14,7 @@ describe('Action Creator: Suppressions', () => {
     let mockSuppression;
 
     beforeEach(() => {
-      mockSuppression = { recipient: 'foo@bar.com', type: 'non_transactional' } ;
+      mockSuppression = { recipient: 'foo/@bar.com', type: 'non_transactional' } ;
     });
 
     it('makes api call with correct parameter', async () => {
@@ -25,7 +25,7 @@ describe('Action Creator: Suppressions', () => {
           type: 'DELETE_SUPPRESSION',
           meta: {
             method: 'DELETE',
-            url: '/v1/suppression-list/foo@bar.com',
+            url: '/v1/suppression-list/foo%2F%40bar.com',
             headers: {},
             data: { type: mockSuppression.type },
             suppression: mockSuppression
@@ -43,7 +43,7 @@ describe('Action Creator: Suppressions', () => {
           type: 'DELETE_SUPPRESSION',
           meta: {
             method: 'DELETE',
-            url: '/v1/suppression-list/foo@bar.com',
+            url: '/v1/suppression-list/foo%2F%40bar.com',
             headers: { 'x-msys-subaccount': 101 },
             data: { type: mockSuppression.type },
             suppression: mockSuppression


### PR DESCRIPTION
Refer to [TR-1643](https://jira.int.messagesystems.com/browse/TR-1643)

### What Changed
 - Encodes recipient email address when making API to get and delete suppressions

### How To Test
 - Visit /lists/suppressions/create
 - Create a suppression with "Email Address" including a forward slash or question mark (e.g. brian/kemper@sparkpots.com)
 - Visit /lists/suppressions
 - Click "Filter by Email" tab
 - Enter your email address with special characters [
 - _Confirm your suppression entries for that email were found_
 - Click delete and confirm
 - _Confirm deleting your suppression entries for that email works_
