### PR TITLE
SA-853 - UX feedback for inbox-placement

### DIFF
--- a/src/components/CopyToClipboard/CopyToClipboard.js
+++ b/src/components/CopyToClipboard/CopyToClipboard.js
@@ -30,14 +30,14 @@ class CopyToClipboard extends Component {
   }
 
   render() {
-    const { label = 'Copy' } = this.props;
+    const { label = 'Copy', primary } = this.props;
     const { copied } = this.state;
 
     const content = copied ? 'Copied to Clipboard' : 'Copy to Clipboard';
 
     return (
       <Tooltip dark content={content}>
-        <Button name="copy-field-button" onClick={this.handleCopy}>
+        <Button primary={primary} name="copy-field-button" onClick={this.handleCopy}>
           <ContentCopy size={14}/> {label}
         </Button>
       </Tooltip>

--- a/src/components/collection/SaveCSVButton.js
+++ b/src/components/collection/SaveCSVButton.js
@@ -2,14 +2,15 @@ import { Button } from '@sparkpost/matchbox';
 import React from 'react';
 import { formatToCsv } from 'src/helpers/downloading';
 
-const SaveCSVButton = ({ data, saveCsv, caption = 'Save As CSV', ...props }) => {
+const SaveCSVButton = ({ data, saveCsv, caption = 'Save As CSV', filename, ...props }) => {
   const now = Math.floor(Date.now() / 1000);
+  const download = filename ? filename : `sparkpost-csv-${now}.csv`;
 
   if (!saveCsv || !data) {
     return null;
   }
 
-  return <Button download={`sparkpost-csv-${now}.csv`} to={formatToCsv({ data, returnBlob: false })} {...props}>{caption}</Button>;
+  return <Button download={download} to={formatToCsv({ data, returnBlob: false })} {...props}>{caption}</Button>;
 };
 
 export default SaveCSVButton;

--- a/src/components/collection/tests/SaveCSVButton.test.js
+++ b/src/components/collection/tests/SaveCSVButton.test.js
@@ -33,4 +33,9 @@ describe('Save CSV Button', () => {
     wrapper.setProps({ caption: 'Click Me!' });
     expect(wrapper.dive().text()).toEqual('Click Me!');
   });
+
+  it('should render with given download filename', () => {
+    wrapper.setProps({ filename: 'NotAVirus.exe' });
+    expect(wrapper).toHaveProp('download', 'NotAVirus.exe');
+  });
 });

--- a/src/pages/inboxPlacement/SeedList.module.scss
+++ b/src/pages/inboxPlacement/SeedList.module.scss
@@ -9,5 +9,5 @@
 }
 
 .CopyButton {
-  margin-left: 20px;
+  margin-right: 20px;
 }

--- a/src/pages/inboxPlacement/SeedListPage.js
+++ b/src/pages/inboxPlacement/SeedListPage.js
@@ -40,8 +40,8 @@ export class SeedListPage extends React.Component {
           <hr className={styles.hr}/>
           <p className={styles.Directions}>
             Next, set up your campaign. Make sure you are sending to the full list of seed email addresses.
-            For best results, set the <strong>`X-SP-Inbox-Placement`</strong> header with a unique value such
-            as <strong>"my-first-test"</strong>.
+            For best results, set the <code>`X-SP-Inbox-Placement`</code> header with a unique value such
+            as <code>"my-first-test"</code>.
             If you don't, you may run into issues if your have more than one test running with the same
             subject line.
           </p>
@@ -52,10 +52,10 @@ export class SeedListPage extends React.Component {
         </div>
         <TextField multiline value={seeds.join('\n')} resize="vertical" rows={10} readOnly/>
         <div>
-          <SaveCSVButton data={csvData} saveCsv={true} caption={<span><FileDownload/>Download CSV</span>}/>
           <span className={styles.CopyButton}>
-            <CopyToClipboard value={seeds.join(',')} label='Copy List'/>
+            <CopyToClipboard primary value={seeds.join(',')} label='Copy List'/>
           </span>
+          <SaveCSVButton data={csvData} saveCsv={true} caption={<span><FileDownload/>Download CSV</span>} filename={'sparkpost-seedlist.csv'}/>
         </div>
       </Panel.Section>
     </>);
@@ -74,14 +74,14 @@ export class SeedListPage extends React.Component {
           content: 'Inbox Placement Tests',
           onClick: () => this.props.history.push('/inbox-placement')
         }}
