### PR TITLE
AC-986: Handle query param for selected plan and promo code

### DIFF
--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -48,14 +48,16 @@ export const ChangePlanForm = ({
         const planVerified = plan.find((x) => x.code === requestParams.code);
         if (planVerified) {
           selectPlan(planVerified);
-          verifyPromoCode({
-            promoCode: requestParams.promo,
-            billingId: planVerified.billingId,
-            meta: {
+          if (requestParams.promo) {
+            verifyPromoCode({
               promoCode: requestParams.promo,
-              showErrorAlert: false
-            }
-          });
+              billingId: planVerified.billingId,
+              meta: {
+                promoCode: requestParams.promo,
+                showErrorAlert: false
+              }
+            });
+          }
         }
       });
     }

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -31,8 +31,9 @@ export const ChangePlanForm = ({
   // },
   currentPlan
 }) => {
-  const [selectedPlan, selectPlan] = useState(null);
-  const { requestParams } = useRouter();
+  const { requestParams: { code, promo } = {}, updateRoute } = useRouter();
+  const allPlans = _.reduce(plans, (result, value) => [...result, ...value], []);
+  const [selectedPlan, selectPlan] = useState(allPlans.find((x) => x.code === code) || null);
   // const [useSavedCC, setUseSavedCC] = useState(null);
   useEffect(() => { getBillingCountries(); }, [getBillingCountries]);
   useEffect(() => { getBillingInfo(); }, [getBillingInfo]);
@@ -43,25 +44,25 @@ export const ChangePlanForm = ({
     }
   },[clearPromoCode, selectedPlan]);
   useEffect(() => {
-    if (requestParams.code) {
-      const allPlans = _.reduce(plans, (result, value) => [...result, ...value], []);
-      const planVerified = allPlans.find((x) => x.code === requestParams.code);
-      if (planVerified) {
-        selectPlan(planVerified);
-        if (requestParams.promo) {
-          verifyPromoCode({
-            promoCode: requestParams.promo,
-            billingId: planVerified.billingId,
-            meta: {
-              promoCode: requestParams.promo,
-              showErrorAlert: false
-            }
-          });
+    if (promo && selectedPlan) {
+      const { billingId } = selectedPlan;
+      verifyPromoCode({
+        promoCode: promo,
+        billingId: billingId,
+        meta: {
+          promoCode: promo,
+          showErrorAlert: false
         }
-      }
+      });
     }
-  },[plans, requestParams.code, requestParams.promo, verifyPromoCode]);
-
+  },[promo, selectedPlan, verifyPromoCode]);
+  useEffect(() => {
+    if (!selectedPlan) { //clears out requestParams when user changes plan
+      updateRoute({
+        undefined
+      });
+    }
+  },[selectedPlan, updateRoute]);
   const applyPromoCode = (promoCode) => {
     verifyPromoCode({ promoCode , billingId: selectedPlan.billingId, meta: { promoCode, showErrorAlert: false }});
   };

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -7,14 +7,13 @@ import qs from 'query-string';
 import PlanSelectSection, { SelectedPlan } from '../components/PlanSelect';
 import CurrentPlanSection from '../components/CurrentPlanSection';
 import { verifyPromoCode, clearPromoCode } from 'src/actions/billing';
+import useRouter from 'src/hooks/useRouter';
 //Actions
 import { getBillingInfo, getPlans } from 'src/actions/account';
 import { getBillingCountries } from 'src/actions/billing';
 //Selectors
 import { selectTieredVisiblePlans, currentPlanSelector, getPromoCodeObject } from 'src/selectors/accountBillingInfo';
 import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
