### PR TITLE
AC-983: New Billing Plan Select

### DIFF
--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -44,7 +44,7 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
           </span>
           : <span> FREE </span>}
       </span>
-      <span className={styles.SupportLabel}>
+      <span className={styles.SupportLabel} {...rest}>
         {showOverage && overage}
         {showIp && ip}
       </span>

--- a/src/components/billing/PlanPrice.module.scss
+++ b/src/components/billing/PlanPrice.module.scss
@@ -15,7 +15,6 @@
 
 .SupportLabel {
   display: block;
-  color: color(gray, 2);
   font-size: font-size(500);
   font-weight: 400;
 }

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -23,7 +23,7 @@ exports[`PlanPrice allows class name overriding 1`] = `
     </span>
   </span>
   <span
-    className="SupportLabel"
+    className="abcd-class"
   />
 </span>
 `;

--- a/src/pages/billing/ChangePlanPage.js
+++ b/src/pages/billing/ChangePlanPage.js
@@ -3,12 +3,17 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Page } from '@sparkpost/matchbox';
 import { PendingPlanBanner } from './components/Banners';
-import ChangePlanForm from './forms/ChangePlanForm';
+import OldChangePlanForm from './forms/ChangePlanForm'; //TODO: Replace in AC-991
 import { canChangePlanSelector } from 'src/selectors/accountBillingInfo';
+import NewChangePlanForm from './forms/NewChangePlanForm';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 
 export class ChangePlanPage extends Component {
 
   render() {
+    //TODO: Remove in AC-991
+    const ChangePlanForm = this.props.newChangePlan ? NewChangePlanForm : OldChangePlanForm;
+
     return (
       <Page breadcrumbAction={{ content: 'Back to billing', to: '/account/billing', Component: Link }}>
         <PendingPlanBanner account={this.props.account} />
@@ -20,7 +25,8 @@ export class ChangePlanPage extends Component {
 
 const mapStateToProps = (state) => ({
   account: state.account,
-  canChangePlan: canChangePlanSelector(state)
+  canChangePlan: canChangePlanSelector(state),
+  newChangePlan: isAccountUiOptionSet('account_feature_limits')(state)
 });
 
 export default connect(mapStateToProps)(ChangePlanPage);

--- a/src/pages/billing/components/CurrentPlanSection.js
+++ b/src/pages/billing/components/CurrentPlanSection.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Panel } from '@sparkpost/matchbox';
+import PlanPrice from 'src/components/billing/PlanPrice';
+import styles from './CurrentPlanSection.module.scss';
+import { PLAN_TIERS } from 'src/constants';
+
+const CurrentPlanSection = ({ currentPlan }) => (
+  <Panel title='Current Plan'>
+    <Panel.Section className={styles.currentPlan}>
+      <div className={styles.Title}>{PLAN_TIERS[currentPlan.tier]}</div>
+      <div className={styles.Plan}>
+        <PlanPrice showOverage showIp showCsm plan={currentPlan} />
+      </div>
+    </Panel.Section>
+  </Panel>
+);
+
+export default CurrentPlanSection;

--- a/src/pages/billing/components/CurrentPlanSection.module.scss
+++ b/src/pages/billing/components/CurrentPlanSection.module.scss
@@ -1,0 +1,14 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.currentPlan {
+  color: color(gray, 5);
+
+  .Title {
+    font-weight: 500;
+  }
+  
+  .Plan {
+    margin: 1rem 0 0 1rem;
+  }
+}
+

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Panel, Button } from '@sparkpost/matchbox';
+import { PLAN_TIERS } from 'src/constants';
+import PlanPrice from 'src/components/billing/PlanPrice';
+
+import styles from './PlanSelect.module.scss';
+
+const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
+  const TIERS = [
+    { key: 'default' },
+    { key: 'test', label: PLAN_TIERS.test },
+    { key: 'starter', label: PLAN_TIERS.starter },
+    { key: 'premier', label: PLAN_TIERS.premier }
+  ];
+
+  const planList = TIERS.map((tier) => {
+    const tierPlans = plans[tier.key];
+    if (!tierPlans) {
+      return;
+    }
+
+    return (
+      <Panel.Section key={`tier_section_${tier.key}`}>
+        <div className={styles.tierLabel}>{tier.label}</div>
+        <div className={styles.tierPlans}>
+          {
+            plans[tier.key].map((bundle) => (
+              <div className={styles.PlanRow} key={`plan_row_${bundle.code}`}>
+                <div>
+                  <PlanPrice showOverage showIp showCsm plan={bundle} />
+                </div>
+                <div>
+                  <Button className={styles.selectButton} onClick={onSelect} size='small'>Select</Button>
+                </div>
+              </div>
+            ))
+          }
+        </div>
+      </Panel.Section>
+    );
+  });
+
+  return (
+    <Panel title='Select A Plan'>
+      {planList}
+    </Panel>
+  );
+}
+;
+
+export default PlanSelectSection;

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Panel, Button } from '@sparkpost/matchbox';
+import { Check } from '@sparkpost/matchbox-icons';
 import { PLAN_TIERS } from 'src/constants';
 import PlanPrice from 'src/components/billing/PlanPrice';
+import cx from 'classnames';
 
 import styles from './PlanSelect.module.scss';
 
