### PR TITLE
AC-989: Add deprecated plan warning

### DIFF
--- a/src/pages/billing/components/CurrentPlanSection.js
+++ b/src/pages/billing/components/CurrentPlanSection.js
@@ -5,7 +5,7 @@ import styles from './CurrentPlanSection.module.scss';
 import { PLAN_TIERS } from 'src/constants';
 import { Warning } from '@sparkpost/matchbox-icons';
 
-const CurrentPlanSection = ({ currentPlan, selectedPlan }) => (
+const CurrentPlanSection = ({ currentPlan, isPlanSelected }) => (
   <Panel title='Current Plan'>
     <Panel.Section className={styles.currentPlan}>
       <div className={styles.Title}>{PLAN_TIERS[currentPlan.tier]}</div>
@@ -13,9 +13,9 @@ const CurrentPlanSection = ({ currentPlan, selectedPlan }) => (
         <PlanPrice showOverage showIp showCsm plan={currentPlan} />
       </div>
     </Panel.Section>
-    {(selectedPlan && currentPlan.status === 'deprecated') && (
+    {(isPlanSelected && currentPlan.status === 'deprecated') && (
       <Panel.Section>
-        <div name='deprecated-warning' className={styles.DeprecatedWarning}>
+        <div className={styles.DeprecatedWarning}>
           <Warning size={28}/>
           <div className={styles.content}>
             <span>Your current plan is no longer available. Once you switch back, </span>

--- a/src/pages/billing/components/CurrentPlanSection.js
+++ b/src/pages/billing/components/CurrentPlanSection.js
@@ -3,8 +3,9 @@ import { Panel } from '@sparkpost/matchbox';
 import PlanPrice from 'src/components/billing/PlanPrice';
 import styles from './CurrentPlanSection.module.scss';
 import { PLAN_TIERS } from 'src/constants';
+import { Warning } from '@sparkpost/matchbox-icons';
 
-const CurrentPlanSection = ({ currentPlan }) => (
+const CurrentPlanSection = ({ currentPlan, selectedPlan }) => (
   <Panel title='Current Plan'>
     <Panel.Section className={styles.currentPlan}>
       <div className={styles.Title}>{PLAN_TIERS[currentPlan.tier]}</div>
@@ -12,6 +13,17 @@ const CurrentPlanSection = ({ currentPlan }) => (
         <PlanPrice showOverage showIp showCsm plan={currentPlan} />
       </div>
     </Panel.Section>
+    {(selectedPlan && currentPlan.status === 'deprecated') && (
+      <Panel.Section>
+        <div name='deprecated-warning' className={styles.DeprecatedWarning}>
+          <Warning size={28}/>
+          <div className={styles.content}>
+            <span>Your current plan is no longer available. Once you switch back, </span>
+            <strong>you won't be able to change back.</strong>
+          </div>
+        </div>
+      </Panel.Section>
+    )}
   </Panel>
 );
 

--- a/src/pages/billing/components/CurrentPlanSection.module.scss
+++ b/src/pages/billing/components/CurrentPlanSection.module.scss
@@ -12,3 +12,16 @@
   }
 }
 
+.DeprecatedWarning {
+  color: color(red);
+  display: flex;
+  font-size: rem(14);
+  line-height: 1.2em;
+  .content {
+    padding: 0 20px;
+    flex: 1 0 0;
+  }
+}
+
+
+

--- a/src/pages/billing/components/tests/CurrentPlanSection.test.js
+++ b/src/pages/billing/components/tests/CurrentPlanSection.test.js
@@ -31,7 +31,7 @@ describe('CurrentPlanSection', () => {
         ...defaultProps.currentPlan,
         status: 'deprecated'
       },
-      selectedPlan: {}
+      isPlanSelected: true
     });
     expect(wrapper.find('Warning')).toExist();
   });

--- a/src/pages/billing/components/tests/CurrentPlanSection.test.js
+++ b/src/pages/billing/components/tests/CurrentPlanSection.test.js
@@ -23,4 +23,16 @@ describe('CurrentPlanSection', () => {
   it('renders correctly', () => {
     expect(subject()).toMatchSnapshot();
   });
+
+  it('renders warning banner if current plan is deprecated', () => {
+    expect(subject().find('Warning')).not.toExist();
+    const wrapper = subject({
+      currentPlan: {
+        ...defaultProps.currentPlan,
+        status: 'deprecated'
+      },
+      selectedPlan: {}
+    });
+    expect(wrapper.find('Warning')).toExist();
+  });
 });

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -103,7 +103,7 @@ export const ChangePlanForm = ({
           }
         </Grid.Column>
         <Grid.Column xs={4}>
-          <CurrentPlanSection currentPlan={currentPlan}/>
+          <CurrentPlanSection currentPlan={currentPlan} selectedPlan={selectedPlan}/>
         </Grid.Column>
       </Grid>
     </form>

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -103,7 +103,7 @@ export const ChangePlanForm = ({
           }
         </Grid.Column>
         <Grid.Column xs={4}>
-          <CurrentPlanSection currentPlan={currentPlan} isPlanSelected={Boolean(selectedPlan)}/>
+          <CurrentPlanSection currentPlan={currentPlan} isPlanSelected={Boolean(selectedBundle)}/>
         </Grid.Column>
       </Grid>
     </form>

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -103,7 +103,7 @@ export const ChangePlanForm = ({
           }
         </Grid.Column>
         <Grid.Column xs={4}>
-          <CurrentPlanSection currentPlan={currentPlan} selectedPlan={selectedPlan}/>
+          <CurrentPlanSection currentPlan={currentPlan} isPlanSelected={Boolean(selectedPlan)}/>
         </Grid.Column>
       </Grid>
     </form>

--- a/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
@@ -82,7 +82,7 @@ exports[`Change Plan Form should render 1`] = `
             "volume": 3,
           }
         }
-        selectedPlan={null}
+        isPlanSelected={false}
       />
     </Grid.Column>
   </Grid>

--- a/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
@@ -82,7 +82,7 @@ exports[`Change Plan Form should render 1`] = `
             "volume": 3,
           }
         }
-        planSelected={false}
+        selectedPlan={null}
       />
     </Grid.Column>
   </Grid>

--- a/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
@@ -82,6 +82,7 @@ exports[`Change Plan Form should render 1`] = `
             "volume": 3,
           }
         }
+        planSelected={false}
       />
     </Grid.Column>
   </Grid>


### PR DESCRIPTION
### What Changed
 - Add deprecated plan warning when selecting new plan

### How To Test
 - If you have an account with deprecated plan, select a new plan
 - Warning should show on right

### To Do
- [ ] Address feedback

### Notes
 - Not sure how to get deprecated plan. May have to ask accounts