### PR TITLE
SA-771 - Inbox Placement Test Content 

### DIFF
--- a/src/actions/inboxPlacement.js
+++ b/src/actions/inboxPlacement.js
@@ -28,3 +28,13 @@ export const getInboxPlacementByProviders = (id) => sparkpostApiRequest({
     }
   }
 });
+
+export function getInboxPlacementTestContent(id) {
+  return sparkpostApiRequest({
+    type: 'GET_INBOX_PLACEMENT_TEST_CONTENT',
+    meta: {
+      method: 'GET',
+      url: `/v1/inbox-placement/${id}/content`
+    }
+  });
+}

--- a/src/actions/tests/inboxPlacement.test.js
+++ b/src/actions/tests/inboxPlacement.test.js
@@ -26,4 +26,15 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
+  it('makes request to get single inbox placement test content', async () => {
+    await inboxPlacement.getInboxPlacementTestContent(1);
+    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+      type: 'GET_INBOX_PLACEMENT_TEST_CONTENT',
+      meta: {
+        method: 'GET',
+        url: '/v1/inbox-placement/1/content'
+      }
+    });
+  });
+
 });

--- a/src/pages/inboxPlacement/TestDetailsPage.js
+++ b/src/pages/inboxPlacement/TestDetailsPage.js
@@ -3,20 +3,35 @@ import { connect } from 'react-redux';
 import { Page, Tabs } from '@sparkpost/matchbox';
 
 import { Loading } from 'src/components';
