### PR TITLE
Sa 873 - Fix Test Name rendering in list and details page

### DIFF
--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -61,11 +61,11 @@ const FilterSortCollectionRow = ({ id, status, subject, test_name, from_address,
             </div>
             <div className = {styles.TestName}>
               {test_name &&
-                <>
+                <span id={'testName'}>
                   <strong>{test_name}</strong>
                   <strong className = {styles.Divider}>{'|'}</strong>
-                </>}
-              <span>{from_address}</span>
+                </span>}
+              <span id={'fromAddress'}>{from_address}</span>
             </div>
             <div className = {styles.TestSchedule}>
               <span ><Schedule className={styles.ScheduleIcon}/></span>

--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -34,14 +34,14 @@ const filterBoxConfig = {
     </div>)
 };
 
-const FilterSortCollectionRow = ({ id, status, subject, test_name, from_address, start_time, end_time, placement }, iterator) => (
+const FilterSortCollectionRow = ({ id, status, subject, test_name, from_address, start_time, end_time, placement }) => (
   [
     <Table.Row
-      key={iterator}
+      key={id}
       className={styles.TableRow}
       rowData={[
-        <div className = {styles.TabbedCellBody}>
-          <div className = {styles.SubjectContainer}>
+        <div className={styles.TabbedCellBody}>
+          <div className={styles.SubjectContainer}>
             <div className={styles.TooltipWrapper}>
               <Tooltip
                 disabled={status === STATUS.COMPLETED}
@@ -59,16 +59,17 @@ const FilterSortCollectionRow = ({ id, status, subject, test_name, from_address,
                 <strong>{subject}</strong>
               </PageLink>
             </div>
-            <div className = {styles.TestName}>
-              {test_name &&
-                <span id={'testName'}>
+            <div className={styles.TestName}>
+              {test_name && (
+                <>
                   <strong>{test_name}</strong>
-                  <strong className = {styles.Divider}>{'|'}</strong>
-                </span>}
-              <span id={'fromAddress'}>{from_address}</span>
+                  <strong className={styles.Divider}>{'|'}</strong>
+                </>
+              )}
+              <span>{from_address}</span>
             </div>
-            <div className = {styles.TestSchedule}>
-              <span ><Schedule className={styles.ScheduleIcon}/></span>
+            <div className={styles.TestSchedule}>
+              <span><Schedule className={styles.ScheduleIcon}/></span>
               <span>{formatScheduleLine(status, start_time, end_time)}</span>
             </div>
           </div>

--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -60,8 +60,11 @@ const FilterSortCollectionRow = ({ id, status, subject, test_name, from_address,
               </PageLink>
             </div>
             <div className = {styles.TestName}>
-              <strong>{test_name}</strong>
-              <strong className = {styles.Divider}>{'|'}</strong>
+              {test_name &&
+                <>
+                  <strong>{test_name}</strong>
+                  <strong className = {styles.Divider}>{'|'}</strong>
+                </>}
               <span>{from_address}</span>
             </div>
             <div className = {styles.TestSchedule}>

--- a/src/pages/inboxPlacement/TestListPage.module.scss
+++ b/src/pages/inboxPlacement/TestListPage.module.scss
@@ -30,10 +30,6 @@
   align-items: center;
   justify-content: center;
   font-size: large;
-
-  strong {
-    color: color(blue, dark);
-  }
 }
 
 .Subject {

--- a/src/pages/inboxPlacement/components/TestDetails.js
+++ b/src/pages/inboxPlacement/components/TestDetails.js
@@ -26,7 +26,7 @@ const TestDetails = ({ details, placementsByProvider }) => {
             <InfoBlock value={format(details.start_time, FORMATS.LONG_DATETIME)} label='Started'/>
             <InfoBlock value={details.end_time ? format(details.end_time, FORMATS.LONG_DATETIME) : '--'}
               label='Finished'/>
-            <InfoBlock value='test_name' label='Inbox Placement Test Name'/>
+            <InfoBlock value={details.test_name || 'None'} label='Inbox Placement Test Name'/>
           </Grid>
 
         </Panel.Section>

--- a/src/pages/inboxPlacement/components/tests/TestDetails.test.js
+++ b/src/pages/inboxPlacement/components/tests/TestDetails.test.js
@@ -29,7 +29,7 @@ describe('Component: TestDetails', () => {
       subject: 'Fooo'
     };
     const wrapper = subject({ details: detailsWithoutName });
-    expect(wrapper.find('InfoBlock').at(3).prop('value')).toEqual('None');
+    expect(wrapper.find('InfoBlock').at(3)).toHaveProp('value', 'None');
   });
 
   it('renders providers breakdown correctly', () => {

--- a/src/pages/inboxPlacement/components/tests/TestDetails.test.js
+++ b/src/pages/inboxPlacement/components/tests/TestDetails.test.js
@@ -10,7 +10,8 @@ describe('Component: TestDetails', () => {
       details: {
         start_time: '2019-07-08T15:49:56.954Z',
         end_time: null,
-        subject: 'Fooo'
+        subject: 'Fooo',
+        test_name: 'Baz'
       },
       placementsByProvider: []
     };
@@ -19,6 +20,16 @@ describe('Component: TestDetails', () => {
 
   it('renders correctly', () => {
     expect(subject()).toMatchSnapshot();
+  });
+
+  it('renders test name as None when it does not exist', () => {
+    const detailsWithoutName = {
+      start_time: '2019-07-08T15:49:56.954Z',
+      end_time: null,
+      subject: 'Fooo'
+    };
+    const wrapper = subject({ details: detailsWithoutName });
+    expect(wrapper.find('InfoBlock').at(3).prop('value')).toEqual('None');
   });
 
   it('renders providers breakdown correctly', () => {

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/TestDetails.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/TestDetails.test.js.snap
@@ -26,7 +26,7 @@ exports[`Component: TestDetails renders correctly 1`] = `
         />
         <InfoBlock
           label="Inbox Placement Test Name"
-          value="test_name"
+          value="Baz"
         />
       </Grid>
     </Panel.Section>

--- a/src/pages/inboxPlacement/tests/TestListPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestListPage.test.js
@@ -43,4 +43,15 @@ describe('Page: Test List', () => {
     const wrapper = subject({ error: true });
     expect(wrapper.find('ApiErrorBanner')).toExist();
   });
+
+  it('doest not render test name and divider if test name does not exist', () => {
+    const wrapper = subject();
+    const rowFn = wrapper.find('FilterSortCollection').prop('rowComponent');
+
+    const { test_name, ...testWithoutName } = tests[0];
+    const row = rowFn(testWithoutName)[0];
+    const firstColumn = (shallow(shallow(row).prop('children')[0]));
+    expect(firstColumn.find({ id: 'testName' })).not.toExist();
+    expect(firstColumn.find({ id: 'fromAddress' })).toExist();
+  });
 });

--- a/src/pages/inboxPlacement/tests/TestListPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestListPage.test.js
@@ -5,7 +5,6 @@ import { tests } from './mockTests';
 import { TestListPage } from '../TestListPage';
 
 describe('Page: Test List', () => {
-
   const subject = ({ ...props }) => {
     const defaults = {
       testsError: false,
@@ -13,6 +12,7 @@ describe('Page: Test List', () => {
       tests: [],
       listTests: jest.fn()
     };
+
     return shallow(<TestListPage {...defaults} {...props} />);
   };
 
@@ -45,26 +45,22 @@ describe('Page: Test List', () => {
   });
 
   describe('Test Name:', () => {
-
-    const renderFirstColumn = (rowProps) => {
+    const renderFirstColumn = (props) => {
       const wrapper = subject();
-      const rowFn = wrapper.find('FilterSortCollection').prop('rowComponent');
-      const row = rowFn(rowProps)[0];
-      return shallow(shallow(row).prop('children')[0]);
+      const Rows = wrapper.find('FilterSortCollection').prop('rowComponent');
+      const Row = () => shallow(<Rows {...tests[0]} {...props} />).prop('rowData');
+
+      return shallow(<Row />);
     };
 
     it('render test name and divider if test name exists', () => {
-      const firstColumn = renderFirstColumn(tests[0]);
-      const spanTexts = firstColumn.find('span');
-      expect(spanTexts.someWhere((text) => (text).text().includes(tests[0].test_name))).toEqual(true);
+      const wrapper = renderFirstColumn();
+      expect(wrapper.at(0)).toIncludeText(tests[0].test_name);
     });
 
     it('doest not render test name and divider if test name does not exist', () => {
-      const { test_name, ...testWithoutName } = tests[0];
-      const firstColumn = renderFirstColumn(testWithoutName);
-      const spanTexts = firstColumn.find('span');
-      expect(spanTexts.someWhere((text) => (text).text().includes(tests[0].from_address))).toEqual(true);
-      expect(spanTexts.someWhere((text) => (text).text().includes(tests[0].test_name))).toEqual(false);
+      const wrapper = renderFirstColumn({ test_name: undefined });
+      expect(wrapper.at(0)).not.toIncludeText('|');
     });
   });
 });

--- a/src/pages/inboxPlacement/tests/TestListPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestListPage.test.js
@@ -44,14 +44,27 @@ describe('Page: Test List', () => {
     expect(wrapper.find('ApiErrorBanner')).toExist();
   });
 
-  it('doest not render test name and divider if test name does not exist', () => {
-    const wrapper = subject();
-    const rowFn = wrapper.find('FilterSortCollection').prop('rowComponent');
+  describe('Test Name:', () => {
 
-    const { test_name, ...testWithoutName } = tests[0];
-    const row = rowFn(testWithoutName)[0];
-    const firstColumn = (shallow(shallow(row).prop('children')[0]));
-    expect(firstColumn.find({ id: 'testName' })).not.toExist();
-    expect(firstColumn.find({ id: 'fromAddress' })).toExist();
+    const renderFirstColumn = (rowProps) => {
+      const wrapper = subject();
+      const rowFn = wrapper.find('FilterSortCollection').prop('rowComponent');
+      const row = rowFn(rowProps)[0];
+      return shallow(shallow(row).prop('children')[0]);
+    };
+
+    it('render test name and divider if test name exists', () => {
+      const firstColumn = renderFirstColumn(tests[0]);
+      const spanTexts = firstColumn.find('span');
+      expect(spanTexts.someWhere((text) => (text).text().includes(tests[0].test_name))).toEqual(true);
+    });
+
+    it('doest not render test name and divider if test name does not exist', () => {
+      const { test_name, ...testWithoutName } = tests[0];
+      const firstColumn = renderFirstColumn(testWithoutName);
+      const spanTexts = firstColumn.find('span');
+      expect(spanTexts.someWhere((text) => (text).text().includes(tests[0].from_address))).toEqual(true);
+      expect(spanTexts.someWhere((text) => (text).text().includes(tests[0].test_name))).toEqual(false);
+    });
   });
 });

--- a/src/reducers/inboxPlacement.js
+++ b/src/reducers/inboxPlacement.js
@@ -15,18 +15,21 @@ export default (state = initialState, { type, payload }) => {
       return { ...state, testsPending: false, testsError: payload };
     case 'LIST_TESTS_SUCCESS':
       return { ...state, tests: payload, testsPending: false, testsError: null };
+
     case 'GET_SEEDS_PENDING':
       return { ...state, seedsPending: true, seedsError: null };
     case 'GET_SEEDS_SUCCESS':
       return { ...state, seedsPending: false, seeds: payload, seedsError: null };
     case 'GET_SEEDS_FAIL':
       return { ...state, seedsPending: false, seedsError: payload };
+
     case 'GET_INBOX_PLACEMENT_TEST_PENDING':
       return { ...state, getTestPending: true, getTestError: null };
     case 'GET_INBOX_PLACEMENT_TEST_SUCCESS':
       return { ...state, getTestPending: false, currentTestDetails: payload, getTestError: null };
     case 'GET_INBOX_PLACEMENT_TEST_FAIL':
       return { ...state, getTestPending: false, getTestError: payload };
+
     case 'STOP_INBOX_PLACEMENT_TEST_PENDING':
       return { ...state, stopTestPending: true, stopTestError: null };
     case 'STOP_INBOX_PLACEMENT_TEST_SUCCESS':


### PR DESCRIPTION
### What Changed
 - Don't render test name and the divider if the name is not present.
 - Make the details page actually render the test name rather than the string. Or `None` if not exist.

### How To Test
 - Go to/inbox-placement. Check that the table does not show the divider. 
 - Click on any of the tests. Check that the test name is `None` in the details page. 