### PR TITLE
SA-856 - Add cmd+click functionality to reports' tables.

### DIFF
--- a/src/pages/reports/components/AddFilterLink.js
+++ b/src/pages/reports/components/AddFilterLink.js
@@ -21,8 +21,11 @@ export const AddFilterLink = ({
 
   const currentFilters = currentSearchOptions.filters || [];
 
-  //Needs to first check if cmd/ctrl key is pressed when mouse is released
-  //Then it's saved for use in the onClick handler.
+  /**
+   * Needs to first check if cmd/ctrl key is pressed when mouse is released
+   * Then it's saved for use in the onClick handler. We need both because
+   * onClick does not have the correct values for metaKey and ctrlKey
+   **/
   const handleMouseUp = (e) => {
     setNewTabKeyPressed(e.metaKey || e.ctrlKey);
   };

--- a/src/pages/reports/components/AddFilterLink.js
+++ b/src/pages/reports/components/AddFilterLink.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import qs from 'qs';
@@ -6,7 +6,7 @@ import qs from 'qs';
 import { addFilters } from 'src/actions/reportOptions';
 import { stringifyTypeaheadfilter } from 'src/helpers/string';
 import { selectReportSearchOptions, selectSummaryChartSearchOptions } from 'src/selectors/reportSearchOptions';
-import { UnstyledLink } from '@sparkpost/matchbox';
+import { PageLink } from 'src/components';
 
 export const AddFilterLink = ({
   //From parent
@@ -17,12 +17,20 @@ export const AddFilterLink = ({
   currentSearchOptions,
   addFilters }) => {
 
+  const [isNewTabKeyPressed, setNewTabKeyPressed] = useState(false);
+
   const currentFilters = currentSearchOptions.filters || [];
 
-  const handleOnClick = (e) => {
-    addFilters([newFilter]);
-    //This prevents the browser from following the link and reloading the page.
-    e.preventDefault();
+  //Needs to first check if cmd/ctrl key is pressed when mouse is released
+  //Then it's saved for use in the onClick handler.
+  const handleMouseUp = (e) => {
+    setNewTabKeyPressed(e.metaKey || e.ctrlKey);
+  };
+
+  const handleClick = () => {
+    if (!isNewTabKeyPressed) {
+      addFilters([newFilter]);
+    }
   };
 
   const mergedFilters = _.uniqWith([ ...currentFilters, stringifyTypeaheadfilter(newFilter)], _.isEqual);
@@ -31,7 +39,7 @@ export const AddFilterLink = ({
   const fullLink = `/reports/${reportType}/?${linkParams}`;
 
   return (
-    <UnstyledLink onClick={handleOnClick} to={fullLink}>{content}</UnstyledLink>
+    <PageLink onMouseUp={handleMouseUp} onClick={handleClick} to={fullLink} replace>{content}</PageLink>
   );
 };
 

--- a/src/pages/reports/components/tests/AddFilterLink.test.js
+++ b/src/pages/reports/components/tests/AddFilterLink.test.js
@@ -32,10 +32,23 @@ describe('Add Filter Link', () => {
 
   it('should handle click correctly', () => {
     const wrapper = subject();
-    const preventDefaultMock = jest.fn();
-    wrapper.find('UnstyledLink').simulate('click', { preventDefault: preventDefaultMock });
+    wrapper.find('PageLink').simulate('mouseUp', {});
+    wrapper.find('PageLink').simulate('click');
 
     expect(baseProps.addFilters).toHaveBeenCalledWith([{ id: 0, type: 'Subaccount', value: 'Master Account (ID 0)' }]);
-    expect(preventDefaultMock).toHaveBeenCalled();
+  });
+
+  it('should handle click while holding down meta(cmd) key correctly', () => {
+    const wrapper = subject();
+    wrapper.find('PageLink').simulate('mouseUp', { metaKey: true });
+    wrapper.find('PageLink').simulate('click');
+    expect(baseProps.addFilters).not.toHaveBeenCalled();
+  });
+
+  it('should handle click while holding down control key correctly', () => {
+    const wrapper = subject();
+    wrapper.find('PageLink').simulate('mouseUp', { ctrlKey: true });
+    wrapper.find('PageLink').simulate('click');
+    expect(baseProps.addFilters).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/reports/components/tests/__snapshots__/AddFilterLink.test.js.snap
+++ b/src/pages/reports/components/tests/__snapshots__/AddFilterLink.test.js.snap
@@ -1,19 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Add Filter Link should render correctly for other reports and should not include metrics in the link 1`] = `
-<UnstyledLink
+<PageLink
   onClick={[Function]}
+  onMouseUp={[Function]}
+  replace={true}
   to="/reports/bounce/?filters=Campaign%3A%20shiny%20new%20filter&filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0"
 >
   master account
-</UnstyledLink>
+</PageLink>
 `;
 
 exports[`Add Filter Link should render correctly for the summary report and include metrics in the link 1`] = `
-<UnstyledLink
+<PageLink
   onClick={[Function]}
+  onMouseUp={[Function]}
+  replace={true}
   to="/reports/summary/?filters=Campaign%3A%20shiny%20new%20filter&filters=Subaccount%3AMaster%20Account%20%28ID%200%29%3A0&metrics=count_something"
 >
   master account
-</UnstyledLink>
+</PageLink>
 `;


### PR DESCRIPTION
### What Changed
 - Added an onMouseUp check to see if the command/control key is being pressed. If so, then don't add a new filter but allow the default behavior, which is to open in new tab.
 - Changed `UnstyledLink` to `PageLink`.

### How To Test
 -Go to summary reports under reports/summary. 
 - Change the group by in the table to another filter type.
 - Click on the filter link. It should add another filter without refreshing the page.
 - Verify that you can command+click on the filter and open a new tab as well. 
 - Do the same for rejections, bounce, and delayed.