### PR TITLE
SE-193 Handle lowercase batch_status in UI

### DIFF
--- a/src/pages/recipientValidation/components/ListResults.js
+++ b/src/pages/recipientValidation/components/ListResults.js
@@ -37,24 +37,26 @@ export class ListResults extends Component {
   handlePoll = (id) => {
     const { showAlert, getJobStatus, stopPolling } = this.props;
     return getJobStatus(id).then(({ complete, batch_status }) => {
-      const normalizedStatus = batch_status.toLowerCase();
+      if (batch_status) {
+        const normalizedStatus = batch_status.toLowerCase();
 
-      if (normalizedStatus === 'error') {
-        stopPolling(id);
-        showAlert({
-          type: 'error',
-          message: 'Recipient Validation Failed. Please Try Again.',
-          dedupeId: id
-        });
-      }
+        if (normalizedStatus === 'error') {
+          stopPolling(id);
+          showAlert({
+            type: 'error',
+            message: 'Recipient Validation Failed. Please Try Again.',
+            dedupeId: id
+          });
+        }
 
-      if (complete && normalizedStatus === 'success') {
-        stopPolling(id);
-        showAlert({
-          type: 'success',
-          message: 'Recipient Validation Results Ready',
-          dedupeId: id
-        });
+        if (complete && normalizedStatus === 'success') {
+          stopPolling(id);
+          showAlert({
+            type: 'success',
+            message: 'Recipient Validation Results Ready',
+            dedupeId: id
+          });
+        }
       }
     });
   }

--- a/src/pages/recipientValidation/components/ListResults.js
+++ b/src/pages/recipientValidation/components/ListResults.js
@@ -37,7 +37,9 @@ export class ListResults extends Component {
   handlePoll = (id) => {
     const { showAlert, getJobStatus, stopPolling } = this.props;
     return getJobStatus(id).then(({ complete, batch_status }) => {
-      if (batch_status === 'ERROR') {
+      const normalizedStatus = batch_status.toLowerCase();
+
+      if (normalizedStatus === 'error') {
         stopPolling(id);
         showAlert({
           type: 'error',
@@ -46,7 +48,7 @@ export class ListResults extends Component {
         });
       }
 
-      if (complete && batch_status === 'SUCCESS') {
+      if (complete && normalizedStatus === 'success') {
         stopPolling(id);
         showAlert({
           type: 'success',

--- a/src/pages/recipientValidation/components/ListResults.js
+++ b/src/pages/recipientValidation/components/ListResults.js
@@ -37,26 +37,22 @@ export class ListResults extends Component {
   handlePoll = (id) => {
     const { showAlert, getJobStatus, stopPolling } = this.props;
     return getJobStatus(id).then(({ complete, batch_status }) => {
-      if (batch_status) {
-        const normalizedStatus = batch_status.toLowerCase();
+      if (batch_status === 'error') {
+        stopPolling(id);
+        showAlert({
+          type: 'error',
+          message: 'Recipient Validation Failed. Please Try Again.',
+          dedupeId: id
+        });
+      }
 
-        if (normalizedStatus === 'error') {
-          stopPolling(id);
-          showAlert({
-            type: 'error',
-            message: 'Recipient Validation Failed. Please Try Again.',
-            dedupeId: id
-          });
-        }
-
-        if (complete && normalizedStatus === 'success') {
-          stopPolling(id);
-          showAlert({
-            type: 'success',
-            message: 'Recipient Validation Results Ready',
-            dedupeId: id
-          });
-        }
+      if (complete && batch_status === 'success') {
+        stopPolling(id);
+        showAlert({
+          type: 'success',
+          message: 'Recipient Validation Results Ready',
+          dedupeId: id
+        });
       }
     });
   }

--- a/src/pages/recipientValidation/components/ListResultsCard.js
+++ b/src/pages/recipientValidation/components/ListResultsCard.js
@@ -17,8 +17,8 @@ const ListResultsCard = ({ complete = 'unknown', uploaded, rejectedUrl, status }
   }
 
   const loading = !complete;
-  const ready = status === 'SUCCESS';
-  const failed = status === 'ERROR';
+  const ready = status === 'success';
+  const failed = status === 'error';
 
   const renderStatus = () => {
 

--- a/src/pages/recipientValidation/components/tests/ListResults.test.js
+++ b/src/pages/recipientValidation/components/tests/ListResults.test.js
@@ -60,7 +60,7 @@ describe('ListResults', () => {
     });
 
     it('starts shows an alert when polling results are complete', async () => {
-      props.getJobStatus.mockReturnValue(Promise.resolve({ complete: true, batch_status: 'SUCCESS' }));
+      props.getJobStatus.mockReturnValue(Promise.resolve({ complete: true, batch_status: 'success' }));
       wrapper.setProps({ results: testNotComplete, latestId: testNotComplete.listId });
       await expect(props.getJobStatus).toHaveBeenCalledWith(testNotComplete.listId);
       expect(props.showAlert.mock.calls).toMatchSnapshot();
@@ -68,7 +68,7 @@ describe('ListResults', () => {
     });
 
     it('starts shows an alert when polling results fail', async () => {
-      props.getJobStatus.mockReturnValue(Promise.resolve({ complete: false, batch_status: 'ERROR' }));
+      props.getJobStatus.mockReturnValue(Promise.resolve({ complete: false, batch_status: 'error' }));
       wrapper.setProps({ results: testNotComplete, latestId: testNotComplete.listId });
       await expect(props.getJobStatus).toHaveBeenCalledWith(testNotComplete.listId);
       expect(props.showAlert.mock.calls).toMatchSnapshot();

--- a/src/pages/recipientValidation/components/tests/ListResultsCard.test.js
+++ b/src/pages/recipientValidation/components/tests/ListResultsCard.test.js
@@ -19,7 +19,7 @@ describe('ListResultsCard', () => {
       complete: true,
       uploaded: 1541092618,
       rejectedUrl: 'testfile.csv',
-      status: 'SUCCESS'
+      status: 'success'
     });
     expect(wrapper.find('Tag').childAt(1).text()).toEqual('Completed');
     expect(wrapper.find('CheckCircle')).toExist();
@@ -30,7 +30,7 @@ describe('ListResultsCard', () => {
       complete: false,
       uploaded: 1541092618,
       rejectedUrl: 'testfile.csv',
-      status: 'ERROR'
+      status: 'error'
     });
     expect(wrapper.find('Tag').childAt(1).text()).toEqual('Failed. Please try again.');
     expect(wrapper.find('Error')).toExist();

--- a/src/pages/recipientValidation/components/tests/ListResultsCard.test.js
+++ b/src/pages/recipientValidation/components/tests/ListResultsCard.test.js
@@ -19,7 +19,7 @@ describe('ListResultsCard', () => {
       complete: true,
       uploaded: 1541092618,
       rejectedUrl: 'testfile.csv',
-      status: 'success'
+      status: 'SUCCESS'
     });
     expect(wrapper.find('Tag').childAt(1).text()).toEqual('Completed');
     expect(wrapper.find('CheckCircle')).toExist();

--- a/src/pages/recipientValidation/components/tests/ListResultsCard.test.js
+++ b/src/pages/recipientValidation/components/tests/ListResultsCard.test.js
@@ -19,7 +19,7 @@ describe('ListResultsCard', () => {
       complete: true,
       uploaded: 1541092618,
       rejectedUrl: 'testfile.csv',
-      status: 'SUCCESS'
+      status: 'success'
     });
     expect(wrapper.find('Tag').childAt(1).text()).toEqual('Completed');
     expect(wrapper.find('CheckCircle')).toExist();

--- a/src/reducers/recipientValidation.js
+++ b/src/reducers/recipientValidation.js
@@ -44,7 +44,7 @@ export default (state = initialState, { meta, payload, type }) => {
         jobResults: {
           ...state.jobResults,
           [payload.list_id]: {
-            status: payload.batch_status,
+            status: payload.batch_status.toLowerCase(),
             complete: payload.complete,
             uploaded: payload.upload_timestamp,
             rejectedUrl: payload.rejected_external_url

--- a/src/reducers/recipientValidation.js
+++ b/src/reducers/recipientValidation.js
@@ -44,7 +44,7 @@ export default (state = initialState, { meta, payload, type }) => {
         jobResults: {
           ...state.jobResults,
           [payload.list_id]: {
-            status: payload.batch_status && payload.batch_status.toLowerCase(),
+            status: payload.batch_status ? payload.batch_status.toLowerCase() : null,
             complete: payload.complete,
             uploaded: payload.upload_timestamp,
             rejectedUrl: payload.rejected_external_url
@@ -66,7 +66,7 @@ export default (state = initialState, { meta, payload, type }) => {
         jobResults: {
           ...state.jobResults,
           [payload.list_id]: {
-            status: payload.batch_status && payload.batch_status.toLowerCase(),
+            status: payload.batch_status ? payload.batch_status.toLowerCase() : null,
             complete: payload.complete,
             uploaded: payload.upload_timestamp,
             rejectedUrl: payload.rejected_external_url

--- a/src/reducers/recipientValidation.js
+++ b/src/reducers/recipientValidation.js
@@ -44,7 +44,7 @@ export default (state = initialState, { meta, payload, type }) => {
         jobResults: {
           ...state.jobResults,
           [payload.list_id]: {
-            status: payload.batch_status.toLowerCase(),
+            status: payload.batch_status && payload.batch_status.toLowerCase(),
             complete: payload.complete,
             uploaded: payload.upload_timestamp,
             rejectedUrl: payload.rejected_external_url
@@ -66,7 +66,7 @@ export default (state = initialState, { meta, payload, type }) => {
         jobResults: {
           ...state.jobResults,
           [payload.list_id]: {
-            status: payload.batch_status,
+            status: payload.batch_status && payload.batch_status.toLowerCase(),
             complete: payload.complete,
             uploaded: payload.upload_timestamp,
             rejectedUrl: payload.rejected_external_url


### PR DESCRIPTION
Resolves SE-193

### What Changed
* Normalized `batch_status` checking its value in the UI
* Updated relevant tests with more accurate mock data

### How To Test
* Go to `/recipient-validation/list`
* Upload the example .csv file
* Wait for processing to occur and check that the status in the table renders accurately

### To Do
- [x] Figure out why the POST isn't working locally to verify UI update
- [x] Incorporate feedback