### PR TITLE
SA-603 Datepicker Day Precision fix

### DIFF
--- a/src/helpers/messageEvents.js
+++ b/src/helpers/messageEvents.js
@@ -44,7 +44,7 @@ export function parseSearch(search) {
   }
 
   if (range) {
-    dateOptions = { ...dateOptions, ...getRelativeDates(range) };
+    dateOptions = { ...dateOptions, ...getRelativeDates(range, { roundToPrecision: false }) };
   }
 
   const transformedParams = transformParams(rest);

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -95,7 +95,7 @@ export function getPrecisionType(precision) {
  * @param toInput
  * @return {{to: *|moment.Moment, from: *|moment.Moment}}
  */
-export function roundBoundaries(fromInput, toInput) {
+export function roundBoundaries(fromInput, toInput, now = moment()) {
   const from = moment(fromInput);
   const to = moment(toInput);
 
@@ -105,8 +105,10 @@ export function roundBoundaries(fromInput, toInput) {
   const roundInt = (momentPrecision === 'minutes') ? parseInt(precision.replace('min', '')) : 1;
 
   floorMoment(from, roundInt, momentPrecision);
+
   // if we're only at a minute precision, don't round up to the next minute
-  const isToSameAsNow = Math.abs(moment().diff(to, 'minutes')) < 1;
+  const isToSameAsNow = Math.abs(moment(now).diff(to, 'minutes')) < 1;
+
   if (precision !== '1min' && !isToSameAsNow) {
     ceilMoment(to, roundInt, momentPrecision);
   }

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -106,7 +106,10 @@ export function roundBoundaries(fromInput, toInput) {
 
   floorMoment(from, roundInt, momentPrecision);
   // if we're only at a minute precision, don't round up to the next minute
-  if (precision !== '1min') { ceilMoment(to, roundInt, momentPrecision); }
+  const isToSameAsNow = Math.abs(moment().diff(to, 'minutes')) < 1;
+  if (precision !== '1min' && !isToSameAsNow) {
+    ceilMoment(to, roundInt, momentPrecision);
+  }
 
   return { to, from };
 }

--- a/src/helpers/signals.js
+++ b/src/helpers/signals.js
@@ -76,7 +76,7 @@ export const getDates = ({ from, relativeRange, to, now = new Date() } = {}) => 
 
   if (relativeRange !== 'custom') {
     options = {
-      ...getRelativeDates(relativeRange, { now: moment(now).subtract(1, 'day') }),
+      ...getRelativeDates(relativeRange, { now: moment(now).subtract(1, 'day').toDate() }),
       relativeRange: relativeRange
     };
   }

--- a/src/helpers/tests/metrics.test.js
+++ b/src/helpers/tests/metrics.test.js
@@ -200,6 +200,14 @@ describe('metrics helpers', () => {
       expect(resFrom.toISOString()).toEqual(expectedValue.from);
       expect(resTo.toISOString()).toEqual(expectedValue.to);
     }, allCases);
+
+    it('should not round To if it is same as now', () => {
+      const now = '2018-12-18T10:02';
+      const date = moment(new Date(now));
+      Date.now = jest.fn(() => date);
+      const { to } = metricsHelpers.roundBoundaries(moment('2018-11-15T10:59'), moment(now));
+      expect(to.toISOString()).toEqual(date.toISOString()); //Round to ceiling was not called
+    });
   });
 
 

--- a/src/helpers/tests/metrics.test.js
+++ b/src/helpers/tests/metrics.test.js
@@ -178,12 +178,14 @@ describe('metrics helpers', () => {
       const expectedTo = caseObj.timeLabel === '1min' // we don't round at this precision
         ? moment(caseObj.expected.to)
         : moment(caseObj.expected.to).endOf('minutes');
+
       cases.push({
         name: `should round at ${caseObj.timeLabel}`,
         from: moment(caseObj.from),
         to: moment(caseObj.to),
         expectedValue: { from: moment(caseObj.expected.from).toISOString(), to: expectedTo.toISOString() }
       });
+
       cases.push({
         name: `should not round if already at nearest precision for ${caseObj.timeLabel}`,
         from: moment(caseObj.expected.from),
@@ -194,19 +196,19 @@ describe('metrics helpers', () => {
       return cases;
     });
 
-    cases('should round from and to values', ({ timeLabel, from, to, expectedValue }) => {
+    cases('should round from and to values', ({ from, to, expectedValue }) => {
       const { from: resFrom, to: resTo } = metricsHelpers.roundBoundaries(from, to);
 
       expect(resFrom.toISOString()).toEqual(expectedValue.from);
       expect(resTo.toISOString()).toEqual(expectedValue.to);
     }, allCases);
 
-    it('should not round To if it is same as now', () => {
-      const now = '2018-12-18T10:02';
-      const date = moment(new Date(now));
-      Date.now = jest.fn(() => date);
-      const { to } = metricsHelpers.roundBoundaries(moment('2018-11-15T10:59'), moment(now));
-      expect(to.toISOString()).toEqual(date.toISOString()); //Round to ceiling was not called
+    it('should not round to when in future', () => {
+      const now = moment('2016-12-19T10:02');
+      const { from, to } = metricsHelpers.roundBoundaries(moment('2016-02-18T10:59'), now, now);
+
+      expect(from.toISOString()).toEqual(moment('2016-02-18T00:00').toISOString());
+      expect(to.toISOString()).toEqual(now.toISOString());
     });
   });
 

--- a/src/reducers/messageEvents.js
+++ b/src/reducers/messageEvents.js
@@ -135,7 +135,7 @@ export default (state = initialState, { type, payload, meta, extra }) => {
       // Search options
 
     case 'REFRESH_MESSAGE_EVENTS_DATE_OPTIONS': {
-      const dateOptions = { ...state.search.dateOptions, ...payload, ...getRelativeDates(payload.relativeRange, false) };
+      const dateOptions = { ...state.search.dateOptions, ...payload, ...getRelativeDates(payload.relativeRange, { roundToPrecision: false }) };
       return { ...state, search: { ...state.search, dateOptions }};
     }
 

--- a/src/reducers/suppressions.js
+++ b/src/reducers/suppressions.js
@@ -28,7 +28,7 @@ export default (state = initialState, action) => {
       return { ...state, listError: action.payload };
 
 
-    // Fetch list
+      // Fetch list
 
     case 'GET_SUPPRESSIONS_PENDING':
       return { ...state, listLoading: true, listError: null };
@@ -41,7 +41,7 @@ export default (state = initialState, action) => {
 
 
 
-    // Recipients search
+      // Recipients search
 
     case 'SEARCH_SUPPRESSIONS_RECIPIENT_PENDING':
       return { ...state, listLoading: true };
@@ -62,7 +62,7 @@ export default (state = initialState, action) => {
     // Refresh date range for suppression search
 
     case 'REFRESH_SUPPRESSION_SEARCH_DATE_OPTIONS': {
-      const dateOptions = { ...state.search.dateOptions, ...action.payload, ...getRelativeDates(action.payload.relativeRange) };
+      const dateOptions = { ...state.search.dateOptions, ...action.payload, ...getRelativeDates(action.payload.relativeRange, { roundToPrecision: false }) };
       return { ...state, search: { ...state.search, dateOptions }};
     }
 
@@ -92,7 +92,7 @@ export default (state = initialState, action) => {
       return { ...state, deleting: false, deleteError: action.payload };
 
 
-    // Reset results
+      // Reset results
 
     case 'RESET_SUPPRESSIONS_RESULTS':
       return { ...state, list: null };
@@ -103,7 +103,7 @@ export default (state = initialState, action) => {
       return { ...state, persistError: null };
 
 
-    // Parse suppression upload file
+      // Parse suppression upload file
 
     case 'PARSE_SUPPRESSIONS_FILE_FAIL':
       return { ...state, parseError: action.payload };


### PR DESCRIPTION
Fix datepicker from https://github.com/SparkPost/2web2ui/pull/1174. 

Prevent to date from being set into the future by not rounding the to if it's already set to now.

Also disable rounding in suppressions and events. 
