### PR TITLE
SA-902 - Remove link to API docs for Inbox Placement

### DIFF
--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -14,7 +14,6 @@ import { withRouter } from 'react-router-dom';
 import styles from './TestListPage.module.scss';
 import { STATUS } from './constants/test';
 import { Users } from 'src/components/images';
-import { LINKS } from 'src/constants';
 
 const selectOptions = [
   { value: 'Sort By', label: 'Sort By', disabled: true },
@@ -135,12 +134,7 @@ export class TestListPage extends Component {
         show: !error && tests.length === 0,
         title: 'Find and Fix Inbox Placement Issues',
         image: Users,
-        content: <p>Perform seedlist tests that help you predict how your emails are handled by mailbox providers.</p>,
-        secondaryAction: {
-          content: 'Check out our docs',
-          to: LINKS.API_DOCS,
-          external: true
-        }
+        content: <p>Perform seedlist tests that help you predict how your emails are handled by mailbox providers.</p>
       }}
       title='Inbox Placement'
       primaryAction={{ content: 'Start a Test', to: '/inbox-placement/seedlist', component: Link }}

--- a/src/pages/inboxPlacement/tests/__snapshots__/TestListPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/TestListPage.test.js.snap
@@ -8,11 +8,6 @@ exports[`Page: Test List renders page correctly with defaults 1`] = `
         Perform seedlist tests that help you predict how your emails are handled by mailbox providers.
       </p>,
       "image": [Function],
-      "secondaryAction": Object {
-        "content": "Check out our docs",
-        "external": true,
-        "to": "https://developers.sparkpost.com/api",
-      },
       "show": true,
       "title": "Find and Fix Inbox Placement Issues",
     }
@@ -85,11 +80,6 @@ exports[`Page: Test List renders page with tests 1`] = `
         Perform seedlist tests that help you predict how your emails are handled by mailbox providers.
       </p>,
       "image": [Function],
-      "secondaryAction": Object {
-        "content": "Check out our docs",
-        "external": true,
-        "to": "https://developers.sparkpost.com/api",
-      },
       "show": false,
       "title": "Find and Fix Inbox Placement Issues",
     }


### PR DESCRIPTION
### What Changed
 - Removed Link to API docs (since it's a private API) in inbox placement page.

### How To Test
 - go to `/inbox-placement`. Verify that the link to the API no longer exists. The empty page only shows up for accounts without any data, You may need to create an account and add the `inbox_placement` account feature flag. See the feature flag confluence doc for instructions. 
