### PR TITLE
SA-890 -Selected and Hovered dates are highlighted

### DIFF
--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -33,7 +33,7 @@ export class EngagementRecencyPage extends Component {
     tickFormatter: (tick) => `${roundToPlaces(tick * 100, 0)}%`,
     domain: [0, 1],
     ticks: [0, 0.25, 0.5, 0.75, 1.0]
-  })
+  });
 
   getXAxisProps = () => {
     const { xTicks } = this.props;
@@ -41,7 +41,7 @@ export class EngagementRecencyPage extends Component {
       ticks: xTicks,
       tickFormatter: (tick) => moment(tick).format('M/D')
     };
-  }
+  };
 
   getTooltipContent = ({ payload = {}}) => (
     <Fragment>
@@ -55,10 +55,25 @@ export class EngagementRecencyPage extends Component {
         />
       ))}
     </Fragment>
-  )
+  );
 
   renderContent = () => {
-    const { data = [], empty, error, facet, facetId, gap, handleDateSelect, loading, selectedDate, subaccountId } = this.props;
+    const {
+      data = [],
+      empty,
+      error,
+      facet,
+      facetId,
+      gap,
+      handleDateSelect,
+      loading,
+      selectedDate,
+      subaccountId,
+      hoveredDate,
+      handleDateHover,
+      resetDateHover
+    } = this.props;
+
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
 
@@ -87,8 +102,11 @@ export class EngagementRecencyPage extends Component {
               <div className='LiftTooltip'>
                 <BarChart
                   gap={gap}
+                  onMouseOver={handleDateHover}
+                  onMouseOut={resetDateHover}
                   onClick={handleDateSelect}
                   selected={selectedDate}
+                  hovered={hoveredDate}
                   timeSeries={data}
                   tooltipContent={this.getTooltipContent}
                   tooltipWidth='250px'
@@ -111,7 +129,7 @@ export class EngagementRecencyPage extends Component {
         </Grid.Column>
       </Grid>
     );
-  }
+  };
 
   render() {
     const { facet, facetId, subaccountId } = this.props;

--- a/src/pages/signals/components/charts/barchart/BarChart.js
+++ b/src/pages/signals/components/charts/barchart/BarChart.js
@@ -30,7 +30,7 @@ class BarChart extends Component {
       }
       return isActiveDate ? {opacity : 1} : {opacity : .5}
     },