-        title='Inbox Placement | Start a Test'
+        title='Inbox Placement'
+        subtitle='Start a Test'
       >
         <Panel>
           <Panel.Section>
             <h3>Send To These Addresses</h3>
           </Panel.Section>
           {error ? this.renderError() : this.renderContents()}
-
         </Panel>
       </Page>
     );

--- a/src/pages/inboxPlacement/TestDetailsPage.js
+++ b/src/pages/inboxPlacement/TestDetailsPage.js
@@ -68,7 +68,13 @@ export const TestDetailsPage = (props) => {
   }
 
   return (
-    <Page title='Inbox Placement | Results'
+    <Page
+      breadcrumbAction={{
+        content: 'All Inbox Placement Tests',
+        onClick: () => this.props.history.push('/inbox-placement')
+      }}
+      title='Inbox Placement'
+      subtitle='Results'
       primaryArea={<StopTest status={(details || {}).status} loading={stopTestLoading} onStop={stopTest} />}
     >
       <Tabs

--- a/src/pages/inboxPlacement/TestDetailsPage.js
+++ b/src/pages/inboxPlacement/TestDetailsPage.js
@@ -71,7 +71,7 @@ export const TestDetailsPage = (props) => {
     <Page
       breadcrumbAction={{
         content: 'All Inbox Placement Tests',
-        onClick: () => this.props.history.push('/inbox-placement')
+        onClick: () => history.push('/inbox-placement')
       }}
       title='Inbox Placement'
       subtitle='Results'

--- a/src/pages/inboxPlacement/TestListPage.module.scss
+++ b/src/pages/inboxPlacement/TestListPage.module.scss
@@ -39,8 +39,7 @@
 .TestName {
   display: flex;
   padding: 0 0 0 1.3rem;
-  margin: 0.2rem 0 0 0;
-  font-size: font-size(200);
+  font-size: font-size(300);
 
   .Divider {
     margin: 0 0.5rem 0 0.5rem;
@@ -50,12 +49,11 @@
 .TestSchedule {
   display: flex;
   padding: 0 0 0 1.2rem;
-  margin: 0.2rem 0 0 0;
-  font-size: font-size(200);
+  font-size: font-size(300);
 }
 
 .ScheduleIcon {
-  padding: 0 0.2rem 0 0;
+  padding: 0 0.2rem 2px 0;
 }
 
 .TooltipWrapper {
@@ -64,7 +62,7 @@
 
 .ColumnHeader {
   margin-bottom: 0;
-  font-size: font-size(200);
+  font-size: font-size(300);
   padding: 0.4rem 0 0.1rem 0;
 }
 

--- a/src/pages/inboxPlacement/components/InfoBlock.js
+++ b/src/pages/inboxPlacement/components/InfoBlock.js
@@ -3,7 +3,7 @@ import { Grid } from '@sparkpost/matchbox';
 import styles from './InfoBlock.module.scss';
 
 const InfoBlock = ({ label, value, columnProps = {}}) => <Grid.Column {...columnProps}>
-  <span className={styles.InfoLabel}>{label}:</span>
+  <span className={styles.InfoLabel}>{label}</span>
   <br/>
   <span className={styles.InfoValue}>{value}</span>
 </Grid.Column>;

--- a/src/pages/inboxPlacement/components/StopTest.js
+++ b/src/pages/inboxPlacement/components/StopTest.js
@@ -31,7 +31,7 @@ const StopTest = ({ status, onStop, loading }) => {
       confirmVerb='Stop Test'
       cancelVerb='Continue Test'
     />
-    <Button primary onClick={toggleModalVisibility}>Stop Test</Button>
+    <Button primary size='large' onClick={toggleModalVisibility}>Stop Test</Button>
   </>);
 };
 

--- a/src/pages/inboxPlacement/components/TestContent.js
+++ b/src/pages/inboxPlacement/components/TestContent.js
@@ -23,11 +23,11 @@ const TestContent = ({ content, details }) => {
       <h2>{details.subject}</h2>
       <Grid>
         <InfoBlock value={from_address} label='From' columnProps={{ sm: 12, md: 4 }}/>
-        <InfoBlock value={formatBytes(message_size)} label='Raw Message Size:' columnProps={{ sm: 12, md: 4 }}/>
+        <InfoBlock value={formatBytes(message_size)} label='Raw Message Size' columnProps={{ sm: 12, md: 4 }}/>
       </Grid>
     </Panel>
     <Panel>
-      <Tabs selected={selectedTabIndex} tabs={tabs} color='navy' />
+      <Tabs selected={selectedTabIndex} tabs={tabs} color='blue' />
       <Panel.Section>
         <CodeBlock code={content[selectedTabKey] || ''}/>
       </Panel.Section>

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/InfoBlock.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/InfoBlock.test.js.snap
@@ -6,7 +6,6 @@ exports[`Component: InfoBlock renders correctly 1`] = `
     className="InfoLabel"
   >
     Foo
-    :
   </span>
   <br />
   <span

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/StopTest.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/StopTest.test.js.snap
@@ -4,7 +4,7 @@ exports[`Component: StopTest renders button if test is running 1`] = `
 <Button
   onClick={[Function]}
   primary={true}
-  size="default"
+  size="large"
 >
   Stop Test
 </Button>

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/TestContent.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/TestContent.test.js.snap
@@ -26,14 +26,14 @@ exports[`Component: TestContent renders page correctly with defaults 1`] = `
             "sm": 12,
           }
         }
-        label="Raw Message Size:"
+        label="Raw Message Size"
         value="2.52KB"
       />
     </Grid>
   </Panel>
   <Panel>
     <Tabs
-      color="navy"
+      color="blue"
       connectBelow={true}
       selected={0}
       tabs={

--- a/src/pages/inboxPlacement/helpers/formatScheduleLine.js
+++ b/src/pages/inboxPlacement/helpers/formatScheduleLine.js
@@ -13,10 +13,10 @@ export default function formatScheduleLine(status, start_time, end_time) {
       return `Sent ${formatted_start_time} and ${getHoursRemaining(start_time)} hours remaining on test`;
     }
     case STATUS.STOPPED: {
-      return `Sent ${formatted_start_time} and stopped at ${formatDateTime(end_time)}`;
+      return `Sent ${formatted_start_time} and Stopped ${formatDateTime(end_time)}`;
     }
     case STATUS.COMPLETED: {
-      return `Sent ${formatted_start_time} and completed at ${formatDateTime(end_time)}`;
+      return `Sent ${formatted_start_time} and Completed ${formatDateTime(end_time)}`;
     }
     default: {
       return `Sent ${formatted_start_time} and test status unknown`;

--- a/src/pages/inboxPlacement/helpers/tests/formatScheduleLine.test.js
+++ b/src/pages/inboxPlacement/helpers/tests/formatScheduleLine.test.js
@@ -24,13 +24,13 @@ describe('Promo Code async validator', () => {
   it('should format stopped test', () => {
     status = 'stopped';
     end_time = '2019-08-09T18:30:00-04:00';
-    expect(formatLine(status, start_time, end_time)).toEqual('Sent Aug 09, 2019 at 12:30pm and stopped at Aug 09, 2019 at 6:30pm');
+    expect(formatLine(status, start_time, end_time)).toEqual('Sent Aug 09, 2019 at 12:30pm and Stopped Aug 09, 2019 at 6:30pm');
   });
 
   it('should format completed test', () => {
     status = 'completed';
     end_time = '2019-08-09T20:30:00-04:00';
-    expect(formatLine(status, start_time, end_time)).toEqual('Sent Aug 09, 2019 at 12:30pm and completed at Aug 09, 2019 at 8:30pm');
+    expect(formatLine(status, start_time, end_time)).toEqual('Sent Aug 09, 2019 at 12:30pm and Completed Aug 09, 2019 at 8:30pm');
   });
 
   it('handle error state gracefully where status is unknown', () => {

--- a/src/pages/inboxPlacement/tests/__snapshots__/SeedListPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/SeedListPage.test.js.snap
@@ -21,6 +21,7 @@ exports[`Page: SeedList tests render include download csv button with correct fo
       },
     ]
   }
+  filename="sparkpost-seedlist.csv"
   saveCsv={true}
 />
 `;
@@ -34,7 +35,8 @@ exports[`Page: SeedList tests renders page correctly with defaults 1`] = `
     }
   }
   empty={Object {}}
