### PR TITLE
SA-856 - Allow users to open the links in the various reports pages' table in new tabs 

### DIFF
--- a/src/pages/reports/bounce/BouncePage.js
+++ b/src/pages/reports/bounce/BouncePage.js
@@ -3,15 +3,15 @@ import { connect } from 'react-redux';
 import _ from 'lodash';
 import { safeRate } from 'src/helpers/math';
 import { refreshBounceReport } from 'src/actions/bounceReport';
-import { addFilters } from 'src/actions/reportOptions';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
 import { Percent } from 'src/components/formatters';
 import PanelLoading from 'src/components/panelLoading/PanelLoading';
-import { Page, UnstyledLink, Tabs } from '@sparkpost/matchbox';
+import { Page, Tabs } from '@sparkpost/matchbox';
 import ReportOptions from '../components/ReportOptions';
 import BounceChart from './components/BounceChart';
 import MetricsSummary from '../components/MetricsSummary';
 import { mapStateToProps } from 'src/selectors/bounceReport';
+import AddFilterLink from '../components/AddFilterLink';
 
 const columns = [
   { label: 'Reason', width: '45%', sortKey: 'reason' },
@@ -33,7 +33,7 @@ export class BouncePage extends Component {
   }
 
   getRowData = (item) => {
-    const { aggregates = {}, addFilters } = this.props;
+    const { aggregates = {}} = this.props;
     const { reason, domain, bounce_category_name, bounce_class_name, count_bounce, count_admin_bounce } = item;
     // calculate the rate of admin bounces against all bounces
     let numerator = count_bounce;
@@ -46,7 +46,7 @@ export class BouncePage extends Component {
 
     return [
       <LongTextContainer text={reason} />,
-      <UnstyledLink onClick={() => addFilters([{ type: 'Recipient Domain', value: domain }])}>{domain}</UnstyledLink>,
+      <AddFilterLink newFilter={{ type: 'Recipient Domain', value: domain }} reportType={'bounce'} content={domain}/>,
       bounce_category_name,
       bounce_class_name,
       <span>{numerator} <small>(<Percent value={safeRate(numerator, denominator)} />)</small></span>
@@ -162,7 +162,6 @@ export class BouncePage extends Component {
 }
 
 const mapDispatchToProps = {
-  addFilters,
   refreshBounceReport
 };
 

--- a/src/pages/reports/bounce/tests/BouncePage.test.js
+++ b/src/pages/reports/bounce/tests/BouncePage.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BouncePage } from '../BouncePage';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import MetricsSummary from '../../components/MetricsSummary';
 
 describe('BouncePage: ', () => {
@@ -137,19 +137,6 @@ describe('BouncePage: ', () => {
     });
 
     expect(rows).toMatchSnapshot();
-  });
-
-  it('should filter by domain', () => {
-    const rows = wrapper.instance().getRowData({
-      reason: 'u y bounce?',
-      domain: 'gmail',
-      bounce_category_name: 'bouncy',
-      count_bounce: 10
-    });
-
-    const link = mount(rows[1]);
-    link.find('UnstyledLink').simulate('click');
-    expect(props.addFilters).toHaveBeenCalledWith([{ type: 'Recipient Domain', value: 'gmail' }]);
   });
 
   it('should change state when the tab is clicked', () => {

--- a/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
+++ b/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
@@ -334,11 +334,16 @@ Array [
   <LongTextContainer
     text="bouncy boi"
   />,
-  <UnstyledLink
-    onClick={[Function]}
-  >
-    gmail
-  </UnstyledLink>,
+  <Connect(AddFilterLink)
+    content="gmail"
+    newFilter={
+      Object {
+        "type": "Recipient Domain",
+        "value": "gmail",
+      }
+    }
+    reportType="bounce"
+  />,
   "Admin",
   undefined,
   <span>
@@ -360,11 +365,16 @@ Array [
   <LongTextContainer
     text="u y bounce?"
   />,
-  <UnstyledLink
-    onClick={[Function]}
-  >
-    gmail
-  </UnstyledLink>,
+  <Connect(AddFilterLink)
+    content="gmail"
+    newFilter={
+      Object {
+        "type": "Recipient Domain",
+        "value": "gmail",
+      }
+    }
+    reportType="bounce"
+  />,
   "bouncy",
   undefined,
   <span>

--- a/src/pages/reports/components/AddFilterLink.js
+++ b/src/pages/reports/components/AddFilterLink.js
@@ -14,12 +14,10 @@ export const AddFilterLink = ({
   reportType,
   content,
   //From redux
-  summarySearchOptions,
-  reportSearchOptions,
+  currentSearchOptions,
   addFilters }) => {
 
-  const searchOptions = reportType === 'summary' ? summarySearchOptions : reportSearchOptions; //summarySearchOptions includes selected metrics options
-  const oldFilters = searchOptions.filters || [];
+  const currentFilters = currentSearchOptions.filters || [];
 
   const handleOnClick = (e) => {
     addFilters([newFilter]);
@@ -27,8 +25,9 @@ export const AddFilterLink = ({
     e.preventDefault();
   };
 
-  const mergedFilters = _.uniqWith([ ...oldFilters, stringifyTypeaheadfilter(newFilter)], _.isEqual);
-  const linkParams = qs.stringify({ ...searchOptions, filters: mergedFilters }, { arrayFormat: 'repeat' });
+  const mergedFilters = _.uniqWith([ ...currentFilters, stringifyTypeaheadfilter(newFilter)], _.isEqual);
+  const newSearchOptions = { ...currentSearchOptions, filters: mergedFilters };
+  const linkParams = qs.stringify(newSearchOptions, { arrayFormat: 'repeat' });
   const fullLink = `/reports/${reportType}/?${linkParams}`;
 
   return (
@@ -36,9 +35,10 @@ export const AddFilterLink = ({
   );
 };
 
-const mapStateToProps = (state) => ({
-  summarySearchOptions: selectSummaryChartSearchOptions(state),
-  reportSearchOptions: selectReportSearchOptions(state)
+const mapStateToProps = (state, props) => ({
+  currentSearchOptions: (props.reportType === 'summary')
+    ? selectSummaryChartSearchOptions(state)
+    : selectReportSearchOptions(state)
 });
 
 export default connect(mapStateToProps, { addFilters })(AddFilterLink);

--- a/src/pages/reports/components/AddFilterLink.js
+++ b/src/pages/reports/components/AddFilterLink.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import _ from 'lodash';
+import qs from 'qs';
+
+import { addFilters } from 'src/actions/reportOptions';
+import { stringifyTypeaheadfilter } from 'src/helpers/string';
+import { selectReportSearchOptions, selectSummaryChartSearchOptions } from 'src/selectors/reportSearchOptions';
+import { UnstyledLink } from '@sparkpost/matchbox';
+
+export const AddFilterLink = ({
+  //From parent
+  newFilter,
+  reportType,
+  content,
+  //From redux
+  summarySearchOptions,
+  reportSearchOptions,
+  addFilters }) => {
+
+  const searchOptions = reportType === 'summary' ? summarySearchOptions : reportSearchOptions; //summarySearchOptions includes selected metrics options
+  const oldFilters = searchOptions.filters || [];
+
+  const handleOnClick = (e) => {
+    addFilters([newFilter]);
+    //This prevents the browser from following the link and reloading the page.
+    e.preventDefault();
+  };
+
+  const mergedFilters = _.uniqWith([ ...oldFilters, stringifyTypeaheadfilter(newFilter)], _.isEqual);
+  const linkParams = qs.stringify({ ...searchOptions, filters: mergedFilters }, { arrayFormat: 'repeat' });
+  const fullLink = `/reports/${reportType}/?${linkParams}`;
+
+  return (
+    <UnstyledLink onClick={handleOnClick} to={fullLink}>{content}</UnstyledLink>
+  );
+};
+
+const mapStateToProps = (state) => ({
+  summarySearchOptions: selectSummaryChartSearchOptions(state),
+  reportSearchOptions: selectReportSearchOptions(state)
+});
+
+export default connect(mapStateToProps, { addFilters })(AddFilterLink);

--- a/src/pages/reports/components/tests/AddFilterLink.test.js
+++ b/src/pages/reports/components/tests/AddFilterLink.test.js
@@ -10,10 +10,7 @@ describe('Add Filter Link', () => {
     reportType: 'summary',
     content: 'master account',
     addFilters: jest.fn(),
-    reportSearchOptions: {
-      filters
-    },
-    summarySearchOptions: {
+    currentSearchOptions: {
       filters,
       metrics: ['count_something']
     }
@@ -29,7 +26,7 @@ describe('Add Filter Link', () => {
   });
 
   it('should render correctly for other reports and should not include metrics in the link', () => {
-    const wrapper = subject({ reportType: 'bounce' });
+    const wrapper = subject({ reportType: 'bounce' , currentSearchOptions: { filters }});
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/reports/components/tests/AddFilterLink.test.js
+++ b/src/pages/reports/components/tests/AddFilterLink.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { AddFilterLink } from '../AddFilterLink';
+import { shallow } from 'enzyme';
+
+describe('Add Filter Link', () => {
+
+  const filters = ['Campaign: shiny new filter'];
+  const baseProps = {
+    newFilter: { id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' },
+    reportType: 'summary',
+    content: 'master account',
+    addFilters: jest.fn(),
+    reportSearchOptions: {
+      filters
+    },
+    summarySearchOptions: {
+      filters,
+      metrics: ['count_something']
+    }
+  };
+
+  function subject(props) {
+    return shallow(<AddFilterLink {...baseProps} {...props} />);
+  }
+
+  it('should render correctly for the summary report and include metrics in the link', () => {
+    const wrapper = subject();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render correctly for other reports and should not include metrics in the link', () => {
+    const wrapper = subject({ reportType: 'bounce' });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should handle click correctly', () => {
+    const wrapper = subject();
+    const preventDefaultMock = jest.fn();
+    wrapper.find('UnstyledLink').simulate('click', { preventDefault: preventDefaultMock });
+
+    expect(baseProps.addFilters).toHaveBeenCalledWith([{ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' }]);
+    expect(preventDefaultMock).toHaveBeenCalled();
+  });
+});

--- a/src/pages/reports/components/tests/__snapshots__/AddFilterLink.test.js.snap
+++ b/src/pages/reports/components/tests/__snapshots__/AddFilterLink.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Add Filter Link should render correctly for other reports and should not include metrics in the link 1`] = `
+<UnstyledLink
+  onClick={[Function]}
+  to="/reports/bounce/?filters=Campaign%3A%20shiny%20new%20filter&filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
+>
+  master account
+</UnstyledLink>
+`;
+
+exports[`Add Filter Link should render correctly for the summary report and include metrics in the link 1`] = `
+<UnstyledLink
+  onClick={[Function]}
+  to="/reports/summary/?filters=Campaign%3A%20shiny%20new%20filter&filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0&metrics=count_something"
+>
+  master account
+</UnstyledLink>
+`;

--- a/src/pages/reports/delays/DelayPage.js
+++ b/src/pages/reports/delays/DelayPage.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
-import { addFilters } from 'src/actions/reportOptions';
 import { refreshDelayReport } from 'src/actions/delayReport';
 import { selectReportSearchOptions } from 'src/selectors/reportSearchOptions';
 import { Page, Panel } from '@sparkpost/matchbox';
@@ -26,7 +25,7 @@ export class DelayPage extends Component {
       return <PanelLoading />;
     }
 
-    return <DelaysDataTable totalAccepted={totalAccepted} rows={reasons} addFilters={this.props.addFilters} />;
+    return <DelaysDataTable totalAccepted={totalAccepted} rows={reasons} />;
   }
 
   renderTopLevelMetrics() {
@@ -58,9 +57,9 @@ export class DelayPage extends Component {
     return (
       <Page title='Delay Report'>
         <ReportOptions reportLoading={loading} searchOptions={delaySearchOptions} />
-        { this.renderTopLevelMetrics() }
+        {this.renderTopLevelMetrics()}
         <Panel title='Delayed Messages' className='ReasonsTable'>
-          { this.renderDataTable() }
+          {this.renderDataTable()}
         </Panel>
       </Page>
     );
@@ -81,7 +80,6 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
-  addFilters,
   refreshDelayReport
 };
 

--- a/src/pages/reports/delays/components/DelaysDataTable.js
+++ b/src/pages/reports/delays/components/DelaysDataTable.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import _ from 'lodash';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
-import { UnstyledLink } from '@sparkpost/matchbox';
 import { Percent } from 'src/components/formatters';
 import { safeRate } from 'src/helpers/math';
+import AddFilterLink from '../../components/AddFilterLink';
 
 const columns = [
   { label: 'Reason', sortKey: 'reason', width: '45%' },
@@ -14,11 +14,11 @@ const columns = [
 
 export class DelaysDataTable extends Component {
   getRowData = (rowData) => {
-    const { totalAccepted, addFilters } = this.props;
+    const { totalAccepted } = this.props;
     const { reason, domain, count_delayed, count_delayed_first } = rowData;
     return [
       <LongTextContainer text={reason} />,
-      <UnstyledLink onClick={() => addFilters([{ type: 'Recipient Domain', value: domain }])}>{domain}</UnstyledLink>,
+      <AddFilterLink newFilter={{ type: 'Recipient Domain', value: domain }} reportType={'delayed'} content={domain}/>,
       count_delayed,
       <span>{count_delayed_first} (<Percent value={safeRate(count_delayed_first, totalAccepted)} />)</span>
     ];

--- a/src/pages/reports/delays/components/tests/DelaysDataTable.test.js
+++ b/src/pages/reports/delays/components/tests/DelaysDataTable.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DelaysDataTable } from '../DelaysDataTable';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 describe('DelaysDataTable: ', () => {
   let wrapper;
@@ -42,10 +42,4 @@ describe('DelaysDataTable: ', () => {
     expect(rows).toMatchSnapshot();
   });
 
-  it('should filter by domain', () => {
-    const rows = wrapper.instance().getRowData({ reason: 'bad delay', count_delayed: 1, count_delayed_first: 10, domain: 'yahoo.com' });
-    const link = mount(rows[1]);
-    link.find('UnstyledLink').simulate('click');
-    expect(props.addFilters).toHaveBeenCalledWith([{ type: 'Recipient Domain', value: 'yahoo.com' }]);
-  });
 });

--- a/src/pages/reports/delays/components/tests/__snapshots__/DelaysDataTable.test.js.snap
+++ b/src/pages/reports/delays/components/tests/__snapshots__/DelaysDataTable.test.js.snap
@@ -44,11 +44,16 @@ Array [
   <LongTextContainer
     text="bad delay"
   />,
-  <UnstyledLink
-    onClick={[Function]}
-  >
-    gmail.com
-  </UnstyledLink>,
+  <Connect(AddFilterLink)
+    content="gmail.com"
+    newFilter={
+      Object {
+        "type": "Recipient Domain",
+        "value": "gmail.com",
+      }
+    }
+    reportType="delayed"
+  />,
   1,
   <span>
     10

--- a/src/pages/reports/delays/tests/DelayPage.test.js
+++ b/src/pages/reports/delays/tests/DelayPage.test.js
@@ -21,7 +21,6 @@ describe('DelayPage: ', () => {
       count_accepted: 10000
     },
     totalAccepted: 1000,
-    addFilters: jest.fn(),
     refreshDelayReport: jest.fn()
   };
 

--- a/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
+++ b/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
@@ -25,7 +25,6 @@ exports[`DelayPage:  should render 1`] = `
     title="Delayed Messages"
   >
     <DelaysDataTable
-      addFilters={[MockFunction]}
       rows={
         Array [
           Object {
@@ -88,7 +87,6 @@ exports[`DelayPage:  should show loading panel when aggregates are still loading
     title="Delayed Messages"
   >
     <DelaysDataTable
-      addFilters={[MockFunction]}
       rows={
         Array [
           Object {

--- a/src/pages/reports/rejection/RejectionPage.js
+++ b/src/pages/reports/rejection/RejectionPage.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
-import { addFilters } from 'src/actions/reportOptions';
 import { refreshRejectionReport } from 'src/actions/rejectionReport';
 import { selectReportSearchOptions } from 'src/selectors/reportSearchOptions';
 import PanelLoading from 'src/components/panelLoading/PanelLoading';
@@ -26,7 +25,7 @@ export class RejectionPage extends Component {
       return <PanelLoading />;
     }
 
-    return <DataTable list={list} addFilters={this.props.addFilters} />;
+    return <DataTable list={list} />;
   }
 
   renderTopLevelMetrics() {
@@ -74,7 +73,6 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = {
-  addFilters,
   refreshRejectionReport
 };
 export default connect(mapStateToProps, mapDispatchToProps)(RejectionPage);

--- a/src/pages/reports/rejection/components/DataTable.js
+++ b/src/pages/reports/rejection/components/DataTable.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { TableCollection, Empty, LongTextContainer } from 'src/components';
-import { UnstyledLink } from '@sparkpost/matchbox';
+import AddFilterLink from '../../components/AddFilterLink';
 
 const columns = [
   { label: 'Reason', width: '45%', sortKey: 'reason' },
@@ -11,11 +11,10 @@ const columns = [
 
 export class DataTable extends Component {
   getRowData = (rowData) => {
-    const { addFilters } = this.props;
     const { reason, domain, rejection_category_name, count_rejected } = rowData;
     return [
       <LongTextContainer text={reason} />,
-      <UnstyledLink onClick={() => addFilters([{ type: 'Recipient Domain', value: domain }])}>{ domain }</UnstyledLink>,
+      <AddFilterLink newFilter={{ type: 'Recipient Domain', value: domain }} reportType={'rejections'} content={domain}/>,
       rejection_category_name,
       count_rejected
     ];

--- a/src/pages/reports/rejection/components/tests/DataTable.test.js
+++ b/src/pages/reports/rejection/components/tests/DataTable.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DataTable } from '../DataTable';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 jest.mock('src/helpers/reports');
 
@@ -42,19 +42,9 @@ describe('Rejection Data Table: ', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  describe('getRowData', () => {
-    it('should render row data properly', () => {
-      const rows = wrapper.instance().getRowData({ reason: 'bad delay', rejection_category_name: 'cat1', count_rejected: 10, domain: 'gmail.com' });
-
-      expect(rows).toMatchSnapshot();
-    });
-
-    it('should filter by domain', () => {
-      const rows = wrapper.instance().getRowData({ reason: 'bad delay', rejection_category_name: 'cat1', count_rejected: 10, domain: 'gmail.com' });
-      const link = mount(rows[1]);
-      link.find('UnstyledLink').simulate('click');
-      expect(props.addFilters).toHaveBeenCalledWith([{ type: 'Recipient Domain', value: 'gmail.com' }]);
-    });
-
+  it('getRowData should render row data properly', () => {
+    const rows = wrapper.instance().getRowData({ reason: 'bad delay', rejection_category_name: 'cat1', count_rejected: 10, domain: 'gmail.com' });
+    expect(rows).toMatchSnapshot();
   });
+
 });

--- a/src/pages/reports/rejection/components/tests/__snapshots__/DataTable.test.js.snap
+++ b/src/pages/reports/rejection/components/tests/__snapshots__/DataTable.test.js.snap
@@ -5,11 +5,16 @@ Array [
   <LongTextContainer
     text="bad delay"
   />,
-  <UnstyledLink
-    onClick={[Function]}
-  >
-    gmail.com
-  </UnstyledLink>,
+  <Connect(AddFilterLink)
+    content="gmail.com"
+    newFilter={
+      Object {
+        "type": "Recipient Domain",
+        "value": "gmail.com",
+      }
+    }
+    reportType="rejections"
+  />,
   "cat1",
   10,
 ]

--- a/src/pages/reports/rejection/tests/RejectionPage.test.js
+++ b/src/pages/reports/rejection/tests/RejectionPage.test.js
@@ -32,7 +32,6 @@ describe('RejectionPage: ', () => {
         count_rejected: 14,
         count_targeted: 100
       },
-      addFilters: jest.fn(),
       refreshRejectionReport: jest.fn()
     };
 

--- a/src/pages/reports/rejection/tests/__snapshots__/RejectionPage.test.js.snap
+++ b/src/pages/reports/rejection/tests/__snapshots__/RejectionPage.test.js.snap
@@ -41,7 +41,6 @@ exports[`RejectionPage:  renders loading pannel when aggregates are still loadin
   />
   <hr />
   <DataTable
-    addFilters={[MockFunction]}
     list={
       Array [
         Object {
@@ -87,7 +86,6 @@ exports[`RejectionPage:  should render 1`] = `
   </Connect(MetricsSummary)>
   <hr />
   <DataTable
-    addFilters={[MockFunction]}
     list={
       Array [
         Object {

--- a/src/pages/reports/summary/components/Table.js
+++ b/src/pages/reports/summary/components/Table.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import cx from 'classnames';
 
 import { _getTableData } from 'src/actions/summaryChart';
+import { addFilters } from 'src/actions/reportOptions';
 import typeaheadCacheSelector from 'src/selectors/reportFilterTypeaheadCache';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 
@@ -14,11 +15,16 @@ import { GROUP_CONFIG } from './tableConfig';
 import _ from 'lodash';
 
 import styles from './Table.module.scss';
-import qs from 'query-string';
+import qs from 'qs';
 import { stringifyTypeaheadfilter } from 'src/helpers/string';
 import { selectSummaryChartSearchOptions } from 'src/selectors/reportSearchOptions';
 
 export class Table extends Component {
+
+  handleRowClick = (item, e) => {
+    this.props.addFilters([item]);
+    e.preventDefault();
+  };
 
   getColumnHeaders() {
     const { metrics, groupBy } = this.props;
@@ -66,9 +72,9 @@ export class Table extends Component {
 
       const currentFilters = searchOptions.filters || [];
       const mergedFilters = _.uniqWith([ ...currentFilters, stringifyTypeaheadfilter(filter)], _.isEqual);
-      const linkParams = qs.stringify({ ...searchOptions, filters: mergedFilters });
+      const linkParams = qs.stringify({ ...searchOptions, filters: mergedFilters }, { arrayFormat: 'repeat' });
 
-      const primaryCol = groupBy === 'aggregate' ? 'Aggregate Total' : <UnstyledLink to={`/reports/summary/?${linkParams}`}>{filter.value}</UnstyledLink>;
+      const primaryCol = groupBy === 'aggregate' ? 'Aggregate Total' : <UnstyledLink onClick={(e) => this.handleRowClick(filter, e)} to={`/reports/summary/?${linkParams}`}>{filter.value} </UnstyledLink>;
       const metricCols = metrics.map((metric) => (
         <div className={styles.RightAlign}>
           <Unit value={row[metric.key]} unit={metric.unit}/>
@@ -159,4 +165,4 @@ const mapStateToProps = (state) => ({
   searchOptions: selectSummaryChartSearchOptions(state),
   ...state.summaryChart
 });
-export default connect(mapStateToProps, { _getTableData })(Table);
+export default connect(mapStateToProps, { _getTableData, addFilters })(Table);

--- a/src/pages/reports/summary/components/tests/Table.test.js
+++ b/src/pages/reports/summary/components/tests/Table.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Table } from '../Table';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import _ from 'lodash';
 
 describe('Summary Table', () => {
@@ -8,7 +8,6 @@ describe('Summary Table', () => {
   let wrapper;
 
   const props = {
-    addFilters: jest.fn(),
     _getTableData: jest.fn(),
     refresh: jest.fn(),
     metrics: [
@@ -21,10 +20,7 @@ describe('Summary Table', () => {
     ],
     tableData: [],
     tableLoading: false,
-    hasSubaccounts: false,
-    searchOptions: {
-      filters: []
-    }
+    hasSubaccounts: false
   };
 
   const data = [
@@ -51,24 +47,11 @@ describe('Summary Table', () => {
     expect(wrapper.find('Loading')).toHaveLength(1);
   });
 
-  describe('group by', () => {
-    let snaps;
-    beforeEach(() => {
-      wrapper.setProps({ groupBy: 'subaccount' });
-      const func = wrapper.instance().getRowData();
-      const results = _.flatten(data.map(func));
-
-      snaps = _.map(results, (item) => mount(item));
-    });
-
-    it('should render row data', () => {
-      expect(snaps).toMatchSnapshot();
-    });
-
-    it('should handle row click', () => {
-      snaps[0].find('UnstyledLink').simulate('click');
-      expect(props.addFilters).toHaveBeenCalledWith([{ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' }]);
-    });
+  it('should render group by row data', () => {
+    wrapper.setProps({ groupBy: 'subaccount' });
+    const func = wrapper.instance().getRowData();
+    const results = _.flatten(data.map(func));
+    expect(results).toMatchSnapshot();
   });
 
   it('should render with aggregate data', () => {

--- a/src/pages/reports/summary/components/tests/Table.test.js
+++ b/src/pages/reports/summary/components/tests/Table.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Table } from '../Table';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import _ from 'lodash';
 
 describe('Summary Table', () => {
@@ -51,17 +51,24 @@ describe('Summary Table', () => {
     expect(wrapper.find('Loading')).toHaveLength(1);
   });
 
-  it('should render row data', () => {
-    const snaps = [];
-    wrapper.setProps({ groupBy: 'subaccount' });
-    const func = wrapper.instance().getRowData();
-    const results = _.flatten(data.map(func));
+  describe('group by', () => {
+    let snaps;
+    beforeEach(() => {
+      wrapper.setProps({ groupBy: 'subaccount' });
+      const func = wrapper.instance().getRowData();
+      const results = _.flatten(data.map(func));
 
-    _.each(results, (item, i) => {
-      snaps.push(shallow(item));
+      snaps = _.map(results, (item) => mount(item));
     });
 
-    expect(snaps).toMatchSnapshot();
+    it('should render row data', () => {
+      expect(snaps).toMatchSnapshot();
+    });
+
+    it('should handle row click', () => {
+      snaps[0].find('UnstyledLink').simulate('click');
+      expect(props.addFilters).toHaveBeenCalledWith([{ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' }]);
+    });
   });
 
   it('should render with aggregate data', () => {

--- a/src/pages/reports/summary/components/tests/Table.test.js
+++ b/src/pages/reports/summary/components/tests/Table.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Table } from '../Table';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import _ from 'lodash';
 
-describe('Summary Table ', () => {
+describe('Summary Table', () => {
 
   let wrapper;
 
@@ -21,7 +21,10 @@ describe('Summary Table ', () => {
     ],
     tableData: [],
     tableLoading: false,
-    hasSubaccounts: false
+    hasSubaccounts: false,
+    searchOptions: {
+      filters: []
+    }
   };
 
   const data = [
@@ -48,20 +51,17 @@ describe('Summary Table ', () => {
     expect(wrapper.find('Loading')).toHaveLength(1);
   });
 
-  it('should render row data & handle click', () => {
+  it('should render row data', () => {
     const snaps = [];
     wrapper.setProps({ groupBy: 'subaccount' });
     const func = wrapper.instance().getRowData();
     const results = _.flatten(data.map(func));
 
     _.each(results, (item, i) => {
-      snaps.push(mount(item));
+      snaps.push(shallow(item));
     });
 
     expect(snaps).toMatchSnapshot();
-
-    snaps[0].find('UnstyledLink').simulate('click');
-    expect(props.addFilters).toHaveBeenCalledWith([{ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' }]);
   });
 
   it('should render with aggregate data', () => {

--- a/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
@@ -1,24 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Summary Table  should render row data & handle click 1`] = `
+exports[`Summary Table should render row data 1`] = `
 Array [
-  <UnstyledLink
-    onClick={[Function]}
+  <a
+    href="/reports/summary/?filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
+    rel=""
+    target=""
   >
-    <a
-      onClick={[Function]}
-    >
-      Master Account (ID 0)
-    </a>
-  </UnstyledLink>,
+    Master Account (ID 0)
+  </a>,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    >
-      123
-    </Unit>
+    />
   </div>,
   <div
     className="RightAlign"
@@ -26,27 +22,21 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    >
-      12,345
-    </Unit>
+    />
   </div>,
-  <UnstyledLink
-    onClick={[Function]}
+  <a
+    href="/reports/summary/?filters=Subaccount%3Asub%201%20name%3A555"
+    rel=""
+    target=""
   >
-    <a
-      onClick={[Function]}
-    >
-      sub 1 name
-    </a>
-  </UnstyledLink>,
+    sub 1 name
+  </a>,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    >
-      123
-    </Unit>
+    />
   </div>,
   <div
     className="RightAlign"
@@ -54,27 +44,21 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    >
-      12,345
-    </Unit>
+    />
   </div>,
-  <UnstyledLink
-    onClick={[Function]}
+  <a
+    href="/reports/summary/?filters=Subaccount%3ADeleted%20%28ID%201010%29%3A1010"
+    rel=""
+    target=""
   >
-    <a
-      onClick={[Function]}
-    >
-      Deleted (ID 1010)
-    </a>
-  </UnstyledLink>,
+    Deleted (ID 1010)
+  </a>,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    >
-      123
-    </Unit>
+    />
   </div>,
   <div
     className="RightAlign"
@@ -82,14 +66,12 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    >
-      12,345
-    </Unit>
+    />
   </div>,
 ]
 `;
 
-exports[`Summary Table  should render with aggregate data 1`] = `
+exports[`Summary Table should render with aggregate data 1`] = `
 <TableCollection
   defaultSortColumn={null}
   defaultSortDirection="asc"
@@ -107,7 +89,7 @@ exports[`Summary Table  should render with aggregate data 1`] = `
 />
 `;
 
-exports[`Summary Table  should render with data 1`] = `
+exports[`Summary Table should render with data 1`] = `
 <TableCollection
   columns={
     Array [
@@ -162,7 +144,7 @@ exports[`Summary Table  should render with data 1`] = `
 />
 `;
 
-exports[`Summary Table  should render with no data 1`] = `
+exports[`Summary Table should render with no data 1`] = `
 <Panel>
   <Panel.Section>
     <GroupByOption

--- a/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
@@ -1,29 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Summary Table group by should render row data 1`] = `
+exports[`Summary Table should render group by row data 1`] = `
 Array [
-  <UnstyledLink
-    onClick={[Function]}
-    to="/reports/summary/?filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
-  >
-    <a
-      href="/reports/summary/?filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
-      onClick={[Function]}
-      rel=""
-      target=""
-    >
-      Master Account (ID 0)
-       
-    </a>
-  </UnstyledLink>,
+  <Connect(AddFilterLink)
+    content="Master Account (ID 0)"
+    newFilter={
+      Object {
+        "id": 0,
+        "type": "Subaccount",
+        "value": "Master Account (ID 0)",
+      }
+    }
+    reportType="summary"
+  />,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    >
-      123
-    </Unit>
+    />
   </div>,
   <div
     className="RightAlign"
@@ -31,32 +26,25 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    >
-      12,345
-    </Unit>
+    />
   </div>,
-  <UnstyledLink
-    onClick={[Function]}
-    to="/reports/summary/?filters=Subaccount%3Asub%201%20name%3A555"
-  >
-    <a
-      href="/reports/summary/?filters=Subaccount%3Asub%201%20name%3A555"
-      onClick={[Function]}
-      rel=""
-      target=""
-    >
-      sub 1 name
-       
-    </a>
-  </UnstyledLink>,
+  <Connect(AddFilterLink)
+    content="sub 1 name"
+    newFilter={
+      Object {
+        "id": 555,
+        "type": "Subaccount",
+        "value": "sub 1 name",
+      }
+    }
+    reportType="summary"
+  />,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    >
-      123
-    </Unit>
+    />
   </div>,
   <div
     className="RightAlign"
@@ -64,32 +52,25 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    >
-      12,345
-    </Unit>
+    />
   </div>,
-  <UnstyledLink
-    onClick={[Function]}
-    to="/reports/summary/?filters=Subaccount%3ADeleted%20%28ID%201010%29%3A1010"
-  >
-    <a
-      href="/reports/summary/?filters=Subaccount%3ADeleted%20%28ID%201010%29%3A1010"
-      onClick={[Function]}
-      rel=""
-      target=""
-    >
-      Deleted (ID 1010)
-       
-    </a>
-  </UnstyledLink>,
+  <Connect(AddFilterLink)
+    content="Deleted (ID 1010)"
+    newFilter={
+      Object {
+        "id": 1010,
+        "type": "Subaccount",
+        "value": "Deleted (ID 1010)",
+      }
+    }
+    reportType="summary"
+  />,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    >
-      123
-    </Unit>
+    />
   </div>,
   <div
     className="RightAlign"
@@ -97,9 +78,7 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    >
-      12,345
-    </Unit>
+    />
   </div>,
 ]
 `;

--- a/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/Table.test.js.snap
@@ -1,20 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Summary Table should render row data 1`] = `
+exports[`Summary Table group by should render row data 1`] = `
 Array [
-  <a
-    href="/reports/summary/?filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
-    rel=""
-    target=""
+  <UnstyledLink
+    onClick={[Function]}
+    to="/reports/summary/?filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
   >
-    Master Account (ID 0)
-  </a>,
+    <a
+      href="/reports/summary/?filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
+      onClick={[Function]}
+      rel=""
+      target=""
+    >
+      Master Account (ID 0)
+       
+    </a>
+  </UnstyledLink>,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    />
+    >
+      123
+    </Unit>
   </div>,
   <div
     className="RightAlign"
@@ -22,21 +31,32 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    />
+    >
+      12,345
+    </Unit>
   </div>,
-  <a
-    href="/reports/summary/?filters=Subaccount%3Asub%201%20name%3A555"
-    rel=""
-    target=""
+  <UnstyledLink
+    onClick={[Function]}
+    to="/reports/summary/?filters=Subaccount%3Asub%201%20name%3A555"
   >
-    sub 1 name
-  </a>,
+    <a
+      href="/reports/summary/?filters=Subaccount%3Asub%201%20name%3A555"
+      onClick={[Function]}
+      rel=""
+      target=""
+    >
+      sub 1 name
+       
+    </a>
+  </UnstyledLink>,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    />
+    >
+      123
+    </Unit>
   </div>,
   <div
     className="RightAlign"
@@ -44,21 +64,32 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    />
+    >
+      12,345
+    </Unit>
   </div>,
-  <a
-    href="/reports/summary/?filters=Subaccount%3ADeleted%20%28ID%201010%29%3A1010"
-    rel=""
-    target=""
+  <UnstyledLink
+    onClick={[Function]}
+    to="/reports/summary/?filters=Subaccount%3ADeleted%20%28ID%201010%29%3A1010"
   >
-    Deleted (ID 1010)
-  </a>,
+    <a
+      href="/reports/summary/?filters=Subaccount%3ADeleted%20%28ID%201010%29%3A1010"
+      onClick={[Function]}
+      rel=""
+      target=""
+    >
+      Deleted (ID 1010)
+       
+    </a>
+  </UnstyledLink>,
   <div
     className="RightAlign"
   >
     <Unit
       value={123}
-    />
+    >
+      123
+    </Unit>
   </div>,
   <div
     className="RightAlign"
@@ -66,7 +97,9 @@ Array [
     <Unit
       unit="millisecond"
       value={12345}
-    />
+    >
+      12,345
+    </Unit>
   </div>,
 ]
 `;


### PR DESCRIPTION
### What Changed
 - Added a href to the summary table. 
 - Stop the page from redirecting if just adding a new filter on the existing page.

### How To Test
 -Go to summary reports under reports/summary. 
 - Change the group by in the table to another filter type.
 - Click on the filter link. It should add another filter without refreshing the page.
 - Verify that you can right click on the filter and open a new tab as well. 