### PR TITLE
SA-852 Custom reports access check defaults to false

### DIFF
--- a/src/selectors/customReports.js
+++ b/src/selectors/customReports.js
@@ -2,7 +2,7 @@ import { selectCondition } from 'src/selectors/accessConditionState';
 import { isUserUiOptionSet } from 'src/helpers/conditions/user';
 import _ from 'lodash';
 
-export const selectReportsEnhancementsEnabled = (state) => selectCondition(isUserUiOptionSet('feature_reports_enhancements', true))(state);
+export const selectReportsEnhancementsEnabled = (state) => selectCondition(isUserUiOptionSet('feature_reports_enhancements', false))(state);
 
 export const selectCustomReports = (state) => {
   // A value of `false` represents zero saved reports

--- a/src/selectors/tests/__snapshots__/customReports.test.js.snap
+++ b/src/selectors/tests/__snapshots__/customReports.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Selectors: customReports returns reports ehancements feature flag 1`] = `true`;
-
 exports[`Selectors: customReports returns sorted custom reports 1`] = `
 Array [
   Object {

--- a/src/selectors/tests/customReports.test.js
+++ b/src/selectors/tests/customReports.test.js
@@ -12,7 +12,12 @@ describe('Selectors: customReports', () => {
       feature_reports_enhancements: true
     });
 
-    expect(selectors.selectReportsEnhancementsEnabled(state)).toMatchSnapshot();
+    expect(selectors.selectReportsEnhancementsEnabled(state)).toBe(true);
+  });
+
+  it('returns false when flag is not set', () => {
+    setUIOptions({});
+    expect(selectors.selectReportsEnhancementsEnabled(state)).toBe(false);
   });
 
   it('returns sorted custom reports', () => {


### PR DESCRIPTION

### What Changed
- Fixes the custom reports selector to default to `false`
- Custom Reports UI should no longer render without the flag

### How To Test
- Log into an account without  the `feature_reports_enhancements` user flag – check summary report

### To Do
- [ ] Any feedback
