### PR TITLE
SA-893 - Use Total Injection instead of total recipients

### DIFF
--- a/src/pages/signals/components/EngagementRecencyOverview.js
+++ b/src/pages/signals/components/EngagementRecencyOverview.js
@@ -193,7 +193,7 @@ class EngagementRecencyOverview extends React.Component {
           <Column
             align="right"
             dataKey="total_engagement"
-            label="Total Recipients"
+            label="Total Injections"
             width="15%"
             component={({ total_engagement }) => <NumericDataCell value={total_engagement} />}
           />

--- a/src/pages/signals/components/tests/__snapshots__/EngagementRecencyOverview.test.js.snap
+++ b/src/pages/signals/components/tests/__snapshots__/EngagementRecencyOverview.test.js.snap
@@ -122,7 +122,7 @@ exports[`EngagementRecencyOverview renders overview panel with controls and tabl
       align="right"
       component={[Function]}
       dataKey="total_engagement"
-      label="Total Recipients"
+      label="Total Injections"
       width="15%"
     />
   </Connect(SummaryTable)>


### PR DESCRIPTION
### What Changed
 - Changed table header for engagement recency from `Total Recipients` to `Total Injections`

### How To Test
 - Go to `/signals/engagement`. Check that the rightmost table header reads `Total Injections`.
