### PR TITLE
AC-935: Added auth response

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -79,10 +79,14 @@ export function authenticate(username, password, rememberMe = false, access_toke
       })
       .catch((err) => {
         const { response = {}} = err;
-        const { data = {}} = response;
-        const { error_description: errorDescription } = data;
+        const { data = {}, status } = response;
+        let { error_description: errorDescription } = data;
 
         // TODO: handle a timeout error better
+
+        if (status === 403) {
+          errorDescription = `${errorDescription || 'Something went wrong.'} Please email compliance@sparkpost.com if you need assistance.`;
+        }
 
         dispatch({
           type: 'LOGIN_FAIL',

--- a/src/actions/tests/__snapshots__/auth.test.js.snap
+++ b/src/actions/tests/__snapshots__/auth.test.js.snap
@@ -18,6 +18,24 @@ Array [
 ]
 `;
 
+exports[`Action Creator: Auth authenticate tests should dispatch a failed login if login fails with 403 1`] = `
+Array [
+  Array [
+    Object {
+      "type": "LOGIN_PENDING",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "errorDescription": "login failed Please email compliance@sparkpost.com if you need assistance.",
+      },
+      "type": "LOGIN_FAIL",
+    },
+  ],
+]
+`;
+
 exports[`Action Creator: Auth authenticate tests should login if user is not TFA 1`] = `
 Array [
   Array [

--- a/src/actions/tests/auth.test.js
+++ b/src/actions/tests/auth.test.js
@@ -154,6 +154,22 @@ describe('Action Creator: Auth', () => {
 
     });
 
+    it('should dispatch a failed login if login fails with 403', async () => {
+      sparkpostLogin.mockRejectedValue({
+        response: {
+          status: 403,
+          data: {
+            error_description: 'login failed'
+          }
+        }
+      });
+
+      const thunk = authActions.authenticate('bar', 'pw', true);
+      await thunk(dispatchMock, getStateMock);
+      expect(dispatchMock.mock.calls).toMatchSnapshot();
+
+    });
+
     it('should return auth status on login failure', async () => {
       sparkpostLogin.mockRejectedValue({
         response: {

--- a/src/pages/auth/components/LoginForm.js
+++ b/src/pages/auth/components/LoginForm.js
@@ -8,7 +8,7 @@ import { trimWhitespaces } from 'src/helpers/string';
 import { Button, Error } from '@sparkpost/matchbox';
 
 export const LoginForm = ({ loginPending, loginError, handleSubmit }) => <React.Fragment>
-  {loginError && <Error error={loginError} />}
+  {loginError && <div style={{ marginBottom: '12px' }}><Error error={loginError}/></div>}
   <form onSubmit={handleSubmit}>
     <Field
       autoFocus

--- a/src/pages/auth/components/tests/__snapshots__/LoginForm.test.js.snap
+++ b/src/pages/auth/components/tests/__snapshots__/LoginForm.test.js.snap
@@ -96,9 +96,17 @@ exports[`renders correctly when logging in 1`] = `
 
 exports[`renders errors 1`] = `
 <Fragment>
-  <Error
-    error="asplode"
-  />
+  <div
+    style={
+      Object {
+        "marginBottom": "12px",
+      }
+    }
+  >
+    <Error
+      error="asplode"
+    />
+  </div>
   <form>
     <Field
       autoFocus={true}


### PR DESCRIPTION
### What Changed
 - Added error message to contact compliance on 403 message

### How To Test
 - Coordinate with accounts to lock/unlock IP
 - Login
 - Message should say message + `Please email compliance@sparkopst.com if you need assistance`.

### To Do
- [ ] Address feedback