### PR TITLE
TR-1781 - Fix creating new template in V2

### DIFF
--- a/src/actions/helpers/templates.js
+++ b/src/actions/helpers/templates.js
@@ -18,8 +18,8 @@ export const getTestDataKey = ({ id, username, mode }) => ([ 'tpldata', username
 export const shapeContent = (content = {}) => {
   const shapedContent = {
     ...content,
+    text: content.text,
     reply_to: _.isEmpty(content.reply_to) ? undefined : content.reply_to,
-    text: _.isEmpty(content.text) ? undefined : content.text,
     html: _.isEmpty(content.html) ? undefined : content.html,
     amp_html: _.isEmpty(content.amp_html) ? undefined : content.amp_html
   };

--- a/src/actions/helpers/templates.js
+++ b/src/actions/helpers/templates.js
@@ -18,6 +18,8 @@ export const getTestDataKey = ({ id, username, mode }) => ([ 'tpldata', username
 export const shapeContent = (content = {}) => {
   const shapedContent = {
     ...content,
+    // The API won't create a new template unless either `content.text` or `content.html` has content.
+    // This allows a new template to be created by passing an empty string as the template's text content.
     text: content.text,
     reply_to: _.isEmpty(content.reply_to) ? undefined : content.reply_to,
     html: _.isEmpty(content.html) ? undefined : content.html,

--- a/src/actions/helpers/tests/templates.test.js
+++ b/src/actions/helpers/tests/templates.test.js
@@ -28,7 +28,7 @@ describe('.shapeContent', () => {
   });
 
   it('should return content object without `text` key', () => {
-    expect(shapeContent({ text: '' }).text).toBeUndefined();
+    expect(shapeContent({ text: '' }).text).toBe('');
   });
 
   it('should return content object without `html` key', () => {


### PR DESCRIPTION
[TR-1781](https://jira.int.messagesystems.com/browse/TR-1781)

### What Changed
- Text content passed to create method will travel with `POST` as the API does not support a null value for the text field
- This was introduced as the result of a prior bug fix for the original templates implementation

### How To Test
- Go to `/templatesV2` and click 'Create New'
- Complete the form and click 'Next'

### To Do
- [ ] Incorporate feedback
- [X] Add supporting test to check that request is passing along an empty string via `content.text` < -- Nevermind - updating the existing test accomplishes this as the `CreatePage.test.js` is already making this check
