### PR TITLE
SA-891: Updated behavior for `undefined` data

### DIFF
--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -64,8 +64,7 @@ export class HealthScorePage extends Component {
     const selectedWeights = _.get(_.find(data, ['date', selectedDate]), 'weights', []);
     const selectedWeightsAreEmpty = selectedWeights.every(({ weight }) => weight === null);
     const dataForSelectedWeight = data.map(({ date, weights }) => ({ date, ..._.find(weights, ['weight_type', selectedComponent]) }));
-    const selectedDataIsZero = dataForSelectedWeight.every(({ weight_value }) => weight_value <= 0);
-
+    const selectedDataIsZero = dataForSelectedWeight.every(({ weight_value }) => (!weight_value || weight_value <= 0));
     let panelContent;
 
     if (empty) {

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -70,11 +70,15 @@ describe('Signals Health Score Page', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders weight chart at 100% if data all data is 0', () => {
+  it('renders weight chart at 100% if data all data is 0/undefined', () => {
     const newData = [
       {
         date: '2017-01-01',
         weights: [{ weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0 }]
+      },
+      {
+        date: '2017-01-02',
+        weights: [{ weight_type: 'Hard Bounces', weight: 0.5, weight_value: undefined }]
       }
     ];
     wrapper.setProps({ data: newData });


### PR DESCRIPTION

### What Changed
 - Added check for undefined in charts

### How To Test
 - Point env to prod and use 108 account (I can help if needed with this step)
 - Go to `/signals/health-score/sid/0`
 - Check the different components on right side and click `Unsubscribes`
 - Check that the chart has 100%
 - Check the other charts with data keep proper scaling with data

### To Do
- [ ] Address feedback