@@ -24,16 +26,26 @@ const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
         <div className={styles.tierLabel}>{tier.label}</div>
         <div className={styles.tierPlans}>
           {
-            plans[tier.key].map((bundle) => (
-              <div className={styles.PlanRow} key={`plan_row_${bundle.code}`}>
-                <div>
-                  <PlanPrice showOverage showIp showCsm plan={bundle} />
+            plans[tier.key].map((bundle) => {
+              const isCurrentPlan = currentPlan.code === bundle.code;
+              return (
+                <div className={cx(styles.PlanRow, isCurrentPlan && styles.SelectedPlan)} key={`plan_row_${bundle.code}`}>
+                  <div>
+                    {isCurrentPlan && <Check className={styles.CheckIcon}/>}
+                    <PlanPrice showOverage showIp showCsm plan={bundle} />
+                  </div>
+                  <div>
+                    <Button
+                      className={styles.selectButton}
+                      disabled={isCurrentPlan}
+                      onClick={onSelect}
+                      size='small'>
+                        Select
+                    </Button>
+                  </div>
                 </div>
-                <div>
-                  <Button className={styles.selectButton} onClick={onSelect} size='small'>Select</Button>
-                </div>
-              </div>
-            ))
+              );
+            })
           }
         </div>
       </Panel.Section>

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -4,6 +4,7 @@ import { Check } from '@sparkpost/matchbox-icons';
 import { PLAN_TIERS } from 'src/constants';
 import PlanPrice from 'src/components/billing/PlanPrice';
 import cx from 'classnames';
+import _ from 'lodash';
 
 import styles from './PlanSelect.module.scss';
 
@@ -26,25 +27,19 @@ export const SelectedPlan = ({ plan, onChange }) => (
 );
 
 const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
-  const TIERS = [
-    { key: 'default' },
-    { key: 'test', label: PLAN_TIERS.test },
-    { key: 'starter', label: PLAN_TIERS.starter },
-    { key: 'premier', label: PLAN_TIERS.premier }
-  ];
 
