### PR TITLE
SA-888 - Use Health Score endpoint to get injections data

### DIFF
--- a/src/actions/signals.js
+++ b/src/actions/signals.js
@@ -97,20 +97,3 @@ export const getSpamHits = signalsActionCreator({
   dimension: 'spam-hits',
   type: 'GET_SPAM_HITS'
 });
-
-export const getInjections = ({
-  from,
-  to
-}) => sparkpostApiRequest({
-  type: 'GET_INJECTIONS',
-  meta: {
-    method: 'GET',
-    headers: {},
-    url: '/v1/signals/injections',
-    showErrorAlert: false,
-    params: {
-      from: formatInputDate(from),
-      to: formatInputDate(to)
-    }
-  }
-});

--- a/src/actions/tests/__snapshots__/signals.test.js.snap
+++ b/src/actions/tests/__snapshots__/signals.test.js.snap
@@ -161,24 +161,6 @@ Array [
 ]
 `;
 
-exports[`Signals Actions .getInjections by default 1`] = `
-Array [
-  Object {
-    "meta": Object {
-      "headers": Object {},
-      "method": "GET",
-      "params": Object {
-        "from": "2018-01-12",
-        "to": "2018-01-13",
-      },
-      "showErrorAlert": false,
-      "url": "/v1/signals/injections",
-    },
-    "type": "GET_INJECTIONS",
-  },
-]
-`;
-
 exports[`Signals Actions .getSpamHits by default 1`] = `
 Array [
   Object {

--- a/src/actions/tests/signals.test.js
+++ b/src/actions/tests/signals.test.js
@@ -85,10 +85,4 @@ describe('Signals Actions', () => {
       action: () => actions.getCurrentHealthScore({ ...requiredOptions })
     }
   });
-
-  snapshotActionCases('.getInjections', {
-    'by default': {
-      action: () => actions.getInjections({ ...requiredOptions })
-    }
-  });
 });

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -119,34 +119,30 @@ export class HealthScorePage extends Component {
                   }}
                   xAxisProps={this.getXAxisProps()}
                 />
