### PR TITLE
SD-942 - Incorporate Shared Pool in the select dropdown, add supporti…

### DIFF
--- a/src/pages/ipPools/components/PoolForm.js
+++ b/src/pages/ipPools/components/PoolForm.js
@@ -30,7 +30,24 @@ export class PoolForm extends Component {
       };
     }));
 
+    // If the pool has available IPs with auto warmup enabled,
+    // render the 'Shared Pool' option in the `<select/>`
+    const getPoolsWithAutoWarmup = () => pools.filter((currentPool) => {
+      if (currentPool.ips) {
+        const ipsWithAutoWarmup = currentPool.ips.filter((ip) => ip.auto_warmup_enabled);
+
+        if (ipsWithAutoWarmup.length > 0) {
+          return currentPool;
+        }
+      }
+    });
+
+    if (getPoolsWithAutoWarmup().length) {
+      overflowPools.unshift({ label: 'Shared Pool', value: 'shared pool' });
+    }
+
     overflowPools.unshift({ label: 'None', value: '' });
+
     return overflowPools;
   }
 

--- a/src/pages/ipPools/components/PoolForm.js
+++ b/src/pages/ipPools/components/PoolForm.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
 import { connect } from 'react-redux';
 import { Field, reduxForm } from 'redux-form';
 import { withRouter } from 'react-router-dom';
@@ -19,7 +18,7 @@ export class PoolForm extends Component {
   getOverflowPoolOptions = () => {
     const { pools, pool } = this.props;
 
-    const overflowPools = _.compact(pools.map((currentPool) => {
+    const overflowPools = (pools.map((currentPool) => {
       if (currentPool.auto_warmup_overflow_pool || currentPool.id === pool.id) {
         return null;
       }
@@ -28,7 +27,7 @@ export class PoolForm extends Component {
         label: `${currentPool.name} (${currentPool.id})`,
         value: currentPool.id
       };
-    }));
+    })).filter(Boolean); // See: https://stackoverflow.com/a/32906951
 
     // If the pool has available IPs with auto warmup enabled,
     // render the 'Shared Pool' option in the `<select/>`

--- a/src/pages/ipPools/components/PoolForm.js
+++ b/src/pages/ipPools/components/PoolForm.js
@@ -7,6 +7,7 @@ import { SendingDomainTypeaheadWrapper, TextFieldWrapper } from 'src/components'
 import AccessControl from 'src/components/auth/AccessControl';
 import { required } from 'src/helpers/validation';
 import { configFlag } from 'src/helpers/conditions/config';
+import { inSPC, inSPCEU } from 'src/config/tenant';
 import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
 import { any } from 'src/helpers/conditions';
 import { selectCurrentPool } from 'src/selectors/ipPools';
@@ -30,11 +31,15 @@ export class PoolForm extends Component {
     })).filter(Boolean); // See: https://stackoverflow.com/a/32906951
 
     // If the pool has available IPs with auto warmup enabled,
+    // *and* the user is in SPC or SPCEU,
     // render the 'Shared Pool' option in the `<select/>`
     const hasPoolsWithAutoWarmup = pools.some(({ ips }) => ips.some((ip) => ip.auto_warmup_enabled));
 