-import { getInboxPlacementByProviders, getInboxPlacementTest } from 'src/actions/inboxPlacement';
+import { getInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent } from 'src/actions/inboxPlacement';
+import { showAlert } from 'src/actions/globalAlert';
 import TestDetails from './components/TestDetails';
 import TestContent from './components/TestContent';
 import useTabs from 'src/hooks/useTabs';
 import { RedirectAndAlert } from 'src/components/globalAlert';
 
 export const TestDetailsPage = (props) => {
-  const { history, id, tabIndex, loading, error, details, placementsByProvider, getInboxPlacementTest, getInboxPlacementByProviders } = props;
+  const {
+    history,
+    id,
+    tabIndex,
+    loading,
+    details,
+    placementsByProvider,
+    content,
+    error,
+    getInboxPlacementTest,
+    getInboxPlacementByProviders,
+    getInboxPlacementTestContent
+  } = props;
+
   const [selectedTabIndex, tabs] = useTabs(TABS, tabIndex);
 
   useEffect(() => {
     getInboxPlacementTest(id);
     getInboxPlacementByProviders(id);
-  }, [getInboxPlacementTest, getInboxPlacementByProviders, id]);
+    getInboxPlacementTestContent(id);
+  }, [getInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent, id]);
 
   useEffect(() => {
     history.replace(`/inbox-placement/details/${id}/${TABS[selectedTabIndex].key}`);
@@ -27,7 +42,7 @@ export const TestDetailsPage = (props) => {
     const selectedTabKey = tabs[selectedTabIndex].key;
     switch (selectedTabKey) {
       case 'content':
-        return <TestContent/>;
+        return <TestContent content={content} details={details}/>;
       default:
         return <TestDetails details={details} placementsByProvider={placementsByProvider}/>;
     }
@@ -67,11 +82,12 @@ function mapStateToProps(state, props) {
   return {
     tabIndex: currentTabIndex > 0 ? currentTabIndex : 0,
     id,
-    loading: state.inboxPlacement.getTestPending || state.inboxPlacement.getByProviderPending,
-    error: state.inboxPlacement.getTestError || state.inboxPlacement.getByProviderError,
-    details: state.inboxPlacement.currentTestDetails,
-    placementsByProvider: state.inboxPlacement.placementsByProvider || []
+    loading: state.inboxPlacement.getTestPending || state.inboxPlacement.getByProviderPending || state.inboxPlacement.getTestContentPending,
+    error: state.inboxPlacement.getTestError || state.inboxPlacement.getByProviderError || state.inboxPlacement.getTestContentError,
+    details: state.inboxPlacement.currentTestDetails || {},
+    placementsByProvider: state.inboxPlacement.placementsByProvider || [],
+    content: state.inboxPlacement.currentTestContent || {}
   };
 }
 
-export default connect(mapStateToProps, { getInboxPlacementTest, getInboxPlacementByProviders })(TestDetailsPage);
+export default connect(mapStateToProps, { getInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent, showAlert })(TestDetailsPage);

--- a/src/pages/inboxPlacement/components/TestContent.js
+++ b/src/pages/inboxPlacement/components/TestContent.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Panel, CodeBlock, Tabs, Grid } from '@sparkpost/matchbox';
 import useTabs from 'src/hooks/useTabs';
-import styles from './TestContent.module.scss';
-
 import { formatBytes } from 'src/helpers/units';
+import InfoBlock from './InfoBlock';
 
 const TABS = [
   { content: 'Raw Message', key: 'raw_message' },
@@ -20,27 +19,20 @@ const TestContent = ({ content, details }) => {
 
   return (
     <>
-    <Panel title={details.subject} sectioned>
+    <Panel sectioned>
+      <h2>{details.subject}</h2>
       <Grid>
-        <Grid.Column sm={12} md={3}>
-          From:
-          <br/>
-          <span className={styles.FromAddress}>{from_address}</span>
-        </Grid.Column>
-        <Grid.Column xs={12} md={3}>
-          Raw Message Size:
-          <br/>
-          {formatBytes(message_size)}
-        </Grid.Column>
+        <InfoBlock value={from_address} label='From' columnProps={{ sm: 12, md: 4 }}/>
+        <InfoBlock value={formatBytes(message_size)} label='Raw Message Size:' columnProps={{ sm: 12, md: 4 }}/>
       </Grid>
     </Panel>
-      <Panel>
-        <Tabs selected={selectedTabIndex} tabs={tabs} />
-        <Panel.Section>
-          <CodeBlock code={content[selectedTabKey] || ''}/>
-        </Panel.Section>
-      </Panel>
-      </>
+    <Panel>
+      <Tabs selected={selectedTabIndex} tabs={tabs} color='navy' />
+      <Panel.Section>
+        <CodeBlock code={content[selectedTabKey] || ''}/>
+      </Panel.Section>
+    </Panel>
+    </>
   );
 };
 

--- a/src/pages/inboxPlacement/components/TestContent.js
+++ b/src/pages/inboxPlacement/components/TestContent.js
@@ -1,11 +1,48 @@
 import React from 'react';
-import { Panel } from '@sparkpost/matchbox';
+import { Panel, CodeBlock, Tabs, Grid } from '@sparkpost/matchbox';
+import useTabs from 'src/hooks/useTabs';
+import styles from './TestContent.module.scss';
 
-const TestContent = () => (
-  <Panel.Section>
-    <h1>Contents</h1>
-  </Panel.Section>
-);
+import { formatBytes } from 'src/helpers/units';
+
+const TABS = [
+  { content: 'Raw Message', key: 'raw_message' },
+  { content: 'HTML', key: 'html' },
+  { content: 'AMP HTML', key: 'amp' },
+  { content: 'Text', key: 'text' },
+  { content: 'Headers', key: 'headers' }
+];
+
+const TestContent = ({ content, details }) => {
+  const [selectedTabIndex, tabs] = useTabs(TABS);
+  const selectedTabKey = tabs[selectedTabIndex].key;
+  const { from_address, message_size } = details;
+
+  return (
+    <>
+    <Panel title={details.subject} sectioned>
+      <Grid>
+        <Grid.Column sm={12} md={3}>
+          From:
+          <br/>
+          <span className={styles.FromAddress}>{from_address}</span>
+        </Grid.Column>
+        <Grid.Column xs={12} md={3}>
+          Raw Message Size:
+          <br/>
+          {formatBytes(message_size)}
+        </Grid.Column>
+      </Grid>
+    </Panel>
+      <Panel>
+        <Tabs selected={selectedTabIndex} tabs={tabs} />
+        <Panel.Section>
+          <CodeBlock code={content[selectedTabKey] || ''}/>
+        </Panel.Section>
+      </Panel>
+      </>
+  );
+};
 
 export default TestContent;
 

--- a/src/pages/inboxPlacement/components/TestContent.module.scss
+++ b/src/pages/inboxPlacement/components/TestContent.module.scss
@@ -1,0 +1,3 @@
+.FromAddress {
+  word-break: break-all;
+}

--- a/src/pages/inboxPlacement/components/TestContent.module.scss
+++ b/src/pages/inboxPlacement/components/TestContent.module.scss
@@ -1,3 +1,0 @@
-.FromAddress {
-  word-break: break-all;
-}

--- a/src/pages/inboxPlacement/components/tests/TestContent.test.js
+++ b/src/pages/inboxPlacement/components/tests/TestContent.test.js
@@ -1,0 +1,31 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import TestContent from '../TestContent';
+
+
+describe('Inbox Placement Test Content', () => {
+  const mockDetails = {
+    subject: 'foo',
+    message_size: 2580,
+    from_address: 'foo@bar.com'
+  };
+  const mockContent = {
+    raw_message: 'The Raw message',
+    html: '<div>Cool HTML!</div>',
+    text: 'Cool Text!',
+    amp: 'Cool AMP!',
+    headers: 'Some: Headers'
+  };
+
+  const props = {
+    details: mockDetails,
+    content: mockContent
+  };
+
+  it('renders page correctly with defaults', () => {
+    const wrapper = shallow(<TestContent {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+

--- a/src/pages/inboxPlacement/components/tests/TestContent.test.js
+++ b/src/pages/inboxPlacement/components/tests/TestContent.test.js
@@ -1,10 +1,10 @@
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 import TestContent from '../TestContent';
 
 
-describe('Inbox Placement Test Content', () => {
+describe('Component: TestContent', () => {
   const mockDetails = {
     subject: 'foo',
     message_size: 2580,
@@ -26,6 +26,13 @@ describe('Inbox Placement Test Content', () => {
   it('renders page correctly with defaults', () => {
     const wrapper = shallow(<TestContent {...props} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('changes tabs correctly', () => {
+    const wrapper = mount(<TestContent {...props} />);
+    expect(wrapper.find('Tabs').prop('selected')).toEqual(0);
+    wrapper.find('Tab').last().simulate('click');
+    expect(wrapper.find('Tabs').prop('selected')).toEqual(4);
   });
 });
 

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/TestContent.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/TestContent.test.js.snap
@@ -1,37 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Inbox Placement Test Content renders page correctly with defaults 1`] = `
+exports[`Component: TestContent renders page correctly with defaults 1`] = `
 <Fragment>
   <Panel
     sectioned={true}
-    title="foo"
   >
+    <h2>
+      foo
+    </h2>
     <Grid>
-      <Grid.Column
-        md={3}
-        sm={12}
-      >
-        From:
-        <br />
-        <span
-          className="FromAddress"
-        >
-          foo@bar.com
-        </span>
-      </Grid.Column>
-      <Grid.Column
-        md={3}
-        xs={12}
-      >
-        Raw Message Size:
-        <br />
-        2.52KB
-      </Grid.Column>
+      <InfoBlock
+        columnProps={
+          Object {
+            "md": 4,
+            "sm": 12,
+          }
+        }
+        label="From"
+        value="foo@bar.com"
+      />
+      <InfoBlock
+        columnProps={
+          Object {
+            "md": 4,
+            "sm": 12,
+          }
+        }
+        label="Raw Message Size:"
+        value="2.52KB"
+      />
     </Grid>
   </Panel>
   <Panel>
     <Tabs
-      color="orange"
+      color="navy"
       connectBelow={true}
       selected={0}
       tabs={

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/TestContent.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/TestContent.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Inbox Placement Test Content renders page correctly with defaults 1`] = `
+<Fragment>
+  <Panel
+    sectioned={true}
+    title="foo"
+  >
+    <Grid>
+      <Grid.Column
+        md={3}
+        sm={12}
+      >
+        From:
+        <br />
+        <span
+          className="FromAddress"
+        >
+          foo@bar.com
+        </span>
+      </Grid.Column>
+      <Grid.Column
+        md={3}
+        xs={12}
+      >
+        Raw Message Size:
+        <br />
+        2.52KB
+      </Grid.Column>
+    </Grid>
+  </Panel>
+  <Panel>
+    <Tabs
+      color="orange"
+      connectBelow={true}
+      selected={0}
+      tabs={
+        Array [
+          Object {
+            "content": "Raw Message",
+            "key": "raw_message",
+          },
+          Object {
+            "content": "HTML",
+            "key": "html",
+          },
+          Object {
+            "content": "AMP HTML",
+            "key": "amp",
+          },
+          Object {
+            "content": "Text",
+            "key": "text",
+          },
+          Object {
+            "content": "Headers",
+            "key": "headers",
+          },
+        ]
+      }
+    />
+    <Panel.Section>
+      <CodeBlock
+        code="The Raw message"
+        height={355}
+        numbered={false}
+      />
+    </Panel.Section>
+  </Panel>
+</Fragment>
+`;

--- a/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
@@ -7,6 +7,7 @@ describe('Page: Single Inbox Placement Test', () => {
     const defaults = {
       getInboxPlacementTest: jest.fn(),
       getInboxPlacementByProviders: jest.fn(),
+      getInboxPlacementTestContent: jest.fn(),
       tabIndex: 0,
       id: 0,
       loading: false,

--- a/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
@@ -26,8 +26,12 @@ describe('Page: Single Inbox Placement Test', () => {
 
   it('calls getInboxPlacementTest on load', () => {
     const getInboxPlacementTest = jest.fn().mockReturnValue({});
-    mount(<TestDetailsPage getInboxPlacementTest={getInboxPlacementTest}
+    mount(<TestDetailsPage
+      details={{}}
+      content={{}}
+      getInboxPlacementTest={getInboxPlacementTest}
       getInboxPlacementByProviders={jest.fn()}
+      getInboxPlacementTestContent={jest.fn()}
       id={101}
       tabIndex={1} //not working nicely with tabIndex=0; TestDetails component
       history={{ replace: jest.fn() }}/>);
@@ -68,9 +72,13 @@ describe('Page: Single Inbox Placement Test', () => {
   it('updates URL when tabs change', () => {
     const mockHistory = { replace: jest.fn() };
     const wrapper = mount(<TestDetailsPage tabIndex={1}
+      details={{}}
+      content={{}}
       history={mockHistory}
       getInboxPlacementTest={jest.fn()}
-      getInboxPlacementByProviders={jest.fn()}/>);
+      getInboxPlacementByProviders={jest.fn()}
+      getInboxPlacementTestContent={jest.fn()}
+    />);
     wrapper.find('Tab').last().simulate('click');
     expect(mockHistory.replace).toHaveBeenCalled();
   });

--- a/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
@@ -26,17 +26,22 @@ describe('Page: Single Inbox Placement Test', () => {
 
   it('calls getInboxPlacementTest on load', () => {
     const getInboxPlacementTest = jest.fn().mockReturnValue({});
+    const getInboxPlacementByProviders = jest.fn().mockReturnValue({});
+    const getInboxPlacementTestContent = jest.fn().mockReturnValue({});
+
     mount(<TestDetailsPage
       details={{}}
       content={{}}
       getInboxPlacementTest={getInboxPlacementTest}
-      getInboxPlacementByProviders={jest.fn()}
-      getInboxPlacementTestContent={jest.fn()}
+      getInboxPlacementByProviders={getInboxPlacementByProviders}
+      getInboxPlacementTestContent={getInboxPlacementTestContent}
       id={101}
       tabIndex={1} //not working nicely with tabIndex=0; TestDetails component
       history={{ replace: jest.fn() }}/>);
 
     expect(getInboxPlacementTest).toHaveBeenCalled();
+    expect(getInboxPlacementByProviders).toHaveBeenCalled();
+    expect(getInboxPlacementTestContent).toHaveBeenCalled();
   });
 
   it('renders loading', () => {

--- a/src/reducers/inboxPlacement.js
+++ b/src/reducers/inboxPlacement.js
@@ -26,6 +26,13 @@ export default (state = initialState, { type, payload }) => {
     case 'GET_INBOX_PLACEMENT_TEST_BY_PROVIDER_FAIL':
       return { ...state, getByProviderPending: false, getByProviderError: payload };
 
+    case 'GET_INBOX_PLACEMENT_TEST_CONTENT_PENDING':
+      return { ...state, getTestContentPending: true, getTestContentError: null };
+    case 'GET_INBOX_PLACEMENT_TEST_CONTENT_SUCCESS':
+      return { ...state, getTestContentPending: false, currentTestContent: payload, getTestContentError: null };
+    case 'GET_INBOX_PLACEMENT_TEST_CONTENT_FAIL':
+      return { ...state, getTestContentPending: false, getTestContentError: payload };
+
     default:
       return state;
   }

--- a/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
+++ b/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Inbox Placement Reducer get specific inbox placement test content pending 1`] = `
 Object {
-  "currentTestDetails": null,
+  "currentTestDetails": Object {},
   "getTestContentError": null,
   "getTestContentPending": true,
   "seeds": Array [],
@@ -12,7 +12,7 @@ Object {
 
 exports[`Inbox Placement Reducer get specific inbox placement test content pending fail 1`] = `
 Object {
-  "currentTestDetails": null,
+  "currentTestDetails": Object {},
   "getTestContentError": Object {
     "errors": Array [
       Object {
@@ -31,7 +31,7 @@ Object {
   "currentTestContent": Object {
     "fakeData": true,
   },
-  "currentTestDetails": null,
+  "currentTestDetails": Object {},
   "getTestContentError": null,
   "getTestContentPending": false,
   "seeds": Array [],

--- a/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
+++ b/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Inbox Placement Reducer get specific inbox placement test content pending 1`] = `
+Object {
+  "currentTestDetails": null,
+  "getTestContentError": null,
+  "getTestContentPending": true,
+  "seeds": Array [],
+  "seedsPending": false,
+}
+`;
+
+exports[`Inbox Placement Reducer get specific inbox placement test content pending fail 1`] = `
+Object {
+  "currentTestDetails": null,
+  "getTestContentError": Object {
+    "errors": Array [
+      Object {
+        "message": "Some error occurred",
+      },
+    ],
+  },
+  "getTestContentPending": false,
+  "seeds": Array [],
+  "seedsPending": false,
+}
+`;
+
+exports[`Inbox Placement Reducer get specific inbox placement test content success 1`] = `
+Object {
+  "currentTestContent": Object {
+    "fakeData": true,
+  },
+  "currentTestDetails": null,
+  "getTestContentError": null,
+  "getTestContentPending": false,
+  "seeds": Array [],
+  "seedsPending": false,
+}
+`;
+
 exports[`Inbox Placement Reducer get specific inbox placement test pending 1`] = `
 Object {
   "currentTestDetails": Object {},

--- a/src/reducers/tests/inboxPlacement.test.js
+++ b/src/reducers/tests/inboxPlacement.test.js
@@ -21,6 +21,17 @@ const TEST_CASES = {
   'get specific inbox placement test pending fail': {
     payload: { errors: [ { message: 'Some error occurred' }]},
     type: 'GET_INBOX_PLACEMENT_TEST_FAIL'
+  },
+  'get specific inbox placement test content pending': {
+    type: 'GET_INBOX_PLACEMENT_TEST_CONTENT_PENDING'
+  },
+  'get specific inbox placement test content success': {
+    payload: { fakeData: true },
+    type: 'GET_INBOX_PLACEMENT_TEST_CONTENT_SUCCESS'
+  },
+  'get specific inbox placement test content pending fail': {
+    payload: { errors: [ { message: 'Some error occurred' }]},
+    type: 'GET_INBOX_PLACEMENT_TEST_CONTENT_FAIL'
   }
 };
 


### PR DESCRIPTION
Implements Content tab of Single Inbox Placement Test

### Tests
- Run seedlist api service locally and modify the `GET /inbox-placement/{id}/content` response to respond something conforming API Spec [1](https://github.com/SparkPost/sparkpost-admin-api-documentation/blob/master/services/inbox_placement_api.md#get-the-content-for-an-inbox-placement-test-get-inbox-placementidcontent). 
- Then navigate to something like `/inbox-placement/details/101` in the URL bar.  DOesn;t need to be `101`. Any number should work depending on how you mock the api response earlier. 
- Navigate to the `content` tab within the page. 

### Todos:
- Use the green/active status component