-import useRouter from 'src/hooks/useRouter';
-import _ from 'lodash';
 
 const FORMNAME = 'changePlan';
 export const ChangePlanForm = ({
@@ -32,16 +31,13 @@ export const ChangePlanForm = ({
   currentPlan
 }) => {
   const { requestParams: { code, promo } = {}, updateRoute } = useRouter();
-  const allPlans = _.reduce(plans, (result, value) => [...result, ...value], []);
+  const allPlans = Object.entries(plans).reduce((acc, curr) => [...curr[1], ...acc],[]);
   const [selectedPlan, selectPlan] = useState(allPlans.find((x) => x.code === code) || null);
   // const [useSavedCC, setUseSavedCC] = useState(null);
   const applyPromoCode = useCallback((promoCode) => {
     const { billingId } = selectedPlan;
     verifyPromoCode({ promoCode , billingId, meta: { promoCode, showErrorAlert: false }});
   },[selectedPlan, verifyPromoCode]);
-  const onSelect = (plan) => {
-    selectPlan(plan);
-  };
   useEffect(() => { getBillingCountries(); }, [getBillingCountries]);
   useEffect(() => { getBillingInfo(); }, [getBillingInfo]);
   useEffect(() => { getPlans(); }, [getPlans]);
@@ -69,7 +65,7 @@ export const ChangePlanForm = ({
             selectedPlan
               ? <SelectedPlan
                 plan={selectedPlan}
-                onChange={onSelect}
+                onChange={selectPlan}
                 promoCodeObj = {promoCodeObj}
                 handlePromoCode = {
                   {
@@ -79,7 +75,7 @@ export const ChangePlanForm = ({
                 }
               />
               : <PlanSelectSection
-                onSelect={onSelect}
+                onSelect={selectPlan}
                 plans={plans}
                 currentPlan={currentPlan}
               />

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -44,22 +44,21 @@ export const ChangePlanForm = ({
   },[clearPromoCode, selectedPlan]);
   useEffect(() => {
     if (requestParams.code) {
-      _.forEach(plans, (plan) => {
-        const planVerified = plan.find((x) => x.code === requestParams.code);
-        if (planVerified) {
-          selectPlan(planVerified);
-          if (requestParams.promo) {
-            verifyPromoCode({
+      const allPlans = _.reduce(plans, (result, value) => [...result, ...value], []);
+      const planVerified = allPlans.find((x) => x.code === requestParams.code);
+      if (planVerified) {
+        selectPlan(planVerified);
+        if (requestParams.promo) {
+          verifyPromoCode({
+            promoCode: requestParams.promo,
+            billingId: planVerified.billingId,
+            meta: {
               promoCode: requestParams.promo,
-              billingId: planVerified.billingId,
-              meta: {
-                promoCode: requestParams.promo,
-                showErrorAlert: false
-              }
-            });
-          }
+              showErrorAlert: false
+            }
+          });
         }
-      });
+      }
     }
   },[plans, requestParams.code, requestParams.promo, verifyPromoCode]);
 

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -10,13 +10,13 @@ import { verifyPromoCode, clearPromoCode } from 'src/actions/billing';
 //Actions
 import { getBillingInfo, getPlans } from 'src/actions/account';
 import { getBillingCountries } from 'src/actions/billing';
-
 //Selectors
 import { selectTieredVisiblePlans, currentPlanSelector, getPromoCodeObject } from 'src/selectors/accountBillingInfo';
 import { changePlanInitialValues } from 'src/selectors/accountBillingForms';
+import useRouter from 'src/hooks/useRouter';
+import _ from 'lodash';
 
 const FORMNAME = 'changePlan';
-
 export const ChangePlanForm = ({
   //Redux Props
   plans,
@@ -32,6 +32,7 @@ export const ChangePlanForm = ({
   currentPlan
 }) => {
   const [selectedPlan, selectPlan] = useState(null);
+  const { requestParams } = useRouter();
   // const [useSavedCC, setUseSavedCC] = useState(null);
   useEffect(() => { getBillingCountries(); }, [getBillingCountries]);
   useEffect(() => { getBillingInfo(); }, [getBillingInfo]);
@@ -41,8 +42,24 @@ export const ChangePlanForm = ({
       clearPromoCode();
     }
   },[clearPromoCode, selectedPlan]);
-  //TODO: Implement in AC-986
-  // useEffect(() => { console.log(selectedPlan, promoCode)}, [verifyPromoCode, promoCode, selectedPlan]);
+  useEffect(() => {
+    if (requestParams.code) {
+      _.forEach(plans, (plan) => {
+        const planVerified = plan.find((x) => x.code === requestParams.code);
+        if (planVerified) {
+          selectPlan(planVerified);
+          verifyPromoCode({
+            promoCode: requestParams.promo,
+            billingId: planVerified.billingId,
+            meta: {
+              promoCode: requestParams.promo,
+              showErrorAlert: false
+            }
+          });
+        }
+      });
+    }
+  },[plans, requestParams.code, requestParams.promo, verifyPromoCode]);
 
   const applyPromoCode = (promoCode) => {
     verifyPromoCode({ promoCode , billingId: selectedPlan.billingId, meta: { promoCode, showErrorAlert: false }});

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Grid } from '@sparkpost/matchbox';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -35,9 +35,10 @@ export const ChangePlanForm = ({
   const allPlans = _.reduce(plans, (result, value) => [...result, ...value], []);
   const [selectedPlan, selectPlan] = useState(allPlans.find((x) => x.code === code) || null);
   // const [useSavedCC, setUseSavedCC] = useState(null);
-  const applyPromoCode = (promoCode) => {
-    verifyPromoCode({ promoCode , billingId: selectedPlan.billingId, meta: { promoCode, showErrorAlert: false }});
-  };
+  const applyPromoCode = useCallback((promoCode) => {
+    const { billingId } = selectedPlan;
+    verifyPromoCode({ promoCode , billingId, meta: { promoCode, showErrorAlert: false }});
+  },[selectedPlan, verifyPromoCode]);
   const onSelect = (plan) => {
     selectPlan(plan);
   };

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -35,6 +35,12 @@ export const ChangePlanForm = ({
   const allPlans = _.reduce(plans, (result, value) => [...result, ...value], []);
   const [selectedPlan, selectPlan] = useState(allPlans.find((x) => x.code === code) || null);
   // const [useSavedCC, setUseSavedCC] = useState(null);
+  const applyPromoCode = (promoCode) => {
+    verifyPromoCode({ promoCode , billingId: selectedPlan.billingId, meta: { promoCode, showErrorAlert: false }});
+  };
+  const onSelect = (plan) => {
+    selectPlan(plan);
+  };
   useEffect(() => { getBillingCountries(); }, [getBillingCountries]);
   useEffect(() => { getBillingInfo(); }, [getBillingInfo]);
   useEffect(() => { getPlans(); }, [getPlans]);
@@ -45,30 +51,14 @@ export const ChangePlanForm = ({
   },[clearPromoCode, selectedPlan]);
   useEffect(() => {
     if (promo && selectedPlan) {
-      const { billingId } = selectedPlan;
-      verifyPromoCode({
-        promoCode: promo,
-        billingId: billingId,
-        meta: {
-          promoCode: promo,
-          showErrorAlert: false
-        }
-      });
+      applyPromoCode(promo);
     }
-  },[promo, selectedPlan, verifyPromoCode]);
+  },[applyPromoCode, promo, selectedPlan, verifyPromoCode]);
   useEffect(() => {
     if (!selectedPlan) { //clears out requestParams when user changes plan
-      updateRoute({
-        undefined
-      });
+      updateRoute({ undefined });
     }
   },[selectedPlan, updateRoute]);
-  const applyPromoCode = (promoCode) => {
-    verifyPromoCode({ promoCode , billingId: selectedPlan.billingId, meta: { promoCode, showErrorAlert: false }});
-  };
-  const onSelect = (plan) => {
-    selectPlan(plan);
-  };
 
   return (
     <form>

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -31,7 +31,7 @@ export const ChangePlanForm = ({
   currentPlan
 }) => {
   const { requestParams: { code, promo } = {}, updateRoute } = useRouter();
-  const allPlans = Object.entries(plans).reduce((acc, curr) => [...curr[1], ...acc],[]);
+  const allPlans = Object.values(plans).reduce((acc, curr) => [...curr, ...acc],[]);
   const [selectedPlan, selectPlan] = useState(allPlans.find((x) => x.code === code) || null);
   // const [useSavedCC, setUseSavedCC] = useState(null);
   const applyPromoCode = useCallback((promoCode) => {

--- a/src/pages/billing/forms/tests/NewChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/NewChangePlanForm.test.js
@@ -95,16 +95,10 @@ describe('Change Plan Form', () => {
         promo: 'THXFISH2'
       }
     },mount);
-    expect(wrapper.find('SelectedPlan')).toHaveProp('plan', { code: '1',
-      includesIp: true,
-      monthly: 100,
-      name: 'One',
-      overage: 0.1,
-      volume: 1,
-      billingId: '1' });
+    expect(wrapper.find('SelectedPlan')).toHaveProp('plan', defaultProps.plans.test[0]);
 
     expect(defaultProps.verifyPromoCode).toHaveBeenCalledWith({ promoCode: 'THXFISH2',
-      billingId: '1',
+      billingId: defaultProps.plans.test[0].billingId,
       meta: { promoCode: 'THXFISH2', showErrorAlert: false }});
   });
 });

--- a/src/pages/billing/forms/tests/NewChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/NewChangePlanForm.test.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { ChangePlanForm } from '../NewChangePlanForm';
 import { shallow, mount } from 'enzyme';
+import useRouter from 'src/hooks/useRouter';
+// import { verifyPromoCode } from 'src/actions/billing';
+// jest.mock('src/actions/billing');
+jest.mock('src/hooks/useRouter');
 
 describe('Change Plan Form', () => {
   const defaultProps = {
@@ -11,7 +15,8 @@ describe('Change Plan Form', () => {
         monthly: 100,
         name: 'One',
         overage: 0.1,
-        volume: 1
+        volume: 1,
+        billingId: '1'
       }],
       'starter': [{
         code: '2',
@@ -20,14 +25,16 @@ describe('Change Plan Form', () => {
         name: 'Two',
         overage: 0.2,
         volume: 2,
-        isFree: true
+        isFree: true,
+        billingId: '2'
       }],
       'premier': [{
         code: '3',
         monthly: 300,
         name: 'Three',
         overage: 0.3,
-        volume: 3
+        volume: 3,
+        billingId: '3'
       }]
     },
     currentPlan: {
@@ -36,25 +43,38 @@ describe('Change Plan Form', () => {
       monthly: 300,
       name: 'Three',
       overage: 0.3,
-      volume: 3
+      volume: 3,
+      billingId: '3'
     },
     getPlans: jest.fn(),
     getBillingCountries: jest.fn(),
     getBillingInfo: jest.fn(),
     clearPromoCode: jest.fn(),
+    verifyPromoCode: jest.fn(() => ({ promoPending: false, promoError: false, selectedPromo: { promoCode: 'THXFISH2' }})),
     billing: {
+      promoPending: false,
+      promoError: false,
+      selectedPromo: {}
+    },
+    promoCodeObj: {
       promoPending: false,
       promoError: false,
       selectedPromo: {}
     }
   };
 
-  const subject = (props, render = shallow) => render(
-    <ChangePlanForm
-      {...defaultProps}
-      {...props}
-    />
-  );
+  const subject = (routerState = {}, render = shallow) => {
+    useRouter.mockReturnValue({
+      requestParams: {},
+      ...routerState
+    });
+
+    return render(
+      <ChangePlanForm
+        {...defaultProps}
+      />
+    );
+  };
 
   it('should render', () => {
     expect(subject()).toMatchSnapshot();
@@ -66,5 +86,25 @@ describe('Change Plan Form', () => {
     expect(defaultProps.getBillingCountries).toHaveBeenCalled();
     expect(defaultProps.getBillingInfo).toHaveBeenCalled();
     expect(defaultProps.clearPromoCode).toHaveBeenCalled();
+  });
+
+  it('selects plan and applies promocode if code present in request params', () => {
+    const wrapper = subject({
+      requestParams: {
+        code: '1',
+        promo: 'THXFISH2'
+      }
+    },mount);
+    expect(wrapper.find('SelectedPlan')).toHaveProp('plan', { code: '1',
+      includesIp: true,
+      monthly: 100,
+      name: 'One',
+      overage: 0.1,
+      volume: 1,
+      billingId: '1' });
+
+    expect(defaultProps.verifyPromoCode).toHaveBeenCalledWith({ promoCode: 'THXFISH2',
+      billingId: '1',
+      meta: { promoCode: 'THXFISH2', showErrorAlert: false }});
   });
 });

--- a/src/pages/billing/forms/tests/NewChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/NewChangePlanForm.test.js
@@ -51,6 +51,7 @@ describe('Change Plan Form', () => {
     getBillingInfo: jest.fn(),
     clearPromoCode: jest.fn(),
     verifyPromoCode: jest.fn(() => ({ promoPending: false, promoError: false, selectedPromo: { promoCode: 'THXFISH2' }})),
+    applyPromoCode: jest.fn(),
     billing: {
       promoPending: false,
       promoError: false,

--- a/src/pages/billing/forms/tests/NewChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/NewChangePlanForm.test.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { ChangePlanForm } from '../NewChangePlanForm';
 import { shallow, mount } from 'enzyme';
 import useRouter from 'src/hooks/useRouter';
-// import { verifyPromoCode } from 'src/actions/billing';
-// jest.mock('src/actions/billing');
 jest.mock('src/hooks/useRouter');
 
 describe('Change Plan Form', () => {
@@ -50,7 +48,7 @@ describe('Change Plan Form', () => {
     getBillingCountries: jest.fn(),
     getBillingInfo: jest.fn(),
     clearPromoCode: jest.fn(),
-    verifyPromoCode: jest.fn(() => ({ promoPending: false, promoError: false, selectedPromo: { promoCode: 'THXFISH2' }})),
+    verifyPromoCode: jest.fn(),
     applyPromoCode: jest.fn(),
     billing: {
       promoPending: false,

--- a/src/pages/billing/forms/tests/NewChangePlanForm.test.js
+++ b/src/pages/billing/forms/tests/NewChangePlanForm.test.js
@@ -66,6 +66,7 @@ describe('Change Plan Form', () => {
   const subject = (routerState = {}, render = shallow) => {
     useRouter.mockReturnValue({
       requestParams: {},
+      updateRoute: () => {},
       ...routerState
     });
 

--- a/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/NewChangePlanForm.test.js.snap
@@ -9,6 +9,7 @@ exports[`Change Plan Form should render 1`] = `
       <PlanSelectSection
         currentPlan={
           Object {
+            "billingId": "3",
             "code": "3",
             "monthly": 300,
             "name": "Three",
@@ -22,6 +23,7 @@ exports[`Change Plan Form should render 1`] = `
           Object {
             "premier": Array [
               Object {
+                "billingId": "3",
                 "code": "3",
                 "monthly": 300,
                 "name": "Three",
@@ -31,6 +33,7 @@ exports[`Change Plan Form should render 1`] = `
             ],
             "starter": Array [
               Object {
+                "billingId": "2",
                 "code": "2",
                 "includesIp": false,
                 "isFree": true,
@@ -42,6 +45,7 @@ exports[`Change Plan Form should render 1`] = `
             ],
             "test": Array [
               Object {
+                "billingId": "1",
                 "code": "1",
                 "includesIp": true,
                 "monthly": 100,
@@ -60,6 +64,7 @@ exports[`Change Plan Form should render 1`] = `
       <CurrentPlanSection
         currentPlan={
           Object {
+            "billingId": "3",
             "code": "3",
             "monthly": 300,
             "name": "Three",


### PR DESCRIPTION

AC-986: Handle query param for selected plan and promo code

### What Changed
 * clicking on a link of this format `/account/billing/plan?code={code}&promo={promoCode}` selects plan(if correct) and applies promocode.
### How To Test
use code = 50K-starter-0519 and any promocode to test

### To Do
- [ ] Address Feedback
