### PR TITLE
SA-855 change default signals date range to 90 days

### DIFF
--- a/src/reducers/signalOptions.js
+++ b/src/reducers/signalOptions.js
@@ -1,6 +1,6 @@
 import { getDates } from 'src/helpers/signals';
 
-const DEFAULT_RANGE = '30days';
+const DEFAULT_RANGE = '90days';
 const initialState = getDates({ relativeRange: DEFAULT_RANGE });
 
 const signalOptionsReducer = (state = initialState, action) => {

--- a/src/reducers/tests/__snapshots__/signalOptions.test.js.snap
+++ b/src/reducers/tests/__snapshots__/signalOptions.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Signal Options Reducer when init 1`] = `
 Object {
-  "relativeRange": "30days",
+  "relativeRange": "90days",
 }
 `;
 


### PR DESCRIPTION
### What Changed
 - Changed default signals time range to 90 days. 
 - Basically undo https://github.com/SparkPost/2web2ui/pull/1002

### How To Test
 - Go to signals page. See that all charts are defaulted to 90 days.
