### PR TITLE
SE-260: Alert create page freezes for certain enterprise customers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34047,6 +34047,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.0.1.tgz",
+      "integrity": "sha512-uCPUD1BtzNjwJBsMFggtvNRfw5vCsarw75TM6Tcj0kCg58YvMnIAuvcPrl6mA91m4BtVvRfPTajZv1OEQpN+hw=="
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^4.0.0",
     "source-map-explorer": "^1.6.0",
+    "use-debounce": "^3.0.1",
     "uuid": "^3.2.1",
     "validator": "^10.2.0"
   },

--- a/src/components/reduxFormWrappers/tests/__snapshots__/ComboBoxTypeaheadWrapper.test.js.snap
+++ b/src/components/reduxFormWrappers/tests/__snapshots__/ComboBoxTypeaheadWrapper.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ComboBoxTypeaheadWrapper renders Combobox typeahead 1`] = `
 <ComboBoxTypeahead
-  debounceFn={[Function]}
   defaultSelected={Array []}
   itemToString={[Function]}
   label="Options"

--- a/src/components/typeahead/ComboBoxTypeahead.js
+++ b/src/components/typeahead/ComboBoxTypeahead.js
@@ -29,7 +29,7 @@ export const ComboBoxTypeahead = ({
 
   useEffect(() => {
     onChange(selected.map(selectedMap));
-  }, [onChange, selectedMap, selected]);
+  }, [onChange, selectedMap, defaultSelected, selected]);
 
   useEffect(() => {
     updateMenuItems(inputValue);
@@ -50,6 +50,8 @@ export const ComboBoxTypeahead = ({
           selectedItem: null
         };
       }
+      case Downshift.stateChangeTypes.changeInput:
+        setInputValue(changes.inputValue);
     }
 
     return changes;
@@ -106,7 +108,7 @@ export const ComboBoxTypeahead = ({
     <Downshift
       defaultHighlightedIndex={0}
       itemToString={itemToString}
-      onInputValueChange={(nextInputValue) => { setInputValue(nextInputValue); }}
+
       stateReducer={stateReducer}
     >
       {typeaheadfn}

--- a/src/components/typeahead/ComboBoxTypeahead.js
+++ b/src/components/typeahead/ComboBoxTypeahead.js
@@ -89,7 +89,7 @@ export const ComboBoxTypeahead = ({
       itemToString,
       label,
       onFocus: () => { openMenu(); },
-      placeholder,
+      placeholder: selectedItems.length ? '' : placeholder,
       readOnly: readOnly || results.length === 0,
       removeItem: (itemToRemove) => {
         const mappedItemToRemove = selectedMap(itemToRemove);
@@ -145,6 +145,7 @@ ComboBoxTypeahead.defaultProps = {
   defaultSelected: [],
   itemToString: (item) => item,
   maxNumberOfResults: 100,
+  placeholder: '',
   results: [],
   selectedMap: (item) => item
 };

--- a/src/components/typeahead/ComboBoxTypeahead.js
+++ b/src/components/typeahead/ComboBoxTypeahead.js
@@ -28,6 +28,12 @@ export const ComboBoxTypeahead = ({
     setMenuItems(nextMenuItems);
   }, 300);
 
+  // Updated list of selected menu items when combo box is being controlled
+  // note, state must be initialized with defaultSelected to avoid a runaway effect
+  useEffect(() => {
+    setSelectedItems(defaultSelected);
+  }, [setSelectedItems, defaultSelected]);
+
   // Report change to selected items (important for redux-form Fields)
   useEffect(() => {
     onChange(selectedItems.map(selectedMap));

--- a/src/components/typeahead/ComboBoxTypeahead.js
+++ b/src/components/typeahead/ComboBoxTypeahead.js
@@ -90,7 +90,7 @@ export const ComboBoxTypeahead = ({
     const isSelectedItemExclusive = isExclusiveItem(selectedItems[0]);
     const items = menuItems
       .filter((item) => (
-        !isSelectedItem(item) && !(hasSelectedItems && isExclusiveItem(item))
+        !isSelectedItemExclusive && !isSelectedItem(item) && !(hasSelectedItems && isExclusiveItem(item))
       ))
       .map((item, index) => getItemProps({
         content: itemToString(item),
@@ -98,7 +98,7 @@ export const ComboBoxTypeahead = ({
         index,
         item
       }));
-    const isMenuOpen = isOpen && Boolean(items.length) && !isSelectedItemExclusive;
+    const isMenuOpen = isOpen && Boolean(items.length);
 
     const inputProps = getInputProps({
       disabled,

--- a/src/components/typeahead/tests/ComboBoxTypeahead.test.js
+++ b/src/components/typeahead/tests/ComboBoxTypeahead.test.js
@@ -119,6 +119,16 @@ describe('ComboBoxTypeahead', () => {
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('readOnly', true);
   });
 
+  it('renders placeholder message when no items have been selected', () => {
+    const wrapper = subject({ placeholder: 'Do something!' });
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('placeholder', 'Do something!');
+  });
+
+  it('does not render placeholder message when items have been selected', () => {
+    const wrapper = subject({ defaultSelected: ['apple'], placeholder: 'Do something!' });
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('placeholder', '');
+  });
+
   it('calls onChange on mount', () => {
     const onChange = jest.fn();
     subject({ defaultSelected: ['pineapple'], onChange });

--- a/src/components/typeahead/tests/ComboBoxTypeahead.test.js
+++ b/src/components/typeahead/tests/ComboBoxTypeahead.test.js
@@ -1,57 +1,147 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
+import { useDebouncedCallback } from 'use-debounce';
 import { ComboBoxTypeahead } from '../ComboBoxTypeahead';
 
-jest.mock('lodash/debounce', () => jest.fn((fn) => {
-  fn.cancel = jest.fn();
-  return fn;
-}));
+jest.mock('use-debounce');
 
 describe('ComboBoxTypeahead', () => {
-  const onChange = jest.fn();
   const subject = (props = {}) => mount(
     <ComboBoxTypeahead
+      defaultSelected={[]}
+      onChange={() => {}}
       results={[
-        'apples',
-        'bananas',
-        'cauliflower'
+        'apple',
+        'banana',
+        'blue ',
+        'cauliflower',
+        'grape',
+        'grapefruit',
+        'orange',
+        'pineapple'
       ]}
-      onChange={onChange}
       {...props}
     />
   );
 
-  it('updates matches when entering text', () => {
-    const wrapper = subject();
-    wrapper.find('ComboBoxTextField').props().onChange({ target: { value: 'appl' }});
-    wrapper.update();
-    const items = wrapper.find('ComboBoxMenu').prop('items');
-    expect(items).toHaveLength(1);
-    expect(items[0].content).toEqual('apples');
-  });
+  const changeInputValue = (wrapper, nextValue) => {
+    const fakeEvent = { target: { value: nextValue }};
 
-  it('updates the field value after selecting an option', () => {
-    const wrapper = subject();
-    wrapper.find('ComboBoxMenu').prop('items').shift().onClick({});
-    wrapper.update();
-    expect(onChange).toHaveBeenCalledWith(['apples']);
-  });
-
-  it('action list does not show when there are no options and the textbox is read-only', () => {
-    const wrapper = subject({ results: []});
-    wrapper.find('ComboBoxTextField').props().onClick({});
-    expect(wrapper.find('ComboBoxTextField').prop('readOnly')).toEqual(true);
-    expect(wrapper.find('ComboBoxMenu').prop('isOpen')).toEqual(false);
-  });
-
-  it('cancels the debounce on unmount', () => {
-    const cancel = jest.fn();
-    const debounceFn = jest.fn((fn) => {
-      fn.cancel = cancel;
-      return fn;
+    act(() => {
+      // simulate a input value change
+      // todo, `simulate('change', fakeEvent)` doesn't work
+      wrapper.find('ComboBoxTextField').prop('onChange')(fakeEvent);
     });
-    const wrapper = subject({ debounceFn });
-    wrapper.unmount();
-    expect(cancel).toHaveBeenCalled();
+
+    wrapper.update(); // ugh
+  };
+
+  const selectMenuItem = (wrapper, itemIndex) => {
+    const fakeEvent = jest.fn();
+    const menuItem = wrapper.find('ComboBoxMenu').prop('items')[itemIndex];
+
+    act(() => {
+      // click menu item to simulate selection
+      menuItem.onClick(fakeEvent, menuItem.content);
+    });
+
+    wrapper.update(); // ugh
+  };
+
+  beforeEach(() => {
+    // need to memoize with useCallback
+    useDebouncedCallback.mockImplementation((fn) => [useCallback(fn, [])]);
+  });
+
+  it('renders max number of menu items', () => {
+    const wrapper = subject({ maxNumberOfResults: 5 });
+    expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(5);
+  });
+
+  it('renders filtered menu items', async () => {
+    const wrapper = subject();
+    changeInputValue(wrapper, 'grape');
+    expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(2);
+  });
+
+  it('renders filtered menu items without selected items', async () => {
+    const wrapper = subject({ defaultSelected: ['grape']});
+    changeInputValue(wrapper, 'grape');
+    expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(1);
+  });
+
+  it('does not render a menu when no matches', async () => {
+    const wrapper = subject();
+    changeInputValue(wrapper, 'xyz');
+    expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', false);
+  });
+
+  it('leaves menu open after a selection', () => {
+    const wrapper = subject();
+    selectMenuItem(wrapper, 0);
+    expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', true);
+  });
+
+  it('resets input value after a selection', () => {
+    const wrapper = subject();
+    changeInputValue(wrapper, 'app');
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('value', 'app');
+    selectMenuItem(wrapper, 0);
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('value', '');
+  });
+
+  it('opens menu on focus', () => {
+    const wrapper = subject();
+
+    act(() => {
+      // todo, `simulate('focus')` doesn't work
+      wrapper.find('ComboBoxTextField').prop('onFocus')();
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', true);
+  });
+
+  it('disables text field', () => {
+    const wrapper = subject({ disabled: true });
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('disabled', true);
+  });
+
+  it('enabled read only mode for text field', () => {
+    const wrapper = subject({ readOnly: true });
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('readOnly', true);
+  });
+
+  it('enabled read only mode for text field when no results are provided', () => {
+    const wrapper = subject({ results: []});
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('readOnly', true);
+  });
+
+  it('calls onChange on mount', () => {
+    const onChange = jest.fn();
+    subject({ defaultSelected: ['pineapple'], onChange });
+    expect(onChange).toHaveBeenCalledWith(['pineapple']);
+  });
+
+  it('calls onChange when selected item is added', () => {
+    const onChange = jest.fn();
+    const wrapper = subject({ onChange });
+
+    selectMenuItem(wrapper, 0);
+
+    expect(onChange).toHaveBeenCalledWith(['apple']);
+  });
+
+  it('calls onChange when selected item is removed', () => {
+    const onChange = jest.fn();
+    const wrapper = subject({ defaultSelected: ['apple', 'pineapple'], onChange });
+
+    act(() => {
+      wrapper.find('ComboBoxTextField').prop('removeItem')('pineapple');
+    });
+
+    expect(onChange).toHaveBeenCalledWith(['apple']);
   });
 });

--- a/src/components/typeahead/tests/ComboBoxTypeahead.test.js
+++ b/src/components/typeahead/tests/ComboBoxTypeahead.test.js
@@ -59,19 +59,34 @@ describe('ComboBoxTypeahead', () => {
     expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(5);
   });
 
-  it('renders filtered menu items', async () => {
+  it('renders filtered menu items', () => {
     const wrapper = subject();
     changeInputValue(wrapper, 'grape');
     expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(2);
   });
 
-  it('renders filtered menu items without selected items', async () => {
+  it('renders filtered menu items without selected items', () => {
     const wrapper = subject({ defaultSelected: ['grape']});
     changeInputValue(wrapper, 'grape');
     expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(1);
   });
 
-  it('does not render a menu when no matches', async () => {
+  it('renders filtered menu items without exclusive items', () => {
+    const wrapper = subject({
+      defaultSelected: [{ content: 'B' }],
+      itemToString: (item) => item.content,
+      results: [
+        { content: 'A', isExclusiveItem: true },
+        { content: 'B' },
+        { content: 'C' }
+      ],
+      selectedMap: (item) => item.content
+    });
+
+    expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(1);
+  });
+
+  it('does not render a menu when no matches', () => {
     const wrapper = subject();
     changeInputValue(wrapper, 'xyz');
     expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', false);
@@ -81,6 +96,15 @@ describe('ComboBoxTypeahead', () => {
     const wrapper = subject();
     selectMenuItem(wrapper, 0);
     expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', true);
+  });
+
+  it('closes menu when exclusive item is selected', () => {
+    const wrapper = subject({
+      itemToString: (item) => item.content,
+      results: [{ content: 'My Example', isExclusiveItem: true }]
+    });
+    selectMenuItem(wrapper, 0);
+    expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', false);
   });
 
   it('resets input value after a selection', () => {
@@ -114,8 +138,12 @@ describe('ComboBoxTypeahead', () => {
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('readOnly', true);
   });
 
-  it('enabled read only mode for text field when no results are provided', () => {
-    const wrapper = subject({ results: []});
+  it('enabled read only mode for text field when an exclusive item is selected', () => {
+    const wrapper = subject({
+      itemToString: (item) => item.content,
+      results: [{ content: 'My Example', isExclusiveItem: true }]
+    });
+    selectMenuItem(wrapper, 0);
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('readOnly', true);
   });
 

--- a/src/components/typeahead/tests/ComboBoxTypeahead.test.js
+++ b/src/components/typeahead/tests/ComboBoxTypeahead.test.js
@@ -157,6 +157,16 @@ describe('ComboBoxTypeahead', () => {
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('placeholder', '');
   });
 
+  it('controls selected items from parent component', () => {
+    const wrapper = subject();
+    const selectedItems = ['apple', 'banana'];
+
+    wrapper.setProps({ defaultSelected: selectedItems });
+    wrapper.update();
+
+    expect(wrapper.find('ComboBoxTextField')).toHaveProp('selectedItems', selectedItems);
+  });
+
   it('calls onChange on mount', () => {
     const onChange = jest.fn();
     subject({ defaultSelected: ['pineapple'], onChange });

--- a/src/pages/alerts/components/fields/SubaccountsField.js
+++ b/src/pages/alerts/components/fields/SubaccountsField.js
@@ -16,50 +16,31 @@ const subaccountToString = (subaccount) => {
 const subaccountMap = (item) => item.id;
 
 export class SubaccountsField extends Component {
-
   componentDidMount() {
     this.props.listSubaccounts();
   }
 
-  getAllAvailableSubaccounts = () => [
-    { id: -1, name: 'Master and all subaccounts' },
-    { id: -2, name: 'Any subaccount' },
-    { id: 0, name: 'Master account' },
-    ...this.props.subaccounts
-  ];
-
-  /*
-  If the field is empty/pristine, show all options.
-  If the user has already entered master & all or entered any subaccount, do no show any options
-  If the user has already entered another subaccount, do not how master & all, nor any subaccount
-   */
-  getSubaccountOptions = () => {
-    const { subaccountsFieldValue, subaccounts } = this.props;
-
-    if (subaccountsFieldValue.length === 0) {
-      return this.getAllAvailableSubaccounts();
-    }
-
-    return (subaccountsFieldValue[0] < 0)
-      ? []
-      : [{ id: 0, name: 'Master account' },
-        ...subaccounts];
-  };
-
   render() {
-    const { disabled, subaccountsFieldValue } = this.props;
+    const { disabled, subaccounts, subaccountsFieldValue } = this.props;
+    const subaccountItems = [
+      { id: -1, name: 'Master and all subaccounts', isExclusiveItem: true },
+      { id: -2, name: 'Any subaccount', isExclusiveItem: true },
+      { id: 0, name: 'Master account' },
+      ...subaccounts
+    ];
+
     //Maps from an array of subaccount ids to an array of full subaccount objects
     const selectedSubaccounts = subaccountsFieldValue.map((subaccountId) =>
       /*Find the correct subaccount object within all available subaccounts. If not found, return a default object with
       an id and a placeholder name.
       */
-      this.getAllAvailableSubaccounts().find(({ id }) => id === subaccountId) || { id: subaccountId, name: 'id:' });
+      subaccountItems.find(({ id }) => id === subaccountId) || { id: subaccountId, name: 'id:' });
 
     return (
       <Field
         name='subaccounts'
         component={ComboBoxTypeaheadWrapper}
-        results={this.getSubaccountOptions()}
+        results={subaccountItems}
         itemToString={subaccountToString}
         selectedMap={subaccountMap}
         disabled={disabled}

--- a/src/pages/alerts/components/fields/tests/SubaccountsField.test.js
+++ b/src/pages/alerts/components/fields/tests/SubaccountsField.test.js
@@ -1,62 +1,45 @@
-import { shallow } from 'enzyme';
 import React from 'react';
+import { shallow } from 'enzyme';
 import { SubaccountsField } from '../SubaccountsField';
-import cases from 'jest-in-case';
 
 describe('Subaccount Field', () => {
-  let props;
-  let wrapper;
+  const subject = (props = {}) => shallow(
+    <SubaccountsField
+      disabled={false}
+      listSubaccounts={() => {}}
+      subaccounts={[
+        { id: 1, name: 'My Subacount' }
+      ]}
+      subaccountsFieldValue={[]}
+      {...props}
+    />
+  );
 
-  beforeEach(() => {
-    props = {
-      hasSubaccounts: true,
-      disabled: false,
-      subaccounts: [{ id: 1, name: 'My Subacount' }],
-      subaccountsFieldValue: [],
-      listSubaccounts: jest.fn()
-    };
-
-    wrapper = shallow(<SubaccountsField {...props} />);
+  it('renders combo box field', () => {
+    expect(subject()).toMatchSnapshot();
   });
 
-  it('should render the Subaccounts Field component correctly', () => {
-    expect(wrapper).toMatchSnapshot();
+  it('calls listSubaccounts on mount', () => {
+    const listSubaccounts = jest.fn();
+    subject({ listSubaccounts });
+    expect(listSubaccounts).toHaveBeenCalled();
   });
 
-  it('gets subaccounts when mounted', () => {
-    wrapper = shallow(<SubaccountsField {...props}/>);
-    expect(props.listSubaccounts).toHaveBeenCalled();
+  it('renders combo box field with mapped field values', () => {
+    const wrapper = subject({ subaccountsFieldValue: [0, 1]});
+    expect(wrapper).toHaveProp('defaultSelected', [
+      { id: 0, name: 'Master account' },
+      { id: 1, name: 'My Subacount' }
+    ]);
   });
 
-  describe('correct options should show when', () => {
-    const subaccountCases = {
-      'no subaccounts are selected':
-      {
-        subaccountsFieldValue: [],
-        expectedLength: 4
-      },
-      'Master and all subaccounts is selected': {
-        subaccountsFieldValue: [-1],
-        expectedLength: 0
-      },
-      'Any subaccount is selected': {
-        subaccountsFieldValue: [-2],
-        expectedLength: 0
-      },
-      'master account is selected': {
-        subaccountsFieldValue: [0],
-        expectedLength: 2
-      },
-      'multiple subaccounts are selected': {
-        subaccountsFieldValue: [0,1],
-        expectedLength: 2
-      }
-    };
-
-    cases('options should be correct when', ({ subaccountsFieldValue, expectedLength }) => {
-      wrapper.setProps({ subaccountsFieldValue });
-      expect(wrapper.find({ name: 'subaccounts' }).prop('results')).toHaveLength(expectedLength);
-    }, subaccountCases);
+  it('renders combo box field with unknown field values', () => {
+    const wrapper = subject({ subaccountsFieldValue: [999]});
+    expect(wrapper).toHaveProp('defaultSelected', [{ id: 999, name: 'id:' }]);
   });
 
+  it('renders disabled combo box field', () => {
+    const wrapper = subject({ disabled: true });
+    expect(wrapper).toHaveProp('disabled', true);
+  });
 });

--- a/src/pages/alerts/components/fields/tests/__snapshots__/SubaccountsField.test.js.snap
+++ b/src/pages/alerts/components/fields/tests/__snapshots__/SubaccountsField.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Subaccount Field should render the Subaccounts Field component correctly 1`] = `
+exports[`Subaccount Field renders combo box field 1`] = `
 <Field
   component={[Function]}
   defaultSelected={Array []}
@@ -13,10 +13,12 @@ exports[`Subaccount Field should render the Subaccounts Field component correctl
     Array [
       Object {
         "id": -1,
+        "isExclusiveItem": true,
         "name": "Master and all subaccounts",
       },
       Object {
         "id": -2,
+        "isExclusiveItem": true,
         "name": "Any subaccount",
       },
       Object {


### PR DESCRIPTION
Refer to [SE-260](https://jira.int.messagesystems.com/browse/SE-260)

### What Changed
 - Combo box typeahead should only render a max of 100 options
 - Combo box menu should remain open after a selection

### How To Test
 - Open /alerts/create page using an account with thousands of subaccounts (e.g. brian.kemper+se-260@sparkpost.com)
 - Select "Health Score" from "Alert Metric" dropdown

_This is the point when your browser would freeze because all the subaccounts were being written to DOM for the combo box menu.  Now, it should not freeze and allow you to continue with creation of an alert._  