### PR TITLE
SA-933 Inbox Placement fix for moment formatting bug

### DIFF
--- a/src/pages/inboxPlacement/helpers/formatScheduleLine.js
+++ b/src/pages/inboxPlacement/helpers/formatScheduleLine.js
@@ -2,7 +2,7 @@
 import moment from 'moment';
 import { STATUS, DURATION_HOURS } from '../constants/test';
 
-const formatDateTime = (start_time) => moment(start_time).format('MMM DD, YYYY [at] h:ma');
+const formatDateTime = (start_time) => moment(start_time).format('MMM DD, YYYY [at] h:mma');
 const getHoursRemaining = (start_time) => moment(start_time).add(DURATION_HOURS, 'hours').diff(moment(), 'hours');
 
 export default function formatScheduleLine(status, start_time, end_time) {


### PR DESCRIPTION
SA-933 https://jira.int.messagesystems.com/browse/SA-933
Screenshot in description
Moment formatting bug, minutes displayed with only 1 digit if starting with 0. 

### What Changed
Added mm instead of m for moment formatting.
So 5:8pm instead of 5:08pm for inbox placement test start time on test list page.

### How To Test
 SA-933
Go to inbox placement from nav, lands on test list page. 
Look at scheduled start and end dates in staging 107
