### PR TITLE
AC-630: Ignore free plans in brightback

### DIFF
--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -68,7 +68,8 @@ export class Confirmation extends React.Component {
     const currentPlanPricing = getPlanPrice(current);
     const selectedPlanPricing = getPlanPrice(selected);
     const isPlanSelected = current.code !== selected.code;
-    const isDowngrade = (currentPlanPricing.price > selectedPlanPricing.price) || (isPlanSelected && current.isFree && selected.isFree);
+    const isFreeToFree = (isPlanSelected && current.isFree && selected.isFree);
+    const isDowngrade = currentPlanPricing.price > selectedPlanPricing.price || isFreeToFree;
     let effectiveDateMarkup = null;
     let ipMarkup = null;
     let addonMarkup = null;

--- a/src/pages/billing/components/Confirmation.js
+++ b/src/pages/billing/components/Confirmation.js
@@ -67,8 +67,8 @@ export class Confirmation extends React.Component {
     const { current = {}, selected = {}, disableSubmit, billingEnabled } = this.props;
     const currentPlanPricing = getPlanPrice(current);
     const selectedPlanPricing = getPlanPrice(selected);
-    const isDowngrade = currentPlanPricing.price > selectedPlanPricing.price;
     const isPlanSelected = current.code !== selected.code;
+    const isDowngrade = (currentPlanPricing.price > selectedPlanPricing.price) || (isPlanSelected && current.isFree && selected.isFree);
     let effectiveDateMarkup = null;
     let ipMarkup = null;
     let addonMarkup = null;
@@ -136,7 +136,7 @@ export class Confirmation extends React.Component {
         </Panel.Section>
         <Panel.Section>
           <Brightback
-            condition={Boolean(billingEnabled && isPlanSelected && selected.isFree)}
+            condition={Boolean(billingEnabled && isPlanSelected && selected.isFree && !current.isFree)}
             config={config.brightback.downgradeToFreeConfig}
             render={({ enabled, to }) => (
               <Button

--- a/src/pages/billing/components/tests/Confirmation.test.js
+++ b/src/pages/billing/components/tests/Confirmation.test.js
@@ -49,6 +49,13 @@ describe('Confirmation: ', () => {
     isFree: true
   };
 
+  const oldFree = {
+    monthly: 0,
+    volume: 100,
+    code: 'old-zero',
+    isFree: true
+  };
+
   beforeEach(() => {
     props = {
       current,
@@ -85,6 +92,12 @@ describe('Confirmation: ', () => {
   it('should render correctly with a downgrade to free', () => {
     wrapper.setProps({ selected: free, billingEnabled: true });
     expect(wrapper).toMatchSnapshot();
+    expect(getButton({ enabled: true, to: 'redirect' })).toMatchSnapshot();
+  });
+
+  it('should render correctly with an old free to free plan change', () => {
+    wrapper.setProps({ selected: free, current: oldFree, billingEnabled: true });
+    expect(wrapper.find('withRouter(Connect(Brightback))').prop('condition')).toEqual(false);
     expect(getButton({ enabled: true, to: 'redirect' })).toMatchSnapshot();
   });
 

--- a/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Confirmation.test.js.snap
@@ -110,7 +110,6 @@ exports[`Confirmation:  should render correctly for an upgrade effectively immed
 
 exports[`Confirmation:  should render correctly for an upgrade effectively immediately 2`] = `
 <Button
-  destructive={false}
   fullWidth={true}
   primary={true}
   size="default"
@@ -293,6 +292,19 @@ exports[`Confirmation:  should render correctly with a downgrade to free 2`] = `
 </Button>
 `;
 
+exports[`Confirmation:  should render correctly with an old free to free plan change 1`] = `
+<Button
+  destructive={true}
+  fullWidth={true}
+  primary={false}
+  size="default"
+  to="redirect"
+  type="button"
+>
+  Downgrade Plan
+</Button>
+`;
+
 exports[`Confirmation:  should render correctly with an upgrade 1`] = `
 <Panel>
   <Panel.Section>
@@ -361,7 +373,6 @@ exports[`Confirmation:  should render correctly with an upgrade 1`] = `
 
 exports[`Confirmation:  should render correctly with an upgrade 2`] = `
 <Button
-  destructive={false}
   fullWidth={true}
   primary={true}
   size="default"


### PR DESCRIPTION
### What Changed
 - Show downgrade, but ignore brightback on free to free plan change

### How To Test
 - On account with deprecated free plan, downgrade to current free plan. Should not enable brightback

### To Do
- [ ] Address any feedback