-  const planList = TIERS.map((tier) => {
-    const tierPlans = plans[tier.key];
+  const planList = _.map(PLAN_TIERS, (label, key) => {
+    const tierPlans = plans[key];
     if (!tierPlans) {
       return;
     }
 
     return (
-      <Panel.Section key={`tier_section_${tier.key}`}>
-        <div className={styles.tierLabel}>{tier.label}</div>
+      <Panel.Section key={`tier_section_${key}`}>
+        <div className={styles.tierLabel}>{label}</div>
         <div className={styles.tierPlans}>
           {
-            plans[tier.key].map((bundle) => {
+            plans[key].map((bundle) => {
               const isCurrentPlan = currentPlan.code === bundle.code;
               return (
                 <div className={cx(styles.PlanRow, isCurrentPlan && styles.SelectedPlan)} key={`plan_row_${bundle.code}`}>

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -10,13 +10,15 @@ import styles from './PlanSelect.module.scss';
 export const SelectedPlan = ({ plan, onChange }) => (
   <Panel title='Your New Plan'>
     <Panel.Section>
-      <div className={styles.Title}>{PLAN_TIERS[plan.tier]}</div>
-      <div className={styles.PlanRow}>
-        <div className={cx(styles.SelectedPlan, styles.Plan)}>
-          <PlanPrice showOverage showIp showCsm plan={plan} />
-        </div>
-        <div>
-          <Button onClick={() => onChange()} size='small' flat color='orange'>Change</Button>
+      <div className={styles.SelectedPlan}>
+        <div className={styles.tierLabel}>{PLAN_TIERS[plan.tier]}</div>
+        <div className={styles.PlanRow}>
+          <div>
+            <PlanPrice showOverage showIp showCsm plan={plan} />
+          </div>
+          <div>
+            <Button onClick={() => onChange()} size='small' flat color='orange'>Change</Button>
+          </div>
         </div>
       </div>
     </Panel.Section>

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -28,42 +28,35 @@ export const SelectedPlan = ({ plan, onChange }) => (
 
 const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
 
-  const planList = _.map(PLAN_TIERS, (label, key) => {
-    const tierPlans = plans[key];
-    if (!tierPlans) {
-      return;
-    }
-
-    return (
-      <Panel.Section key={`tier_section_${key}`}>
-        <div className={styles.tierLabel}>{label}</div>
-        <div className={styles.tierPlans}>
-          {
-            plans[key].map((bundle) => {
-              const isCurrentPlan = currentPlan.code === bundle.code;
-              return (
-                <div className={cx(styles.PlanRow, isCurrentPlan && styles.SelectedPlan)} key={`plan_row_${bundle.code}`}>
-                  <div>
-                    {isCurrentPlan && <Check className={styles.CheckIcon}/>}
-                    <PlanPrice showOverage showIp showCsm plan={bundle} />
-                  </div>
-                  <div>
-                    <Button
-                      className={styles.selectButton}
-                      disabled={isCurrentPlan}
-                      onClick={() => onSelect(bundle)}
-                      size='small'>
-                        Select
-                    </Button>
-                  </div>
+  const planList = _.map(PLAN_TIERS, (label, key) => (
+    <Panel.Section key={`tier_section_${key}`}>
+      <div className={styles.tierLabel}>{label}</div>
+      <div className={styles.tierPlans}>
+        {
+          plans[key].map((bundle) => {
+            const isCurrentPlan = currentPlan.code === bundle.code;
+            return (
+              <div className={cx(styles.PlanRow, isCurrentPlan && styles.SelectedPlan)} key={`plan_row_${bundle.code}`}>
+                <div>
+                  {isCurrentPlan && <Check className={styles.CheckIcon}/>}
+                  <PlanPrice showOverage showIp showCsm plan={bundle} />
                 </div>
-              );
-            })
-          }
-        </div>
-      </Panel.Section>
-    );
-  });
+                <div>
+                  <Button
+                    className={styles.selectButton}
+                    disabled={isCurrentPlan}
+                    onClick={() => onSelect(bundle)}
+                    size='small'>
+                      Select
+                  </Button>
+                </div>
+              </div>
+            );
+          })
+        }
+      </div>
+    </Panel.Section>
+  ));
 
   return (
     <Panel title='Select a Plan'>

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -7,6 +7,22 @@ import cx from 'classnames';
 
 import styles from './PlanSelect.module.scss';
 
+export const SelectedPlan = ({ plan, onChange }) => (
+  <Panel title='Your New Plan'>
+    <Panel.Section>
+      <div className={styles.Title}>{PLAN_TIERS[plan.tier]}</div>
+      <div className={styles.PlanRow}>
+        <div className={cx(styles.SelectedPlan, styles.Plan)}>
+          <PlanPrice showOverage showIp showCsm plan={plan} />
+        </div>
+        <div>
+          <Button onClick={() => onChange()} size='small' flat color='orange'>Change</Button>
+        </div>
+      </div>
+    </Panel.Section>
+  </Panel>
+);
+
 const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
   const TIERS = [
     { key: 'default' },
@@ -38,7 +54,8 @@ const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
                     <Button
                       className={styles.selectButton}
                       disabled={isCurrentPlan}
-                      onClick={onSelect}
+                      onClick={() => onSelect(bundle)}
+                      value={bundle}
                       size='small'>
                         Select
                     </Button>
@@ -53,7 +70,7 @@ const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
   });
 
   return (
-    <Panel title='Select A Plan'>
+    <Panel title='Select a Plan'>
       {planList}
     </Panel>
   );

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -55,7 +55,6 @@ const PlanSelectSection = ({ plans, currentPlan, onSelect }) => {
                       className={styles.selectButton}
                       disabled={isCurrentPlan}
                       onClick={() => onSelect(bundle)}
-                      value={bundle}
                       size='small'>
                         Select
                     </Button>

--- a/src/pages/billing/components/PlanSelect.module.scss
+++ b/src/pages/billing/components/PlanSelect.module.scss
@@ -34,3 +34,19 @@
   position: absolute;
   transform: translate(-20px, 2px);
 }
+
+.SelectedPlan {
+  .Title {
+    font-weight: 500;
+  }
+  
+  .Plan {
+    margin: 1rem 0 0 1rem;
+  }
+
+  :first-child {
+    flex-grow: 1;
+  }
+}
+
+

--- a/src/pages/billing/components/PlanSelect.module.scss
+++ b/src/pages/billing/components/PlanSelect.module.scss
@@ -1,0 +1,27 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.PlanRow {
+  margin: .5rem 1rem;
+  padding: .5rem 0;
+  display: flex;
+
+  :first-child {
+    flex-grow: 1;
+  }
+}
+
+.tierPlans{
+  & > *:not(:last-child) {
+    border-bottom: 1px solid color(gray, 8);
+  }
+  margin: 0;
+}
+
+.tierLabel {
+  font-weight: 500;
+}
+
+.selectButton {
+  padding-left: 20px;
+  padding-right: 20px;
+}

--- a/src/pages/billing/components/PlanSelect.module.scss
+++ b/src/pages/billing/components/PlanSelect.module.scss
@@ -25,3 +25,12 @@
   padding-left: 20px;
   padding-right: 20px;
 }
+
+.SelectedPlan {
+  color: color(orange);
+}
+
+.CheckIcon {
+  position: absolute;
+  transform: translate(-22px, 4px);
+}

--- a/src/pages/billing/components/PlanSelect.module.scss
+++ b/src/pages/billing/components/PlanSelect.module.scss
@@ -32,5 +32,5 @@
 
 .CheckIcon {
   position: absolute;
-  transform: translate(-22px, 4px);
+  transform: translate(-20px, 2px);
 }

--- a/src/pages/billing/components/PlanSelect.module.scss
+++ b/src/pages/billing/components/PlanSelect.module.scss
@@ -34,19 +34,3 @@
   position: absolute;
   transform: translate(-20px, 2px);
 }
-
-.SelectedPlan {
-  .Title {
-    font-weight: 500;
-  }
-  
-  .Plan {
-    margin: 1rem 0 0 1rem;
-  }
-
-  :first-child {
-    flex-grow: 1;
-  }
-}
-
-

--- a/src/pages/billing/components/tests/CurrentPlanSection.test.js
+++ b/src/pages/billing/components/tests/CurrentPlanSection.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CurrentPlanSection from '../CurrentPlanSection';
+
+describe('CurrentPlanSection', () => {
+  const defaultProps = {
+    currentPlan: {
+      tier: 'starter',
+      code: 'big-code',
+      monthly: 300,
+      name: 'Three',
+      overage: 0.3,
+      volume: 3
+    }
+  };
+  const subject = (props) => shallow(
+    <CurrentPlanSection
+      {...defaultProps}
+      {...props}
+    />
+  );
+
+  it('renders correctly', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+});

--- a/src/pages/billing/components/tests/PlanSelect.test.js
+++ b/src/pages/billing/components/tests/PlanSelect.test.js
@@ -7,6 +7,9 @@ describe('Plan Select: ', () => {
 
   const defaultProps = {
     onSelect: jest.fn(),
+    currentPlan: {
+      code: '2'
+    },
     plans: {
       'default': [{
         code: '1',

--- a/src/pages/billing/components/tests/PlanSelect.test.js
+++ b/src/pages/billing/components/tests/PlanSelect.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import PlanSelect from '../PlanSelect';
+import PlanSelect, { SelectedPlan } from '../PlanSelect';
 
-describe('Plan Select: ', () => {
+describe('Plan Select:', () => {
 
   const defaultProps = {
     onSelect: jest.fn(),
@@ -48,4 +48,31 @@ describe('Plan Select: ', () => {
     expect(subject()).toMatchSnapshot();
   });
 
+});
+
+describe('Selected Plan:', () => {
+  const defaultProps = {
+    onChange: jest.fn(),
+    plan: {
+      tier: 'starter',
+      code: '2',
+      includesIp: false,
+      monthly: 0,
+      name: 'Two',
+      overage: 0.2,
+      volume: 2,
+      isFree: true
+    }
+  };
+
+  const subject = (props) => shallow(
+    <SelectedPlan
+      {...defaultProps}
+      {...props}
+    />
+  );
+
+  it('should render plan price with the plan', () => {
+    expect(subject()).toMatchSnapshot();
+  });
 });

--- a/src/pages/billing/components/tests/PlanSelect.test.js
+++ b/src/pages/billing/components/tests/PlanSelect.test.js
@@ -11,14 +11,6 @@ describe('Plan Select:', () => {
       code: '2'
     },
     plans: {
-      'default': [{
-        code: '1',
-        includesIp: true,
-        monthly: 100,
-        name: 'One',
-        overage: 0.1,
-        volume: 1
-      }],
       'test': [{
         code: '2',
         includesIp: false,
@@ -34,6 +26,14 @@ describe('Plan Select:', () => {
         name: 'Three',
         overage: 0.3,
         volume: 3
+      }],
+      'premier': [{
+        code: '4',
+        includesIp: true,
+        monthly: 400,
+        name: 'Four',
+        overage: 0.4,
+        volume: 4
       }]
     }
   };
@@ -54,7 +54,7 @@ describe('Selected Plan:', () => {
   const defaultProps = {
     onChange: jest.fn(),
     plan: {
-      tier: 'starter',
+      tier: 'test',
       code: '2',
       includesIp: false,
       monthly: 0,

--- a/src/pages/billing/components/tests/PlanSelect.test.js
+++ b/src/pages/billing/components/tests/PlanSelect.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PlanSelect from '../PlanSelect';
+
+describe('Plan Select: ', () => {
+
+  const defaultProps = {
+    onSelect: jest.fn(),
+    plans: {
+      'default': [{
+        code: '1',
+        includesIp: true,
+        monthly: 100,
+        name: 'One',
+        overage: 0.1,
+        volume: 1
+      }],
+      'test': [{
+        code: '2',
+        includesIp: false,
+        monthly: 0,
+        name: 'Two',
+        overage: 0.2,
+        volume: 2,
+        isFree: true
+      }],
+      'starter': [{
+        code: '3',
+        monthly: 300,
+        name: 'Three',
+        overage: 0.3,
+        volume: 3
+      }]
+    }
+  };
+
+  const subject = (props) => shallow(
+    <PlanSelect
+      {...defaultProps}
+      {...props}
+    />);
+
+  it('should render correctly', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+});

--- a/src/pages/billing/components/tests/__snapshots__/CurrentPlanSection.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/CurrentPlanSection.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CurrentPlanSection renders correctly 1`] = `
+<Panel
+  title="Current Plan"
+>
+  <Panel.Section
+    className="currentPlan"
+  >
+    <div
+      className="Title"
+    >
+      Starter
+    </div>
+    <div
+      className="Plan"
+    >
+      <PlanPrice
+        plan={
+          Object {
+            "code": "big-code",
+            "monthly": 300,
+            "name": "Three",
+            "overage": 0.3,
+            "tier": "starter",
+            "volume": 3,
+          }
+        }
+        showCsm={true}
+        showIp={true}
+        showOverage={true}
+      />
+    </div>
+  </Panel.Section>
+</Panel>
+`;

--- a/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
@@ -149,43 +149,45 @@ exports[`Selected Plan: should render plan price with the plan 1`] = `
 >
   <Panel.Section>
     <div
-      className="Title"
-    >
-      Starter
-    </div>
-    <div
-      className="PlanRow"
+      className="SelectedPlan"
     >
       <div
-        className="SelectedPlan Plan"
+        className="tierLabel"
       >
-        <PlanPrice
-          plan={
-            Object {
-              "code": "2",
-              "includesIp": false,
-              "isFree": true,
-              "monthly": 0,
-              "name": "Two",
-              "overage": 0.2,
-              "tier": "starter",
-              "volume": 2,
-            }
-          }
-          showCsm={true}
-          showIp={true}
-          showOverage={true}
-        />
+        Starter
       </div>
-      <div>
-        <Button
-          color="orange"
-          flat={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Change
-        </Button>
+      <div
+        className="PlanRow"
+      >
+        <div>
+          <PlanPrice
+            plan={
+              Object {
+                "code": "2",
+                "includesIp": false,
+                "isFree": true,
+                "monthly": 0,
+                "name": "Two",
+                "overage": 0.2,
+                "tier": "starter",
+                "volume": 2,
+              }
+            }
+            showCsm={true}
+            showIp={true}
+            showOverage={true}
+          />
+        </div>
+        <div>
+          <Button
+            color="orange"
+            flat={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Change
+          </Button>
+        </div>
       </div>
     </div>
   </Panel.Section>

--- a/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
@@ -5,49 +5,6 @@ exports[`Plan Select: should render correctly 1`] = `
   title="Select a Plan"
 >
   <Panel.Section
-    key="tier_section_default"
-  >
-    <div
-      className="tierLabel"
-    />
-    <div
-      className="tierPlans"
-    >
-      <div
-        className="PlanRow"
-        key="plan_row_1"
-      >
-        <div>
-          <PlanPrice
-            plan={
-              Object {
-                "code": "1",
-                "includesIp": true,
-                "monthly": 100,
-                "name": "One",
-                "overage": 0.1,
-                "volume": 1,
-              }
-            }
-            showCsm={true}
-            showIp={true}
-            showOverage={true}
-          />
-        </div>
-        <div>
-          <Button
-            className="selectButton"
-            disabled={false}
-            onClick={[Function]}
-            size="small"
-          >
-            Select
-          </Button>
-        </div>
-      </div>
-    </div>
-  </Panel.Section>
-  <Panel.Section
     key="tier_section_test"
   >
     <div
@@ -140,6 +97,51 @@ exports[`Plan Select: should render correctly 1`] = `
       </div>
     </div>
   </Panel.Section>
+  <Panel.Section
+    key="tier_section_premier"
+  >
+    <div
+      className="tierLabel"
+    >
+      Premier
+    </div>
+    <div
+      className="tierPlans"
+    >
+      <div
+        className="PlanRow"
+        key="plan_row_4"
+      >
+        <div>
+          <PlanPrice
+            plan={
+              Object {
+                "code": "4",
+                "includesIp": true,
+                "monthly": 400,
+                "name": "Four",
+                "overage": 0.4,
+                "volume": 4,
+              }
+            }
+            showCsm={true}
+            showIp={true}
+            showOverage={true}
+          />
+        </div>
+        <div>
+          <Button
+            className="selectButton"
+            disabled={false}
+            onClick={[Function]}
+            size="small"
+          >
+            Select
+          </Button>
+        </div>
+      </div>
+    </div>
+  </Panel.Section>
 </Panel>
 `;
 
@@ -154,7 +156,7 @@ exports[`Selected Plan: should render plan price with the plan 1`] = `
       <div
         className="tierLabel"
       >
-        Starter
+        Test Account
       </div>
       <div
         className="PlanRow"
@@ -169,7 +171,7 @@ exports[`Selected Plan: should render plan price with the plan 1`] = `
                 "monthly": 0,
                 "name": "Two",
                 "overage": 0.2,
-                "tier": "starter",
+                "tier": "test",
                 "volume": 2,
               }
             }

--- a/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
@@ -37,6 +37,7 @@ exports[`Plan Select:  should render correctly 1`] = `
         <div>
           <Button
             className="selectButton"
+            disabled={false}
             onClick={[MockFunction]}
             size="small"
           >
@@ -58,10 +59,13 @@ exports[`Plan Select:  should render correctly 1`] = `
       className="tierPlans"
     >
       <div
-        className="PlanRow"
+        className="PlanRow SelectedPlan"
         key="plan_row_2"
       >
         <div>
+          <Check
+            className="CheckIcon"
+          />
           <PlanPrice
             plan={
               Object {
@@ -82,6 +86,7 @@ exports[`Plan Select:  should render correctly 1`] = `
         <div>
           <Button
             className="selectButton"
+            disabled={true}
             onClick={[MockFunction]}
             size="small"
           >
@@ -125,6 +130,7 @@ exports[`Plan Select:  should render correctly 1`] = `
         <div>
           <Button
             className="selectButton"
+            disabled={false}
             onClick={[MockFunction]}
             size="small"
           >

--- a/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Plan Select:  should render correctly 1`] = `
+<Panel
+  title="Select A Plan"
+>
+  <Panel.Section
+    key="tier_section_default"
+  >
+    <div
+      className="tierLabel"
+    />
+    <div
+      className="tierPlans"
+    >
+      <div
+        className="PlanRow"
+        key="plan_row_1"
+      >
+        <div>
+          <PlanPrice
+            plan={
+              Object {
+                "code": "1",
+                "includesIp": true,
+                "monthly": 100,
+                "name": "One",
+                "overage": 0.1,
+                "volume": 1,
+              }
+            }
+            showCsm={true}
+            showIp={true}
+            showOverage={true}
+          />
+        </div>
+        <div>
+          <Button
+            className="selectButton"
+            onClick={[MockFunction]}
+            size="small"
+          >
+            Select
+          </Button>
+        </div>
+      </div>
+    </div>
+  </Panel.Section>
+  <Panel.Section
+    key="tier_section_test"
+  >
+    <div
+      className="tierLabel"
+    >
+      Test Account
+    </div>
+    <div
+      className="tierPlans"
+    >
+      <div
+        className="PlanRow"
+        key="plan_row_2"
+      >
+        <div>
+          <PlanPrice
+            plan={
+              Object {
+                "code": "2",
+                "includesIp": false,
+                "isFree": true,
+                "monthly": 0,
+                "name": "Two",
+                "overage": 0.2,
+                "volume": 2,
+              }
+            }
+            showCsm={true}
+            showIp={true}
+            showOverage={true}
+          />
+        </div>
+        <div>
+          <Button
+            className="selectButton"
+            onClick={[MockFunction]}
+            size="small"
+          >
+            Select
+          </Button>
+        </div>
+      </div>
+    </div>
+  </Panel.Section>
+  <Panel.Section
+    key="tier_section_starter"
+  >
+    <div
+      className="tierLabel"
+    >
+      Starter
+    </div>
+    <div
+      className="tierPlans"
+    >
+      <div
+        className="PlanRow"
+        key="plan_row_3"
+      >
+        <div>
+          <PlanPrice
+            plan={
+              Object {
+                "code": "3",
+                "monthly": 300,
+                "name": "Three",
+                "overage": 0.3,
+                "volume": 3,
+              }
+            }
+            showCsm={true}
+            showIp={true}
+            showOverage={true}
+          />
+        </div>
+        <div>
+          <Button
+            className="selectButton"
+            onClick={[MockFunction]}
+            size="small"
+          >
+            Select
+          </Button>
+        </div>
+      </div>
+    </div>
+  </Panel.Section>
+</Panel>
+`;

--- a/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/PlanSelect.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Plan Select:  should render correctly 1`] = `
+exports[`Plan Select: should render correctly 1`] = `
 <Panel
-  title="Select A Plan"
+  title="Select a Plan"
 >
   <Panel.Section
     key="tier_section_default"
@@ -38,7 +38,7 @@ exports[`Plan Select:  should render correctly 1`] = `
           <Button
             className="selectButton"
             disabled={false}
-            onClick={[MockFunction]}
+            onClick={[Function]}
             size="small"
           >
             Select
@@ -87,7 +87,7 @@ exports[`Plan Select:  should render correctly 1`] = `
           <Button
             className="selectButton"
             disabled={true}
-            onClick={[MockFunction]}
+            onClick={[Function]}
             size="small"
           >
             Select
@@ -131,12 +131,61 @@ exports[`Plan Select:  should render correctly 1`] = `
           <Button
             className="selectButton"
             disabled={false}
-            onClick={[MockFunction]}
+            onClick={[Function]}
             size="small"
           >
             Select
           </Button>
         </div>
+      </div>
+    </div>
+  </Panel.Section>
+</Panel>
+`;
+
+exports[`Selected Plan: should render plan price with the plan 1`] = `
+<Panel
+  title="Your New Plan"
+>
+  <Panel.Section>
+    <div
+      className="Title"
+    >
+      Starter
+    </div>
+    <div
+      className="PlanRow"
+    >
+      <div
+        className="SelectedPlan Plan"
+      >
+        <PlanPrice
+          plan={
+            Object {
+              "code": "2",
+              "includesIp": false,
+              "isFree": true,
+              "monthly": 0,
+              "name": "Two",
+              "overage": 0.2,
+              "tier": "starter",
+              "volume": 2,
+            }
+          }
+          showCsm={true}
+          showIp={true}
+          showOverage={true}
+        />
+      </div>
+      <div>
+        <Button
+          color="orange"
+          flat={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Change
+        </Button>
       </div>
     </div>
   </Panel.Section>

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Grid } from '@sparkpost/matchbox';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -6,7 +6,7 @@ import { reduxForm, formValueSelector } from 'redux-form';
 import qs from 'query-string';
 
 import promoCodeValidate from '../helpers/promoCodeValidate';
-import PlanSelectSection from '../components/PlanSelect';
+import PlanSelectSection, { SelectedPlan } from '../components/PlanSelect';
 import CurrentPlanSection from '../components/CurrentPlanSection';
 
 //Actions
@@ -33,6 +33,7 @@ const ChangePlanForm = ({
   // selectedPlan,
   currentPlan
 }) => {
+  const [selectedPlan, selectPlan] = useState(null);
 
   // const [useSavedCC, setUseSavedCC] = useState(null);
   useEffect(() => { fetchAccount(); }, [fetchAccount]);
@@ -42,14 +43,26 @@ const ChangePlanForm = ({
   //TODO: Implement in AC-986
   // useEffect(() => { console.log(selectedPlan, promoCode)}, [verifyPromoCode, promoCode, selectedPlan]);
 
+  const onSelect = (plan) => {
+    selectPlan(plan);
+  };
+
   return (
     <form>
       <Grid>
         <Grid.Column xs={8}>
-          <PlanSelectSection
-            plans={plans}
-            currentPlan={currentPlan}
-          />
+          {
+            selectedPlan
+              ? <SelectedPlan
+                plan={selectedPlan}
+                onChange={onSelect}
+              />
+              : <PlanSelectSection
+                onSelect={onSelect}
+                plans={plans}
+                currentPlan={currentPlan}
+              />
+          }
         </Grid.Column>
         <Grid.Column xs={4}>
           <CurrentPlanSection currentPlan={currentPlan}/>

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Grid } from '@sparkpost/matchbox';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { reduxForm, formValueSelector } from 'redux-form';
+import { reduxForm } from 'redux-form';
 import qs from 'query-string';
 
 import promoCodeValidate from '../helpers/promoCodeValidate';
@@ -10,7 +10,7 @@ import PlanSelectSection, { SelectedPlan } from '../components/PlanSelect';
 import CurrentPlanSection from '../components/CurrentPlanSection';
 
 //Actions
-import { fetch as fetchAccount, getBillingInfo, getPlans } from 'src/actions/account';
+import { getBillingInfo, getPlans } from 'src/actions/account';
 import { getBillingCountries } from 'src/actions/billing';
 
 //Selectors
@@ -19,10 +19,9 @@ import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
 
 const FORMNAME = 'changePlan';
 
-const ChangePlanForm = ({
+export const ChangePlanForm = ({
   //Redux Props
   plans,
-  fetchAccount,
   getBillingInfo,
   getBillingCountries,
   getPlans,
@@ -30,13 +29,11 @@ const ChangePlanForm = ({
   // initialValues: {
   //   promoCode
   // },
-  // selectedPlan,
   currentPlan
 }) => {
   const [selectedPlan, selectPlan] = useState(null);
 
   // const [useSavedCC, setUseSavedCC] = useState(null);
-  useEffect(() => { fetchAccount(); }, [fetchAccount]);
   useEffect(() => { getBillingCountries(); }, [getBillingCountries]);
   useEffect(() => { getBillingInfo(); }, [getBillingInfo]);
   useEffect(() => { getPlans(); }, [getPlans]);
@@ -74,18 +71,15 @@ const ChangePlanForm = ({
 
 const mapStateToProps = (state, props) => {
   const { code: planCode, promo: promoCode } = qs.parse(props.location.search);
-  const selector = formValueSelector(FORMNAME);
 
   return {
     plans: selectTieredVisiblePlans(state),
     initialValues: changePlanInitialValues(state, { planCode, promoCode }),
-    currentPlan: currentPlanSelector(state),
-    selectedPlan: selector(state, 'planpicker') || {}
+    currentPlan: currentPlanSelector(state)
   };
 };
 
 const mapDispatchToProps = ({
-  fetchAccount,
   getBillingInfo,
   getBillingCountries,
   getPlans

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -48,6 +48,7 @@ const ChangePlanForm = ({
         <Grid.Column xs={8}>
           <PlanSelectSection
             plans={plans}
+            currentPlan={currentPlan}
           />
         </Grid.Column>
         <Grid.Column xs={4}>

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -1,0 +1,92 @@
+import React, { useEffect } from 'react';
+import { Grid } from '@sparkpost/matchbox';
+import { withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { reduxForm, formValueSelector } from 'redux-form';
+import qs from 'query-string';
+
+import promoCodeValidate from '../helpers/promoCodeValidate';
+import PlanSelectSection from '../components/PlanSelect';
+import CurrentPlanSection from '../components/CurrentPlanSection';
+
+//Actions
+import { fetch as fetchAccount, getBillingInfo, getPlans } from 'src/actions/account';
+import { getBillingCountries } from 'src/actions/billing';
+
+//Selectors
+import { selectTieredVisiblePlans, currentPlanSelector } from 'src/selectors/accountBillingInfo';
+import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
+
+const FORMNAME = 'changePlan';
+
+const ChangePlanForm = ({
+  //Redux Props
+  plans,
+  fetchAccount,
+  getBillingInfo,
+  getBillingCountries,
+  getPlans,
+  // verifyPromoCode,
+  // initialValues: {
+  //   promoCode
+  // },
+  // selectedPlan,
+  currentPlan
+}) => {
+
+  // const [useSavedCC, setUseSavedCC] = useState(null);
+  useEffect(() => { fetchAccount(); }, [fetchAccount]);
+  useEffect(() => { getBillingCountries(); }, [getBillingCountries]);
+  useEffect(() => { getBillingInfo(); }, [getBillingInfo]);
+  useEffect(() => { getPlans(); }, [getPlans]);
+  //TODO: Implement in AC-986
+  // useEffect(() => { console.log(selectedPlan, promoCode)}, [verifyPromoCode, promoCode, selectedPlan]);
+
+  return (
+    <form>
+      <Grid>
+        <Grid.Column xs={8}>
+          <PlanSelectSection
+            plans={plans}
+          />
+        </Grid.Column>
+        <Grid.Column xs={4}>
+          <CurrentPlanSection currentPlan={currentPlan}/>
+        </Grid.Column>
+      </Grid>
+    </form>
+  );
+};
+
+const mapStateToProps = (state, props) => {
+  const { code: planCode, promo: promoCode } = qs.parse(props.location.search);
+  const selector = formValueSelector(FORMNAME);
+
+  return {
+    plans: selectTieredVisiblePlans(state),
+    initialValues: changePlanInitialValues(state, { planCode, promoCode }),
+    currentPlan: currentPlanSelector(state),
+    selectedPlan: selector(state, 'planpicker') || {}
+  };
+};
+
+const mapDispatchToProps = ({
+  fetchAccount,
+  getBillingInfo,
+  getBillingCountries,
+  getPlans
+});
+
+const formOptions = {
+  form: FORMNAME,
+  enableReinitialize: true,
+  asyncValidate: promoCodeValidate(FORMNAME),
+  asyncChangeFields: ['planpicker'],
+  asyncBlurFields: ['promoCode']
+};
+
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(
+    reduxForm(formOptions)(ChangePlanForm)
+  )
+);

--- a/src/pages/billing/forms/tests/NewChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/NewChangePlanForm.test.js
@@ -5,7 +5,7 @@ import { shallow, mount } from 'enzyme';
 describe('Change Plan Form', () => {
   const defaultProps = {
     plans: {
-      'default': [{
+      'test': [{
         code: '1',
         includesIp: true,
         monthly: 100,
@@ -13,7 +13,7 @@ describe('Change Plan Form', () => {
         overage: 0.1,
         volume: 1
       }],
-      'test': [{
+      'starter': [{
         code: '2',
         includesIp: false,
         monthly: 0,
@@ -22,7 +22,7 @@ describe('Change Plan Form', () => {
         volume: 2,
         isFree: true
       }],
-      'starter': [{
+      'premier': [{
         code: '3',
         monthly: 300,
         name: 'Three',
@@ -31,7 +31,7 @@ describe('Change Plan Form', () => {
       }]
     },
     currentPlan: {
-      tier: 'starter',
+      tier: 'premier',
       code: '3',
       monthly: 300,
       name: 'Three',

--- a/src/pages/billing/forms/tests/NewChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/NewChangePlanForm.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { ChangePlanForm } from '../NewChangePlanForm';
+import { shallow, mount } from 'enzyme';
+
+describe('Change Plan Form', () => {
+  const defaultProps = {
+    plans: {
+      'default': [{
+        code: '1',
+        includesIp: true,
+        monthly: 100,
+        name: 'One',
+        overage: 0.1,
+        volume: 1
+      }],
+      'test': [{
+        code: '2',
+        includesIp: false,
+        monthly: 0,
+        name: 'Two',
+        overage: 0.2,
+        volume: 2,
+        isFree: true
+      }],
+      'starter': [{
+        code: '3',
+        monthly: 300,
+        name: 'Three',
+        overage: 0.3,
+        volume: 3
+      }]
+    },
+    currentPlan: {
+      tier: 'starter',
+      code: '3',
+      monthly: 300,
+      name: 'Three',
+      overage: 0.3,
+      volume: 3
+    },
+    getPlans: jest.fn(),
+    getBillingCountries: jest.fn(),
+    getBillingInfo: jest.fn()
+  };
+
+  const subject = (props, render = shallow) => render(
+    <ChangePlanForm
+      {...defaultProps}
+      {...props}
+    />
+  );
+
+  it('should render', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('should call functions on initial render', () => {
+    subject({}, mount);
+    expect(defaultProps.getPlans).toHaveBeenCalled();
+    expect(defaultProps.getBillingCountries).toHaveBeenCalled();
+    expect(defaultProps.getBillingInfo).toHaveBeenCalled();
+  });
+});

--- a/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Change Plan Form should render 1`] = `
+<form>
+  <Grid>
+    <Grid.Column
+      xs={8}
+    >
+      <PlanSelectSection
+        currentPlan={
+          Object {
+            "code": "3",
+            "monthly": 300,
+            "name": "Three",
+            "overage": 0.3,
+            "tier": "starter",
+            "volume": 3,
+          }
+        }
+        onSelect={[Function]}
+        plans={
+          Object {
+            "default": Array [
+              Object {
+                "code": "1",
+                "includesIp": true,
+                "monthly": 100,
+                "name": "One",
+                "overage": 0.1,
+                "volume": 1,
+              },
+            ],
+            "starter": Array [
+              Object {
+                "code": "3",
+                "monthly": 300,
+                "name": "Three",
+                "overage": 0.3,
+                "volume": 3,
+              },
+            ],
+            "test": Array [
+              Object {
+                "code": "2",
+                "includesIp": false,
+                "isFree": true,
+                "monthly": 0,
+                "name": "Two",
+                "overage": 0.2,
+                "volume": 2,
+              },
+            ],
+          }
+        }
+      />
+    </Grid.Column>
+    <Grid.Column
+      xs={4}
+    >
+      <CurrentPlanSection
+        currentPlan={
+          Object {
+            "code": "3",
+            "monthly": 300,
+            "name": "Three",
+            "overage": 0.3,
+            "tier": "starter",
+            "volume": 3,
+          }
+        }
+      />
+    </Grid.Column>
+  </Grid>
+</form>
+`;

--- a/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
@@ -13,24 +13,14 @@ exports[`Change Plan Form should render 1`] = `
             "monthly": 300,
             "name": "Three",
             "overage": 0.3,
-            "tier": "starter",
+            "tier": "premier",
             "volume": 3,
           }
         }
         onSelect={[Function]}
         plans={
           Object {
-            "default": Array [
-              Object {
-                "code": "1",
-                "includesIp": true,
-                "monthly": 100,
-                "name": "One",
-                "overage": 0.1,
-                "volume": 1,
-              },
-            ],
-            "starter": Array [
+            "premier": Array [
               Object {
                 "code": "3",
                 "monthly": 300,
@@ -39,7 +29,7 @@ exports[`Change Plan Form should render 1`] = `
                 "volume": 3,
               },
             ],
-            "test": Array [
+            "starter": Array [
               Object {
                 "code": "2",
                 "includesIp": false,
@@ -48,6 +38,16 @@ exports[`Change Plan Form should render 1`] = `
                 "name": "Two",
                 "overage": 0.2,
                 "volume": 2,
+              },
+            ],
+            "test": Array [
+              Object {
+                "code": "1",
+                "includesIp": true,
+                "monthly": 100,
+                "name": "One",
+                "overage": 0.1,
+                "volume": 1,
               },
             ],
           }
@@ -64,7 +64,7 @@ exports[`Change Plan Form should render 1`] = `
             "monthly": 300,
             "name": "Three",
             "overage": 0.3,
-            "tier": "starter",
+            "tier": "premier",
             "volume": 3,
           }
         }


### PR DESCRIPTION
### What Changed
 - Add new select for plans

### How To Test
 - Add account ui option 'account_feature_limits'
 - Go to `/account/billing/plan`
 - Verify the look compared to snapshot

### To Do
- [ ] ~Mock new bundle and plan endpoint~
- [ ] ~Map new bundles and plans to new plan select~
- [x] Let select functionality work in form
- [x] Add testing for new form