-    (key,isActiveDate,selectedFill) =>`${key}${isActiveDate}${selectedFill}`
+    (key, isActiveDate, selectedFill) =>`${key}${isActiveDate}${selectedFill}`
   );
 
   renderBar = ({ key, selected, hovered, fill, activeFill }) => (
@@ -46,7 +46,7 @@ class BarChart extends Component {
       activeFill={activeFill}
       cursor='pointer'
       shape={(props) => {
-        const selectedFill = (key === 'health_score') ? healthScoreThresholds[props.ranking].barColor : activeFill;
+        const selectedFill = (key === 'health_score' && props.ranking) ? healthScoreThresholds[props.ranking].barColor : activeFill;
         const isActiveDate= (props.date === hovered) || (props.date === selected);
         const selectedStyle = selected ? this.getSelectedStyle(key, isActiveDate, selectedFill) : {};
 
@@ -66,7 +66,7 @@ class BarChart extends Component {
   };
 
   renderBackgrounds = () => {
-    const { onClick, onMouseOver, ykey } = this.props;
+    const { onClick, onMouseOver } = this.props;
 
     return (
       <Bar
@@ -86,7 +86,24 @@ class BarChart extends Component {
   }
 
   render() {
-    const { cartesianGridProps, gap, height, disableHover, margin, timeSeries, tooltipContent, tooltipWidth, width, xAxisRefLines, yAxisRefLines, xKey, xAxisProps, yDomain, yAxisProps } = this.props;
+    const {
+      cartesianGridProps,
+      disableHover,
+      gap,
+      height,
+      isLink,
+      margin,
+      timeSeries,
+      tooltipContent,
+      tooltipWidth,
+      width,
+      xAxisRefLines,
+      yAxisRefLines,
+      xKey,
+      xAxisProps,
+      yDomain,
+      yAxisProps,
+     } = this.props;
 
     return (
       <div className='LiftTooltip' onMouseOut={this.props.onMouseOut}>
@@ -95,7 +112,7 @@ class BarChart extends Component {
             barCategoryGap={gap}
             data={timeSeries}
             margin={margin}
-            cursor={(disableHover) ? 'pointer' : undefined}
+            cursor={(isLink) ? 'pointer' : 'default'}
           >
             {this.renderBackgrounds()}
             <CartesianGrid
@@ -165,8 +182,8 @@ class BarChart extends Component {
 }
 
 BarChart.propTypes = {
-  fill: PropTypes.string,
   activeFill: PropTypes.string,
+  fill: PropTypes.string,
   gap: PropTypes.number,
   onClick: PropTypes.func,
   tooltipContent: PropTypes.func,
@@ -175,12 +192,12 @@ BarChart.propTypes = {
 };
 
 BarChart.defaultProps = {
-  fill: '#B3ECEF',
   activeFill: '#22838A',
+  fill: '#B3ECEF',
   gap: 1,
   height: 250,
-  width: '99%',
   margin: { top: 12, left: 18, right: 0, bottom: 5 },
+  width: '99%',
   xAxisRefLines: [],
   yAxisRefLines: [],
   xKey: 'date',

--- a/src/pages/signals/components/charts/barchart/BarChart.js
+++ b/src/pages/signals/components/charts/barchart/BarChart.js
@@ -28,7 +28,7 @@ class BarChart extends Component {
       if (key === 'health_score' || key === 'injections' || key === 'weight_value')  {
        return isActiveDate ? {fill: selectedFill} : {};
       }
-      return isActiveDate ? {opacity : 1} : {opacity : .7}
+      return isActiveDate ? {opacity : 1} : {opacity : .5}
     },
     (key,isActiveDate,selectedFill) =>`${key}${isActiveDate}${selectedFill}`
   );

--- a/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
+++ b/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
@@ -86,14 +86,14 @@ describe('BarChart Component', () => {
     expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.opacity).toEqual(1);
   });
 
-  it('renders a pointer cursor on the entire chart if disablehover is true', () => {
-    wrapper.setProps({ disableHover: true });
+  it('renders a pointer cursor on the entire chart if isLink is true', () => {
+    wrapper.setProps({ isLink: true });
     expect(wrapper.find('ComposedChart')).toHaveProp('cursor', 'pointer');
   });
 
-  it('renders a pointer cursor on only the bars if disablehover is false', () => {
-    wrapper.setProps({ disableHover: false });
-    expect(wrapper.find('ComposedChart')).toHaveProp('cursor', undefined);
+  it('renders a pointer cursor on only the bars if isLink is false', () => {
+    wrapper.setProps({ isLink: false });
+    expect(wrapper.find('ComposedChart')).toHaveProp('cursor', 'default');
     expect(wrapper.find('Bar').at(0)).toHaveProp('cursor', 'pointer');
 
   });

--- a/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
+++ b/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
@@ -1,6 +1,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import BarChart from '../BarChart';
+import healthScoreThresholds from 'src/pages/signals/constants/healthScoreThresholds';
+
 
 describe('BarChart Component', () => {
   let wrapper;
@@ -35,27 +37,65 @@ describe('BarChart Component', () => {
   });
 
   it('renders a normal bar chart with correct fill for selected/hovered threshold events', () => {
-    wrapper.setProps({ selected: '2011-01-01', yKey: 'health_score', timeSeries: [{ health_score: 75, ranking: 'warning', date: '2011-01-01' }]});
-    const payload = { fill: '#fill', health_score: 75, ranking: 'warning', date: '2011-01-01' };
-    expect(wrapper.find('Bar').at(0).props().shape(payload).props).toMatchSnapshot();
+    const key = 'health_score';
+    wrapper.setProps({ selected: '2011-01-01', yKey: key, timeSeries: [{ [key]: 75, ranking: 'warning', date: '2011-01-01' }]});
+    const payload = { fill: '#fill', [key]: 75, ranking: 'warning', date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual(healthScoreThresholds.warning.barColor);
   });
 
   it('renders a normal bar chart with correct fill for non-selected/hovered threshold events', () => {
-    wrapper.setProps({ selected: undefined, yKey: 'health_score', timeSeries: [{ health_score: 75, ranking: 'warning', date: '2011-01-01' }]});
-    const payload = { fill: '#fill', health_score: 75, ranking: 'warning', date: '2011-01-01' };
-    expect(wrapper.find('Bar').at(0).props().shape(payload).props).toMatchSnapshot();
+    const key = 'health_score';
+    wrapper.setProps({ selected: undefined, yKey: key, timeSeries: [{ [key]: 75, ranking: 'warning', date: '2011-01-01' }]});
+    const payload = { fill: '#fill', [key]: 75, ranking: 'warning', date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#fill');
   });
 
   it('renders a normal bar chart with correct fill for selected/hovered non-threshold events', () => {
-    wrapper.setProps({ selected: '2011-01-01', yKey: 'injections', timeSeries: [{ injections: 75, date: '2011-01-01' }]});
-    const payload = { fill: '#fill', injections: 75, ranking: 'warning', date: '2011-01-01' };
-    expect(wrapper.find('Bar').at(0).props().shape(payload).props).toMatchSnapshot();
+    const key = 'injections';
+    wrapper.setProps({ selected: '2011-01-01', yKey: key, timeSeries: [{ [key]: 75, date: '2011-01-01' }]});
+    const payload = { fill: '#fill', [key]: 75, date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#activeFill');
   });
 
   it('renders a normal bar chart with correct fill for non-selected/hovered non-threshold events', () => {
-    wrapper.setProps({ selected: undefined, yKey: 'injections', timeSeries: [{ injections: 75, date: '2011-01-01' }]});
-    const payload = { fill: '#fill', injections: 75, ranking: 'warning', date: '2011-01-01' };
-    expect(wrapper.find('Bar').at(0).props().shape(payload).props.fill).toEqual('#fill');
+    const key = 'injections';
+    wrapper.setProps({ selected: undefined, yKey: key, timeSeries: [{ [key]: 75, date: '2011-01-01' }]});
+    const payload = { fill: '#fill', [key]: 75, date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#fill');
+  });
+
+  it('renders a normal bar chart with correct fill for non-selected/hovered stacked bar events', () => {
+    const key = 'c_new';
+    wrapper.setProps({ selected: undefined, yKey: key, timeSeries: [{ [key]: 75, date: '2011-01-01' }]});
+    const payload = { fill: '#fill', [key]: 75, date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#fill');
+  });
+
+  it('renders a normal bar chart with less opaque fill fo stacked bar events when selected exists for another date', () => {
+    const key = 'c_new';
+    wrapper.setProps({ selected: '2011-01-02', yKey: key, timeSeries: [{ [key]: 75, date: '2011-01-01' },{ [key]: 80, date: '2011-01-02' }]});
+    const payload = { fill: '#fill', [key]: 75, date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#fill');
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.opacity).toEqual(.7);
+  });
+
+  it('renders a normal bar chart with correct fill for selected/hovered stacked bar events', () => {
+    const key = 'c_new';
+    wrapper.setProps({ selected: '2011-01-01', yKey: key, timeSeries: [{ [key]: 75, date: '2011-01-01' }]});
+    const payload = { fill: '#fill', [key]: 75, date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.opacity).toEqual(1);
+  });
+
+  it('renders a pointer cursor on the entire chart if disablehover is true', () => {
+    wrapper.setProps({ disableHover: true });
+    expect(wrapper.find('ComposedChart')).toHaveProp('cursor', 'pointer');
+  });
+
+  it('renders a pointer cursor on only the bars if disablehover is false', () => {
+    wrapper.setProps({ disableHover: false });
+    expect(wrapper.find('ComposedChart')).toHaveProp('cursor', undefined);
+    expect(wrapper.find('Bar').at(0)).toHaveProp('cursor', 'pointer');
+
   });
 
   it('renders a stacked bar chart correctly', () => {
@@ -64,13 +104,7 @@ describe('BarChart Component', () => {
     expect(bars).toMatchSnapshot();
   });
 
-  it('renders background bars with no opacity if unselected', () => {
-    const payload = { payload: { date: '2011-01-01' }, test: 'test' };
-    expect(wrapper.find('Bar').at(0).props().shape(payload)).toMatchSnapshot();
-  });
-
-  it('renders background bars with opacity if selected', () => {
-    wrapper.setProps({ selected: '2011-01-01' });
+  it('renders background bars with no opacity', () => {
     const payload = { payload: { date: '2011-01-01' }, test: 'test' };
     expect(wrapper.find('Bar').at(0).props().shape(payload)).toMatchSnapshot();
   });

--- a/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
+++ b/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
@@ -76,7 +76,7 @@ describe('BarChart Component', () => {
     wrapper.setProps({ selected: '2011-01-02', yKey: key, timeSeries: [{ [key]: 75, date: '2011-01-01' },{ [key]: 80, date: '2011-01-02' }]});
     const payload = { fill: '#fill', [key]: 75, date: '2011-01-01' };
     expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#fill');
-    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.opacity).toEqual(.7);
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.opacity).toEqual(.5);
   });
 
   it('renders a normal bar chart with correct fill for selected/hovered stacked bar events', () => {

--- a/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
+++ b/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
@@ -13,6 +13,7 @@ exports[`BarChart Component renders a normal bar chart correctly 1`] = `
     <ComposedChart
       barCategoryGap={1}
       barGap={4}
+      cursor="default"
       data={
         Array [
           Object {

--- a/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
+++ b/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
@@ -200,66 +200,6 @@ exports[`BarChart Component renders a normal bar chart correctly 1`] = `
 </div>
 `;
 
-exports[`BarChart Component renders a normal bar chart with correct fill for non-selected/hovered threshold events 1`] = `
-Object {
-  "animationBegin": 0,
-  "animationDuration": 1500,
-  "animationEasing": "ease",
-  "date": "2011-01-01",
-  "fill": "#fill",
-  "health_score": 75,
-  "height": 0,
-  "isAnimationActive": false,
-  "isUpdateAnimationActive": false,
-  "opacity": 0,
-  "radius": 0,
-  "ranking": "warning",
-  "width": 0,
-  "x": 0,
-  "y": 0,
-}
-`;
-
-exports[`BarChart Component renders a normal bar chart with correct fill for selected/hovered non-threshold events 1`] = `
-Object {
-  "animationBegin": 0,
-  "animationDuration": 1500,
-  "animationEasing": "ease",
-  "date": "2011-01-01",
-  "fill": "#fill",
-  "height": 0,
-  "injections": 75,
-  "isAnimationActive": false,
-  "isUpdateAnimationActive": false,
-  "opacity": 0,
-  "radius": 0,
-  "ranking": "warning",
-  "width": 0,
-  "x": 0,
-  "y": 0,
-}
-`;
-
-exports[`BarChart Component renders a normal bar chart with correct fill for selected/hovered threshold events 1`] = `
-Object {
-  "animationBegin": 0,
-  "animationDuration": 1500,
-  "animationEasing": "ease",
-  "date": "2011-01-01",
-  "fill": "#fill",
-  "health_score": 75,
-  "height": 0,
-  "isAnimationActive": false,
-  "isUpdateAnimationActive": false,
-  "opacity": 0,
-  "radius": 0,
-  "ranking": "warning",
-  "width": 0,
-  "x": 0,
-  "y": 0,
-}
-`;
-
 exports[`BarChart Component renders a stacked bar chart correctly 1`] = `
 Array [
   <Bar
@@ -309,24 +249,7 @@ Array [
 ]
 `;
 
-exports[`BarChart Component renders background bars with no opacity if unselected 1`] = `
-<Rectangle
-  animationBegin={0}
-  animationDuration={1500}
-  animationEasing="ease"
-  height={0}
-  isAnimationActive={false}
-  isUpdateAnimationActive={false}
-  opacity={0}
-  radius={0}
-  test="test"
-  width={0}
-  x={0}
-  y={0}
-/>
-`;
-
-exports[`BarChart Component renders background bars with opacity if selected 1`] = `
+exports[`BarChart Component renders background bars with no opacity 1`] = `
 <Rectangle
   animationBegin={0}
   animationDuration={1500}

--- a/src/pages/signals/components/previews/EngagementRecencyPreview.js
+++ b/src/pages/signals/components/previews/EngagementRecencyPreview.js
@@ -35,6 +35,7 @@ export class EngagementRecencyPreview extends Component {
       <BarChart
         height={170}
         disableHover
+        isLink
         margin={{ top: 12, left: 12, right: 0, bottom: 12 }}
         gap={gap}
         timeSeries={data}

--- a/src/pages/signals/components/previews/HealthScorePreview.js
+++ b/src/pages/signals/components/previews/HealthScorePreview.js
@@ -26,6 +26,7 @@ export class HealthScorePreview extends Component {
       <BarChart
         height={170}
         disableHover
+        isLink
         margin={{ top: 12, left: 12, right: 0, bottom: 12 }}
         gap={gap}
         timeSeries={data}

--- a/src/pages/signals/components/previews/SpamTrapsPreview.js
+++ b/src/pages/signals/components/previews/SpamTrapsPreview.js
@@ -29,6 +29,7 @@ export class SpamTrapsPreview extends Component {
       <BarChart
         height={170}
         disableHover
+        isLink
         margin={{ top: 12, left: 12, right: 0, bottom: 12 }}
         gap={gap}
         timeSeries={data}

--- a/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
@@ -22,6 +22,7 @@ exports[`Signals EngagementRecencyPreview Component renders correctly 1`] = `
         fill="#B3ECEF"
         gap={0.5}
         height={170}
+        isLink={true}
         margin={
           Object {
             "bottom": 12,

--- a/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
@@ -23,6 +23,7 @@ exports[`Signals HealthScorePreview Component renders correctly 1`] = `
         fill="#B3ECEF"
         gap={0.5}
         height={170}
+        isLink={true}
         margin={
           Object {
             "bottom": 12,

--- a/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
@@ -22,6 +22,7 @@ exports[`Signals SpamTrapsPreview Component renders correctly 1`] = `
         fill="#B3ECEF"
         gap={0.5}
         height={170}
+        isLink={true}
         margin={
           Object {
             "bottom": 12,

--- a/src/pages/signals/containers/tests/withDateSelection.test.js
+++ b/src/pages/signals/containers/tests/withDateSelection.test.js
@@ -35,10 +35,17 @@ describe('Signals Spam Trap Details Container', () => {
     expect(wrapper).toHaveProp('selectedDate', '2015-01-01');
   });
 
-  it('handles date select', () => {
+  it('handles date select for a new date', () => {
     const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
     wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
     expect(wrapper).toHaveProp('selectedDate', '2015-01-01');
+  });
+
+  it('handles date select for re-selecting the already selected date by defaulting to last date', () => {
+    const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
+    wrapper.setState({ selectedDate: '2015-01-01' });
+    wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
+    expect(wrapper).toHaveProp('selectedDate', '2999-99-99');
   });
 
   it('handles date hover', () => {

--- a/src/pages/signals/containers/withDateSelection.js
+++ b/src/pages/signals/containers/withDateSelection.js
@@ -25,17 +25,28 @@ export class WithDateSelection extends Component {
     const { selectedDate } = this.state;
 
     const dataSetChanged = prevProps.data !== data;
-    let selectedDataByDay = _.find(data, ['date', selectedDate]);
+    const selectedDataByDay = _.find(data, ['date', selectedDate]);
 
-    // Select last date in time series
+
     if (dataSetChanged && !selectedDataByDay) {
-      selectedDataByDay = _.last(data);
-      this.setState({ selectedDate: selectedDataByDay.date });
+      this.setDefaultSelected();
     }
   }
 
+  // Select last date in time series
+  setDefaultSelected() {
+    const lastDataByDay = _.last(this.props.data);
+    this.setState({ selectedDate: lastDataByDay.date });
+  }
+
   handleDateSelect = (node) => {
-    this.setState({ selectedDate: _.get(node, 'payload.date') });
+    const newDate = _.get(node, 'payload.date');
+
+    if (newDate === this.state.selectedDate) {
+      this.setDefaultSelected();
+    } else {
+      this.setState({ selectedDate: _.get(node, 'payload.date') });
+    }
   }
 
   handleDateHover = (node) => {

--- a/src/pages/signals/containers/withDateSelection.js
+++ b/src/pages/signals/containers/withDateSelection.js
@@ -25,7 +25,7 @@ export class WithDateSelection extends Component {
     const { selectedDate } = this.state;
 
     const dataSetChanged = prevProps.data !== data;
-    const selectedDataByDay = _.find(data, ['date', selectedDate]);
+    const selectedDataByDay = data.find(({ date }) => date === selectedDate);
 
 
     if (dataSetChanged && !selectedDataByDay) {


### PR DESCRIPTION
### What Changed
 - Selected and hovered dates have opacity 1 while unselected have opacity ~.7~ .5 for spam trap and engagement recency. All charts on the health score detail page remain the same. 
 - Changed tests to assertion tests. 

### How To Test
 - Log into account with signals data. Go to engagement recency details page or spam trap details page. Verify that hovering and selecting the bars shows a highlighted state.

### To Do
- [x] Per UX request, selecting an already selected bar results in default state.
