### PR TITLE
SA-891: Charts max out at 100%

### DIFF
--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -160,8 +160,10 @@ export class HealthScorePage extends Component {
                       )}
                       yKey='weight_value'
                       yAxisProps={{
-                        tickFormatter: (tick) => `${roundToPlaces(tick * 100, 3)}%`
+                        tickFormatter: (tick) => `${roundToPlaces(tick * 100, 3)}%`,
+                        interval: 'preserveStartEnd'
                       }}
+                      yDomain={[0, (dataMax) => dataMax > 0 ? dataMax : 1 ]}
                       xAxisProps={this.getXAxisProps()}
                     />
                   </Fragment>

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -64,6 +64,7 @@ export class HealthScorePage extends Component {
     const selectedWeights = _.get(_.find(data, ['date', selectedDate]), 'weights', []);
     const selectedWeightsAreEmpty = selectedWeights.every(({ weight }) => weight === null);
     const dataForSelectedWeight = data.map(({ date, weights }) => ({ date, ..._.find(weights, ['weight_type', selectedComponent]) }));
+    const selectedDataIsZero = dataForSelectedWeight.every(({ weight_value }) => weight_value <= 0);
 
     let panelContent;
 
@@ -160,10 +161,9 @@ export class HealthScorePage extends Component {
                       )}
                       yKey='weight_value'
                       yAxisProps={{
-                        tickFormatter: (tick) => `${roundToPlaces(tick * 100, 3)}%`,
-                        interval: 'preserveStartEnd'
+                        tickFormatter: (tick) => `${roundToPlaces(tick * 100, 3)}%`
                       }}
-                      yDomain={[0, (dataMax) => dataMax > 0 ? dataMax : 1 ]}
+                      yDomain={selectedDataIsZero ? [0, 1] : [0, 'auto']}
                       xAxisProps={this.getXAxisProps()}
                     />
                   </Fragment>

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -70,6 +70,17 @@ describe('Signals Health Score Page', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders weight chart at 100% if data all data is 0', () => {
+    const newData = [
+      {
+        date: '2017-01-01',
+        weights: [{ weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0 }]
+      }
+    ];
+    wrapper.setProps({ data: newData });
+    expect(wrapper.find('BarChart').at(2).prop('yDomain')).toEqual([0, 1]);
+  });
+
   it('renders component weights bar height dynamically', () => {
     expect(wrapper.find('DivergingBar').at(0).prop('barHeight')).toEqual(140);
     const newData = [

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -318,10 +318,17 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
           xKey="date"
           yAxisProps={
             Object {
+              "interval": "preserveStartEnd",
               "tickFormatter": [Function],
             }
           }
           yAxisRefLines={Array []}
+          yDomain={
+            Array [
+              0,
+              [Function],
+            ]
+          }
           yKey="weight_value"
           yRange={
             Array [

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -318,7 +318,6 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
           xKey="date"
           yAxisProps={
             Object {
-              "interval": "preserveStartEnd",
               "tickFormatter": [Function],
             }
           }
@@ -326,7 +325,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
           yDomain={
             Array [
               0,
-              [Function],
+              "auto",
             ]
           }
           yKey="weight_value"


### PR DESCRIPTION
### What Changed
 - Health score chart percentage when containing 0 data caps at 100%

### How To Test
 - Switch env to prod and use 108 account (ask me if you need help getting it set up)
 - Go to `/signals/health-score/sid/0` and switch to `Unsubscribes` component from right side
 - Check that chart caps at 100%

### To Do
- [ ] Address feedback

### Notes
 - I checked other charts and it doesn't seem like anything else needs the restriction since it seems like other percentages are already capping domain.