-  title="Inbox Placement | Start a Test"
+  subtitle="Start a Test"
+  title="Inbox Placement"
 >
   <Panel>
     <Panel.Section>
@@ -60,13 +62,13 @@ exports[`Page: SeedList tests renders page correctly with defaults 1`] = `
           className="Directions"
         >
           Next, set up your campaign. Make sure you are sending to the full list of seed email addresses. For best results, set the 
-          <strong>
+          <code>
             \`X-SP-Inbox-Placement\`
-          </strong>
+          </code>
            header with a unique value such as 
-          <strong>
+          <code>
             "my-first-test"
-          </strong>
+          </code>
           . If you don't, you may run into issues if your have more than one test running with the same subject line.
         </p>
         <p>
@@ -88,6 +90,15 @@ exports[`Page: SeedList tests renders page correctly with defaults 1`] = `
         value=""
       />
       <div>
+        <span
+          className="CopyButton"
+        >
+          <CopyToClipboard
+            label="Copy List"
+            primary={true}
+            value=""
+          />
+        </span>
         <SaveCSVButton
           caption={
             <span>
@@ -96,16 +107,9 @@ exports[`Page: SeedList tests renders page correctly with defaults 1`] = `
             </span>
           }
           data={Array []}
+          filename="sparkpost-seedlist.csv"
           saveCsv={true}
         />
-        <span
-          className="CopyButton"
-        >
-          <CopyToClipboard
-            label="Copy List"
-            value=""
-          />
-        </span>
       </div>
     </Panel.Section>
   </Panel>

--- a/src/pages/inboxPlacement/tests/__snapshots__/TestDetailsPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/TestDetailsPage.test.js.snap
@@ -14,13 +14,20 @@ exports[`Page: Single Inbox Placement Test handles errors 1`] = `
 
 exports[`Page: Single Inbox Placement Test renders page correctly with defaults 1`] = `
 <Page
+  breadcrumbAction={
+    Object {
+      "content": "All Inbox Placement Tests",
+      "onClick": [Function],
+    }
+  }
   empty={Object {}}
   primaryArea={
     <StopTest
       onStop={[Function]}
     />
   }
-  title="Inbox Placement | Results"
+  subtitle="Results"
+  title="Inbox Placement"
 >
   <Tabs
     color="orange"


### PR DESCRIPTION
### What Changed
 - Addressed UX feedback for Inbox-placement.

### How To Test
 - Verify that all UX feedback has been addressed.

### Changes:

#### Landing page:
- [x] Mis-aligned clock icon should be margin-top: -2px
- [x] Change complete at to Completed. Same with stopped at
- [x] ~Table row secondary text is too small - should be exactly .8rem~ Per conversation with Jon, he reommended using text-size(300)
- [x] Too much spacing between Test name, email address, and date information - remove top margins entirely

#### Start test page:
- [x] Seedlist csv should be named sparkpost-seedlist.csv  instead of sparkpost-csv-1569267513.csv
- [x]  Page titles should match our standard pattern of secondary text
- [x] `X-SP-Inbox-Placement` and the `"my-first-test"` should be wrapped in a code element
- [x] Copy list (primary orange)
- [x] Download CSV (secondary)

Individual Test Pages:
- [x]  Page titles should match our standard pattern of secondary text
- [x] "Stop test" button should be a large button
- [x] Need a back breadcrumb link
- [x] Remove all colons for details labels
- [x] Under content, use `blue` tabs not `navy`

