### PR TITLE
AC-983: Fixed passed down styling

### DIFF
--- a/src/components/billing/PlanPrice.js
+++ b/src/components/billing/PlanPrice.js
@@ -3,8 +3,9 @@ import _ from 'lodash';
 import { getPlanPrice } from 'src/helpers/billing';
 import styles from './PlanPrice.module.scss';
 import { formatCurrency } from 'src/helpers/units';
+import cx from 'classnames';
 
-const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false, selectedPromo = {}, ...rest }) => {
+const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false, selectedPromo = {}, className }) => {
   if (_.isEmpty(plan)) {
     return null;
   }
@@ -32,8 +33,8 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
   const hasDiscount = discountAmount !== priceInfo.price;
 
   return (
-    <span className='notranslate'>
-      <span className={styles.MainLabel} {...rest}>
+    <span className={cx('notranslate', className)} >
+      <span className={styles.MainLabel}>
         <strong>{plan.volume.toLocaleString()}</strong><span> emails/month </span>
         {priceInfo.price > 0
           ? <span>
@@ -44,7 +45,7 @@ const PlanPrice = ({ plan, showOverage = false, showIp = false, showCsm = false,
           </span>
           : <span> FREE </span>}
       </span>
-      <span className={styles.SupportLabel} {...rest}>
+      <span className={styles.SupportLabel}>
         {showOverage && overage}
         {showIp && ip}
       </span>

--- a/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PlanPrice.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`PlanPrice allows class name overriding 1`] = `
 <span
-  className="notranslate"
+  className="notranslate abcd-class"
 >
   <span
-    className="abcd-class"
+    className="MainLabel"
   >
     <strong>
       50,000
@@ -23,7 +23,7 @@ exports[`PlanPrice allows class name overriding 1`] = `
     </span>
   </span>
   <span
-    className="abcd-class"
+    className="SupportLabel"
   />
 </span>
 `;


### PR DESCRIPTION
### What Changed
 - Fixed styling on 

### How To Test
 - Check that plan picker looks correct on `/account/billing/plan` without `account_feature_flags` option
 - Check that plan select looks correct on `/account/billing/plan` with feature flag
 - Check that plan picker looks correct on `/onboarding/plan`

### To Do
- [ ] Address feedback
