### PR TITLE
AC-987: Fixed promo code state bug

### DIFF
--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -66,10 +66,12 @@ export const ChangePlanForm = ({
 
   //clears out requestParams when user changes plan
   useEffect(() => {
-    if (!selectedBundle && gotBundles) {
+    if (!selectedBundle && gotBundles.current) {
       updateRoute({ undefined });
+    } else if (code) {
+      selectBundle(allBundles.find(({ bundle }) => bundle === code));
     }
-  },[selectedBundle, updateRoute]);
+  },[selectedBundle, code, allBundles, updateRoute]);
 
   return (
     <form >


### PR DESCRIPTION
### What Changed
 - Fix bug with query params being cleared before loading bundles or async initialize state

### How To Test
 - Navigate to http://app.sparkpost.test/account/billing/plan?code=100K-premier-0519&promo=THXFISH2 on staging
 - Check that behavior is correct

### To Do
- [ ] Address feedback
