### PR TITLE
SA-874 Make filter box appear for all tables + inbox placement list page changes

### DIFF
--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -5,7 +5,6 @@ import qs from 'query-string';
 import _ from 'lodash';
 import { withRouter } from 'react-router-dom';
 import Pagination from './Pagination';
-import { DEFAULT_PER_PAGE_BUTTONS } from 'src/constants';
 import FilterBox from './FilterBox';
 import { objectSortMatch } from 'src/helpers/sortMatch';
 
@@ -104,8 +103,8 @@ export class Collection extends Component {
   }
 
   renderFilterBox() {
-    const { filterBox, rows, perPageButtons = DEFAULT_PER_PAGE_BUTTONS } = this.props;
-    if (filterBox.show && (rows.length > Math.min(...perPageButtons))) {
+    const { filterBox, rows } = this.props;
+    if (filterBox.show) {
       return <FilterBox {...filterBox} rows={rows} onChange={this.debouncedHandleFilterChange} />;
     }
     return null;

--- a/src/pages/inboxPlacement/TestListPage.module.scss
+++ b/src/pages/inboxPlacement/TestListPage.module.scss
@@ -16,7 +16,7 @@
 }
 
 .FilterBox {
-  width: 80%;
+  width: 100%;
   float: left;
   margin: 0 spacing() 0 0;
 }

--- a/src/pages/inboxPlacement/components/FilterSortCollection.js
+++ b/src/pages/inboxPlacement/components/FilterSortCollection.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Select, Panel, Table } from '@sparkpost/matchbox';
+import { Select, Panel, Table, Grid } from '@sparkpost/matchbox';
 import { Collection } from 'src/components';
 import _ from 'lodash';
 import styles from './FilterSortCollection.module.scss';
@@ -18,11 +18,9 @@ const FilterSortCollection = ({ wrapperComponent, title, selectOptions, filterBo
   const TableBody = (props) => <tbody>{props.children}</tbody>;
 
   const CollectionWrapperComponent = (props) => (
-    <>
-      <div className={styles.TableWrapper}>
-        <Table>{props.children}</Table>
-      </div>
-    </>
+    <div className={styles.TableWrapper}>
+      <Table>{props.children}</Table>
+    </div>
   );
 
   const WrapperComponent = wrapperComponent ? wrapperComponent : CollectionWrapperComponent;
@@ -46,17 +44,21 @@ const FilterSortCollection = ({ wrapperComponent, title, selectOptions, filterBo
           <Panel.Section className = {styles.Title}>
             <h3>{title}</h3>
           </Panel.Section>
-          <Panel.Section>
-            <div className = {styles.FilterPanel}>
-              {filterBox}
-              <Select
-                id='sortSelect'
-                value='Sort By'
-                options={selectOptions}
-                onChange={sortOnChange}
-              />
-            </div>
-          </Panel.Section>
+          <div className = {styles.FilterPanel}>
+            <Grid>
+              <Grid.Column xs={12} md={9}>
+                {filterBox}
+              </Grid.Column>
+              <Grid.Column xs={12} md={3}>
+                <Select
+                  id='sortSelect'
+                  defaultValue={defaultSortColumn}
+                  options={selectOptions}
+                  onChange={sortOnChange}
+                />
+              </Grid.Column>
+            </Grid>
+          </div>
           {collection}
         </Panel>
         {pagination}

--- a/src/pages/inboxPlacement/components/FilterSortCollection.module.scss
+++ b/src/pages/inboxPlacement/components/FilterSortCollection.module.scss
@@ -1,11 +1,11 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 .Title {
-  padding: spacing(larger) 2rem;
+  padding: spacing(base) 1rem;
 }
 
 .FilterPanel {
-  padding: 0 1rem 0 1rem;
+  padding: 1rem 1rem 0;
   align-items: center;
   justify-content: center;
 }


### PR DESCRIPTION
### What Changed
 - Made the filter box appear for all tables.
 - Fixed the design of FilterSortCollection. Not sure why it broke?

### How To Test
 - Go to /inbox-placement and see that the filterbox appears and looks like the mocks. 
 - Quick check of other tables to make sure nothing's broken. Might need to make a new account to get <10 items.
