### PR TITLE
FE-724 - Updating sidebar navigation markup to make it keyboard accessible

### DIFF
--- a/src/components/navigation/components/NavGroup.js
+++ b/src/components/navigation/components/NavGroup.js
@@ -37,13 +37,21 @@ const NavGroup = (props) => {
 
   return (
     <li>
-      <a onClick={() => setOpen(!open)} className={linkClasses}>
+      {/* eslint-disable jsx-a11y/anchor-is-valid */}
+      <a
+        onClick={() => setOpen(!open)}
+        className={linkClasses}
+        aria-expanded={open ? 'true' : 'false'}
+        role="button"
+        href="javascript:void(0);"
+      >
         <span className={styles.iconWrapper}>
           <Icon size={21} className={styles.icon}/>
         </span>
         <div className={styles.Label}>{label}</div>
         <ChevronLeft className={styles.chevron}/>
       </a>
+
       <ul className={styles.NestedList}>
         {children.map((child, key) => <NavItem {...child} mobile={mobile} location={location} key={key} toggleMobileNav={toggleMobileNav}/>)}
       </ul>

--- a/src/components/navigation/components/NavItem.js
+++ b/src/components/navigation/components/NavItem.js
@@ -41,7 +41,11 @@ const NavItem = (props) => {
 
   return (
     <li>
-      <Link to={to} className={linkClasses} onClick={mobile ? toggleMobileNav : null}>
+      <Link
+        to={to}
+        className={linkClasses}
+        onClick={mobile ? toggleMobileNav : null}
+      >
         {Icon && <span className={styles.iconWrapper}><Icon size={21} className={styles.icon}/></span>}
         <div className={styles.Label}>{label}</div>
         {releaseTag && <div className={styles.releaseTag}>{releaseTag}</div>}

--- a/src/components/navigation/components/NavItem.module.scss
+++ b/src/components/navigation/components/NavItem.module.scss
@@ -33,6 +33,7 @@
   -moz-osx-font-smoothing: grayscale;
   transition: color 0.15s ease-in-out;
   user-select: none;
+  cursor: pointer;
 
   &.mobile {
     padding: rem(15) rem(18);
@@ -45,21 +46,26 @@
     padding-top: rem(20);
   }
 
-  &:hover {
-    color: color(gray, 0);
-    cursor: pointer;
-    .chevron { fill: color(gray, 1); }
-    .icon { fill: color(gray, 1); }
-  }
-
+  &:hover,
+  &:active,
   &:focus {
     color: color(gray, 0);
+
+    .chevron {
+      fill: color(gray, 1);
+    }
+
+    .icon {
+      fill: color(gray, 1);
+    }
   }
 
   &.isActive:not(.hasChildren) {
     color: color(orange);
     font-weight: 500;
-    .icon { fill: color(orange); }
+    .icon {
+      fill: color(orange);
+    }
   }
 
   &.hasChildren {

--- a/src/components/navigation/components/NavItem.module.scss
+++ b/src/components/navigation/components/NavItem.module.scss
@@ -46,6 +46,11 @@
     padding-top: rem(20);
   }
 
+  .chevron,
+  .icon {
+    transition: fill 0.15s ease-in-out;
+  }
+
   &:hover,
   &:active,
   &:focus {

--- a/src/components/navigation/components/NavItem.module.scss
+++ b/src/components/navigation/components/NavItem.module.scss
@@ -68,6 +68,7 @@
   &.isActive:not(.hasChildren) {
     color: color(orange);
     font-weight: 500;
+
     .icon {
       fill: color(orange);
     }

--- a/src/components/navigation/components/NavItem.module.scss
+++ b/src/components/navigation/components/NavItem.module.scss
@@ -31,7 +31,7 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  transition: 0.15s;
+  transition: color 0.15s ease-in-out;
   user-select: none;
 
   &.mobile {

--- a/src/components/navigation/components/NavItem.module.scss
+++ b/src/components/navigation/components/NavItem.module.scss
@@ -22,16 +22,16 @@
   display: flex;
   padding: rem(9) rem(18);
   color: color(gray, 2);
-
   text-decoration: none;
-  border-bottom: none;
+  border: 0;
+  background-color: transparent;
+  width: auto;
   font-size: font-size(400);
   font-weight: 500;
   line-height: line-height(500);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-
   transition: 0.15s;
   user-select: none;
 

--- a/src/components/navigation/components/NavItem.module.scss
+++ b/src/components/navigation/components/NavItem.module.scss
@@ -22,10 +22,9 @@
   display: flex;
   padding: rem(9) rem(18);
   color: color(gray, 2);
+
   text-decoration: none;
-  border: 0;
-  background-color: transparent;
-  width: auto;
+  border-bottom: none;
   font-size: font-size(400);
   font-weight: 500;
   line-height: line-height(500);

--- a/src/components/navigation/components/tests/NavGroup.test.js
+++ b/src/components/navigation/components/tests/NavGroup.test.js
@@ -35,10 +35,13 @@ describe('NavGroup tests', () => {
 
   it('should toggle open state when clicking link', () => {
     expect(wrapper.find('a').hasClass('isOpen')).toBe(false);
+    expect(wrapper.find('a')).toHaveProp('aria-expanded', 'false');
     wrapper.children().find('a').simulate('click');
     expect(wrapper.find('a').hasClass('isOpen')).toBe(true);
+    expect(wrapper.find('a')).toHaveProp('aria-expanded', 'true');
     wrapper.children().find('a').simulate('click');
     expect(wrapper.find('a').hasClass('isOpen')).toBe(false);
+    expect(wrapper.find('a')).toHaveProp('aria-expanded', 'false');
   });
 
   it('should be open if any children has matching path', () => {

--- a/src/components/navigation/components/tests/__snapshots__/NavGroup.test.js.snap
+++ b/src/components/navigation/components/tests/__snapshots__/NavGroup.test.js.snap
@@ -3,8 +3,11 @@
 exports[`NavGroup tests should render children correctly 1`] = `
 <li>
   <a
+    aria-expanded="false"
     className="Link hasChildren"
+    href="javascript:void(0);"
     onClick={[Function]}
+    role="button"
   >
     <span
       className="iconWrapper"
@@ -53,8 +56,11 @@ exports[`NavGroup tests should render children correctly 1`] = `
 exports[`NavGroup tests should render correctly on mobile 1`] = `
 <li>
   <a
+    aria-expanded="false"
     className="Link hasChildren mobile"
+    href="javascript:void(0);"
     onClick={[Function]}
+    role="button"
   >
     <span
       className="iconWrapper"


### PR DESCRIPTION
[FE-724](https://jira.int.messagesystems.com/browse/FE-724)

### What Changed
- Added `href` values to links that were missing them to make them keyboard accessible
- Added `role="button"` to `a` elements that do not navigate to new routes or pages
- Added `aria-expanded` attribute to relevant nav items that collapse and expand. This value toggles when clicked (or by hitting enter with the keyboard)
- Replaced `transition` property to target `color` specifically to improve performance 

### How To Test
- Use the keyboard to tab to the relevant nav items
- Make sure the keyboard can be used to expand and collapse subsections within the nav via the enter key
- Make sure all items can be "clicked" on using the enter key

### To Do
- [ ] Incorporate feedback
