### PR TITLE
AC 985 - Promocode Field

### DIFF
--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -69,7 +69,7 @@ export class OnboardingPlanPage extends Component {
 
   applyPromoCode = (promoCode) => {
     const { verifyPromoCode } = this.props;
-    verifyPromoCode({ promoCode , billingId: this.props.selectedPlan.billingId, meta: { promoCode }});
+    verifyPromoCode({ promoCode , billingId: this.props.selectedPlan.billingId, meta: { promoCode, showErrorAlert: false }});
   }
 
   onPlanSelect = (e) => {

--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -53,7 +53,7 @@ export class OnboardingPlanPage extends Component {
     if (selectedPromo.promoCode && !values.planpicker.isFree) {
       const { promoCode } = selectedPromo;
       newValues.promoCode = promoCode;
-      action = verifyPromoCode({ promoCode, billingId: values.planpicker.billingId, meta: { promoCode }});
+      action = verifyPromoCode({ promoCode, billingId: values.planpicker.billingId, meta: { promoCode, showErrorAlert: false }});
     }
 
     // Note: billingCreate will update the subscription if the account is AWS

--- a/src/pages/onboarding/tests/ChoosePlan.test.js
+++ b/src/pages/onboarding/tests/ChoosePlan.test.js
@@ -98,7 +98,7 @@ describe('ChoosePlan page tests', () => {
       expect(props.verifyPromoCode).toHaveBeenCalledWith({
         promoCode: 'test-promo-code',
         billingId: 'test-id',
-        meta: { promoCode: 'test-promo-code' }
+        meta: { promoCode: 'test-promo-code', showErrorAlert: false }
       });
       expect(instance.props.billingCreate).toHaveBeenCalledWith({ ...values, discountId: 'test-discount' });
       expect(instance.props.history.push).toHaveBeenCalledWith('/onboarding/sending-domain');


### PR DESCRIPTION
AC 985 - Promocode Field

### What Changed
added flag to verifyPromocode in ChangePlan to stop showing double alerts.

### How To Test
Check if this field works correctly on /account/billing/plan(requires feature flag - account_feature_limits ) and /onboarding/plan.

### To Do
- [ ] Address Feedback
