### PR TITLE
TR-1754 - Address issue with HTML and text string being submitted to server with PUT and POST requests

### DIFF
--- a/src/actions/helpers/templates.js
+++ b/src/actions/helpers/templates.js
@@ -16,9 +16,13 @@ export const getTestDataKey = ({ id, username, mode }) => ([ 'tpldata', username
 
 // Shape the content attributes for API
 export const shapeContent = (content = {}) => {
-  if (_.isEmpty(content.reply_to)) {
-    return _.omit(content, 'reply_to');
-  }
+  const shapedContent = {
+    ...content,
+    reply_to: _.isEmpty(content.reply_to) ? null : content.reply_to,
+    text: _.isEmpty(content.text) ? null : content.text,
+    html: _.isEmpty(content.html) ? null : content.html,
+    amp_html: _.isEmpty(content.amp_html) ? null : content.amp_html
+  };
 
-  return content;
+  return shapedContent;
 };

--- a/src/actions/helpers/templates.js
+++ b/src/actions/helpers/templates.js
@@ -18,10 +18,10 @@ export const getTestDataKey = ({ id, username, mode }) => ([ 'tpldata', username
 export const shapeContent = (content = {}) => {
   const shapedContent = {
     ...content,
-    reply_to: _.isEmpty(content.reply_to) ? null : content.reply_to,
-    text: _.isEmpty(content.text) ? null : content.text,
-    html: _.isEmpty(content.html) ? null : content.html,
-    amp_html: _.isEmpty(content.amp_html) ? null : content.amp_html
+    reply_to: _.isEmpty(content.reply_to) ? undefined : content.reply_to,
+    text: _.isEmpty(content.text) ? undefined : content.text,
+    html: _.isEmpty(content.html) ? undefined : content.html,
+    amp_html: _.isEmpty(content.amp_html) ? undefined : content.amp_html
   };
 
   return shapedContent;

--- a/src/actions/helpers/tests/templates.test.js
+++ b/src/actions/helpers/tests/templates.test.js
@@ -20,18 +20,18 @@ describe('.shapeContent', () => {
   });
 
   it('should return content object without `reply_to` key', () => {
-    expect(shapeContent({ reply_to: '' }).reply_to).toBeNull();
+    expect(shapeContent({ reply_to: '' }).reply_to).toBeUndefined();
   });
 
   it('should return content object without `amp_html` key', () => {
-    expect(shapeContent({ amp_html: '' }).amp_html).toBeNull();
+    expect(shapeContent({ amp_html: '' }).amp_html).toBeUndefined();
   });
 
   it('should return content object without `text` key', () => {
-    expect(shapeContent({ text: '' }).text).toBeNull();
+    expect(shapeContent({ text: '' }).text).toBeUndefined();
   });
 
   it('should return content object without `html` key', () => {
-    expect(shapeContent({ html: '' }).html).toBeNull();
+    expect(shapeContent({ html: '' }).html).toBeUndefined();
   });
 });

--- a/src/actions/helpers/tests/templates.test.js
+++ b/src/actions/helpers/tests/templates.test.js
@@ -19,7 +19,19 @@ describe('.shapeContent', () => {
     expect(shapeContent({ reply_to: 'test@example.com' })).toHaveProperty('reply_to');
   });
 
-  it('should return content object without reply_to key', () => {
-    expect(shapeContent({ reply_to: '' })).not.toHaveProperty('reply_to');
+  it('should return content object without `reply_to` key', () => {
+    expect(shapeContent({ reply_to: '' }).reply_to).toBeNull();
+  });
+
+  it('should return content object without `amp_html` key', () => {
+    expect(shapeContent({ amp_html: '' }).amp_html).toBeNull();
+  });
+
+  it('should return content object without `text` key', () => {
+    expect(shapeContent({ text: '' }).text).toBeNull();
+  });
+
+  it('should return content object without `html` key', () => {
+    expect(shapeContent({ html: '' }).html).toBeNull();
   });
 });

--- a/src/actions/tests/__snapshots__/templates.test.js.snap
+++ b/src/actions/tests/__snapshots__/templates.test.js.snap
@@ -82,7 +82,12 @@ Array [
   Object {
     "meta": Object {
       "data": Object {
-        "content": Object {},
+        "content": Object {
+          "amp_html": null,
+          "html": null,
+          "reply_to": null,
+          "text": null,
+        },
         "form": "data",
         "id": "id",
         "shared_with_subaccounts": false,
@@ -233,7 +238,12 @@ Array [
         "id": "id",
       },
       "data": Object {
-        "content": Object {},
+        "content": Object {
+          "amp_html": null,
+          "html": null,
+          "reply_to": null,
+          "text": null,
+        },
         "form": "data",
       },
       "headers": Object {},

--- a/src/actions/tests/__snapshots__/templates.test.js.snap
+++ b/src/actions/tests/__snapshots__/templates.test.js.snap
@@ -83,10 +83,10 @@ Array [
     "meta": Object {
       "data": Object {
         "content": Object {
-          "amp_html": null,
-          "html": null,
-          "reply_to": null,
-          "text": null,
+          "amp_html": undefined,
+          "html": undefined,
+          "reply_to": undefined,
+          "text": undefined,
         },
         "form": "data",
         "id": "id",
@@ -239,10 +239,10 @@ Array [
       },
       "data": Object {
         "content": Object {
-          "amp_html": null,
-          "html": null,
-          "reply_to": null,
-          "text": null,
+          "amp_html": undefined,
+          "html": undefined,
+          "reply_to": undefined,
+          "text": undefined,
         },
         "form": "data",
       },


### PR DESCRIPTION
[TR-1754](https://jira.int.messagesystems.com/browse/TR-1754)

### What Changed
- Updated templates helper `shapeContent()` to supply `null` values for the template content when the user provides an empty string

### How To Test
- Clone this branch
- Navigate to `/templates`
- Follow steps in the Escalation ticket to verify the bug is no longer occurring - [ESCSP-3246](https://jira.int.messagesystems.com/browse/ESCSP-3246)

### To Do
- [x] Incorporate feedback