-                {/*
-                  Spam Trap data when faceted by mailbox providers does not exist
-                  Remove when injections are returned from the health score endpoint
-                */}
-                {facet !== 'mb_provider' && (
-                  <>
-                    <ChartHeader title='Injections' tooltipContent={INJECTIONS_INFO} />
-                    <BarChart
-                      margin = {newModelMarginsOther}
-                      gap={gap}
-                      height={190}
-                      onClick={handleDateSelect}
-                      onMouseOver={handleDateHover}
-                      selected={selectedDate}
-                      hovered={hoveredDate}
-                      onMouseOut={resetDateHover}
-                      timeSeries={data}
-                      tooltipContent={({ payload = {}}) => (
-                        <TooltipMetric label='Injections' value={formatFullNumber(payload.injections)} />
-                      )}
-                      yKey='injections'
-                      yAxisProps={{
-                        tickFormatter: (tick) => formatNumber(tick)
-                      }}
-                      xAxisProps={this.getXAxisProps()}
-                    />
-                  </>
-                )}
+
+
+                <ChartHeader title='Injections' tooltipContent={INJECTIONS_INFO} />
+                <BarChart
+                  margin = {newModelMarginsOther}
+                  gap={gap}
+                  height={190}
+                  onClick={handleDateSelect}
+                  onMouseOver={handleDateHover}
+                  selected={selectedDate}
+                  hovered={hoveredDate}
+                  onMouseOut={resetDateHover}
+                  timeSeries={data}
+                  tooltipContent={({ payload = {}}) => (
+                    <TooltipMetric label='Injections' value={formatFullNumber(payload.injections)} />
+                  )}
+                  yKey='injections'
+                  yAxisProps={{
+                    tickFormatter: (tick) => formatNumber(tick)
+                  }}
+                  xAxisProps={this.getXAxisProps()}
+                />
+
+
 
                 {(selectedComponent && !selectedWeightsAreEmpty) && (
                   <Fragment>

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -58,7 +58,7 @@ export class HealthScorePage extends Component {
   }
 
   renderContent = () => {
-    const { data = [], facet, handleDateSelect, handleDateHover, loading, gap, empty, error, selectedDate, hoveredDate, resetDateHover } = this.props;
+    const { data = [], handleDateSelect, handleDateHover, loading, gap, empty, error, selectedDate, hoveredDate, resetDateHover } = this.props;
     const { selectedComponent } = this.state;
 
     const selectedWeights = _.get(_.find(data, ['date', selectedDate]), 'weights', []);
@@ -119,8 +119,6 @@ export class HealthScorePage extends Component {
                   }}
                   xAxisProps={this.getXAxisProps()}
                 />
-
-
                 <ChartHeader title='Injections' tooltipContent={INJECTIONS_INFO} />
                 <BarChart
                   margin = {newModelMarginsOther}
@@ -141,9 +139,6 @@ export class HealthScorePage extends Component {
                   }}
                   xAxisProps={this.getXAxisProps()}
                 />
-
-
-
                 {(selectedComponent && !selectedWeightsAreEmpty) && (
                   <Fragment>
                     <ChartHeader title={HEALTH_SCORE_COMPONENTS[selectedComponent].chartTitle} />

--- a/src/pages/signals/dashboards/HealthScoreDashboard.js
+++ b/src/pages/signals/dashboards/HealthScoreDashboard.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { list as getSubaccounts } from 'src/actions/subaccounts';
-import { getCurrentHealthScore, getInjections } from 'src/actions/signals';
+import { getCurrentHealthScore } from 'src/actions/signals';
 import { Grid } from '@sparkpost/matchbox';
 import Page from '../components/SignalsPage';
 import HealthScoreOverview from '../containers/HealthScoreOverviewContainer';
@@ -15,7 +15,7 @@ import InfoTooltip from '../components/InfoTooltip';
 import { HEALTH_SCORE_INFO } from '../constants/info';
 
 export function HealthScoreDashboard(props) {
-  const { from, getCurrentHealthScore, getInjections, getSubaccounts, relativeRange, subaccounts, to } = props;
+  const { from, getCurrentHealthScore, getSubaccounts, relativeRange, subaccounts, to } = props;
 
   // Gets subaccount info on mount
   useEffect(() => {
@@ -27,8 +27,7 @@ export function HealthScoreDashboard(props) {
     // Ordered by ascending sid to guarantee account rollup (-1) is returned
     // order_by: 'sid' is the default behavior
     getCurrentHealthScore({ relativeRange, order: 'asc', limit: 1, from, to });
-    getInjections({ relativeRange, from, to });
-  }, [getCurrentHealthScore, getInjections, relativeRange, from, to]);
+  }, [getCurrentHealthScore, relativeRange, from, to]);
 
   return (
     <Page
@@ -73,8 +72,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = {
   getCurrentHealthScore,
-  getSubaccounts,
-  getInjections
+  getSubaccounts
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(HealthScoreDashboard);

--- a/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
@@ -18,7 +18,6 @@ describe('Signals Health Score Dashboard', () => {
     <HealthScoreDashboard
       getCurrentHealthScore={() => {}}
       getSubaccounts={() => {}}
-      getInjections={() => {}}
       relativeRange='90days'
       from='2015-01-01'
       to='2015-01-05'
@@ -37,15 +36,9 @@ describe('Signals Health Score Dashboard', () => {
     expect(getSubaccounts).toHaveBeenCalled();
   });
 
-  it('calls getCurrentHealthScore getInjections on mount', () => {
-    const getInjections = jest.fn();
+  it('calls getCurrentHealthScore on mount', () => {
     const getCurrentHealthScore = jest.fn();
-    subject({ getInjections, getCurrentHealthScore }, mount);
-    expect(getInjections).toHaveBeenCalledWith({
-      from: '2015-01-01',
-      relativeRange: '90days',
-      to: '2015-01-05'
-    });
+    subject({ getCurrentHealthScore }, mount);
     expect(getCurrentHealthScore).toHaveBeenCalledWith({
       from: '2015-01-01',
       limit: 1,

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -60,13 +60,6 @@ describe('Signals Health Score Page', () => {
     expect(wrapper.find('withRouter(Connect(WithDetails(SpamTrapsPreview)))')).not.toContainMatchingElement();
   });
 
-  it('does not render injections chart when faceted by mailbox provider', () => {
-    wrapper.setProps({ facet: 'mb_provider' });
-    wrapper.update();
-    expect(wrapper.find({ title: 'Injections' })).not.toExist();
-    expect(wrapper.find({ yKey: 'injections' })).not.toExist();
-  });
-
   it('renders error correctly', () => {
     wrapper.setProps({ error: { message: 'error message' }});
     expect(wrapper).toMatchSnapshot();

--- a/src/reducers/signals.js
+++ b/src/reducers/signals.js
@@ -7,7 +7,6 @@ const initialDimensionState = {
 
 const initialState = {
   currentHealthScore: initialDimensionState,
-  injections: initialDimensionState,
   spamHits: initialDimensionState,
   healthScore: initialDimensionState,
   engagementRecency: initialDimensionState,
@@ -18,16 +17,6 @@ const initialState = {
 
 const signalsReducer = (state = initialState, { type, payload, meta }) => {
   switch (type) {
-    case 'GET_INJECTIONS_FAIL':
-      return { ...state, injections: { ...initialDimensionState, error: payload.error, loading: false }};
-
-    case 'GET_INJECTIONS_PENDING':
-      return { ...state, injections: { ...initialDimensionState, loading: true }};
-
-    case 'GET_INJECTIONS_SUCCESS': {
-      const { data, total_count: totalCount } = payload;
-      return { ...state, injections: { ...initialDimensionState, data, loading: false, totalCount }};
-    }
 
     case 'GET_SPAM_HITS_FAIL':
       return { ...state, spamHits: { ...initialDimensionState, error: payload.error, loading: false }};

--- a/src/reducers/tests/__snapshots__/signals.test.js.snap
+++ b/src/reducers/tests/__snapshots__/signals.test.js.snap
@@ -125,12 +125,6 @@ Object {
     "loading": false,
     "totalCount": 0,
   },
-  "injections": Object {
-    "data": Array [],
-    "error": null,
-    "loading": false,
-    "totalCount": 0,
-  },
   "spamHits": Object {
     "data": Array [],
     "error": null,
@@ -143,49 +137,6 @@ Object {
     "loading": false,
     "totalCount": 0,
   },
-}
-`;
-
-exports[`Signals Reducer injections fail 1`] = `
-Object {
-  "data": Array [],
-  "error": [Error: Oh no!],
-  "loading": false,
-  "totalCount": 0,
-}
-`;
-
-exports[`Signals Reducer injections pending 1`] = `
-Object {
-  "data": Array [],
-  "error": null,
-  "loading": true,
-  "totalCount": 0,
-}
-`;
-
-exports[`Signals Reducer injections success 1`] = `
-Object {
-  "data": Array [
-    Object {
-      "date": "2019-03-24",
-      "injections": 75000000000,
-      "spam_hits": 1,
-    },
-    Object {
-      "date": "2019-03-25",
-      "injections": 75000000000,
-      "spam_hits": 1,
-    },
-    Object {
-      "date": "2019-03-26",
-      "injections": 75000000000,
-      "spam_hits": 1,
-    },
-  ],
-  "error": null,
-  "loading": false,
-  "totalCount": 3,
 }
 `;
 

--- a/src/reducers/tests/signals.test.js
+++ b/src/reducers/tests/signals.test.js
@@ -92,36 +92,5 @@ cases('Signals Reducer', ({ name, key, ...action }) => {
       ],
       total_count: 3
     }
-  },
-  'injections fail': {
-    key: 'injections',
-    type: 'GET_INJECTIONS_FAIL',
-    payload: {
-      error: new Error('Oh no!')
-    }
-  },
-  'injections pending': {
-    key: 'injections',
-    type: 'GET_INJECTIONS_PENDING'
-  },
-  'injections success': {
-    key: 'injections',
-    type: 'GET_INJECTIONS_SUCCESS',
-    payload: {
-      data: [{
-        date: '2019-03-24',
-        injections: 75000000000,
-        spam_hits: 1
-      },{
-        date: '2019-03-25',
-        injections: 75000000000,
-        spam_hits: 1
-      },{
-        date: '2019-03-26',
-        injections: 75000000000,
-        spam_hits: 1
-      }],
-      total_count: 3
-    }
   }
 });

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -294,7 +294,7 @@ export const selectHealthScoreDetails = createSelector(
     });
 
     // Merge in rankings
-    const mergedHistory = _.map(filledHistory, (healthData) => ({ ranking: rankHealthScore(roundToPlaces(healthData.health_score * 100, 1)), ...healthData }));
+    const mergedHistory = filledHistory.map((healthData) => ({ ranking: rankHealthScore(roundToPlaces(healthData.health_score * 100, 1)), ...healthData }));
 
     const isEmpty = mergedHistory.every((values) => values.health_score === null);
 

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -293,7 +293,7 @@ export const selectHealthScoreDetails = createSelector(
       from, to
     });
 
-    // Merge in injections and rankings
+    // Merge in rankings
     const mergedHistory = _.map(filledHistory, (healthData) => ({ ranking: rankHealthScore(roundToPlaces(healthData.health_score * 100, 1)), ...healthData }));
 
     const isEmpty = mergedHistory.every((values) => values.health_score === null);

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -25,7 +25,6 @@ export const getUnsubscribeRateByCohortData = (state, props) => _.get(state, 'si
 export const getComplaintsByCohortData = (state, props) => _.get(state, 'signals.complaintsByCohort', {});
 export const getHealthScoreData = (state, props) => _.get(state, 'signals.healthScore', {});
 export const getCurrentHealthScoreData = (state, props) => _.get(state, 'signals.currentHealthScore', {});
-export const getInjections = (state, props) => _.get(state, 'signals.injections', {});
 
 // Details
 export const selectSpamHitsDetails = createSelector(
@@ -268,9 +267,10 @@ export const selectHealthScoreDetails = createSelector(
     const match = data.find((item) => String(item[facet]) === facetId) || {};
 
     const history = _.get(match, 'history', []);
-    const normalizedHistory = history.map(({ dt: date, weights, ...values }) => ({
+    const normalizedHistory = history.map(({ dt: date, weights, total_injection_count: injections, ...values }) => ({
       date,
       weights: _.sortBy(weights, ({ weight }) => parseFloat(weight)),
+      injections,
       ...values
     }));
 
@@ -287,16 +287,14 @@ export const selectHealthScoreDetails = createSelector(
           { weight_type: 'eng cohorts: new, 14-day', weight: null, weight_value: null },
           { weight_type: 'eng cohorts: unengaged', weight: null, weight_value: null }
         ],
-        health_score: null
+        health_score: null,
+        injections: null
       },
       from, to
     });
 
     // Merge in injections and rankings
-    const mergedHistory = _.map(filledHistory, (healthData) => {
-      const spamData = _.find(spamDetails.data, ['date', healthData.date]);
-      return { injections: spamData.injections, ranking: rankHealthScore(roundToPlaces(healthData.health_score * 100, 1)), ...healthData };
-    });
+    const mergedHistory = _.map(filledHistory, (healthData) => ({ ranking: rankHealthScore(roundToPlaces(healthData.health_score * 100, 1)), ...healthData }));
 
     const isEmpty = mergedHistory.every((values) => values.health_score === null);
 
@@ -426,21 +424,19 @@ export const selectHealthScoreOverviewData = createSelector(
 );
 
 export const selectCurrentHealthScoreDashboard = createSelector(
-  [getCurrentHealthScoreData, getOptions, getInjections],
-  ({ data, loading, error }, { from, to }, injections) => {
+  [getCurrentHealthScoreData, getOptions],
+  ({ data, loading, error }, { from, to }) => {
     const accountData = _.find(data, ['sid', -1]) || {};
     const history = accountData.history || [];
 
-    const normalizedHistory = history.map(({ dt: date, health_score, ...values }) => {
+    const normalizedHistory = history.map(({ dt: date, health_score, total_injection_count: injections, ...values }) => {
       const roundedHealthScore = roundToPlaces(health_score * 100, 1);
-      const injectionData = _.find(injections.data, ['dt', date]) || {};
-
       return {
         ...values,
         date,
         health_score: roundedHealthScore,
         ranking: rankHealthScore(roundedHealthScore),
-        injections: injectionData.injections
+        injections
       };
     });
 

--- a/src/selectors/tests/__snapshots__/signals.test.js.snap
+++ b/src/selectors/tests/__snapshots__/signals.test.js.snap
@@ -1155,7 +1155,7 @@ Object {
       Object {
         "date": "2018-01-02",
         "health_score": 0.8,
-        "injections": null,
+        "injections": undefined,
         "ranking": "good",
         "weights": Array [],
       },
@@ -1426,6 +1426,7 @@ Object {
           "date": "2018-01-01",
           "health_score": 74.3,
           "ranking": "warning",
+          "total_injection_count": 182400,
           "weights": Array [
             Object {
               "weight": 0.5,
@@ -1454,6 +1455,7 @@ Object {
           "date": "2018-01-03",
           "health_score": 98,
           "ranking": "good",
+          "total_injection_count": 35000,
           "weights": Array [],
         },
       ],
@@ -1502,6 +1504,7 @@ Array [
         "date": "2018-01-01",
         "health_score": 74.3,
         "ranking": "warning",
+        "total_injection_count": 182400,
         "weights": Array [
           Object {
             "weight": 0.5,
@@ -1530,6 +1533,7 @@ Array [
         "date": "2018-01-03",
         "health_score": 98,
         "ranking": "good",
+        "total_injection_count": 35000,
         "weights": Array [],
       },
     ],

--- a/src/selectors/tests/__snapshots__/signals.test.js.snap
+++ b/src/selectors/tests/__snapshots__/signals.test.js.snap
@@ -1160,7 +1160,6 @@ Object {
         "weights": Array [],
       },
       Object {
-        "WoW": null,
         "date": "2018-01-03",
         "health_score": 0.98,
         "injections": 35000,
@@ -1228,9 +1227,9 @@ Object {
       "health_score": 80,
       "injections": 100,
       "ranking": "good",
+      "weights": Array [],
     },
     Object {
-      "WoW": null,
       "date": "2018-01-03",
       "health_score": 98,
       "injections": 100,
@@ -1317,7 +1316,7 @@ Object {
     "max": 10,
     "relativeMax": 20,
   },
-  "total_count": 10,
+  "totalCount": 1,
 }
 `;
 
@@ -1450,9 +1449,9 @@ Object {
           "health_score": 80,
           "ranking": "good",
           "total_injection_count": 12345,
+          "weights": Array [],
         },
         Object {
-          "WoW": null,
           "date": "2018-01-03",
           "health_score": 98,
           "ranking": "good",
@@ -1463,7 +1462,7 @@ Object {
       "sending_domain": "test.com",
     },
   ],
-  "total_count": 10,
+  "totalCount": 1,
 }
 `;
 
@@ -1529,9 +1528,9 @@ Array [
         "health_score": 80,
         "ranking": "good",
         "total_injection_count": 12345,
+        "weights": Array [],
       },
       Object {
-        "WoW": null,
         "date": "2018-01-03",
         "health_score": 98,
         "ranking": "good",
@@ -1698,7 +1697,7 @@ Object {
     "max": 856,
     "relativeMax": 0.3,
   },
-  "total_count": 1,
+  "totalCount": 2,
 }
 `;
 

--- a/src/selectors/tests/__snapshots__/signals.test.js.snap
+++ b/src/selectors/tests/__snapshots__/signals.test.js.snap
@@ -1155,7 +1155,7 @@ Object {
       Object {
         "date": "2018-01-02",
         "health_score": 0.8,
-        "injections": undefined,
+        "injections": 12345,
         "ranking": "good",
         "weights": Array [],
       },
@@ -1449,6 +1449,7 @@ Object {
           "date": "2018-01-02",
           "health_score": 80,
           "ranking": "good",
+          "total_injection_count": 12345,
         },
         Object {
           "WoW": null,
@@ -1527,6 +1528,7 @@ Array [
         "date": "2018-01-02",
         "health_score": 80,
         "ranking": "good",
+        "total_injection_count": 12345,
       },
       Object {
         "WoW": null,

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -27,7 +27,7 @@ describe('Selectors: signals', () => {
       },
       signals: {
         spamHits: {
-          total_count: 1,
+          totalCount: 2,
           data: [
             {
               sending_domain: 'test.com',
@@ -86,7 +86,7 @@ describe('Selectors: signals', () => {
           error: null
         },
         engagementRecency: {
-          total_count: 10,
+          totalCount: 1,
           data: [
             {
               sending_domain: 'test.com',
@@ -117,7 +117,7 @@ describe('Selectors: signals', () => {
           error: null
         },
         engagementRateByCohort: {
-          total_count: 10,
+          totalCount: 1,
           data: [
             {
               sending_domain: 'test.com',
@@ -145,7 +145,7 @@ describe('Selectors: signals', () => {
           error: null
         },
         unsubscribeRateByCohort: {
-          total_count: 10,
+          totalCount: 1,
           data: [
             {
               sending_domain: 'test.com',
@@ -173,7 +173,7 @@ describe('Selectors: signals', () => {
           error: null
         },
         complaintsByCohort: {
-          total_count: 10,
+          totalCount: 1,
           data: [
             {
               sending_domain: 'test.com',
@@ -201,7 +201,7 @@ describe('Selectors: signals', () => {
           error: null
         },
         healthScore: {
-          total_count: 10,
+          totalCount: 1,
           data: [
             {
               current_weights: [],
@@ -234,21 +234,21 @@ describe('Selectors: signals', () => {
                 {
                   dt: '2018-01-02',
                   health_score: 0.8,
+                  weights: [],
                   total_injection_count: 12345
                 },
                 {
                   dt: '2018-01-03',
                   health_score: 0.98, // good
                   weights: [],
-                  total_injection_count: 35000,
-                  WoW: null
+                  total_injection_count: 35000
                 }
               ]
             }
           ]
         },
         currentHealthScore: {
-          total_count: 10,
+          totalCount: 1,
           data: [
             {
               sid: -1,
@@ -266,14 +266,14 @@ describe('Selectors: signals', () => {
                 {
                   dt: '2018-01-02',
                   health_score: 0.8,
-                  total_injection_count: 100
+                  total_injection_count: 100,
+                  weights: []
                 },
                 {
                   dt: '2018-01-03',
                   health_score: 0.98, // good
                   weights: [],
-                  total_injection_count: 100,
-                  WoW: null
+                  total_injection_count: 100
                 }
               ]
             }

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -233,7 +233,8 @@ describe('Selectors: signals', () => {
                 },
                 {
                   dt: '2018-01-02',
-                  health_score: 0.8
+                  health_score: 0.8,
+                  total_injection_count: 12345
                 },
                 {
                   dt: '2018-01-03',

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -212,6 +212,7 @@ describe('Selectors: signals', () => {
                 {
                   dt: '2018-01-01',
                   health_score: 0.74321, // bad
+                  total_injection_count: 182400,
                   weights: [
                     {
                       weight_type: 'eng cohorts: new, 14-day',
@@ -238,6 +239,7 @@ describe('Selectors: signals', () => {
                   dt: '2018-01-03',
                   health_score: 0.98, // good
                   weights: [],
+                  total_injection_count: 35000,
                   WoW: null
                 }
               ]
@@ -257,27 +259,23 @@ describe('Selectors: signals', () => {
                 {
                   dt: '2018-01-01',
                   health_score: 0.74321, // bad
+                  total_injection_count: 100,
                   weights: []
                 },
                 {
                   dt: '2018-01-02',
-                  health_score: 0.8
+                  health_score: 0.8,
+                  total_injection_count: 100
                 },
                 {
                   dt: '2018-01-03',
                   health_score: 0.98, // good
                   weights: [],
+                  total_injection_count: 100,
                   WoW: null
                 }
               ]
             }
-          ]
-        },
-        injections: {
-          data: [
-            { injections: 100, spam_hits: 1, dt: '2018-01-01' },
-            { injections: 100, spam_hits: 1, dt: '2018-01-02' },
-            { injections: 100, spam_hits: 1, dt: '2018-01-03' }
           ]
         }
       }


### PR DESCRIPTION
### What Changed
 - Used `total_injection_count` from the health score endpoint in the selector to get injections.
 - Removed the call to `/signals/injection` in the health score page and all related code.
 - Allow the injection chart to be shown for mailbox provider facet.

### How To Test
 - Best to point to production and use the 108 account but there is still one data point in staging from June 10th.
 - Go to the health score overview page `signals/health-score`. Check that the number of injections came from the health score endpoint by checking the UI value and the value returned by the API call.
 - Do the same thing for the details view. You can access the details view by clicking one of hte facet links in table in the health score overview page.
 - Check that the injections chart appears for mailbox-provider facet. Do this by filtering by mailbox provider in the overview page and then clicking on the mailbox provider facet. 
