### PR TITLE
SE-268: Events Filters UX Improvements

### DIFF
--- a/src/helpers/tests/validation.test.js
+++ b/src/helpers/tests/validation.test.js
@@ -57,7 +57,7 @@ const cases = {
   eventsQuery: {
     good: [[{ key: 'reason', value: 'fo*o' }],
       [{ key: 'campaigns', value: 'foo, bar' }]],
-    bad: [[{}],
+    bad: [[{ key: 'reason' }],
       [{ value: 'foo' }]],
     multiArg: true
   },

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -39,10 +39,10 @@ export function recipientEmail(value) {
 }
 
 export function eventsQuery(filter) {
-  if (!filter || !filter.value) {
+  if (!filter.value && filter.key) {
     return 'Required';
   }
-  if (!filter.key) {
+  if (filter.value && !filter.key) {
     return 'Select a Filter';
   }
   return undefined;

--- a/src/pages/reports/components/ShareModal.js
+++ b/src/pages/reports/components/ShareModal.js
@@ -86,10 +86,15 @@ export class ShareModal extends Component {
 
   render() {
     const { open } = this.state;
+    const { triggerComponent: TriggerComponent } = this.props;
 
     return (
       <Fragment>
-        <Button id='shareModalButton' disabled={this.props.disabled} fullWidth onClick={this.toggleModal}>Share</Button>
+        {
+          TriggerComponent
+            ? <TriggerComponent id='shareModalButton' disabled={this.props.disabled} onClick={this.toggleModal}/>
+            : <Button id='shareModalButton' disabled={this.props.disabled} fullWidth onClick={this.toggleModal}>Share</Button>
+        }
         <Modal open={open} onClose={this.toggleModal}>
           {open && <WindowEvent event='keydown' handler={this.handleKeydown} />}
           <Panel title='Share this report'>

--- a/src/pages/reports/messageEvents/components/AdvancedFiltersModal.js
+++ b/src/pages/reports/messageEvents/components/AdvancedFiltersModal.js
@@ -5,6 +5,7 @@ import { WindowEvent, Modal, Button } from '@sparkpost/matchbox';
 import { onEscape } from 'src/helpers/keyEvents';
 import { getFiltersFromSearchQueries } from '../helpers/transformData.js';
 import SearchForm from './SearchForm';
+import _ from 'lodash';
 
 export class AdvancedFiltersModal extends Component {
   state = {
@@ -21,7 +22,8 @@ export class AdvancedFiltersModal extends Component {
 
   handleApply = (values) => {
     const { searchQuery, ...events } = values;
-    const filters = getFiltersFromSearchQueries(searchQuery);
+    const filteredSearchQuery = searchQuery.filter((filter) => !_.isEmpty(filter));
+    const filters = getFiltersFromSearchQueries(filteredSearchQuery);
     const enabledEventsArray = Object.keys(events).filter((key) => Boolean(events[key]));
     this.props.updateMessageEventsSearchOptions({ events: enabledEventsArray, ...filters });
     this.toggleModal();

--- a/src/pages/reports/messageEvents/components/AdvancedFiltersModal.js
+++ b/src/pages/reports/messageEvents/components/AdvancedFiltersModal.js
@@ -39,7 +39,7 @@ export class AdvancedFiltersModal extends Component {
     const { modalOpen } = this.state;
     return (
       <Fragment>
-        <Button onClick={this.toggleModal}>More Filters</Button>
+        <Button onClick={this.toggleModal}>Add Filters</Button>
         <Modal open={modalOpen} onClose={this.toggleModal}>
           <WindowEvent event='keydown' handler={this.handleKeyDown} />
           <SearchForm handleApply = {this.handleApply} handleCancel = {this.toggleModal} />

--- a/src/pages/reports/messageEvents/components/MessageEventsSearch.js
+++ b/src/pages/reports/messageEvents/components/MessageEventsSearch.js
@@ -5,7 +5,8 @@ import moment from 'moment';
 import _ from 'lodash';
 import { getMessageEvents, refreshMessageEventsDateRange, updateMessageEventsSearchOptions, addFilters } from 'src/actions/messageEvents';
 import { selectMessageEventsSearchOptions } from 'src/selectors/messageEvents';
-import { Panel, Grid, TextField } from '@sparkpost/matchbox';
+import { Panel, Grid, TextField, UnstyledLink } from '@sparkpost/matchbox';
+import { Share } from '@sparkpost/matchbox-icons';
 import AdvancedFiltersModal from './AdvancedFiltersModal';
 import ActiveFilters from './ActiveFilters';
 import ShareModal from '../../components/ShareModal';
@@ -16,6 +17,7 @@ import { stringToArray } from 'src/helpers/string';
 import { onEnter } from 'src/helpers/keyEvents';
 import { FORMATS, RELATIVE_DATE_OPTIONS, ALL_EVENTS_FILTERS } from 'src/constants';
 import config from 'src/config';
+import styles from './MessageEventsSearch.module.scss';
 
 export class MessageEventsSearch extends Component {
 
@@ -62,6 +64,13 @@ export class MessageEventsSearch extends Component {
     return (
       <Panel>
         <Panel.Section>
+          <div className={styles.filterTitle}>
+            <h3>Filter Events</h3>
+            <ShareModal
+              searchOptions={searchOptions}
+              triggerComponent={(props) => (<UnstyledLink {...props}>Share These Results <Share /></UnstyledLink>)}
+            />
+          </div>
           <Grid>
             <Grid.Column xs={12} md={5} xl={6}>
               <DatePicker
@@ -79,7 +88,7 @@ export class MessageEventsSearch extends Component {
                 }}
               />
             </Grid.Column>
-            <Grid.Column xs={12} md={5}>
+            <Grid.Column>
               <TextField
                 labelHidden
                 placeholder={recipients.placeholder}
@@ -87,12 +96,11 @@ export class MessageEventsSearch extends Component {
                 onKeyDown={onEnter(this.handleRecipientsChange)}
                 onFocus={() => this.setState({ recipientError: null })}
                 error={this.state.recipientError}
-                connectRight={<AdvancedFiltersModal />}
               />
             </Grid.Column>
-            <Grid.Column>
-              <ShareModal disabled={loading} searchOptions={searchOptions} />
-            </Grid.Column>
+            <div className={styles.filterButton}>
+              <AdvancedFiltersModal/>
+            </div>
           </Grid>
         </Panel.Section>
         <ActiveFilters />

--- a/src/pages/reports/messageEvents/components/MessageEventsSearch.js
+++ b/src/pages/reports/messageEvents/components/MessageEventsSearch.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import _ from 'lodash';
 import { getMessageEvents, refreshMessageEventsDateRange, updateMessageEventsSearchOptions, addFilters } from 'src/actions/messageEvents';
 import { selectMessageEventsSearchOptions } from 'src/selectors/messageEvents';
-import { Panel, Grid, TextField } from '@sparkpost/matchbox';
+import { Panel, TextField } from '@sparkpost/matchbox';
 import AdvancedFiltersModal from './AdvancedFiltersModal';
 import ActiveFilters from './ActiveFilters';
 import ShareModal from '../../components/ShareModal';
@@ -63,8 +63,8 @@ export class MessageEventsSearch extends Component {
     return (
       <Panel>
         <Panel.Section>
-          <Grid>
-            <Grid.Column xs={12} md={5} xl={6}>
+          <div className={styles.Filters}>
+            <div className={styles.DateFilter}>
               <DatePicker
                 {...search.dateOptions}
                 relativeDateOptions={RELATIVE_DATE_OPTIONS}
@@ -79,8 +79,8 @@ export class MessageEventsSearch extends Component {
                   canChangeMonth: false
                 }}
               />
-            </Grid.Column>
-            <Grid.Column>
+            </div>
+            <div className={styles.RecipientFilter}>
               <TextField
                 labelHidden
                 placeholder={recipients.placeholder}
@@ -89,14 +89,14 @@ export class MessageEventsSearch extends Component {
                 onFocus={() => this.setState({ recipientError: null })}
                 error={this.state.recipientError}
               />
-            </Grid.Column>
-            <div className={styles.paddingLeft}>
+            </div>
+            <div>
               <AdvancedFiltersModal/>
             </div>
-            <div className={styles.paddingLeft}>
+            <div>
               <ShareModal disabled={loading} searchOptions={searchOptions} />
             </div>
-          </Grid>
+          </div>
         </Panel.Section>
         <ActiveFilters />
       </Panel>

--- a/src/pages/reports/messageEvents/components/MessageEventsSearch.js
+++ b/src/pages/reports/messageEvents/components/MessageEventsSearch.js
@@ -5,8 +5,7 @@ import moment from 'moment';
 import _ from 'lodash';
 import { getMessageEvents, refreshMessageEventsDateRange, updateMessageEventsSearchOptions, addFilters } from 'src/actions/messageEvents';
 import { selectMessageEventsSearchOptions } from 'src/selectors/messageEvents';
-import { Panel, Grid, TextField, UnstyledLink } from '@sparkpost/matchbox';
-import { Share } from '@sparkpost/matchbox-icons';
+import { Panel, Grid, TextField } from '@sparkpost/matchbox';
 import AdvancedFiltersModal from './AdvancedFiltersModal';
 import ActiveFilters from './ActiveFilters';
 import ShareModal from '../../components/ShareModal';
@@ -64,13 +63,6 @@ export class MessageEventsSearch extends Component {
     return (
       <Panel>
         <Panel.Section>
-          <div className={styles.filterTitle}>
-            <h3>Filter Events</h3>
-            <ShareModal
-              searchOptions={searchOptions}
-              triggerComponent={(props) => (<UnstyledLink {...props}>Share These Results <Share /></UnstyledLink>)}
-            />
-          </div>
           <Grid>
             <Grid.Column xs={12} md={5} xl={6}>
               <DatePicker
@@ -98,8 +90,11 @@ export class MessageEventsSearch extends Component {
                 error={this.state.recipientError}
               />
             </Grid.Column>
-            <div className={styles.filterButton}>
+            <div className={styles.paddingLeft}>
               <AdvancedFiltersModal/>
+            </div>
+            <div className={styles.paddingLeft}>
+              <ShareModal disabled={loading} searchOptions={searchOptions} />
             </div>
           </Grid>
         </Panel.Section>

--- a/src/pages/reports/messageEvents/components/MessageEventsSearch.module.scss
+++ b/src/pages/reports/messageEvents/components/MessageEventsSearch.module.scss
@@ -1,11 +1,22 @@
-.filterTitle {
-  padding-top: .3rem;
-  display: flex;
-  :first-child{
-    flex: 1 0 0;
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.Filters {
+  display: grid;
+  grid-column-gap: spacing();
+  grid-row-gap: spacing();
+  grid-template-columns: 1.25fr 1fr auto auto;
+}
+
+.DateFilter {
+  @media only screen and (max-width: breakpoint(medium)) {
+    grid-column-start: 1;
+    grid-column-end: 5;
   }
 }
 
-.paddingLeft {
-  padding-left: 1rem;
+.RecipientFilter {
+  @media only screen and (max-width: breakpoint(medium)) {
+    grid-column-start: 1;
+    grid-column-end: 3;
+  }
 }

--- a/src/pages/reports/messageEvents/components/MessageEventsSearch.module.scss
+++ b/src/pages/reports/messageEvents/components/MessageEventsSearch.module.scss
@@ -6,6 +6,6 @@
   }
 }
 
-.filterButton {
+.paddingLeft {
   padding-left: 1rem;
 }

--- a/src/pages/reports/messageEvents/components/MessageEventsSearch.module.scss
+++ b/src/pages/reports/messageEvents/components/MessageEventsSearch.module.scss
@@ -1,0 +1,11 @@
+.filterTitle {
+  padding-top: .3rem;
+  display: flex;
+  :first-child{
+    flex: 1 0 0;
+  }
+}
+
+.filterButton {
+  padding-left: 1rem;
+}

--- a/src/pages/reports/messageEvents/components/SearchForm.js
+++ b/src/pages/reports/messageEvents/components/SearchForm.js
@@ -38,7 +38,7 @@ export class SearchForm extends Component {
 
 const mapStateToProps = (state) => ({
   initialValues: {
-    searchQuery: getSearchQueriesFromFilters(state.messageEvents.search),
+    searchQuery: [...getSearchQueriesFromFilters(state.messageEvents.search), {}],
     ...getBooleanEventsObject(state.messageEvents.search.events)
   },
   eventListing: selectMessageEventListing(state)

--- a/src/pages/reports/messageEvents/components/SearchForm.module.scss
+++ b/src/pages/reports/messageEvents/components/SearchForm.module.scss
@@ -2,7 +2,8 @@
 
 .CheckBoxGrid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-rows: repeat(9, 1fr);
+  grid-auto-flow: column;
 
   fieldset {
     white-space: normal;
@@ -10,7 +11,7 @@
   }
 
   @media screen and (min-width: breakpoint(medium)) {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-rows: repeat(5, 1fr);
   }
 }
 

--- a/src/pages/reports/messageEvents/components/SearchQuery.js
+++ b/src/pages/reports/messageEvents/components/SearchQuery.js
@@ -29,7 +29,6 @@ const getPlaceholderText = _.memoize((key) => {
 
 export default ({ fields }) => (
   <Fragment>
-    <Button className = {styles.AddButton} color="blue" flat onClick={() => fields.push({})}> Add Filter<AddCircleOutline className = {styles.Icon}/></Button>
     {fields.map((member, index) => (
       <Grid key={index}>
         <Grid.Column
@@ -70,5 +69,6 @@ export default ({ fields }) => (
         </Grid.Column>
       </Grid>
     ))}
+    <Button className = {styles.AddButton} color="blue" flat onClick={() => fields.push({})}> Add Filter<AddCircleOutline className = {styles.Icon}/></Button>
   </Fragment >
 );

--- a/src/pages/reports/messageEvents/components/SearchQuery.js
+++ b/src/pages/reports/messageEvents/components/SearchQuery.js
@@ -5,7 +5,7 @@ import styles from './SearchForm.module.scss';
 import { Field } from 'redux-form';
 import { getFiltersAsArray } from '../helpers/transformData.js';
 import { SelectWrapper, TextFieldWrapper } from 'src/components/reduxFormWrappers';
-import { required, eventsQuery } from 'src/helpers/validation';
+import { eventsQuery } from 'src/helpers/validation';
 import { EVENTS_SEARCH_FILTERS } from 'src/constants';
 import _ from 'lodash';
 
@@ -41,7 +41,6 @@ export default ({ fields }) => (
               name={`${member}.key`}
               component={SelectWrapper}
               options={getAvailableOptions(fields.getAll(), index)}
-              validate={required}
             />
           </div>
         </Grid.Column>

--- a/src/pages/reports/messageEvents/components/tests/AdvancedFiltersModal.test.js
+++ b/src/pages/reports/messageEvents/components/tests/AdvancedFiltersModal.test.js
@@ -37,10 +37,21 @@ describe('Component: AdvancedFiltersModal', () => {
     expect(props.updateMessageEventsSearchOptions).toHaveBeenCalledWith(params);
   });
 
+  it('should remove empty filters when trying to apply filters', () => {
+    wrapper.setState({ modalOpen: true });
+    wrapper.instance().handleApply({ searchQuery: [{}, { key: 'campaigns', value: 'foo' }], click: true, bounce: false });
+    const params = {
+      ...getEmptyFilters(EVENTS_SEARCH_FILTERS),
+      'campaigns': ['foo'],
+      'events': ['click']
+    };
+    expect(props.updateMessageEventsSearchOptions).toHaveBeenCalledWith(params);
+  });
+
   it('should close the modal when handleApply is called', () => {
     wrapper.setState({ modalOpen: true });
     expect(wrapper.find('Modal').props().open).toEqual(true);
-    wrapper.instance().handleApply({});
+    wrapper.instance().handleApply({ searchQuery: []});
     expect(wrapper.find('Modal').props().open).toEqual(false);
   });
 

--- a/src/pages/reports/messageEvents/components/tests/SearchQuery.test.js
+++ b/src/pages/reports/messageEvents/components/tests/SearchQuery.test.js
@@ -45,12 +45,12 @@ describe('SearchForm', () => {
   });
 
   it('add button works', () => {
-    wrapper.find('Button').first().simulate('click');
+    wrapper.find('Button').last().simulate('click');
     expect(props.fields.push).toHaveBeenCalled();
   });
 
   it('remove button works', () => {
-    wrapper.find('Button').last().simulate('click');
+    wrapper.find('Button').at(2).simulate('click');
     expect(props.fields.remove).toHaveBeenCalledWith(2);
   });
 

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/AdvancedFiltersModal.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/AdvancedFiltersModal.test.js.snap
@@ -6,7 +6,7 @@ exports[`Component: AdvancedFiltersModal should render initially and sync to sta
     onClick={[Function]}
     size="default"
   >
-    More Filters
+    Add Filters
   </Button>
   <Modal
     onClose={[Function]}

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/MessageEventsSearch.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/MessageEventsSearch.test.js.snap
@@ -3,6 +3,17 @@
 exports[`Component: MessageEventsSearch renders correctly 1`] = `
 <Panel>
   <Panel.Section>
+    <div
+      className="filterTitle"
+    >
+      <h3>
+        Filter Events
+      </h3>
+      <withRouter(Connect(ShareModal))
+        searchOptions={Object {}}
+        triggerComponent={[Function]}
+      />
+    </div>
     <Grid>
       <Grid.Column
         md={5}
@@ -48,12 +59,8 @@ exports[`Component: MessageEventsSearch renders correctly 1`] = `
           to={2018-02-15T12:00:00.000Z}
         />
       </Grid.Column>
-      <Grid.Column
-        md={5}
-        xs={12}
-      >
+      <Grid.Column>
         <TextField
-          connectRight={<Connect(AdvancedFiltersModal) />}
           error={null}
           labelHidden={true}
           onBlur={[Function]}
@@ -64,12 +71,11 @@ exports[`Component: MessageEventsSearch renders correctly 1`] = `
           type="text"
         />
       </Grid.Column>
-      <Grid.Column>
-        <withRouter(Connect(ShareModal))
-          disabled={false}
-          searchOptions={Object {}}
-        />
-      </Grid.Column>
+      <div
+        className="filterButton"
+      >
+        <Connect(AdvancedFiltersModal) />
+      </div>
     </Grid>
   </Panel.Section>
   <Connect(ActiveFilters) />

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/MessageEventsSearch.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/MessageEventsSearch.test.js.snap
@@ -3,11 +3,11 @@
 exports[`Component: MessageEventsSearch renders correctly 1`] = `
 <Panel>
   <Panel.Section>
-    <Grid>
-      <Grid.Column
-        md={5}
-        xl={6}
-        xs={12}
+    <div
+      className="Filters"
+    >
+      <div
+        className="DateFilter"
       >
         <AppDatePicker
           dateFieldFormat="MMM Do h:mma"
@@ -47,8 +47,10 @@ exports[`Component: MessageEventsSearch renders correctly 1`] = `
           roundToPrecision={false}
           to={2018-02-15T12:00:00.000Z}
         />
-      </Grid.Column>
-      <Grid.Column>
+      </div>
+      <div
+        className="RecipientFilter"
+      >
         <TextField
           error={null}
           labelHidden={true}
@@ -59,21 +61,17 @@ exports[`Component: MessageEventsSearch renders correctly 1`] = `
           resize="both"
           type="text"
         />
-      </Grid.Column>
-      <div
-        className="paddingLeft"
-      >
+      </div>
+      <div>
         <Connect(AdvancedFiltersModal) />
       </div>
-      <div
-        className="paddingLeft"
-      >
+      <div>
         <withRouter(Connect(ShareModal))
           disabled={false}
           searchOptions={Object {}}
         />
       </div>
-    </Grid>
+    </div>
   </Panel.Section>
   <Connect(ActiveFilters) />
 </Panel>

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/MessageEventsSearch.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/MessageEventsSearch.test.js.snap
@@ -3,17 +3,6 @@
 exports[`Component: MessageEventsSearch renders correctly 1`] = `
 <Panel>
   <Panel.Section>
-    <div
-      className="filterTitle"
-    >
-      <h3>
-        Filter Events
-      </h3>
-      <withRouter(Connect(ShareModal))
-        searchOptions={Object {}}
-        triggerComponent={[Function]}
-      />
-    </div>
     <Grid>
       <Grid.Column
         md={5}
@@ -72,9 +61,17 @@ exports[`Component: MessageEventsSearch renders correctly 1`] = `
         />
       </Grid.Column>
       <div
-        className="filterButton"
+        className="paddingLeft"
       >
         <Connect(AdvancedFiltersModal) />
+      </div>
+      <div
+        className="paddingLeft"
+      >
+        <withRouter(Connect(ShareModal))
+          disabled={false}
+          searchOptions={Object {}}
+        />
       </div>
     </Grid>
   </Panel.Section>

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/SearchQuery.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/SearchQuery.test.js.snap
@@ -2,18 +2,6 @@
 
 exports[`SearchForm should render correctly with existing filters 1`] = `
 <Fragment>
-  <Button
-    className="AddButton"
-    color="blue"
-    flat={true}
-    onClick={[Function]}
-    size="default"
-  >
-     Add Filter
-    <AddCircleOutline
-      className="Icon"
-    />
-  </Button>
   <Grid
     key="0"
   >
@@ -192,6 +180,18 @@ exports[`SearchForm should render correctly with existing filters 1`] = `
       </p>
     </Grid.Column>
   </Grid>
+  <Button
+    className="AddButton"
+    color="blue"
+    flat={true}
+    onClick={[Function]}
+    size="default"
+  >
+     Add Filter
+    <AddCircleOutline
+      className="Icon"
+    />
+  </Button>
 </Fragment>
 `;
 

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/SearchQuery.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/SearchQuery.test.js.snap
@@ -24,7 +24,6 @@ exports[`SearchForm should render correctly with existing filters 1`] = `
               },
             ]
           }
-          validate={[Function]}
         />
       </div>
     </Grid.Column>
@@ -83,7 +82,6 @@ exports[`SearchForm should render correctly with existing filters 1`] = `
               },
             ]
           }
-          validate={[Function]}
         />
       </div>
     </Grid.Column>
@@ -143,7 +141,6 @@ exports[`SearchForm should render correctly with existing filters 1`] = `
               },
             ]
           }
-          validate={[Function]}
         />
       </div>
     </Grid.Column>

--- a/src/pages/reports/messageEvents/helpers/transformData.js
+++ b/src/pages/reports/messageEvents/helpers/transformData.js
@@ -13,9 +13,13 @@ export function getFiltersFromSearchQueries(searchQueries = []) {
 
   // Build a single object containing a key for each filter, initialised to an empty array
   const emptyFilters = getEmptyFilters(EVENTS_SEARCH_FILTERS);
-
   // Collect queries into an array of objects of form {key: value}
-  const queries = searchQueries.map(({ key, value }) => ({ [key]: stringToArray(value) }));
+  const queries = searchQueries.reduce((queryArray, { key, value }) => {
+    if (key && value) {
+      queryArray.push({ [key]: stringToArray(value) });
+    }
+    return queryArray;
+  }, []);
 
   return Object.assign(emptyFilters, ...queries);
 }
@@ -28,7 +32,7 @@ export function getFiltersFromSearchQueries(searchQueries = []) {
 export function getSearchQueriesFromFilters(filters) {
 
   //Filters out all search terms that are not part of the search query in AdvancedFilters
-  const { dateOptions, recipients, events, ...rest } = filters;
+  const { dateOptions: _dateOptions, recipients: _recipients, events: _events, ...rest } = filters;
 
   const nonEmptyFilters = removeEmptyFilters(rest);
   const newSearchQueries = _.map(nonEmptyFilters, (value, key) => ({ key, value: value.join(',') }));

--- a/src/pages/reports/messageEvents/helpers/transformData.js
+++ b/src/pages/reports/messageEvents/helpers/transformData.js
@@ -14,12 +14,7 @@ export function getFiltersFromSearchQueries(searchQueries = []) {
   // Build a single object containing a key for each filter, initialised to an empty array
   const emptyFilters = getEmptyFilters(EVENTS_SEARCH_FILTERS);
   // Collect queries into an array of objects of form {key: value}
-  const queries = searchQueries.reduce((queryArray, { key, value }) => {
-    if (key && value) {
-      queryArray.push({ [key]: stringToArray(value) });
-    }
-    return queryArray;
-  }, []);
+  const queries = searchQueries.map(({ key, value }) => ({ [key]: stringToArray(value) }));
 
   return Object.assign(emptyFilters, ...queries);
 }


### PR DESCRIPTION
### What Changed
 - Change made to events filter box

### How To Test
#### Filters Panel:
- [x] "Filter Events" panel title
- [x] Share button is replaced with link like in mockup
- [x] Rename "More Filters" button to "Add Filters" and separate from recipient filter bar
#### Advanced Filters Modal:
- [x] When this modal is opened, there should always be a blank filter select/input ready
- [x] "Add Filter" button is under filters, not above them.
- [x] Event type checkboxes are organized alphabetically down the columns, not across the rows.
 

### To Do
- [ ] Address feedback
