### PR TITLE
SA-954 - Improve Selected and Hovered states

### DIFF
--- a/src/pages/signals/ComplaintsByCohortPage.js
+++ b/src/pages/signals/ComplaintsByCohortPage.js
@@ -1,3 +1,4 @@
+/* eslint max-lines: ["error", 200] */
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { getComplaintsByCohort, getEngagementRecency } from 'src/actions/signals';
@@ -68,7 +69,19 @@ export class ComplaintsByCohortPage extends Component {
   }
 
   renderContent = () => {
-    const { data = [], dataEngRecency = [], facet, facetId, handleDateSelect, loading, empty, error, selectedDate, subaccountId } = this.props;
+    const {
+      data = [],
+      dataEngRecency = [],
+      facet,
+      facetId,
+      handleDateSelect,
+      loading,
+      empty,
+      error,
+      selectedDate,
+      shouldHighlightSelected,
+      subaccountId
+    } = this.props;
     const selectedComplaints = _.find(data, ['date', selectedDate]) || {};
     const selectedEngagementRecency = _.find(dataEngRecency, ['date', selectedDate]) || {};
     let chartPanel;
@@ -100,6 +113,7 @@ export class ComplaintsByCohortPage extends Component {
                   height={300}
                   onClick={handleDateSelect}
                   selected={selectedDate}
+                  shouldHighlightSelected={shouldHighlightSelected}
                   lines={data}
                   tooltipWidth='250px'
                   tooltipContent={this.getTooltipContent}

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -1,3 +1,4 @@
+/* eslint max-lines: ["error", 200] */
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { getEngagementRateByCohort, getEngagementRecency } from 'src/actions/signals';
@@ -70,7 +71,17 @@ export class EngagementRateByCohortPage extends Component {
 
   renderContent = () => {
     const {
-      data = [], dataEngRecency = [], facet, facetId, handleDateSelect, loading, empty, error, selectedDate, subaccountId
+      data = [],
+      dataEngRecency = [],
+      facet,
+      facetId,
+      handleDateSelect,
+      loading,
+      empty,
+      error,
+      selectedDate,
+      shouldHighlightSelected,
+      subaccountId
     } = this.props;
     const selectedEngagementRate = _.find(data, ['date', selectedDate]) || {};
     const selectedEngagementRecency = _.find(dataEngRecency, ['date', selectedDate]) || {};
@@ -104,6 +115,7 @@ export class EngagementRateByCohortPage extends Component {
                   height={300}
                   onClick={handleDateSelect}
                   selected={selectedDate}
+                  shouldHighlightSelected={shouldHighlightSelected}
                   lines={data}
                   tooltipWidth='250px'
                   tooltipContent={this.getTooltipContent}

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -71,7 +71,8 @@ export class EngagementRecencyPage extends Component {
       subaccountId,
       hoveredDate,
       handleDateHover,
-      resetDateHover
+      resetDateHover,
+      shouldHighlightSelected
     } = this.props;
 
     const selectedCohorts = _.find(data, ['date', selectedDate]) || {};
@@ -107,6 +108,7 @@ export class EngagementRecencyPage extends Component {
                   onClick={handleDateSelect}
                   selected={selectedDate}
                   hovered={hoveredDate}
+                  shouldHighlightSelected={shouldHighlightSelected}
                   timeSeries={data}
                   tooltipContent={this.getTooltipContent}
                   tooltipWidth='250px'

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -58,7 +58,7 @@ export class HealthScorePage extends Component {
   }
 
   renderContent = () => {
-    const { data = [], handleDateSelect, handleDateHover, loading, gap, empty, error, selectedDate, hoveredDate, resetDateHover } = this.props;
+    const { data = [], handleDateSelect, handleDateHover, loading, gap, empty, error, selectedDate, hoveredDate, shouldHighlightSelected, resetDateHover } = this.props;
     const { selectedComponent } = this.state;
 
     const selectedWeights = _.get(_.find(data, ['date', selectedDate]), 'weights', []);
@@ -91,12 +91,13 @@ export class HealthScorePage extends Component {
             {panelContent || (
               <Fragment>
                 <BarChart
-                  margin = {newModelMarginsHealthScore}
+                  margin={newModelMarginsHealthScore}
                   gap={gap}
                   onClick={handleDateSelect}
                   onMouseOver={handleDateHover}
                   onMouseOut={resetDateHover}
                   disableHover={false}
+                  shouldHighlightSelected={shouldHighlightSelected}
                   selected={selectedDate}
                   hovered={hoveredDate}
                   timeSeries={data}
@@ -128,6 +129,7 @@ export class HealthScorePage extends Component {
                   onMouseOver={handleDateHover}
                   selected={selectedDate}
                   hovered={hoveredDate}
+                  shouldHighlightSelected={shouldHighlightSelected}
                   onMouseOut={resetDateHover}
                   timeSeries={data}
                   tooltipContent={({ payload = {}}) => (
@@ -151,6 +153,7 @@ export class HealthScorePage extends Component {
                       onMouseOut={resetDateHover}
                       hovered={hoveredDate}
                       selected={selectedDate}
+                      shouldHighlightSelected={shouldHighlightSelected}
                       timeSeries={dataForSelectedWeight}
                       tooltipContent={({ payload = {}}) => (
                         <TooltipMetric

--- a/src/pages/signals/SpamTrapPage.js
+++ b/src/pages/signals/SpamTrapPage.js
@@ -79,7 +79,7 @@ export class SpamTrapPage extends Component {
   )
 
   renderContent = () => {
-    const { data = [], handleDateSelect, loading, gap, empty, error, selectedDate, handleDateHover, resetDateHover, hoveredDate } = this.props;
+    const { data = [], handleDateSelect, loading, gap, empty, error, selectedDate, handleDateHover, resetDateHover, hoveredDate, shouldHighlightSelected } = this.props;
     const { calculation } = this.state;
     const selectedSpamTrapHits = _.find(data, ['date', selectedDate]) || {};
     let chartPanel;
@@ -124,6 +124,7 @@ export class SpamTrapPage extends Component {
                   onMouseOver={handleDateHover}
                   onMouseOut={resetDateHover}
                   hovered={hoveredDate}
+                  shouldHighlightSelected={shouldHighlightSelected}
                   tooltipContent={this.getTooltipContent}
                   yKeys={
                     spamTrapHitTypesCollection

--- a/src/pages/signals/UnsubscribeRateByCohortPage.js
+++ b/src/pages/signals/UnsubscribeRateByCohortPage.js
@@ -1,3 +1,4 @@
+/* eslint max-lines: ["error", 200] */
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { getUnsubscribeRateByCohort, getEngagementRecency } from 'src/actions/signals';
@@ -69,7 +70,17 @@ export class UnsubscribeRateByCohortPage extends Component {
 
   renderContent = () => {
     const {
-      data = [], dataEngRecency = [], facet, facetId, handleDateSelect, loading, empty, error, selectedDate, subaccountId
+      data = [],
+      dataEngRecency = [],
+      facet,
+      facetId,
+      handleDateSelect,
+      loading,
+      empty,
+      error,
+      selectedDate,
+      shouldHighlightSelected,
+      subaccountId
     } = this.props;
     const selectedUnsubscribe = _.find(data, ['date', selectedDate]) || {};
     const selectedEngagementRecency = _.find(dataEngRecency, ['date', selectedDate]) || {};
@@ -103,6 +114,7 @@ export class UnsubscribeRateByCohortPage extends Component {
                   height={300}
                   onClick={handleDateSelect}
                   selected={selectedDate}
+                  shouldHighlightSelected={shouldHighlightSelected}
                   lines={data}
                   tooltipWidth='250px'
                   tooltipContent={this.getTooltipContent}

--- a/src/pages/signals/components/charts/barchart/BarChart.js
+++ b/src/pages/signals/components/charts/barchart/BarChart.js
@@ -189,6 +189,7 @@ BarChart.propTypes = {
   fill: PropTypes.string,
   gap: PropTypes.number,
   onClick: PropTypes.func,
+  shouldHighlightSelected: PropTypes.bool,
   tooltipContent: PropTypes.func,
   tooltipWidth: PropTypes.string,
   yKeys: PropTypes.arrayOf(PropTypes.object)

--- a/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
+++ b/src/pages/signals/components/charts/barchart/tests/BarChart.test.js
@@ -50,6 +50,13 @@ describe('BarChart Component', () => {
     expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#fill');
   });
 
+  it('renders a normal bar chart with correct fill for selected event but with shouldHighlightSelected set to false', () => {
+    const key = 'health_score';
+    wrapper.setProps({ selected: '2011-01-01', shouldHighlightSelected: false, yKey: key, timeSeries: [{ [key]: 75, ranking: 'warning', date: '2011-01-01' }]});
+    const payload = { fill: '#fill', [key]: 75, ranking: 'warning', date: '2011-01-01' };
+    expect(wrapper.find({ dataKey: key }).at(0).props().shape(payload).props.fill).toEqual('#fill');
+  });
+
   it('renders a normal bar chart with correct fill for selected/hovered non-threshold events', () => {
     const key = 'injections';
     wrapper.setProps({ selected: '2011-01-01', yKey: key, timeSeries: [{ [key]: 75, date: '2011-01-01' }]});
@@ -103,6 +110,19 @@ describe('BarChart Component', () => {
     const bars = wrapper.find('Bar').slice(1);
     expect(bars).toMatchSnapshot();
   });
+
+  it('renders a tooltip when hovered over', () => {
+    const key = 'health_score';
+    wrapper.setProps({ hovered: '2011-01-01', yKey: key, timeSeries: [{ [key]: 75, ranking: 'warning', date: '2011-01-01' }], disableHover: false });
+    expect(wrapper.find('ComposedChart').find('Tooltip')).toExist();
+  });
+
+  it('does not render a tooltip when not hovering over', () => {
+    const key = 'health_score';
+    wrapper.setProps({ hovered: null, yKey: key, timeSeries: [{ [key]: 75, ranking: 'warning', date: '2011-01-01' }], disableHover: false });
+    expect(wrapper.find('ComposedChart').find('Tooltip')).not.toExist();
+  });
+
 
   it('renders background bars with no opacity', () => {
     const payload = { payload: { date: '2011-01-01' }, test: 'test' };

--- a/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
+++ b/src/pages/signals/components/charts/barchart/tests/__snapshots__/BarChart.test.js.snap
@@ -126,51 +126,6 @@ exports[`BarChart Component renders a normal bar chart correctly 1`] = `
         width={0}
         xAxisId={0}
       />
-      <Tooltip
-        active={false}
-        animationDuration={400}
-        animationEasing="ease"
-        content={
-          <Tooltip
-            offset={25}
-            width="200px"
-          >
-            [MockFunction]
-          </Tooltip>
-        }
-        contentStyle={Object {}}
-        coordinate={
-          Object {
-            "x": 0,
-            "y": 0,
-          }
-        }
-        cursor={false}
-        cursorStyle={Object {}}
-        filterNull={true}
-        isAnimationActive={false}
-        itemSorter={[Function]}
-        itemStyle={Object {}}
-        labelStyle={Object {}}
-        offset={25}
-        position={
-          Object {
-            "x": 0,
-            "y": 0,
-          }
-        }
-        separator=" : "
-        useTranslate3d={false}
-        viewBox={
-          Object {
-            "x1": 0,
-            "x2": 0,
-            "y1": 0,
-            "y2": 0,
-          }
-        }
-        wrapperStyle={Object {}}
-      />
       <Bar
         activeFill="#activeFill"
         animationBegin={0}

--- a/src/pages/signals/components/charts/linechart/LineChart.js
+++ b/src/pages/signals/components/charts/linechart/LineChart.js
@@ -45,7 +45,7 @@ class LineChart extends Component {
   }
 
   renderBackgrounds = () => {
-    const { xKey, selected, onClick } = this.props;
+    const { xKey, selected, shouldHighlightSelected, onClick } = this.props;
 
     return (
       <Bar
@@ -56,7 +56,7 @@ class LineChart extends Component {
         onClick={onClick}
         shape={
           ({ payload, background, ...rest }) => (
-            <Rectangle {...rest} {...background} opacity={payload[xKey] === selected ? 0.4 : 0} />
+            <Rectangle {...rest} {...background} opacity={(payload[xKey] === selected && shouldHighlightSelected) ? 0.4 : 0} />
           )
         }
       />

--- a/src/pages/signals/components/charts/linechart/LineChart.js
+++ b/src/pages/signals/components/charts/linechart/LineChart.js
@@ -121,6 +121,7 @@ LineChart.defaultProps = {
   width: '99%',
   lineType: 'linear',
   margin: { top: 12, left: 18, right: 0, bottom: 5 },
+  shouldHighlightSelected: true,
   xKey: 'date',
   yKey: 'value',
   yRange: ['auto', 'auto']

--- a/src/pages/signals/components/charts/linechart/LineChart.js
+++ b/src/pages/signals/components/charts/linechart/LineChart.js
@@ -110,6 +110,7 @@ class LineChart extends Component {
 LineChart.propTypes = {
   lineType: PropTypes.string,
   onClick: PropTypes.func,
+  shouldHighlightSelected: PropTypes.bool,
   tooltipContent: PropTypes.func,
   tooltipWidth: PropTypes.string,
   yKeys: PropTypes.arrayOf(PropTypes.object)

--- a/src/pages/signals/components/charts/linechart/tests/LineChart.test.js
+++ b/src/pages/signals/components/charts/linechart/tests/LineChart.test.js
@@ -40,13 +40,19 @@ describe('LineChart Component', () => {
 
   it('renders background bars with no opacity if unselected', () => {
     const payload = { payload: { date: '2011-01-01' }, test: 'test' };
-    expect(wrapper.find('Bar').at(0).props().shape(payload)).toMatchSnapshot();
+    expect(wrapper.find('Bar').at(0).props().shape(payload).props.opacity).toEqual(0);
   });
 
-  it('renders background bars with opacity if selected', () => {
-    wrapper.setProps({ selected: '2011-01-01' });
+  it('renders background bars with no opacity if selected but shouldHighlightSelected is false', () => {
+    wrapper.setProps({ selected: '2011-01-01', shouldHighlightSelected: false });
     const payload = { payload: { date: '2011-01-01' }, test: 'test' };
-    expect(wrapper.find('Bar').at(0).props().shape(payload)).toMatchSnapshot();
+    expect(wrapper.find('Bar').at(0).props().shape(payload).props.opacity).toEqual(0);
+  });
+
+  it('renders background bars with opacity if selected & shouldHighlightSelected is true', () => {
+    wrapper.setProps({ selected: '2011-01-01', shouldHighlightSelected: true });
+    const payload = { payload: { date: '2011-01-01' }, test: 'test' };
+    expect(wrapper.find('Bar').at(0).props().shape(payload).props.opacity).toEqual(0.4);
   });
 
   it('renders a dot if selected', () => {

--- a/src/pages/signals/components/charts/linechart/tests/__snapshots__/LineChart.test.js.snap
+++ b/src/pages/signals/components/charts/linechart/tests/__snapshots__/LineChart.test.js.snap
@@ -290,37 +290,3 @@ exports[`LineChart Component renders active dot 1`] = `
   test="test"
 />
 `;
-
-exports[`LineChart Component renders background bars with no opacity if unselected 1`] = `
-<Rectangle
-  animationBegin={0}
-  animationDuration={1500}
-  animationEasing="ease"
-  height={0}
-  isAnimationActive={false}
-  isUpdateAnimationActive={false}
-  opacity={0}
-  radius={0}
-  test="test"
-  width={0}
-  x={0}
-  y={0}
-/>
-`;
-
-exports[`LineChart Component renders background bars with opacity if selected 1`] = `
-<Rectangle
-  animationBegin={0}
-  animationDuration={1500}
-  animationEasing="ease"
-  height={0}
-  isAnimationActive={false}
-  isUpdateAnimationActive={false}
-  opacity={0.4}
-  radius={0}
-  test="test"
-  width={0}
-  x={0}
-  y={0}
-/>
-`;

--- a/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
@@ -31,6 +31,7 @@ exports[`Signals EngagementRecencyPreview Component renders correctly 1`] = `
             "top": 12,
           }
         }
+        shouldHighlightSelected={true}
         timeSeries={
           Array [
             1,

--- a/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
@@ -32,6 +32,7 @@ exports[`Signals HealthScorePreview Component renders correctly 1`] = `
             "top": 12,
           }
         }
+        shouldHighlightSelected={true}
         timeSeries={
           Array [
             1,

--- a/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
@@ -31,6 +31,7 @@ exports[`Signals SpamTrapsPreview Component renders correctly 1`] = `
             "top": 12,
           }
         }
+        shouldHighlightSelected={true}
         timeSeries={
           Array [
             1,

--- a/src/pages/signals/containers/tests/__snapshots__/withDateSelection.test.js.snap
+++ b/src/pages/signals/containers/tests/__snapshots__/withDateSelection.test.js.snap
@@ -8,5 +8,6 @@ exports[`Signals Spam Trap Details Container should set date if provided one 1`]
   hoveredDate={null}
   resetDateHover={[Function]}
   selectedDate="2015-01-01"
+  shouldHighlightSelected={false}
 />
 `;

--- a/src/pages/signals/containers/tests/withDateSelection.test.js
+++ b/src/pages/signals/containers/tests/withDateSelection.test.js
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import { WithDateSelection } from '../withDateSelection';
-// import _ from 'lodash';
 
 describe('Signals Spam Trap Details Container', () => {
   const Component = () => <div>test</div>;
@@ -39,13 +38,22 @@ describe('Signals Spam Trap Details Container', () => {
     const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
     wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
     expect(wrapper).toHaveProp('selectedDate', '2015-01-01');
+    expect(wrapper).toHaveProp('shouldHighlightSelected', true);
   });
 
-  it('handles date select for re-selecting the already selected date by defaulting to last date', () => {
+  it('handles date select for un-selecting the already selected date by defaulting to last date', () => {
     const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
     wrapper.setState({ selectedDate: '2015-01-01' });
     wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
     expect(wrapper).toHaveProp('selectedDate', '2999-99-99');
+  });
+
+  it('handles date select for un-selecting the already selected date by resetting shouldHighlightSelected & hovered', () => {
+    const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
+    wrapper.setState({ selectedDate: '2015-01-01' });
+    wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
+    expect(wrapper).toHaveProp('shouldHighlightSelected', false);
+    expect(wrapper).toHaveProp('hoveredDate', null);
   });
 
   it('handles date hover', () => {

--- a/src/pages/signals/containers/tests/withDateSelection.test.js
+++ b/src/pages/signals/containers/tests/withDateSelection.test.js
@@ -43,14 +43,14 @@ describe('Signals Spam Trap Details Container', () => {
 
   it('handles date select for un-selecting the already selected date by defaulting to last date', () => {
     const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
-    wrapper.setState({ selectedDate: '2015-01-01' });
+    wrapper.setState({ selectedDate: '2015-01-01', shouldHighlightSelected: true });
     wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
     expect(wrapper).toHaveProp('selectedDate', '2999-99-99');
   });
 
   it('handles date select for un-selecting the already selected date by resetting shouldHighlightSelected & hovered', () => {
     const wrapper = subject({ data: [{ date: '2015-01-01' }, { date: '2999-99-99' }]});
-    wrapper.setState({ selectedDate: '2015-01-01' });
+    wrapper.setState({ selectedDate: '2015-01-01', shouldHighlightSelected: true });
     wrapper.prop('handleDateSelect')({ payload: { date: '2015-01-01' }});
     expect(wrapper).toHaveProp('shouldHighlightSelected', false);
     expect(wrapper).toHaveProp('hoveredDate', null);

--- a/src/pages/signals/containers/withDateSelection.js
+++ b/src/pages/signals/containers/withDateSelection.js
@@ -43,7 +43,9 @@ export class WithDateSelection extends Component {
   handleDateSelect = (node) => {
     const newDate = _.get(node, 'payload.date');
 
-    if (newDate === this.state.selectedDate) {
+    if (newDate === this.state.selectedDate &&
+      this.state.shouldHighlightSelected) { //second condition allows user to select last date when in default state
+
       this.setDefaultSelected();
     } else {
       this.setState({ selectedDate: _.get(node, 'payload.date'), shouldHighlightSelected: true });

--- a/src/pages/signals/containers/withDateSelection.js
+++ b/src/pages/signals/containers/withDateSelection.js
@@ -5,7 +5,8 @@ import _ from 'lodash';
 export class WithDateSelection extends Component {
   state = {
     selectedDate: null,
-    hoveredDate: null
+    hoveredDate: null,
+    shouldHighlightSelected: false
   }
 
   componentDidMount() {
@@ -36,7 +37,7 @@ export class WithDateSelection extends Component {
   // Select last date in time series
   setDefaultSelected() {
     const lastDataByDay = _.last(this.props.data);
-    this.setState({ selectedDate: lastDataByDay.date });
+    this.setState({ selectedDate: lastDataByDay.date, hoveredDate: null, shouldHighlightSelected: false });
   }
 
   handleDateSelect = (node) => {
@@ -45,7 +46,7 @@ export class WithDateSelection extends Component {
     if (newDate === this.state.selectedDate) {
       this.setDefaultSelected();
     } else {
-      this.setState({ selectedDate: _.get(node, 'payload.date') });
+      this.setState({ selectedDate: _.get(node, 'payload.date'), shouldHighlightSelected: true });
     }
   }
 
@@ -58,11 +59,18 @@ export class WithDateSelection extends Component {
   }
 
   render() {
-    const { component: WrappedComponent, selected, hovered, ...rest } = this.props;
-    const { selectedDate, hoveredDate } = this.state;
+    const { component: WrappedComponent, selected: _selected, hovered: _hovered, ...rest } = this.props;
+    const { selectedDate, hoveredDate, shouldHighlightSelected } = this.state;
 
     return (
-      <WrappedComponent {...rest} selectedDate={selectedDate} hoveredDate={hoveredDate} handleDateSelect={this.handleDateSelect} handleDateHover={this.handleDateHover} resetDateHover={this.resetDateHover}/>
+      <WrappedComponent
+        {...rest}
+        selectedDate={selectedDate}
+        hoveredDate={hoveredDate}
+        shouldHighlightSelected={shouldHighlightSelected}
+        handleDateSelect={this.handleDateSelect}
+        handleDateHover={this.handleDateHover}
+        resetDateHover={this.resetDateHover}/>
     );
   }
 }

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -25,8 +25,6 @@ export function HealthScoreChart(props) {
 
   const { history = [], loading, error, filters } = props;
   const noData = (history) ? !_.some(getHealthScores()) : true;
-  const lastItem = _.last(history) || {};
-  const selectedDate = _.get(lastItem, 'date', '');
 
   if (loading) {
     return <PanelLoading minHeight='407px' />;
@@ -107,7 +105,6 @@ export function HealthScoreChart(props) {
               gap={getGap()}
               onMouseOver={handleDateHover}
               onMouseOut={() => setHovered({})}
-              selected={selectedDate}
               hovered={hoveredDate}
               timeSeries={history}
               tooltipContent={({ payload = {}}) => (payload.ranking) &&

--- a/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
@@ -38,7 +38,6 @@ exports[`Signals Health Score Chart renders happy path correctly 1`] = `
       }
       onMouseOut={[Function]}
       onMouseOver={[Function]}
-      selected="2019-03-27"
       shouldHighlightSelected={true}
       timeSeries={
         Array [

--- a/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/tests/__snapshots__/HealthScoreChart.test.js.snap
@@ -39,6 +39,7 @@ exports[`Signals Health Score Chart renders happy path correctly 1`] = `
       onMouseOut={[Function]}
       onMouseOver={[Function]}
       selected="2019-03-27"
+      shouldHighlightSelected={true}
       timeSeries={
         Array [
           Object {

--- a/src/pages/signals/tests/ComplaintsByCohortPage.test.js
+++ b/src/pages/signals/tests/ComplaintsByCohortPage.test.js
@@ -35,7 +35,8 @@ describe('Signals Complaints Page', () => {
       loading: false,
       empty: false,
       xTicks: [1,2],
-      selectedDate: '2017-01-02'
+      selectedDate: '2017-01-02',
+      shouldHighlightSelected: false
     };
     wrapper = shallow(<ComplaintsByCohortPage {...props}/>);
     wrapper.setProps({ data, dataEngRecency });

--- a/src/pages/signals/tests/EngagementRateByCohortPage.test.js
+++ b/src/pages/signals/tests/EngagementRateByCohortPage.test.js
@@ -36,7 +36,8 @@ describe('Signals Engagement Rate By Cohort Page', () => {
       loading: false,
       empty: false,
       xTicks: [1,2],
-      selectedDate: '2017-01-02'
+      selectedDate: '2017-01-02',
+      shouldHighlightSelected: false
     };
     wrapper = shallow(<EngagementRateByCohortPage {...props}/>);
     wrapper.setProps({ data, dataEngRecency });

--- a/src/pages/signals/tests/UnsubscribeRateByCohortPage.test.js
+++ b/src/pages/signals/tests/UnsubscribeRateByCohortPage.test.js
@@ -35,7 +35,8 @@ describe('Signals Unsubscribe Rate Page', () => {
       loading: false,
       empty: false,
       xTicks: [1,2],
-      selectedDate: '2017-01-02'
+      selectedDate: '2017-01-02',
+      shouldHighlightSelected: false
     };
     wrapper = shallow(<UnsubscribeRateByCohortPage {...props}/>);
     wrapper.setProps({ data, dataEngRecency });

--- a/src/pages/signals/tests/__snapshots__/ComplaintsByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/ComplaintsByCohortPage.test.js.snap
@@ -98,6 +98,7 @@ exports[`Signals Complaints Page renders correctly 1`] = `
             }
             onClick={[MockFunction]}
             selected="2017-01-02"
+            shouldHighlightSelected={false}
             stroke="#000"
             tooltipContent={[Function]}
             tooltipWidth="250px"

--- a/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
@@ -108,6 +108,7 @@ exports[`Signals Engagement Rate By Cohort Page renders correctly 1`] = `
             }
             onClick={[MockFunction]}
             selected="2017-01-02"
+            shouldHighlightSelected={false}
             stroke="#000"
             tooltipContent={[Function]}
             tooltipWidth="250px"

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -108,6 +108,7 @@ exports[`Signals Engagement Recency Page renders correctly 1`] = `
             }
             onClick={[MockFunction]}
             selected="2017-01-02"
+            shouldHighlightSelected={true}
             timeSeries={
               Array [
                 Object {

--- a/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/HealthScorePage.test.js.snap
@@ -92,6 +92,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
           onClick={[MockFunction]}
           onMouseOver={[MockFunction]}
           selected="2017-01-01"
+          shouldHighlightSelected={true}
           timeSeries={
             Array [
               Object {
@@ -215,6 +216,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
           onClick={[MockFunction]}
           onMouseOver={[MockFunction]}
           selected="2017-01-01"
+          shouldHighlightSelected={true}
           timeSeries={
             Array [
               Object {
@@ -293,6 +295,7 @@ exports[`Signals Health Score Page renders correctly when recieving data 1`] = `
           onClick={[MockFunction]}
           onMouseOver={[MockFunction]}
           selected="2017-01-01"
+          shouldHighlightSelected={true}
           timeSeries={
             Array [
               Object {
@@ -498,6 +501,7 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
           onClick={[MockFunction]}
           onMouseOver={[MockFunction]}
           selected="2017-01-01"
+          shouldHighlightSelected={true}
           timeSeries={
             Array [
               Object {
@@ -594,6 +598,7 @@ exports[`Signals Health Score Page renders empty weights 1`] = `
           onClick={[MockFunction]}
           onMouseOver={[MockFunction]}
           selected="2017-01-01"
+          shouldHighlightSelected={true}
           timeSeries={
             Array [
               Object {

--- a/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
@@ -95,6 +95,7 @@ exports[`Signals Spam Trap Page renders correctly 1`] = `
             }
             onClick={[MockFunction]}
             selected="2017-01-01"
+            shouldHighlightSelected={true}
             timeSeries={
               Array [
                 Object {

--- a/src/pages/signals/tests/__snapshots__/UnsubscribeRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/UnsubscribeRateByCohortPage.test.js.snap
@@ -98,6 +98,7 @@ exports[`Signals Unsubscribe Rate Page renders correctly 1`] = `
             }
             onClick={[MockFunction]}
             selected="2017-01-02"
+            shouldHighlightSelected={false}
             stroke="#000"
             tooltipContent={[Function]}
             tooltipWidth="250px"


### PR DESCRIPTION

### What Changed
 - Added a flag `shouldHighlightSelected` to Barchart. This is set to false in the default state which shows the latest recommendations but does not highlight the bar. 
 - Added the flag as props to signals charts. 

### How To Test
 - Go to health score/spam trap/engagement recency pages and hover/select the bars in each graph.
