### PR TITLE
Sa 603 - Add day precision to Summary report datepicker

### DIFF
--- a/src/components/datePicker/ManualEntryForm.js
+++ b/src/components/datePicker/ManualEntryForm.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { Grid, TextField } from '@sparkpost/matchbox';
 import { ArrowForward } from '@sparkpost/matchbox-icons';
 import { formatInputDate, formatInputTime, parseDatetime } from 'src/helpers/date';
-import { getValidDateRange, getPrecision } from 'src/helpers/metrics';
+import { getValidDateRange, getPrecision, getMomentPrecision } from 'src/helpers/metrics';
 import styles from './ManualEntryForm.module.scss';
 
 const DATE_PLACEHOLDER = '1970-01-20';
@@ -83,6 +83,7 @@ export default class ManualEntryForm extends Component {
 
     let precisionLabel = null;
     let precisionLabelValue;
+    let momentPrecision = '';
     const from = parseDatetime(fromDate, fromTime);
     const to = parseDatetime(toDate, toTime);
 
@@ -91,7 +92,8 @@ export default class ManualEntryForm extends Component {
         // allow for prop-level override of "now" (DI, etc.)
         const { now = moment() } = this.props;
         const { from: validatedFrom, to: validatedTo } = getValidDateRange({ from, to, now, roundToPrecision });
-        precisionLabelValue = _.upperFirst(getPrecision(validatedFrom, validatedTo));
+        precisionLabelValue = getPrecision(validatedFrom, validatedTo);
+        momentPrecision = getMomentPrecision(validatedFrom, validatedTo);
       } catch (e) {
         precisionLabelValue = '';
       }
@@ -116,7 +118,8 @@ export default class ManualEntryForm extends Component {
               label='From Time' labelHidden placeholder={TIME_PLACEHOLDER}
               onChange={this.handleFieldChange}
               onBlur={this.handleBlur}
-              value={fromTime} />
+              value={fromTime}
+              disabled={momentPrecision === 'days'} />
           </Grid.Column>
           <Grid.Column xs={1}>
             <div className={styles.ArrowWrapper}>
@@ -137,7 +140,8 @@ export default class ManualEntryForm extends Component {
               label='To Time' labelHidden placeholder={TIME_PLACEHOLDER}
               onChange={this.handleFieldChange}
               onBlur={this.handleBlur}
-              value={toTime} />
+              value={toTime}
+              disabled={momentPrecision === 'days'} />
           </Grid.Column>
         </Grid>
         {precisionLabel}

--- a/src/components/datePicker/tests/ManualEntryForm.test.js
+++ b/src/components/datePicker/tests/ManualEntryForm.test.js
@@ -72,6 +72,27 @@ describe('Component: DatePicker ManualEntryForm', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should disable time picker if precision is day (time difference > 2 days)', () => {
+    wrapper.setProps({
+      from: moment('2018-01-10T10:00:00'),
+      to: moment('2018-01-15T14:00:00')
+    });
+    wrapper.update();
+    expect(wrapper.find({ id: 'fromTime' })).toHaveProp('disabled', true);
+    expect(wrapper.find({ id: 'toTime' })).toHaveProp('disabled', true);
+  });
+
+  it('should enable time picker if precision is minutes or hours (time difference <= 2 days)', () => {
+    mockTo = moment('2018-01-12T10:00:00');
+    wrapper.setProps({
+      from: moment('2018-01-10T10:00:00'),
+      to: moment('2018-01-12T10:00:00')
+    });
+    wrapper.update();
+    expect(wrapper.find({ id: 'fromTime' })).toHaveProp('disabled', false);
+    expect(wrapper.find({ id: 'toTime' })).toHaveProp('disabled', false);
+  });
+
   it('should handle a field change', () => {
     const event = { target: { id: 'fromDate', value: '2018-04-15' }};
 

--- a/src/components/datePicker/tests/__snapshots__/ManualEntryForm.test.js.snap
+++ b/src/components/datePicker/tests/__snapshots__/ManualEntryForm.test.js.snap
@@ -23,6 +23,7 @@ exports[`Component: DatePicker ManualEntryForm should not show precision when ro
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={false}
         id="fromTime"
         label="From Time"
         labelHidden={true}
@@ -58,6 +59,7 @@ exports[`Component: DatePicker ManualEntryForm should not show precision when ro
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={false}
         id="toTime"
         label="To Time"
         labelHidden={true}
@@ -96,6 +98,7 @@ exports[`Component: DatePicker ManualEntryForm should render correctly by defaul
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={true}
         id="fromTime"
         label="From Time"
         labelHidden={true}
@@ -131,6 +134,7 @@ exports[`Component: DatePicker ManualEntryForm should render correctly by defaul
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={true}
         id="toTime"
         label="To Time"
         labelHidden={true}
@@ -175,6 +179,7 @@ exports[`Component: DatePicker ManualEntryForm should sync props to state 1`] = 
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={true}
         id="fromTime"
         label="From Time"
         labelHidden={true}
@@ -210,6 +215,7 @@ exports[`Component: DatePicker ManualEntryForm should sync props to state 1`] = 
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={true}
         id="toTime"
         label="To Time"
         labelHidden={true}
@@ -254,6 +260,7 @@ exports[`Component: DatePicker ManualEntryForm should update state from new prop
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={true}
         id="fromTime"
         label="From Time"
         labelHidden={true}
@@ -289,6 +296,7 @@ exports[`Component: DatePicker ManualEntryForm should update state from new prop
     </Grid.Column>
     <Grid.Column>
       <TextField
+        disabled={true}
         id="toTime"
         label="To Time"
         labelHidden={true}

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -95,25 +95,14 @@ export function getRelativeDates(range, { now = moment().toDate(), roundToPrecis
       break;
 
     case '7days':
-      preciseFrom = moment(now).subtract(7, 'day').toDate();
-      break;
-
     case '10days':
-      preciseFrom = moment(now).subtract(10, 'day').toDate();
-      break;
-
     case '14days':
-      preciseFrom = moment(now).subtract(14, 'day').toDate();
-      break;
-
     case '30days':
-      preciseFrom = moment(now).subtract(30, 'day').toDate();
+    case '90days': {
+      const numberOfDays = parseInt(range.replace('days', ''));
+      preciseFrom = moment(now).subtract(numberOfDays, 'day').toDate();
       break;
-
-    case '90days':
-      preciseFrom = moment(now).subtract(90, 'day').toDate();
-      break;
-
+    }
     case 'custom':
       return { relativeRange: range };
 

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -76,8 +76,12 @@ export function getPrecision(from, to = moment()) {
   return precisionMap.find(({ time }) => diff <= time).value;
 }
 
-export function getMomentPrecision(precision) {
-  return (indexedPrecisions[precision].time <= (60 * 24)) ? 'minutes' : 'hours';
+export function getMomentPrecision(from, to = moment()) {
+  const diff = to.diff(from, 'minutes');
+  if (diff <= (60 * 24)) {
+    return 'minutes';
+  }
+  return diff <= (60 * 24 * 2) ? 'hours' : 'days';
 }
 
 export function getPrecisionType(precision) {
@@ -96,9 +100,9 @@ export function roundBoundaries(fromInput, toInput) {
   const to = moment(toInput);
 
   const precision = getPrecision(from, to);
-  const momentPrecision = getMomentPrecision(precision);
+  const momentPrecision = getMomentPrecision(from, to);
   // extract rounding interval from precision query param value
-  const roundInt = _.parseInt(_.words(precision)[0]) || 1;
+  const roundInt = (momentPrecision === 'minutes') ? parseInt(precision.replace('min', '')) : 1;
 
   floorMoment(from, roundInt, momentPrecision);
   // if we're only at a minute precision, don't round up to the next minute

--- a/src/helpers/tests/date.test.js
+++ b/src/helpers/tests/date.test.js
@@ -75,7 +75,7 @@ describe('Date helpers', () => {
   describe('getRelativeDates', () => {
 
     cases('calculations', ({ range, roundToPrecision, subtractArgs }) => {
-      const date = moment(new Date('2017-12-17T12:00:00')).utc();
+      const date = moment(new Date('2017-12-17T12:00:00'));
       Date.now = jest.fn(() => date);
       const { from, to, relativeRange } = getRelativeDates(range, { roundToPrecision });
       let expectedFrom = moment(date.toDate()).subtract(...subtractArgs);
@@ -105,7 +105,7 @@ describe('Date helpers', () => {
     });
 
     it('should default to rounding the range', () => {
-      const date = moment(new Date('2017-12-17T12:00:00')).utc();
+      const date = moment(new Date('2017-12-17T12:00:00'));
       Date.now = jest.fn(() => date);
       const { from: expectedFrom, to: expectedTo } = roundBoundaries(moment(date.toDate()).subtract(7, 'days'), date);
       const { from, to, relativeRange } = getRelativeDates('7days');

--- a/src/helpers/tests/metrics.test.js
+++ b/src/helpers/tests/metrics.test.js
@@ -101,12 +101,22 @@ describe('metrics helpers', () => {
 
   });
 
-  it('should return minutes as moment precision type', () => {
-    expect(metricsHelpers.getMomentPrecision('1min')).toEqual('minutes');
+  it('should return minute as moment precision type', () => {
+    const from = moment('2016-12-18T00:00').utc();
+    const to = moment('2016-12-18T00:30').utc();
+    expect(metricsHelpers.getMomentPrecision(from, to)).toEqual('minutes');
   });
 
-  it('should return hours as moment precision type', () => {
-    expect(metricsHelpers.getMomentPrecision('day')).toEqual('hours');
+  it('should return hour as moment precision type', () => {
+    const from = moment('2016-12-18T00:00').utc();
+    const to = moment('2016-12-19T00:30').utc();
+    expect(metricsHelpers.getMomentPrecision(from, to)).toEqual('hours');
+  });
+
+  it('should return day as moment precision type', () => {
+    const from = moment('2016-12-18T00:00').utc();
+    const to = moment('2016-12-25T00:30').utc();
+    expect(metricsHelpers.getMomentPrecision(from, to)).toEqual('days');
   });
 
   it('should return hours as precision type', () => {
@@ -140,26 +150,26 @@ describe('metrics helpers', () => {
       {
         timeLabel: 'hour',
         from: '2016-12-16T10:59',
-        to: '2016-12-18T10:01',
-        expected: { from: '2016-12-16T10:00', to: '2016-12-18T10:59' }
+        to: '2016-12-18T09:01',
+        expected: { from: '2016-12-16T10:00', to: '2016-12-18T09:59' }
       },
       {
         timeLabel: 'day',
         from: '2016-11-15T10:59',
         to: '2016-12-18T10:01',
-        expected: { from: '2016-11-15T10:00', to: '2016-12-18T10:59' }
+        expected: { from: '2016-11-15T00:00', to: '2016-12-18T23:59' }
       },
       {
         timeLabel: 'week',
         from: '2016-06-21T10:59',
         to: '2016-12-18T10:02',
-        expected: { from: '2016-06-21T10:00', to: '2016-12-18T10:59' }
+        expected: { from: '2016-06-21T00:00', to: '2016-12-18T23:59' }
       },
       {
         timeLabel: 'month',
         from: '2016-02-18T10:59',
         to: '2016-12-18T10:02',
-        expected: { from: '2016-02-18T10:00', to: '2016-12-18T10:59' }
+        expected: { from: '2016-02-18T00:00', to: '2016-12-18T23:59' }
       }
     ];
 

--- a/src/helpers/tests/signals.test.js
+++ b/src/helpers/tests/signals.test.js
@@ -1,6 +1,8 @@
 import { getFriendlyTitle, getDoD, getCaretProps, getDates } from '../signals';
 import cases from 'jest-in-case';
 import thresholds from 'src/pages/signals/constants/healthScoreThresholds';
+import { roundBoundaries } from 'src/helpers/metrics';
+import moment from 'moment';
 
 cases('.getFriendlyTitle', ({ expected, values }) => {
   expect(getFriendlyTitle(values)).toEqual(expected);
@@ -96,13 +98,14 @@ describe('.getCaretProps', () => {
 
 describe('.getDates', () => {
   it('sets relative range', () => {
+    const { from, to } = roundBoundaries(moment('2017-10-02T04:00:00Z'),moment('2017-12-31T05:59:59.999Z'));
     expect(getDates({
       relativeRange: '90days',
       now: '2018-01-01T05:00:00Z'
     })).toEqual({
       relativeRange: '90days',
-      from: new Date('2017-10-02T04:00:00.000Z'),
-      to: new Date('2017-12-31T05:59:59.999Z')
+      from: from.toDate(),
+      to: to.toDate()
     });
   });
 

--- a/src/pages/signals/components/filters/tests/DateFilter.test.js
+++ b/src/pages/signals/components/filters/tests/DateFilter.test.js
@@ -1,6 +1,8 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import { DateFilter } from '../DateFilter';
+import { roundBoundaries } from 'src/helpers/metrics';
+import moment from 'moment';
 
 describe('DateFilter', () => {
   let props;
@@ -22,12 +24,13 @@ describe('DateFilter', () => {
   it('sets a relative range', () => {
     const wrapper = subject();
     const options = { relativeRange: '90days' };
+    const { from, to } = roundBoundaries(moment('2017-10-02T04:00:00Z'),moment('2017-12-31T05:59:59.999Z'));
 
     wrapper.find('AppDatePicker').prop('onChange')(options);
     expect(props.changeSignalOptions).toHaveBeenCalledWith({
       ...options,
-      from: new Date('2017-10-02T04:00:00.000Z'),
-      to: new Date('2017-12-31T05:59:59.999Z')
+      from: from.toDate(),
+      to: to.toDate()
     });
   });
 


### PR DESCRIPTION

### What Changed
 - Updated getMomentPrecision to include `day` as a precision option. 
 - The datepicker should disable the time text field for date choices > 2 days. Should also default to 12:00 am on the from date to 11:59 on the to date.
 - Refactored some code so it's easier to understand IMO.
 - Updated tests. 

### How To Test
 - Test that the datepicker on the report pages correctly show date ranges of 12:00 - 11:59 for day precision. 
 - Test that hour and minute precision works as before.
 - Test that nothing is breaking on the signals page. The signals page uses the same precision functions and datepicker. 

### To Do
- [ ] Undo some refactoring if it makes less sense than before. 