-    if (hasPoolsWithAutoWarmup) {
-      overflowPools.unshift({ label: 'Shared Pool', value: 'shared pool' });
+    if (hasPoolsWithAutoWarmup && (inSPC() || inSPCEU())) {
+      overflowPools.unshift({
+        label: 'Shared Pool',
+        value: 'shared pool'
+      });
     }
 
     overflowPools.unshift({ label: 'None', value: '' });

--- a/src/pages/ipPools/components/PoolForm.js
+++ b/src/pages/ipPools/components/PoolForm.js
@@ -32,17 +32,9 @@ export class PoolForm extends Component {
 
     // If the pool has available IPs with auto warmup enabled,
     // render the 'Shared Pool' option in the `<select/>`
-    const getPoolsWithAutoWarmup = () => pools.filter((currentPool) => {
-      if (currentPool.ips) {
-        const ipsWithAutoWarmup = currentPool.ips.filter((ip) => ip.auto_warmup_enabled);
+    const hasPoolsWithAutoWarmup = pools.some(({ ips }) => ips.some((ip) => ip.auto_warmup_enabled));
 
-        if (ipsWithAutoWarmup.length > 0) {
-          return currentPool;
-        }
-      }
-    });
-
-    if (getPoolsWithAutoWarmup().length) {
+    if (hasPoolsWithAutoWarmup) {
       overflowPools.unshift({ label: 'Shared Pool', value: 'shared pool' });
     }
 

--- a/src/pages/ipPools/components/tests/PoolForm.test.js
+++ b/src/pages/ipPools/components/tests/PoolForm.test.js
@@ -94,8 +94,44 @@ describe('PoolForm tests', () => {
       expect(wrapper.find(component).prop('options')[1]).toEqual({ label: 'Default (default)', value: 'default' });
     });
 
+    it('shows the "Shared Pool" option in the overflow pool list when any of the available pool IPs have auto warmup enabled', () => {
+      wrapper.setProps({
+        pools: [{
+          name: 'Fake Pool',
+          id: 'fake-pool',
+          ips: [{
+            external_ip: '1.1.1.1'
+          }]
+        }, {
+          name: 'My Pool',
+          id: 'my-pool',
+          ips: [{
+            external_ip: '2.2.2.2.',
+            auto_warmup_enabled: true
+          }]
+        }]
+      });
+
+      expect(wrapper.find(component).prop('options')[1]).toEqual({ label: 'Shared Pool', value: 'shared pool' });
+    });
+
+    it('Does not show the "Shared Pool" option in the overflow pool list when none of the available pool IPs have auto warmup enabled', () => {
+      wrapper.setProps({
+        pools: [{
+          name: 'Fake Pool',
+          id: 'fake-pool',
+          ips: [{
+            external_ip: '1.1.1.1'
+          }]
+        }]
+      });
+
+      expect(wrapper.find(component).prop('options').includes({ label: 'Shared Pool', value: 'shared pool' })).toBe(false);
+    });
+
     it('shows placeholder pool in overflow pool list ', () => {
       wrapper.setProps({ pools: [{ name: 'Default', id: 'default', ips: [{ external_ip: '1.1.1.1' }]}, { name: 'My Pool', id: 'my-pool', ips: []}]});
+
       expect(wrapper.find(component).prop('options')[0]).toEqual({ label: 'None', value: '' });
     });
 

--- a/src/pages/ipPools/components/tests/PoolForm.test.js
+++ b/src/pages/ipPools/components/tests/PoolForm.test.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { PoolForm } from '../PoolForm';
 import config from 'src/config';
-import { SPC_TENANT } from 'src/constants';
+import { SPC_TENANT, SPC_EU_TENANT } from 'src/constants';
 jest.mock('src/config');
 
 describe('PoolForm tests', () => {
@@ -119,6 +119,7 @@ describe('PoolForm tests', () => {
     });
 
     it('shows the "Shared Pool" option in the overflow pool list when any of the available pool IPS have auto warmup enabled and the tenant is in SparkPost Cloud EU', () => {
+      config.tenantId = SPC_EU_TENANT;
       wrapper.setProps({
         pools: [{
           name: 'Fake Pool',

--- a/src/pages/ipPools/components/tests/PoolForm.test.js
+++ b/src/pages/ipPools/components/tests/PoolForm.test.js
@@ -126,7 +126,7 @@ describe('PoolForm tests', () => {
         }]
       });
 
-      expect(wrapper.find(component).prop('options').includes({ label: 'Shared Pool', value: 'shared pool' })).toBe(false);
+      expect(wrapper.find(component).prop('options').some((option) => option.label === 'Shared Pool' && option.value === 'shared pool')).toBe(false);
     });
 
     it('shows placeholder pool in overflow pool list ', () => {

--- a/src/pages/ipPools/components/tests/PoolForm.test.js
+++ b/src/pages/ipPools/components/tests/PoolForm.test.js
@@ -84,6 +84,22 @@ describe('PoolForm', () => {
 
   describe('overflow pool', () => {
     const component = 'Field[name="auto_warmup_overflow_pool"]';
+    const poolsWithAutoWarmupEnabled = {
+      pools: [{
+        name: 'Fake Pool',
+        id: 'fake-pool',
+        ips: [{
+          external_ip: '1.1.1.1'
+        }]
+      }, {
+        name: 'My Pool',
+        id: 'my-pool',
+        ips: [{
+          external_ip: '2.2.2.2.',
+          auto_warmup_enabled: true
+        }]
+      }]
+    };
 
     it('does not render if editing default pool', () => {
       wrapper.setProps({ pool: { id: 'default', name: 'Default' }});
@@ -98,44 +114,14 @@ describe('PoolForm', () => {
     it('shows the "Shared Pool" option in the overflow pool list when any of the available pool IPs have auto warmup enabled and the tenant is in SparkPost Cloud', () => {
       config.tenantId = SPC_TENANT;
 
-      wrapper.setProps({
-        pools: [{
-          name: 'Fake Pool',
-          id: 'fake-pool',
-          ips: [{
-            external_ip: '1.1.1.1'
-          }]
-        }, {
-          name: 'My Pool',
-          id: 'my-pool',
-          ips: [{
-            external_ip: '2.2.2.2.',
-            auto_warmup_enabled: true
-          }]
-        }]
-      });
+      wrapper.setProps(poolsWithAutoWarmupEnabled);
 
       expect(wrapper.find(component).prop('options')[1]).toEqual({ label: 'Shared Pool', value: 'shared pool' });
     });
 
     it('shows the "Shared Pool" option in the overflow pool list when any of the available pool IPS have auto warmup enabled and the tenant is in SparkPost Cloud EU', () => {
       config.tenantId = SPC_EU_TENANT;
-      wrapper.setProps({
-        pools: [{
-          name: 'Fake Pool',
-          id: 'fake-pool',
-          ips: [{
-            external_ip: '1.1.1.1'
-          }]
-        }, {
-          name: 'My Pool',
-          id: 'my-pool',
-          ips: [{
-            external_ip: '2.2.2.2.',
-            auto_warmup_enabled: true
-          }]
-        }]
-      });
+      wrapper.setProps(poolsWithAutoWarmupEnabled);
 
       expect(wrapper.find(component).prop('options')[1]).toEqual({ label: 'Shared Pool', value: 'shared pool' });
     });
@@ -150,6 +136,13 @@ describe('PoolForm', () => {
           }]
         }]
       });
+
+      expect(wrapper.find(component).prop('options').some((option) => option.label === 'Shared Pool' && option.value === 'shared pool')).toBe(false);
+    });
+
+    it('Does not show the "Shared Pool" option in the overflow pool list when the tenant is not in SparkPost Cloud or SparkPost Cloud EU', () => {
+      config.tenantId = 'foo';
+      wrapper.setProps(poolsWithAutoWarmupEnabled);
 
       expect(wrapper.find(component).prop('options').some((option) => option.label === 'Shared Pool' && option.value === 'shared pool')).toBe(false);
     });

--- a/src/pages/ipPools/components/tests/PoolForm.test.js
+++ b/src/pages/ipPools/components/tests/PoolForm.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { PoolForm } from '../PoolForm';
 import config from 'src/config';
+import { SPC_TENANT } from 'src/constants';
 jest.mock('src/config');
 
 describe('PoolForm tests', () => {
@@ -94,7 +95,30 @@ describe('PoolForm tests', () => {
       expect(wrapper.find(component).prop('options')[1]).toEqual({ label: 'Default (default)', value: 'default' });
     });
 
-    it('shows the "Shared Pool" option in the overflow pool list when any of the available pool IPs have auto warmup enabled', () => {
+    it('shows the "Shared Pool" option in the overflow pool list when any of the available pool IPs have auto warmup enabled and the tenant is in SparkPost Cloud', () => {
+      config.tenantId = SPC_TENANT;
+
+      wrapper.setProps({
+        pools: [{
+          name: 'Fake Pool',
+          id: 'fake-pool',
+          ips: [{
+            external_ip: '1.1.1.1'
+          }]
+        }, {
+          name: 'My Pool',
+          id: 'my-pool',
+          ips: [{
+            external_ip: '2.2.2.2.',
+            auto_warmup_enabled: true
+          }]
+        }]
+      });
+
+      expect(wrapper.find(component).prop('options')[1]).toEqual({ label: 'Shared Pool', value: 'shared pool' });
+    });
+
+    it('shows the "Shared Pool" option in the overflow pool list when any of the available pool IPS have auto warmup enabled and the tenant is in SparkPost Cloud EU', () => {
       wrapper.setProps({
         pools: [{
           name: 'Fake Pool',

--- a/src/pages/ipPools/components/tests/PoolForm.test.js
+++ b/src/pages/ipPools/components/tests/PoolForm.test.js
@@ -5,7 +5,7 @@ import config from 'src/config';
 import { SPC_TENANT, SPC_EU_TENANT } from 'src/constants';
 jest.mock('src/config');
 
-describe('PoolForm tests', () => {
+describe('PoolForm', () => {
   let props;
   let wrapper;
 

--- a/src/pages/ipPools/components/tests/__snapshots__/PoolForm.test.js.snap
+++ b/src/pages/ipPools/components/tests/__snapshots__/PoolForm.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PoolForm tests should render form 1`] = `
+exports[`PoolForm should render form 1`] = `
 <Panel>
   <form
     onSubmit={[MockFunction]}


### PR DESCRIPTION
[SD-941 - Provide Shared Pool Option in AutoIP Warmup UI](https://jira.int.messagesystems.com/browse/SD-942)

### What Changed
- Incorporated check for IPs with `auto_warmup_enabled` that renders the 'Shared Pool' `<option>` when present
- Added supporting tests


### How To Test
1. Navigate to `/account/ip-pools/edit/carnold_all_cold`
1. The 'Overflow Pool' `<select>` should render with 'Shared Pool' selected
1. Switch to the `master` branch
1. The 'Overflow Pool' `<select>` should render with 'None' selected

*NOTE FOR REVIEWERS:* I believe I implemented this correctly, but double checking the business requirements would be a good idea - I'm new to this feature so want to make sure I'm not introducing anything unusual!

### To Do
- [x] Incorporate feedback
