### PR TITLE
SE-161 Alerts Pre-release polish 

### DIFF
--- a/src/pages/alerts/CreatePageNew.js
+++ b/src/pages/alerts/CreatePageNew.js
@@ -20,9 +20,9 @@ export class CreatePageNew extends Component {
     const { createAlert, showUIAlert, history } = this.props;
     return createAlert({
       data: formatFormValues(values)
-    }).then(() => {
+    }).then(({ id }) => {
       showUIAlert({ type: 'success', message: 'Alert created' });
-      history.push('/alerts-new');
+      history.push(`/alerts-new/details/${id}`);
     });
   };
 
@@ -42,10 +42,13 @@ export class CreatePageNew extends Component {
       );
     }
 
+    const backBreadcrumb = idToDuplicate
+      ? { content: 'Back to Alert', to: `/alerts-new/details/${idToDuplicate}` }
+      : { content: 'Back to Alerts', to: '/alerts-new' };
     return (
       <Page
         title='Create Alert'
-        breadcrumbAction={{ content: 'Back to Alerts', to: '/alerts-new', component: Link }}>
+        breadcrumbAction={{ ...backBreadcrumb, component: Link }}>
         <AlertFormNew
           submitting={loading}
           onSubmit={this.handleCreate}

--- a/src/pages/alerts/DetailsPage.js
+++ b/src/pages/alerts/DetailsPage.js
@@ -54,7 +54,7 @@ export class DetailsPage extends Component {
   };
 
   render() {
-    const { loading, deletePending, alert = {}, error, id } = this.props;
+    const { loading, deletePending, alert = {}, error, id, hasSubaccounts } = this.props;
     const { isDeleteModalOpen } = this.state;
     const { name } = alert;
 
@@ -80,7 +80,9 @@ export class DetailsPage extends Component {
           <Button flat onClick={this.openDeleteModal}><Delete className={styles.Icon}/>Delete</Button>
           </>}
       >
-        {!_.isEmpty(alert) && <AlertDetails alert={alert} id={id} subaccountIdToString={this.subaccountIdToString}/>}
+        {!_.isEmpty(alert) &&
+          <AlertDetails alert={alert} id={id} subaccountIdToString={this.subaccountIdToString} hasSubaccounts={hasSubaccounts}/>
+        }
         <DeleteModal
           open={isDeleteModalOpen}
           title='Are you sure you want to delete this alert?'

--- a/src/pages/alerts/EditPageNew.js
+++ b/src/pages/alerts/EditPageNew.js
@@ -21,12 +21,12 @@ export class EditPageNew extends Component {
       data: formatFormValues(values)
     }).then(() => {
       showUIAlert({ type: 'success', message: 'Alert updated' });
-      history.push('/alerts-new');
+      history.push(`/alerts-new/details/${id}`);
     });
   };
 
   render() {
-    const { loading, getError, getLoading } = this.props;
+    const { loading, getError, getLoading, id } = this.props;
 
     if (getLoading) {
       return <Loading/>;
@@ -35,7 +35,7 @@ export class EditPageNew extends Component {
     if (getError) {
       return (
         <RedirectAndAlert
-          to='/alerts-new'
+          to={`/alerts-new/details/${id}`}
           alert={{ type: 'error', message: getError.message }}
         />
       );
@@ -44,7 +44,7 @@ export class EditPageNew extends Component {
     return (
       <Page
         title='Edit Alert'
-        breadcrumbAction={{ content: 'Back to Alerts', to: '/alerts-new', component: Link }}>
+        breadcrumbAction={{ content: 'Back to Alert', to: `/alerts-new/details/${id}`, component: Link }}>
         <AlertFormNew
           submitting={loading}
           onSubmit={this.handleUpdate}

--- a/src/pages/alerts/ListPageNew.js
+++ b/src/pages/alerts/ListPageNew.js
@@ -73,7 +73,7 @@ export class ListPageNew extends Component {
                   <h3>{alert.name}</h3>
                 </Panel.Section>
                 <Panel.Section className = {styles.Footer}>
-                  <Tooltip content='View Details' width='100px'>
+                  <Tooltip dark content='View Details' width='100px' horizontalOffset='-8px'>
                     <Button flat component={Link} to = {`/alerts-new/details/${alert.id}`}><RemoveRedEye className = {styles.Icon}/></Button>
                   </Tooltip>
                 </Panel.Section>

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -25,7 +25,7 @@ class AlertCollectionNew extends Component {
       { label: 'Alert Name', sortKey: 'name', width: '40%' },
       { label: 'Metric', sortKey: 'metric' },
       { label: 'Last Triggered', sortKey: 'last_triggered_timestamp' },
-      { label: 'Active', sortKey: 'muted' },
+      { label: 'Mute', sortKey: 'muted' },
       null
     ];
 

--- a/src/pages/alerts/components/AlertCollectionNew.js
+++ b/src/pages/alerts/components/AlertCollectionNew.js
@@ -39,7 +39,7 @@ class AlertCollectionNew extends Component {
       <Tag>{METRICS[metric]}</Tag>,
       <DisplayDate timestamp={last_triggered_timestamp} formattedDate={last_triggered_formatted || 'Never Triggered'} />,
       <AlertToggle muted={muted} id={id} />,
-      <Tooltip content='Delete' width='auto'>
+      <Tooltip dark content='Delete' width='auto' horizontalOffset='-8px'>
         <Button flat onClick={deleteFn}>
           <Delete className={styles.Icon}/>
         </Button>

--- a/src/pages/alerts/components/AlertDetails.js
+++ b/src/pages/alerts/components/AlertDetails.js
@@ -5,8 +5,9 @@ import LabelledValue from 'src/components/labelledValue/LabelledValue';
 import { MAILBOX_PROVIDERS } from 'src/constants';
 import styles from './AlertDetails.module.scss';
 import AlertToggle from './AlertToggleNew';
-import { EmailIcon, SlackIcon, WebhookIcon } from 'src/components/icons';
+import { SlackIcon, WebhookIcon } from 'src/components/icons';
 import { Link } from 'react-router-dom';
+import { getEvaluatorOptions } from '../helpers/alertForm';
 
 const extraChannels = [
   {
@@ -21,7 +22,7 @@ const extraChannels = [
   }
 ];
 
-export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
+export const AlertDetails = ({ alert, id, subaccountIdToString, hasSubaccounts }) => {
   const { metric, channels = {}, filters = [], subaccounts = [], threshold_evaluator = {}, any_subaccount, muted } = alert;
   const { source, operator, value } = threshold_evaluator;
 
@@ -46,26 +47,41 @@ export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
   };
 
   const renderFilteredBy = () => {
-    const subaccount = (
-      <span key={'subaccounts'}>
-        Subaccounts: {getSubaccountsTags()}
-      </span>
-    );
-    const filtersTags = filters.map((filter) => (
+    //Shows subaccounts filter if the account has subaccounts and if the subaccount value is not `Master and all`
+    const shouldShowSubaccounts = hasSubaccounts && ((subaccounts.length > 0 && subaccounts[0] !== -1) || any_subaccount);
+    const subaccount = shouldShowSubaccounts
+      ? (
+        <span key={'subaccounts'}>
+          <h6 className={styles.BoldInline}>Subaccounts</h6> {getSubaccountsTags()}
+        </span>
+      )
+      : undefined;
+
+    //Only show 'and' if it's not the first filter or if there's a subaccounts filter
+    const filtersTags = filters.map((filter, i) => (
       <span key={filter.filter_type}>
-        and {FILTERS_FRIENDLY_NAMES[filter.filter_type]}: {getFilterValuesTags(filter.filter_type, filter.filter_values)}
+        {(shouldShowSubaccounts || i > 0) && 'and'} <h6 className={styles.BoldInline}>{FILTERS_FRIENDLY_NAMES[filter.filter_type]}</h6> {getFilterValuesTags(filter.filter_type, filter.filter_values)}
       </span>
     ));
-    return [subaccount, ...filtersTags];
+
+    const renderedFilters = [subaccount, ...filtersTags].filter(Boolean);
+
+    //If no subaccount or filters, do not show this row.
+    if (renderedFilters.length === 0) {
+      return undefined;
+    }
+    return renderedFilters;
   };
 
   const renderEvaluated = () => {
-    const sourceTag = <Tag className={styles.FirstTag}>{SOURCE_FRIENDLY_NAMES[source]}</Tag>;
-    const operatorText = (source === 'raw') ? OPERATOR_FRIENDLY_NAMES[operator].toLowerCase() : `change ${OPERATOR_FRIENDLY_NAMES[operator].toLowerCase()}`;
-    const suffix = (source === 'raw') ? '' : '%';
+    const sourceTag = (metric === 'health_score') ? <Tag className={styles.FirstTag}>{SOURCE_FRIENDLY_NAMES[source]}</Tag> : '';
+    const percentChangeText = (source === 'raw') ? '' : 'change ';
+    const operatorText = (sourceTag) ? OPERATOR_FRIENDLY_NAMES[operator].toLowerCase() : OPERATOR_FRIENDLY_NAMES[operator];
+    const { suffix } = getEvaluatorOptions(metric, source);
     const valueTag = <Tag className={styles.Tags}>{value}{suffix}</Tag>;
     return (<>
       {sourceTag}
+      {percentChangeText}
       {operatorText}
       {valueTag}
       </>);
@@ -78,10 +94,9 @@ export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
     return (
       <>
         {emails && emails.length > 0 && (
-          <div key="email">
-            Email: {emails.map((email) => (
-              <Tag key={email} className={styles.TagsWithIcon}>
-                <EmailIcon className={styles.Icon}/>
+          <div id='email'>
+            <h6 className={styles.BoldInline}>Email</h6> {emails.map((email) => (
+              <Tag key={email} className={styles.Tags}>
                 <span className={styles.TagText}>{email}</span>
               </Tag>
             ))}
@@ -89,7 +104,7 @@ export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
         )}
         {visibleExtraChannels.map(({ icon: Icon, key, label }) => (
           <div key={key}>
-            {label}: <Tag className={styles.TagsWithIcon}>
+            <h6 className={styles.BoldInline}>{label}</h6> <Tag className={styles.TagsWithIcon}>
               <Icon className={styles.Icon}/>
               <span className={styles.TagText}>{restChannels[key].target}</span>
             </Tag>
@@ -100,19 +115,27 @@ export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
   };
 
   const detailsMap = [
-    { label: 'Alert Metric:', render: (() => METRICS[metric]), bold: true },
-    { label: 'Evaluated:', render: (() => (renderEvaluated())) },
+    { label: 'Metric:', render: (() => <h6>{METRICS[metric]}</h6>) },
+    { label: 'Condition:', render: (() => (renderEvaluated())) },
     { label: 'Filtered By:', render: (() => (renderFilteredBy())) },
     { label: 'Notify:', render: (() => (renderNotify())) },
     { label: 'Mute:', render: (() => (<AlertToggle muted={muted} id={id} />)) }
   ];
 
   const renderAlertDetails = () =>
-    detailsMap.map(({ label, render, bold }, i) => (
-      <Panel.Section key={i}>
-        <LabelledValue label={label} bold={Boolean(bold)} value={render()}/>
-      </Panel.Section>
-    ));
+    detailsMap.map(({ label, render, bold }, i) => {
+      const renderedValue = render();
+      //Don't show rows with empty values (should only be applicable to filters)
+      if (!renderedValue) {
+        return null;
+      }
+      return (
+        <Panel.Section key={i}>
+          <LabelledValue label={label}>
+            {renderedValue}
+          </LabelledValue>
+        </Panel.Section>);
+    });
 
   return (
     <Panel>

--- a/src/pages/alerts/components/AlertDetails.js
+++ b/src/pages/alerts/components/AlertDetails.js
@@ -81,8 +81,8 @@ export const AlertDetails = ({ alert, id, subaccountIdToString, hasSubaccounts }
     const valueTag = <Tag className={styles.Tags}>{value}{suffix}</Tag>;
     return (<>
       {sourceTag}
-      {percentChangeText}
-      {operatorText}
+      <h6 className={styles.BoldInline}>{percentChangeText}</h6>
+      <h6 className={styles.BoldInline}>{operatorText}</h6>
       {valueTag}
       </>);
   };

--- a/src/pages/alerts/components/AlertDetails.js
+++ b/src/pages/alerts/components/AlertDetails.js
@@ -104,7 +104,7 @@ export const AlertDetails = ({ alert, id, subaccountIdToString }) => {
     { label: 'Evaluated:', render: (() => (renderEvaluated())) },
     { label: 'Filtered By:', render: (() => (renderFilteredBy())) },
     { label: 'Notify:', render: (() => (renderNotify())) },
-    { label: 'Active:', render: (() => (<AlertToggle muted={muted} id={id} />)) }
+    { label: 'Mute:', render: (() => (<AlertToggle muted={muted} id={id} />)) }
   ];
 
   const renderAlertDetails = () =>

--- a/src/pages/alerts/components/AlertDetails.module.scss
+++ b/src/pages/alerts/components/AlertDetails.module.scss
@@ -6,6 +6,10 @@
   top: rem(8);
 }
 
+.BoldInline{
+  display: inline;
+}
+
 .Button {
   float: right;
   width: rem(100);

--- a/src/pages/alerts/components/AlertForm.module.scss
+++ b/src/pages/alerts/components/AlertForm.module.scss
@@ -21,8 +21,6 @@
 }
 
 .OptionalText {
-  color: color(gray,5);
-  font-size: rem(13);
   font-weight: normal;
 }
 

--- a/src/pages/alerts/components/AlertFormNew.js
+++ b/src/pages/alerts/components/AlertFormNew.js
@@ -92,10 +92,12 @@ export class AlertFormNew extends Component {
       hasSubaccounts,
       formErrors,
       formMeta,
-      isNewAlert
+      isNewAlert,
+      isDuplicate
     } = this.props;
 
     const submitText = submitting ? 'Submitting...' : (isNewAlert ? 'Create Alert' : 'Update Alert');
+    const isSubmitDisabled = (pristine && !isDuplicate) || submitting; //Allows user to create the same alert if if's a duplicate
     const formSpec = getFormSpec(metric);
     const channelsError = this.isNotificationChannelsEmpty(formMeta, formErrors);
 
@@ -146,7 +148,7 @@ export class AlertFormNew extends Component {
                   {channelsError && <Error wrapper='div' error='At least one notification channel must be not empty'/>}
                   {this.renderNotificationChannels()}
                 </div>
-                <Button submit primary disabled={pristine || submitting} className={styles.SubmitButton}>{submitText}</Button>
+                <Button submit primary disabled={isSubmitDisabled} className={styles.SubmitButton}>{submitText}</Button>
               </Panel.Section>
             </Grid.Column>
           </Grid>

--- a/src/pages/alerts/components/AlertFormNew.js
+++ b/src/pages/alerts/components/AlertFormNew.js
@@ -133,7 +133,7 @@ export class AlertFormNew extends Component {
                 }
                 {formSpec.hasFilters &&
                   <div className={styles.Filters}>
-                    <label><h5>Filtered by <span className={styles.OptionalText}>optional</span></h5></label>
+                    <label><h5>Filtered by <small className={styles.OptionalText}>optional</small></h5></label>
                     {hasSubaccounts &&
                       <SubaccountField
                         disabled={submitting}

--- a/src/pages/alerts/components/AlertFormNew.js
+++ b/src/pages/alerts/components/AlertFormNew.js
@@ -31,14 +31,14 @@ const notificationChannelData = {
   },
   slack: {
     icon: <SlackIcon />,
-    subtitle: 'Integrate alerts into your Slack channel',
+    subtitle: 'Integrate this alert with Slack',
     fieldProps: {
       placeholder: 'https://hooks.slack.com/services/T00/B00/XX '
     }
   },
   webhook: {
     icon: <WebhookIcon />,
-    subtitle: 'Create a webhook for your alerts',
+    subtitle: 'Create a webhook for this alert',
     fieldProps: {
       placeholder: 'https://example.com/webhook-target'
     }

--- a/src/pages/alerts/components/AlertToggleNew.js
+++ b/src/pages/alerts/components/AlertToggleNew.js
@@ -32,7 +32,7 @@ export class AlertToggle extends Component {
         <Toggle
           id={id.toString()}
           compact
-          checked={!muted}
+          checked={muted}
           disabled={pending}
           onChange={this.handleToggle}
         />

--- a/src/pages/alerts/components/fields/tests/EvaluatorFields.test.js
+++ b/src/pages/alerts/components/fields/tests/EvaluatorFields.test.js
@@ -42,10 +42,6 @@ describe('Evaluator Fields Component', () => {
   describe('slider length with', () => {
 
     const formCases = {
-      'no source size': {
-        prop: { metric: 'block_bounce_rate' },
-        length: 8
-      },
       'no operator size': {
         prop: { source: 'week_over_week' },
         length: 7

--- a/src/pages/alerts/components/tests/AlertDetails.test.js
+++ b/src/pages/alerts/components/tests/AlertDetails.test.js
@@ -41,7 +41,7 @@ describe('Alert Details Component', () => {
     const newAlert = { ...alert, threshold_evaluator: { source: 'week_over_week', operator: 'gt', value: 5 }};
     const wrapper = shallow(<AlertDetails {...props} alert={newAlert} />);
     const evaluatorWrapper = wrapper.find({ label: 'Condition:' }).dive();
-    expect(evaluatorWrapper.findWhere((node) => node.text() === 'change ')).toExist();
+    expect(evaluatorWrapper.findWhere((node) => node.debug() === 'change ')).toExist();
   });
 
   it('should show % in suffix when source is WOW change', () => {

--- a/src/pages/alerts/components/tests/AlertDetails.test.js
+++ b/src/pages/alerts/components/tests/AlertDetails.test.js
@@ -21,7 +21,8 @@ describe('Alert Details Component', () => {
   const props = {
     alert,
     id: 'alert-id',
-    subaccountIdToString: jest.fn((a) => a)
+    subaccountIdToString: jest.fn((a) => a),
+    hasSubaccounts: true
   };
 
   it('should render the alert details component correctly', () => {
@@ -39,14 +40,14 @@ describe('Alert Details Component', () => {
   it('should prepend change to the operator when source is WOW change', () => {
     const newAlert = { ...alert, threshold_evaluator: { source: 'week_over_week', operator: 'gt', value: 5 }};
     const wrapper = shallow(<AlertDetails {...props} alert={newAlert} />);
-    const evaluatorWrapper = wrapper.find({ label: 'Evaluated:' }).dive();
-    expect(evaluatorWrapper.findWhere((node) => node.text() === 'change above')).toExist();
+    const evaluatorWrapper = wrapper.find({ label: 'Condition:' }).dive();
+    expect(evaluatorWrapper.findWhere((node) => node.text() === 'change ')).toExist();
   });
 
   it('should show % in suffix when source is WOW change', () => {
     const newAlert = { ...alert, threshold_evaluator: { source: 'week_over_week', operator: 'gt', value: 5 }};
     const wrapper = shallow(<AlertDetails {...props} alert={newAlert} />);
-    const evaluatorWrapper = wrapper.find({ label: 'Evaluated:' }).dive();
+    const evaluatorWrapper = wrapper.find({ label: 'Condition:' }).dive();
     expect(evaluatorWrapper.findWhere((node) => node.text() === '%')).toExist();
   });
 
@@ -54,7 +55,7 @@ describe('Alert Details Component', () => {
     const newAlert = { ...alert, channels: { emails: ['Myemail@email.com', 'email@ddress.com']}};
     const wrapper = shallow(<AlertDetails {...props} alert={newAlert} />);
     const notifyWrapper = wrapper.find({ label: 'Notify:' }).dive();
-    expect(notifyWrapper.find('EmailIcon')).toExist();
+    expect(notifyWrapper.find({ id: 'email' })).toExist();
     expect(notifyWrapper.find('SlackIcon')).not.toExist();
     expect(notifyWrapper.find('WebhookIcon')).not.toExist();
   });
@@ -63,7 +64,7 @@ describe('Alert Details Component', () => {
     const newAlert = { ...alert, channels: { slack: { target: 'myslackTarget' }}};
     const wrapper = shallow(<AlertDetails {...props} alert={newAlert} />);
     const notifyWrapper = wrapper.find({ label: 'Notify:' }).dive();
-    expect(notifyWrapper.find('EmailIcon')).not.toExist();
+    expect(notifyWrapper.find({ id: 'email' })).not.toExist();
     expect(notifyWrapper.find('SlackIcon')).toExist();
   });
 });

--- a/src/pages/alerts/components/tests/AlertFormNew.test.js
+++ b/src/pages/alerts/components/tests/AlertFormNew.test.js
@@ -87,7 +87,8 @@ describe('Alert Form Component', () => {
 
     const defaultFormState = {
       pristine: false,
-      submitting: false
+      submitting: false,
+      isDuplicate: false
     };
 
     it('should disable submit button when form is pristine', () => {
@@ -100,8 +101,15 @@ describe('Alert Form Component', () => {
     it('should disable submit button when form is submitting', () => {
       wrapper.setProps(defaultFormState);
       expect(wrapper.find('Button')).toHaveProp('disabled', false);
-      wrapper.setProps({ pristine: true });
+      wrapper.setProps({ submitting: true });
       expect(wrapper.find('Button')).toHaveProp('disabled', true);
+    });
+
+    it('should enable submit button when form is pristine but it is a duplicate', () => {
+      wrapper.setProps(defaultFormState);
+      expect(wrapper.find('Button')).toHaveProp('disabled', false);
+      wrapper.setProps({ pristine: true, isDuplicate: true });
+      expect(wrapper.find('Button')).toHaveProp('disabled', false);
     });
 
     it('should display Submitting when submitting ', () => {

--- a/src/pages/alerts/components/tests/AlertToggleNew.test.js
+++ b/src/pages/alerts/components/tests/AlertToggleNew.test.js
@@ -16,7 +16,7 @@ describe('AlertToggle Component', () => {
   it('should render initial state', () => {
     const wrapper = subject();
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('Toggle')).toBeChecked();
+    expect(wrapper.find('Toggle')).not.toBeChecked();
   });
 
   it('should render pending state', () => {
@@ -40,17 +40,17 @@ describe('AlertToggle Component', () => {
       type: 'success'
     });
 
-    expect(wrapper.find('Toggle')).not.toBeChecked();
+    expect(wrapper.find('Toggle')).toBeChecked();
   });
 
   it('should handle a failed toggle', async () => {
     const setMutedStatus = jest.fn(() => Promise.reject());
-    const wrapper = subject({ setMutedStatus, muted: true });
+    const wrapper = subject({ setMutedStatus });
 
     await wrapper.find('Toggle').prop('onChange')();
 
     expect(setMutedStatus).toHaveBeenCalledWith({
-      muted: false,
+      muted: true,
       id: 'mock-id'
     });
 

--- a/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
@@ -18,7 +18,7 @@ exports[`TestCollection Component should render 1`] = `
         "sortKey": "last_triggered_timestamp",
       },
       Object {
-        "label": "Active",
+        "label": "Mute",
         "sortKey": "muted",
       },
       null,

--- a/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertCollectionNew.test.js.snap
@@ -99,8 +99,9 @@ Array [
   <Tooltip
     bottom={true}
     content="Delete"
+    dark={true}
     forcePosition={false}
-    horizontalOffset="0px"
+    horizontalOffset="-8px"
     preferredDirection={
       Object {
         "bottom": true,
@@ -147,8 +148,9 @@ Array [
   <Tooltip
     bottom={true}
     content="Delete"
+    dark={true}
     forcePosition={false}
-    horizontalOffset="0px"
+    horizontalOffset="-8px"
     preferredDirection={
       Object {
         "bottom": true,
@@ -195,8 +197,9 @@ Array [
   <Tooltip
     bottom={true}
     content="Delete"
+    dark={true}
     forcePosition={false}
-    horizontalOffset="0px"
+    horizontalOffset="-8px"
     preferredDirection={
       Object {
         "bottom": true,

--- a/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
@@ -22,149 +22,150 @@ exports[`Alert Details Component should render the alert details component corre
     key="0"
   >
     <LabelledValue
-      bold={true}
-      label="Alert Metric:"
-      value="Health Score"
-    />
+      label="Metric:"
+    >
+      <h6>
+        Health Score
+      </h6>
+    </LabelledValue>
   </Panel.Section>
   <Panel.Section
     key="1"
   >
     <LabelledValue
-      bold={false}
-      label="Evaluated:"
-      value={
-        <React.Fragment>
-          <Tag
-            className="FirstTag"
-          >
-            Value
-          </Tag>
-          below
-          <Tag
-            className="Tags"
-          >
-            80
-            
-          </Tag>
-        </React.Fragment>
-      }
-    />
+      label="Condition:"
+    >
+      <Tag
+        className="FirstTag"
+      >
+        Value
+      </Tag>
+      below
+      <Tag
+        className="Tags"
+      >
+        80
+      </Tag>
+    </LabelledValue>
   </Panel.Section>
   <Panel.Section
     key="2"
   >
     <LabelledValue
-      bold={false}
       label="Filtered By:"
-      value={
-        Array [
-          <span>
-            Subaccounts: 
-            <Tag
-              className="Tags"
-            >
-              -1
-            </Tag>
-          </span>,
-          <span>
-            and 
-            Mailbox Provider
-            : 
-            <Tag
-              className="Tags"
-            >
-              Gmail
-            </Tag>
-          </span>,
-        ]
-      }
-    />
+    >
+      <span
+        key="mailbox_provider"
+      >
+         
+        <h6
+          className="BoldInline"
+        >
+          Mailbox Provider
+        </h6>
+         
+        <Tag
+          className="Tags"
+          key="mailbox_provider-gmail"
+        >
+          Gmail
+        </Tag>
+      </span>
+    </LabelledValue>
   </Panel.Section>
   <Panel.Section
     key="3"
   >
     <LabelledValue
-      bold={false}
       label="Notify:"
-      value={
-        <React.Fragment>
-          <div>
-            Email: 
-            <Tag
-              className="TagsWithIcon"
-            >
-              <EmailIcon
-                className="Icon"
-              />
-              <span
-                className="TagText"
-              >
-                Myemail@email.com
-              </span>
-            </Tag>
-            <Tag
-              className="TagsWithIcon"
-            >
-              <EmailIcon
-                className="Icon"
-              />
-              <span
-                className="TagText"
-              >
-                email@ddress.com
-              </span>
-            </Tag>
-          </div>
-          <div>
-            Slack
-            : 
-            <Tag
-              className="TagsWithIcon"
-            >
-              <SlackIcon
-                className="Icon"
-              />
-              <span
-                className="TagText"
-              >
-                https://hooks.slack.com/services/X
-              </span>
-            </Tag>
-          </div>
-          <div>
-            Webhook
-            : 
-            <Tag
-              className="TagsWithIcon"
-            >
-              <WebhookIcon
-                className="Icon"
-              />
-              <span
-                className="TagText"
-              >
-                target.com/200
-              </span>
-            </Tag>
-          </div>
-        </React.Fragment>
-      }
-    />
+    >
+      <div
+        id="email"
+      >
+        <h6
+          className="BoldInline"
+        >
+          Email
+        </h6>
+         
+        <Tag
+          className="Tags"
+          key="Myemail@email.com"
+        >
+          <span
+            className="TagText"
+          >
+            Myemail@email.com
+          </span>
+        </Tag>
+        <Tag
+          className="Tags"
+          key="email@ddress.com"
+        >
+          <span
+            className="TagText"
+          >
+            email@ddress.com
+          </span>
+        </Tag>
+      </div>
+      <div
+        key="slack"
+      >
+        <h6
+          className="BoldInline"
+        >
+          Slack
+        </h6>
+         
+        <Tag
+          className="TagsWithIcon"
+        >
+          <SlackIcon
+            className="Icon"
+          />
+          <span
+            className="TagText"
+          >
+            https://hooks.slack.com/services/X
+          </span>
+        </Tag>
+      </div>
+      <div
+        key="webhook"
+      >
+        <h6
+          className="BoldInline"
+        >
+          Webhook
+        </h6>
+         
+        <Tag
+          className="TagsWithIcon"
+        >
+          <WebhookIcon
+            className="Icon"
+          />
+          <span
+            className="TagText"
+          >
+            target.com/200
+          </span>
+        </Tag>
+      </div>
+    </LabelledValue>
   </Panel.Section>
   <Panel.Section
     key="4"
   >
     <LabelledValue
-      bold={false}
       label="Mute:"
-      value={
-        <Connect(AlertToggle)
-          id="alert-id"
-          muted={false}
-        />
-      }
-    />
+    >
+      <Connect(AlertToggle)
+        id="alert-id"
+        muted={false}
+      />
+    </LabelledValue>
   </Panel.Section>
 </Panel>
 `;

--- a/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
@@ -40,7 +40,14 @@ exports[`Alert Details Component should render the alert details component corre
       >
         Value
       </Tag>
-      below
+      <h6
+        className="BoldInline"
+      />
+      <h6
+        className="BoldInline"
+      >
+        below
+      </h6>
       <Tag
         className="Tags"
       >

--- a/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertDetails.test.js.snap
@@ -157,7 +157,7 @@ exports[`Alert Details Component should render the alert details component corre
   >
     <LabelledValue
       bold={false}
-      label="Active:"
+      label="Mute:"
       value={
         <Connect(AlertToggle)
           id="alert-id"

--- a/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
@@ -125,7 +125,7 @@ exports[`Alert Form Component should render the alert form component correctly 1
               icon={<SlackIcon />}
               id="slack"
               key="slack"
-              subtitle="Integrate alerts into your Slack channel"
+              subtitle="Integrate this alert with Slack"
               title="Slack"
             >
               <Field
@@ -140,7 +140,7 @@ exports[`Alert Form Component should render the alert form component correctly 1
               icon={<WebhookIcon />}
               id="webhook"
               key="webhook"
-              subtitle="Create a webhook for your alerts"
+              subtitle="Create a webhook for this alert"
               title="Webhook"
             >
               <Field

--- a/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertFormNew.test.js.snap
@@ -83,11 +83,11 @@ exports[`Alert Form Component should render the alert form component correctly 1
             <label>
               <h5>
                 Filtered by 
-                <span
+                <small
                   className="OptionalText"
                 >
                   optional
-                </span>
+                </small>
               </h5>
             </label>
             <Connect(SubaccountsField)

--- a/src/pages/alerts/components/tests/__snapshots__/AlertToggleNew.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertToggleNew.test.js.snap
@@ -5,7 +5,7 @@ exports[`AlertToggle Component should render initial state 1`] = `
   className="Wrapper"
 >
   <Toggle
-    checked={true}
+    checked={false}
     compact={true}
     disabled={false}
     id="mock-id"

--- a/src/pages/alerts/helpers/alertForm.js
+++ b/src/pages/alerts/helpers/alertForm.js
@@ -55,10 +55,10 @@ export const getFormSpec = (metric) => {
 };
 
 export const getEvaluatorOptions = (metric, source) => {
-  const operatorArray = (metric !== 'monthly_sending_limit' && source === 'raw') ? ['lt','gt'] : ['gt'];
+  const operatorArray = (metric === 'health_score' && source === 'raw') ? ['lt','gt'] : ['gt'];
   const operatorOptions = getOptionsFromMap(operatorArray, OPERATOR_FRIENDLY_NAMES);
 
-  const suffix = (metric !== 'health_score' || source !== 'raw') ? '%' : '';
+  const suffix = (metric === 'health_score' && source === 'raw') ? '' : '%';
 
   const getSliderProps = () => {
     if (source !== 'raw') {

--- a/src/pages/alerts/helpers/tests/alertForm.test.js
+++ b/src/pages/alerts/helpers/tests/alertForm.test.js
@@ -34,7 +34,7 @@ describe('Alert form helper: ', () => {
 
   const expectedRealtimeMetric = {
     suffix: '%',
-    operatorOptions: [{ label: 'Below', value: 'lt' }, { label: 'Above', value: 'gt' }],
+    operatorOptions: [{ label: 'Above', value: 'gt' }],
     sliderLabel: 'Bounce Percentage',
     sliderPrecision: 2
   };

--- a/src/pages/alerts/tests/CreatePageNew.test.js
+++ b/src/pages/alerts/tests/CreatePageNew.test.js
@@ -48,11 +48,16 @@ describe('Page: Alerts Create', () => {
     expect(props.getAlert).toHaveBeenCalledWith({ id: 'alert-id-1' });
   });
 
+  it('breadcrumb should link to details page if its a duplicate alert', () => {
+    wrapper.setProps({ idToDuplicate: 'alert-id-1' });
+    expect(wrapper.find('Page').prop('breadcrumbAction').to).toEqual('/alerts-new/details/alert-id-1');
+  });
+
   it('should handle submit', async () => {
     formatFormValues.mockImplementationOnce((a) => a);
     await wrapper.find(AlertFormNew).simulate('submit', { value: 'mock value' });
     expect(props.createAlert).toHaveBeenCalledWith({ data: { value: 'mock value' }});
     expect(props.showUIAlert).toHaveBeenCalled();
-    expect(props.history.push).toHaveBeenCalledWith('/alerts-new');
+    expect(props.history.push).toHaveBeenCalledWith('/alerts-new/details/mock-id');
   });
 });

--- a/src/pages/alerts/tests/EditPageNew.test.js
+++ b/src/pages/alerts/tests/EditPageNew.test.js
@@ -8,7 +8,7 @@ jest.mock('../helpers/formatFormValues');
 
 describe('Page: Alerts Edit', () => {
   const props = {
-    updateAlert: jest.fn(() => Promise.resolve({ id: 'mock-id' })),
+    updateAlert: jest.fn(() => Promise.resolve({})),
     showUIAlert: jest.fn(),
     error: null,
     history: {
@@ -52,6 +52,6 @@ describe('Page: Alerts Edit', () => {
     await wrapper.find(AlertFormNew).simulate('submit', { value: 'mock value' });
     expect(props.updateAlert).toHaveBeenCalledWith({ data: { value: 'mock value' }, id: props.id });
     expect(props.showUIAlert).toHaveBeenCalled();
-    expect(props.history.push).toHaveBeenCalledWith('/alerts-new');
+    expect(props.history.push).toHaveBeenCalledWith('/alerts-new/details/alert-id-1');
   });
 });

--- a/src/pages/alerts/tests/__snapshots__/DetailsPage.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/DetailsPage.test.js.snap
@@ -43,6 +43,7 @@ exports[`Page: Alert Details should render Alert Details Page 1`] = `
         "name": "My Alert",
       }
     }
+    hasSubaccounts={true}
     id="alert-id"
     subaccountIdToString={[Function]}
   />

--- a/src/pages/alerts/tests/__snapshots__/EditPageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/EditPageNew.test.js.snap
@@ -5,8 +5,8 @@ exports[`Page: Alerts Edit should render happy path 1`] = `
   breadcrumbAction={
     Object {
       "component": [Function],
-      "content": "Back to Alerts",
-      "to": "/alerts-new",
+      "content": "Back to Alert",
+      "to": "/alerts-new/details/alert-id-1",
     }
   }
   empty={Object {}}

--- a/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/ListPageNew.test.js.snap
@@ -93,8 +93,9 @@ exports[`Page: Alerts List should render happy path 1`] = `
           <Tooltip
             bottom={true}
             content="View Details"
+            dark={true}
             forcePosition={false}
-            horizontalOffset="0px"
+            horizontalOffset="-8px"
             preferredDirection={
               Object {
                 "bottom": true,
@@ -150,8 +151,9 @@ exports[`Page: Alerts List should render happy path 1`] = `
           <Tooltip
             bottom={true}
             content="View Details"
+            dark={true}
             forcePosition={false}
-            horizontalOffset="0px"
+            horizontalOffset="-8px"
             preferredDirection={
               Object {
                 "bottom": true,


### PR DESCRIPTION
### What Changed
 - Made all the changes outlined in the AC

### How To Test
 - Confirm that all changes working as intended. 

### To Do
- [x] List | Tooltips should be dark and fix offset
- [x] List | “Active” -> “Mute
- [x] Edit | Breadcrumb and Updating should lead back to Details, not List
- [x] Details: Metric | “Alert Metric” should be “Metric"
- [x] Details: Metric | Monthly Sending Limit:  [Value] above [100]  ->  Above [100%]
- [x] Details: Metric | Bounce Rate: [Value] above [30] -> Above [20%]
- [x] Details: Evaluated | Make above/below bolded as well
- [x] Details: Evaluated | “Evaluated” -> “Condition”
- [x] Details: Filtered By | Delete Colons after items being filtered but make semi-bold. Keep “and”  not bold same with notify by
- [x] Details: Filtered By | Make sure the subaccount section doesn’t show up for accounts without subaccounts 
- [x] Details: Filtered By | Subaccounts [Master and all] shouldn’t appear, there is no filter in this case
- [x] Details: Notify | Remove icons from emails
- [x] Details: Duplicate | Fix: Doesn’t let you press create until the from has been changes
- [x] Details: Active | “Active” -> “Mute"
- [x] Create | Create should push to detail, not List
- [x] Create: Bounces | Remove Selector from Bounce rates 
- [x] Create: Slack | Integrate alerts into your Slack channel -> Integrate this alert with Slack
- [x] Create: Webhooks | “Create a webhook for this alert”