### PR TITLE
SA-770 - Display results by seed addresses for mailbox provider

### DIFF
--- a/src/actions/inboxPlacement.js
+++ b/src/actions/inboxPlacement.js
@@ -67,7 +67,14 @@ export function getAllInboxPlacementMessages(id, filters) {
     meta: {
       method: 'GET',
       url: `/v1/inbox-placement/${id}/messages`,
-      params: filters
+      params: filters,
+      showErrorAlert: false
     }
+  });
+}
+
+export function resetState() {
+  return (dispatch) => dispatch({
+    type: 'RESET_STATE'
   });
 }

--- a/src/actions/inboxPlacement.js
+++ b/src/actions/inboxPlacement.js
@@ -60,3 +60,14 @@ export function getInboxPlacementTestContent(id) {
     }
   });
 }
+
+export function getAllInboxPlacementMessages(id, filters) {
+  return sparkpostApiRequest({
+    type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES',
+    meta: {
+      method: 'GET',
+      url: `/v1/inbox-placement/${id}/messages`,
+      params: filters
+    }
+  });
+}

--- a/src/actions/tests/inboxPlacement.test.js
+++ b/src/actions/tests/inboxPlacement.test.js
@@ -67,8 +67,17 @@ describe('Action Creator: Inbox Placement', () => {
       meta: {
         method: 'GET',
         url: '/v1/inbox-placement/1/messages',
-        params: { 'mailbox-provider': 'sparkpost.com' }
+        params: { 'mailbox-provider': 'sparkpost.com' },
+        showErrorAlert: false
       }
     });
+  });
+
+  it('makes request to reset state', () => {
+    const dispatchMock = jest.fn((a) => a);
+    const action = inboxPlacement.resetState()(dispatchMock);
+    expect(action).toEqual(
+      { type: 'RESET_STATE' }
+    );
   });
 });

--- a/src/actions/tests/inboxPlacement.test.js
+++ b/src/actions/tests/inboxPlacement.test.js
@@ -59,4 +59,16 @@ describe('Action Creator: Inbox Placement', () => {
       }
     });
   });
+
+  it('makes request to get all messages with filter', async () => {
+    await inboxPlacement.getAllInboxPlacementMessages(1, { 'mailbox-provider': 'sparkpost.com' });
+    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+      type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES',
+      meta: {
+        method: 'GET',
+        url: '/v1/inbox-placement/1/messages',
+        params: { 'mailbox-provider': 'sparkpost.com' }
+      }
+    });
+  });
 });

--- a/src/config/routes/inboxPlacement.js
+++ b/src/config/routes/inboxPlacement.js
@@ -20,6 +20,14 @@ export default [
     supportDocSearch: 'inbox placement'
   },
   {
+    path: '/inbox-placement/details/:id/:filterType/:filterName',
+    component: inboxPlacement.AllMessagesPage,
+    layout: App,
+    condition: hasGrants('inbox-placement/manage'),
+    title: 'Inbox Placement',
+    supportDocSearch: 'inbox placement'
+  },
+  {
     path: '/inbox-placement',
     component: inboxPlacement.TestListPage,
     layout: App,

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -11,23 +11,22 @@ import InfoBlock from './components/InfoBlock';
 import styles from './AllMessagesPage.module.scss';
 import { formatPercent } from 'src/helpers/units';
 
-export const AllMessagesPage = (props) => {
-  const {
-    history,
-    id,
-    filterType,
-    filterName,
-    messages,
-    loading,
-    status,
-    sent,
-    placement,
-    authentication,
-    error,
-    getInboxPlacementByProviders,
-    getAllInboxPlacementMessages,
-    StopTestComponent = StopTest //This is for unit testing purposes
-  } = props;
+export const AllMessagesPage = ({
+  history,
+  id,
+  filterType,
+  filterName,
+  messages,
+  loading,
+  status,
+  sent,
+  placement,
+  authentication,
+  error,
+  getInboxPlacementByProviders,
+  getAllInboxPlacementMessages,
+  StopTestComponent = StopTest
+}) => {
 
   const loadMessages = useCallback(() => {
     const filters = { [filterType]: filterName };

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -49,6 +49,18 @@ export const AllMessagesPage = ({
       alert={{ type: 'error', message: error.message }}/>;
   }
 
+  const deliveribilityStyleProps = {
+    columnProps: { md: 3 },
+    valueClassName: styles.DeliverabilityValue,
+    labelClassName: styles.DeliverabilityHeader
+  };
+
+  const authenticationStyleProps = {
+    columnProps: { md: 4 },
+    valueClassName: styles.AuthenticationValue,
+    labelClassName: styles.AuthenticationHeader
+  };
+
   return (
     <Page
       breadcrumbAction={{
@@ -68,19 +80,19 @@ export const AllMessagesPage = ({
             <div className={styles.Divider} >
               <h5 className={styles.Title}>Deliverability</h5>
               <Grid className={styles.Panel}>
-                <InfoBlock value={sent} label='Sent' columnProps={{ md: 3 }} className={styles.Deliverability}/>
-                <InfoBlock value={(placement.inbox_pct || 0) * sent} label='Inbox' columnProps={{ md: 3 }} className={styles.Deliverability}/>
-                <InfoBlock value={(placement.spam_pct || 0) * sent} label='Spam' columnProps={{ md: 3 }} className={styles.Deliverability}/>
-                <InfoBlock value={(placement.missing_pct || 0) * sent} label='Missing' columnProps={{ md: 3 }} className={styles.Deliverability}/>
+                <InfoBlock value={sent} label='Sent' {...deliveribilityStyleProps}/>
+                <InfoBlock value={(placement.inbox_pct || 0) * sent} label='Inbox' {...deliveribilityStyleProps}/>
+                <InfoBlock value={(placement.spam_pct || 0) * sent} label='Spam' {...deliveribilityStyleProps}/>
+                <InfoBlock value={(placement.missing_pct || 0) * sent} label='Missing' {...deliveribilityStyleProps}/>
               </Grid>
             </div>
           </Grid.Column>
           <Grid.Column lg={5} md={12}>
             <h5 className={styles.Title}>Authentication</h5>
             <Grid className={styles.Panel}>
-              <InfoBlock value={formatPercent((authentication.spf_pct || 0) * 100)} label='SPF' columnProps={{ md: 4 }} className={styles.Authentication}/>
-              <InfoBlock value={formatPercent((authentication.dkim_pct || 0) * 100)} label='DKIM' columnProps={{ md: 4 }} className={styles.Authentication}/>
-              <InfoBlock value={formatPercent((authentication.dmarc_pct || 0) * 100)} label='DMARC' columnProps={{ md: 4 }} className={styles.Authentication}/>
+              <InfoBlock value={formatPercent((authentication.spf_pct || 0) * 100)} label='SPF' {...authenticationStyleProps}/>
+              <InfoBlock value={formatPercent((authentication.dkim_pct || 0) * 100)} label='DKIM' {...authenticationStyleProps}/>
+              <InfoBlock value={formatPercent((authentication.dmarc_pct || 0) * 100)} label='DMARC' {...authenticationStyleProps}/>
             </Grid>
           </Grid.Column>
         </Grid>
@@ -105,7 +117,7 @@ function mapStateToProps(state, props) {
     filterType,
     filterName,
     status: result.status,
-    sent: result.seedlist_count,
+    sent: result.seedlist_count || 0,
     placement: result.placement || {},
     authentication: result.authentication || {},
     stopTestLoading: state.inboxPlacement.stopTestPending,

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -1,0 +1,122 @@
+import React, { useEffect, useCallback } from 'react';
+import { connect } from 'react-redux';
+import { Grid, Page, Panel } from '@sparkpost/matchbox';
+
+import { Loading } from 'src/components';
+import { getInboxPlacementByProviders, getAllInboxPlacementMessages } from 'src/actions/inboxPlacement';
+import { RedirectAndAlert } from 'src/components/globalAlert';
+import StopTest from './components/StopTest';
+import AllMessagesCollection from './components/AllMessagesCollection';
+import InfoBlock from './components/InfoBlock';
+import styles from './AllMessagesPage.module.scss';
+import { formatPercent } from 'src/helpers/units';
+
+export const AllMessagesPage = (props) => {
+  const {
+    history,
+    id,
+    filterType,
+    filterName,
+    messages,
+    loading,
+    status,
+    sent,
+    placement,
+    authentication,
+    error,
+    getInboxPlacementByProviders,
+    getAllInboxPlacementMessages,
+    StopTestComponent = StopTest //This is for unit testing purposes
+  } = props;
+
+  const loadMessages = useCallback(() => {
+    const filters = { [filterType]: filterName };
+    filterType === 'mailbox-providers' ? getInboxPlacementByProviders(id) : undefined; //TODO add sending ip request
+    getAllInboxPlacementMessages(id, filters);
+  }, [filterName, filterType, getAllInboxPlacementMessages, getInboxPlacementByProviders, id]);
+
+  useEffect(() => {
+    loadMessages();
+  }, [id, loadMessages]);
+
+
+  if (loading) {
+    return <Loading/>;
+  }
+
+  if (error) {
+    return <RedirectAndAlert
+      to={`/inbox-placement/details/${id}`}
+      alert={{ type: 'error', message: error.message }}/>;
+  }
+
+  return (
+    <Page
+      breadcrumbAction={{
+        content: 'Inbox Placement Results',
+        onClick: () => history.push(`/inbox-placement/details/${id}`)
+      }}
+      title='Inbox Placement'
+      subtitle={filterName}
+      primaryArea={<StopTestComponent status={status} id={id} reload={loadMessages} />}
+    >
+      <Panel>
+        <Panel.Section>
+          <h3>Diagnostics</h3>
+        </Panel.Section>
+        <Grid>
+          <Grid.Column md={7} >
+            <div className={styles.Divider} >
+              <h5 className={styles.Title}>Deliverability</h5>
+              <div className={styles.Delivery} >
+                <Grid className={styles.Panel}>
+                  <InfoBlock value={sent} label='Sent' columnProps={{ md: 3 }}/>
+                  <InfoBlock value={(placement.inbox_pct || 0) * sent} label='Inbox' columnProps={{ md: 3 }}/>
+                  <InfoBlock value={(placement.spam_pct || 0) * sent} label='Spam' columnProps={{ md: 3 }}/>
+                  <InfoBlock value={(placement.missing_pct || 0) * sent} label='Missing' columnProps={{ md: 3 }} />
+                </Grid>
+              </div>
+            </div>
+          </Grid.Column>
+          <Grid.Column md={5}>
+            <div className={styles.Divider} >
+              <h5 className={styles.Title}>Authentication</h5>
+              <Grid className={styles.Panel}>
+                <InfoBlock value={formatPercent((authentication.spf_pct || 0) * 100)} label='SPF' columnProps={{ md: 4 }}/>
+                <InfoBlock value={formatPercent((authentication.dkim_pct || 0) * 100)} label='DKIM' columnProps={{ md: 4 }}/>
+                <InfoBlock value={formatPercent((authentication.dmarc_pct || 0) * 100)} label='DMARC' columnProps={{ md: 4 }}/>
+              </Grid>
+            </div>
+          </Grid.Column>
+        </Grid>
+      </Panel>
+      <Panel title={'Seed Diagnostics'}>
+        <AllMessagesCollection data={messages}/>
+      </Panel>
+    </Page>
+  );
+};
+
+
+function mapStateToProps(state, props) {
+  const { id, filterType, filterName } = props.match.params;
+  const result = ((filterType === 'mailbox-providers')
+    ? state.inboxPlacement.placementsByProvider.find(({ mailbox_provider }) => mailbox_provider === filterName)
+    : undefined) || //TODO add sending ip
+    {};
+
+  return {
+    id,
+    filterType,
+    filterName,
+    status: result.status,
+    sent: result.seedlist_count,
+    placement: result.placement || {},
+    authentication: result.authentication || {},
+    stopTestLoading: state.inboxPlacement.stopTestPending,
+    messages: state.inboxPlacement.allMessages,
+    loading: state.inboxPlacement.getAllMessagesPending
+  };
+}
+
+export default connect(mapStateToProps, { getInboxPlacementByProviders, getAllInboxPlacementMessages })(AllMessagesPage);

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -65,28 +65,24 @@ export const AllMessagesPage = (props) => {
           <h3>Diagnostics</h3>
         </Panel.Section>
         <Grid>
-          <Grid.Column md={7} >
+          <Grid.Column lg={7} md={12}>
             <div className={styles.Divider} >
               <h5 className={styles.Title}>Deliverability</h5>
-              <div className={styles.Delivery} >
-                <Grid className={styles.Panel}>
-                  <InfoBlock value={sent} label='Sent' columnProps={{ md: 3 }}/>
-                  <InfoBlock value={(placement.inbox_pct || 0) * sent} label='Inbox' columnProps={{ md: 3 }}/>
-                  <InfoBlock value={(placement.spam_pct || 0) * sent} label='Spam' columnProps={{ md: 3 }}/>
-                  <InfoBlock value={(placement.missing_pct || 0) * sent} label='Missing' columnProps={{ md: 3 }} />
-                </Grid>
-              </div>
-            </div>
-          </Grid.Column>
-          <Grid.Column md={5}>
-            <div className={styles.Divider} >
-              <h5 className={styles.Title}>Authentication</h5>
               <Grid className={styles.Panel}>
-                <InfoBlock value={formatPercent((authentication.spf_pct || 0) * 100)} label='SPF' columnProps={{ md: 4 }}/>
-                <InfoBlock value={formatPercent((authentication.dkim_pct || 0) * 100)} label='DKIM' columnProps={{ md: 4 }}/>
-                <InfoBlock value={formatPercent((authentication.dmarc_pct || 0) * 100)} label='DMARC' columnProps={{ md: 4 }}/>
+                <InfoBlock value={sent} label='Sent' columnProps={{ md: 3 }} className={styles.Deliverability}/>
+                <InfoBlock value={(placement.inbox_pct || 0) * sent} label='Inbox' columnProps={{ md: 3 }} className={styles.Deliverability}/>
+                <InfoBlock value={(placement.spam_pct || 0) * sent} label='Spam' columnProps={{ md: 3 }} className={styles.Deliverability}/>
+                <InfoBlock value={(placement.missing_pct || 0) * sent} label='Missing' columnProps={{ md: 3 }} className={styles.Deliverability}/>
               </Grid>
             </div>
+          </Grid.Column>
+          <Grid.Column lg={5} md={12}>
+            <h5 className={styles.Title}>Authentication</h5>
+            <Grid className={styles.Panel}>
+              <InfoBlock value={formatPercent((authentication.spf_pct || 0) * 100)} label='SPF' columnProps={{ md: 4 }} className={styles.Authentication}/>
+              <InfoBlock value={formatPercent((authentication.dkim_pct || 0) * 100)} label='DKIM' columnProps={{ md: 4 }} className={styles.Authentication}/>
+              <InfoBlock value={formatPercent((authentication.dmarc_pct || 0) * 100)} label='DMARC' columnProps={{ md: 4 }} className={styles.Authentication}/>
+            </Grid>
           </Grid.Column>
         </Grid>
       </Panel>

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Grid, Page, Panel } from '@sparkpost/matchbox';
 
 import { Loading } from 'src/components';
-import { getInboxPlacementByProviders, getAllInboxPlacementMessages } from 'src/actions/inboxPlacement';
+import { getInboxPlacementByProviders, getAllInboxPlacementMessages, resetState } from 'src/actions/inboxPlacement';
 import { RedirectAndAlert } from 'src/components/globalAlert';
 import StopTest from './components/StopTest';
 import AllMessagesCollection from './components/AllMessagesCollection';
@@ -25,6 +25,7 @@ export const AllMessagesPage = ({
   error,
   getInboxPlacementByProviders,
   getAllInboxPlacementMessages,
+  resetState,
   StopTestComponent = StopTest
 }) => {
 
@@ -36,7 +37,8 @@ export const AllMessagesPage = ({
 
   useEffect(() => {
     loadMessages();
-  }, [id, loadMessages]);
+    return (() => resetState());
+  }, [id, loadMessages, resetState]);
 
 
   if (loading) {
@@ -122,8 +124,9 @@ function mapStateToProps(state, props) {
     authentication: result.authentication || {},
     stopTestLoading: state.inboxPlacement.stopTestPending,
     messages: state.inboxPlacement.allMessages,
-    loading: state.inboxPlacement.getAllMessagesPending
+    loading: state.inboxPlacement.getAllMessagesPending,
+    error: state.inboxPlacement.getAllMessagesError
   };
 }
 
-export default connect(mapStateToProps, { getInboxPlacementByProviders, getAllInboxPlacementMessages })(AllMessagesPage);
+export default connect(mapStateToProps, { getInboxPlacementByProviders, getAllInboxPlacementMessages, resetState })(AllMessagesPage);

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -125,7 +125,7 @@ function mapStateToProps(state, props) {
     stopTestLoading: state.inboxPlacement.stopTestPending,
     messages: state.inboxPlacement.allMessages,
     loading: state.inboxPlacement.getAllMessagesPending,
-    error: state.inboxPlacement.getAllMessagesError
+    error: state.inboxPlacement.getAllMessagesError || state.inboxPlacement.getByProviderError
   };
 }
 

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -31,7 +31,7 @@ export const AllMessagesPage = (props) => {
 
   const loadMessages = useCallback(() => {
     const filters = { [filterType]: filterName };
-    filterType === 'mailbox-providers' ? getInboxPlacementByProviders(id) : undefined; //TODO add sending ip request
+    filterType === 'mailbox-provider' ? getInboxPlacementByProviders(id) : undefined; //TODO add sending ip request
     getAllInboxPlacementMessages(id, filters);
   }, [filterName, filterType, getAllInboxPlacementMessages, getInboxPlacementByProviders, id]);
 
@@ -96,7 +96,7 @@ export const AllMessagesPage = (props) => {
 
 function mapStateToProps(state, props) {
   const { id, filterType, filterName } = props.match.params;
-  const result = ((filterType === 'mailbox-providers')
+  const result = ((filterType === 'mailbox-provider')
     ? state.inboxPlacement.placementsByProvider.find(({ mailbox_provider }) => mailbox_provider === filterName)
     : undefined) || //TODO add sending ip
     {};

--- a/src/pages/inboxPlacement/AllMessagesPage.module.scss
+++ b/src/pages/inboxPlacement/AllMessagesPage.module.scss
@@ -1,0 +1,21 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.Divider {
+  border-right: 1px solid color(gray, 8);
+  padding: 0 0 0 50px;
+}
+.Panel {
+  padding-bottom: 20px;
+}
+
+.Title{
+  position: relative;
+  right: 50px;
+  text-align: center;
+  padding: 20px 10px 10px 10px;
+}
+
+ .Delivery{
+   position: relative;
+   left: 20px;
+}

--- a/src/pages/inboxPlacement/AllMessagesPage.module.scss
+++ b/src/pages/inboxPlacement/AllMessagesPage.module.scss
@@ -2,20 +2,27 @@
 
 .Divider {
   border-right: 1px solid color(gray, 8);
-  padding: 0 0 0 50px;
 }
 .Panel {
-  padding-bottom: 20px;
+  padding-bottom: 1rem;
 }
 
 .Title{
-  position: relative;
-  right: 50px;
   text-align: center;
-  padding: 20px 10px 10px 10px;
+  padding: rem(20) rem(20) 0 0;
 }
 
- .Delivery{
-   position: relative;
-   left: 20px;
+.Deliverability{
+  line-height: 2rem;
+  font-size: font-size(500);
+  font-weight: 500;
+  padding-left: rem(50);
+}
+
+.Authentication{
+  line-height: 2rem;
+  padding-left: rem(50);
+  font-weight: 500;
+  font-size: font-size(500);
+  @media screen and (min-width: breakpoint(medium)) { padding-left: rem(20); }
 }

--- a/src/pages/inboxPlacement/AllMessagesPage.module.scss
+++ b/src/pages/inboxPlacement/AllMessagesPage.module.scss
@@ -12,17 +12,30 @@
   padding: rem(20) rem(20) 0 0;
 }
 
-.Deliverability{
+.DeliverabilityValue{
   line-height: 2rem;
-  font-size: font-size(500);
+  font-size: font-size(700);
   font-weight: 500;
   padding-left: rem(50);
 }
 
-.Authentication{
+.AuthenticationValue{
   line-height: 2rem;
+  @media screen and (min-width: breakpoint(medium)) { padding-left: rem(20); }
   padding-left: rem(50);
   font-weight: 500;
-  font-size: font-size(500);
+  font-size: font-size(700);
+}
+
+.DeliverabilityHeader{
+  font-size: font-size(400);
+  font-weight: 400;
+  padding-left: rem(50);
+}
+
+.AuthenticationHeader{
+  padding-left: rem(50);
   @media screen and (min-width: breakpoint(medium)) { padding-left: rem(20); }
+  font-weight: 400;
+  font-size: font-size(400);
 }

--- a/src/pages/inboxPlacement/TestDetailsPage.js
+++ b/src/pages/inboxPlacement/TestDetailsPage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Page, Tabs } from '@sparkpost/matchbox';
 
 import { Loading } from 'src/components';
-import { getInboxPlacementTest, stopInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent } from 'src/actions/inboxPlacement';
+import { getInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent } from 'src/actions/inboxPlacement';
 import TestDetails from './components/TestDetails';
 import TestContent from './components/TestContent';
 import useTabs from 'src/hooks/useTabs';
@@ -23,8 +23,7 @@ export const TestDetailsPage = (props) => {
     getInboxPlacementTest,
     getInboxPlacementByProviders,
     getInboxPlacementTestContent,
-    stopTestLoading,
-    stopInboxPlacementTest
+    StopTestComponent = StopTest //This is for unit test purposes
   } = props;
 
   const [selectedTabIndex, tabs] = useTabs(TABS, tabIndex);
@@ -34,10 +33,6 @@ export const TestDetailsPage = (props) => {
     getInboxPlacementByProviders(id);
     getInboxPlacementTestContent(id);
   }, [getInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent, id]);
-
-  const stopTest = useCallback(() => {
-    stopInboxPlacementTest(id).then(loadTestData);
-  }, [id, loadTestData, stopInboxPlacementTest]);
 
   useEffect(() => {
     loadTestData();
@@ -75,7 +70,7 @@ export const TestDetailsPage = (props) => {
       }}
       title='Inbox Placement'
       subtitle='Results'
-      primaryArea={<StopTest status={(details || {}).status} loading={stopTestLoading} onStop={stopTest} />}
+      primaryArea={<StopTestComponent status={(details || {}).status} id={id} reload={loadTestData} />}
     >
       <Tabs
         selected={selectedTabIndex}
@@ -100,7 +95,6 @@ function mapStateToProps(state, props) {
     tabIndex: currentTabIndex > 0 ? currentTabIndex : 0,
     id,
     loading: state.inboxPlacement.getTestPending || state.inboxPlacement.getByProviderPending || state.inboxPlacement.getTestContentPending,
-    stopTestLoading: state.inboxPlacement.stopTestPending,
     error: state.inboxPlacement.getTestError || state.inboxPlacement.getByProviderError || state.inboxPlacement.getTestContentError,
     details: state.inboxPlacement.currentTestDetails,
     placementsByProvider: state.inboxPlacement.placementsByProvider || [],
@@ -108,4 +102,4 @@ function mapStateToProps(state, props) {
   };
 }
 
-export default connect(mapStateToProps, { getInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent, stopInboxPlacementTest })(TestDetailsPage);
+export default connect(mapStateToProps, { getInboxPlacementTest, getInboxPlacementByProviders, getInboxPlacementTestContent })(TestDetailsPage);

--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -142,8 +142,8 @@ export class TestListPage extends Component {
     );
   }
 }
-const mapStateToProps = (state, props) => ({
-  tests: state.inboxPlacement.tests,
+const mapStateToProps = (state) => ({
+  tests: state.inboxPlacement.tests || [],
   error: state.inboxPlacement.testsError,
   loading: state.inboxPlacement.testsPending
 });

--- a/src/pages/inboxPlacement/components/AllMessagesCollection.js
+++ b/src/pages/inboxPlacement/components/AllMessagesCollection.js
@@ -39,7 +39,7 @@ const RowComponent = ({ email_address, folder, tab, dkim, spf, dmarc }) => (
     <Table.Cell className={styles.Authentication}>{passFail(dmarc)}</Table.Cell>
   </Table.Row>);
 
-const AllMessagesCollectiom = ({ data = []}) => (
+const AllMessagesCollection = ({ data = []}) => (
   <TableCollection
     rows={data}
     wrapperComponent={WrapperComponent}
@@ -49,4 +49,4 @@ const AllMessagesCollectiom = ({ data = []}) => (
     saveCsv={false}
   />);
 
-export default AllMessagesCollectiom;
+export default AllMessagesCollection;

--- a/src/pages/inboxPlacement/components/AllMessagesCollection.js
+++ b/src/pages/inboxPlacement/components/AllMessagesCollection.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Table } from '@sparkpost/matchbox';
+import { TableCollection } from 'src/components/collection';
+import styles from './AllMessagesCollection.module.scss';
+import startCase from 'lodash/startCase';
+import { CheckCircle } from '@sparkpost/matchbox-icons';
+
+export const passFail = (value) => {
+  switch (value) {
+    case 'pass':
+      return <CheckCircle className={styles.Pass}/>;
+    case 'fail':
+      return <span className={styles.Fail}>Fail</span>;
+    default:
+      return '---';
+  }
+};
+const HeaderComponent = () => (<thead>
+  <Table.Row className={styles.HeaderRow}>
+    <Table.HeaderCell className={styles.HeaderCell}></Table.HeaderCell>
+    <Table.HeaderCell className={styles.HeaderCell}>SPF</Table.HeaderCell>
+    <Table.HeaderCell className={styles.HeaderCell}>DKIM</Table.HeaderCell>
+    <Table.HeaderCell className={styles.HeaderCell}>DMARC</Table.HeaderCell>
+  </Table.Row>
+</thead>);
+
+const WrapperComponent = ({ children }) => (
+  <Table>{children}</Table>
+);
+
+const RowComponent = ({ email_address, folder, tab, dkim, spf, dmarc }) => (
+  <Table.Row className={styles.DataRow}>
+    <Table.Cell className={styles.SeedCell}>
+      <h4>{email_address}</h4>
+      <strong>{startCase(folder)}</strong> {tab && (` | ${startCase(tab)} Folder`)}
+    </Table.Cell>
+    <Table.Cell className={styles.Authentication}>{passFail(spf)}</Table.Cell>
+    <Table.Cell className={styles.Authentication}>{passFail(dkim)}</Table.Cell>
+    <Table.Cell className={styles.Authentication}>{passFail(dmarc)}</Table.Cell>
+  </Table.Row>);
+
+const AllMessagesCollectiom = ({ data = []}) => (
+  <TableCollection
+    rows={data}
+    wrapperComponent={WrapperComponent}
+    headerComponent={HeaderComponent}
+    rowComponent={RowComponent}
+    pagination={true}
+    saveCsv={false}
+  />);
+
+export default AllMessagesCollectiom;

--- a/src/pages/inboxPlacement/components/AllMessagesCollection.js
+++ b/src/pages/inboxPlacement/components/AllMessagesCollection.js
@@ -9,10 +9,10 @@ export const passFail = (value) => {
   switch (value) {
     case 'pass':
       return <CheckCircle className={styles.Pass}/>;
-    case 'fail':
-      return <span className={styles.Fail}>Fail</span>;
-    default:
+    case null:
       return '---';
+    default:
+      return <span className={styles.Fail}>{startCase(value)}</span>;
   }
 };
 const HeaderComponent = () => (<thead>

--- a/src/pages/inboxPlacement/components/AllMessagesCollection.module.scss
+++ b/src/pages/inboxPlacement/components/AllMessagesCollection.module.scss
@@ -25,7 +25,8 @@
 
 .HeaderCell{
   text-align: center;
-  font-weight: normal;
+  font-size: 0.8rem;
+  font-weight: 500;
 }
 
 .Pass {

--- a/src/pages/inboxPlacement/components/AllMessagesCollection.module.scss
+++ b/src/pages/inboxPlacement/components/AllMessagesCollection.module.scss
@@ -1,0 +1,37 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.DataRow {
+  line-height: 0.3;
+  &:last-of-type {
+    border-bottom: 0px;
+  }
+}
+
+.HeaderRow {
+  border-bottom: 0px;
+}
+
+.SeedCell {
+  padding: 1.5rem 0 1.5rem 1rem;
+  width: 40%;
+  font-weight: normal;
+}
+
+.Authentication {
+  padding: 1.5rem 0 1.5rem 0;
+  text-align: center;
+  font-weight: normal;
+}
+
+.HeaderCell{
+  text-align: center;
+  font-weight: normal;
+}
+
+.Pass {
+  color: color(green);
+}
+
+.Fail {
+  color: color(red);
+}

--- a/src/pages/inboxPlacement/components/AllMessagesCollection.module.scss
+++ b/src/pages/inboxPlacement/components/AllMessagesCollection.module.scss
@@ -25,7 +25,7 @@
 
 .HeaderCell{
   text-align: center;
-  font-size: 0.8rem;
+  font-size: font-size(400);
   font-weight: 500;
 }
 

--- a/src/pages/inboxPlacement/components/InfoBlock.js
+++ b/src/pages/inboxPlacement/components/InfoBlock.js
@@ -2,10 +2,9 @@ import React from 'react';
 import { Grid } from '@sparkpost/matchbox';
 import styles from './InfoBlock.module.scss';
 
-const InfoBlock = ({ label, value, columnProps = {}}) => <Grid.Column {...columnProps}>
-  <span className={styles.InfoLabel}>{label}</span>
-  <br/>
-  <span className={styles.InfoValue}>{value}</span>
+const InfoBlock = ({ label, value, columnProps = {}, className }) => <Grid.Column {...columnProps}>
+  <div className={className || styles.InfoLabel}>{label}</div>
+  <div className={className || styles.InfoValue}>{value}</div>
 </Grid.Column>;
 
 export default InfoBlock;

--- a/src/pages/inboxPlacement/components/InfoBlock.js
+++ b/src/pages/inboxPlacement/components/InfoBlock.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { Grid } from '@sparkpost/matchbox';
 import styles from './InfoBlock.module.scss';
 
-const InfoBlock = ({ label, value, columnProps = {}, className }) => <Grid.Column {...columnProps}>
-  <div className={className || styles.InfoLabel}>{label}</div>
-  <div className={className || styles.InfoValue}>{value}</div>
+const InfoBlock = ({ label, value, columnProps = {}, labelClassName, valueClassName }) => <Grid.Column {...columnProps}>
+  <div className={labelClassName || styles.InfoLabel}>{label}</div>
+  <div className={valueClassName || styles.InfoValue}>{value}</div>
 </Grid.Column>;
 
 export default InfoBlock;

--- a/src/pages/inboxPlacement/components/ProvidersBreakdown.js
+++ b/src/pages/inboxPlacement/components/ProvidersBreakdown.js
@@ -26,7 +26,7 @@ const WrapperComponent = ({ children }) => (<div className={styles.TableWrapper}
 
 const RowComponent = ({ mailbox_provider, placement, authentication }) => (<Table.Row className={styles.DataRow}>
   <Table.Cell className={styles.ProviderCell}>
-    <strong><PageLink to={`/inbox-placement/details/${id}/mailbox-providers/${mailbox_provider}`}>{mailbox_provider}</PageLink></strong>
+    <strong><PageLink to={`/inbox-placement/details/${id}/mailbox-provider/${mailbox_provider}`}>{mailbox_provider}</PageLink></strong>
   </Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.inbox_pct}/></Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.spam_pct}/></Table.Cell>

--- a/src/pages/inboxPlacement/components/ProvidersBreakdown.js
+++ b/src/pages/inboxPlacement/components/ProvidersBreakdown.js
@@ -20,11 +20,11 @@ const HeaderComponent = () => (<thead>
   </Table.Row>
 </thead>);
 
-const WrapperComponent = ({ children }) => (<div className={styles.TableWrapper}>
+const WrapperComponent = ({ children }) => (<div>
   <Table>{children}</Table>
 </div>);
 
-const RowComponent = ({ mailbox_provider, placement, authentication }) => (<Table.Row className={styles.DataRow}>
+const RowComponent = ({ id, mailbox_provider, placement, authentication }) => (<Table.Row className={styles.DataRow}>
   <Table.Cell className={styles.ProviderCell}>
     <strong><PageLink to={`/inbox-placement/details/${id}/mailbox-provider/${mailbox_provider}`}>{mailbox_provider}</PageLink></strong>
   </Table.Cell>
@@ -37,7 +37,6 @@ const RowComponent = ({ mailbox_provider, placement, authentication }) => (<Tabl
 </Table.Row>);
 
 const ProvidersBreakdown = ({ data = []}) => (<TableCollection
-  className={styles.ProvidersBreakdownTable}
   rows={data}
   wrapperComponent={WrapperComponent}
   headerComponent={HeaderComponent}

--- a/src/pages/inboxPlacement/components/ProvidersBreakdown.js
+++ b/src/pages/inboxPlacement/components/ProvidersBreakdown.js
@@ -26,7 +26,7 @@ const WrapperComponent = ({ children }) => (<div>
 
 const RowComponent = ({ id, mailbox_provider, placement, authentication }) => (<Table.Row className={styles.DataRow}>
   <Table.Cell className={styles.ProviderCell}>
-    <strong><PageLink to={`/inbox-placement/details/${id}/mailbox-provider/${mailbox_provider}`}>{mailbox_provider}</PageLink></strong>
+    <PageLink to={`/inbox-placement/details/${id}/mailbox-provider/${mailbox_provider}`}><strong>{mailbox_provider}</strong></PageLink>
   </Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.inbox_pct}/></Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.spam_pct}/></Table.Cell>

--- a/src/pages/inboxPlacement/components/ProvidersBreakdown.js
+++ b/src/pages/inboxPlacement/components/ProvidersBreakdown.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import { TableCollection } from 'src/components/collection';
 import { formatPercent } from 'src/helpers/units';
 import styles from './ProvidersBreakdown.module.scss';
+import PageLink from 'src/components/pageLink/PageLink';
 
 export const GroupPercentage = ({ value }) => <span className={styles.GroupValue}>{formatPercent(value * 100)}</span>;
 
@@ -25,7 +26,7 @@ const WrapperComponent = ({ children }) => (<div className={styles.TableWrapper}
 
 const RowComponent = ({ mailbox_provider, placement, authentication }) => (<Table.Row className={styles.DataRow}>
   <Table.Cell className={styles.ProviderCell}>
-    <strong>{mailbox_provider}</strong>
+    <strong><PageLink to={`/inbox-placement/details/${id}/mailbox-providers/${mailbox_provider}`}>{mailbox_provider}</PageLink></strong>
   </Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.inbox_pct}/></Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.spam_pct}/></Table.Cell>

--- a/src/pages/inboxPlacement/components/StopTest.js
+++ b/src/pages/inboxPlacement/components/StopTest.js
@@ -1,14 +1,21 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button } from '@sparkpost/matchbox';
 import ConfirmationModal from 'src/components/modals/ConfirmationModal';
 import { STATUS } from '../constants/test';
+import { connect } from 'react-redux';
+import { stopInboxPlacementTest } from 'src/actions/inboxPlacement';
 
-const StopTest = ({ status, onStop, loading }) => {
+export const StopTest = (props) => {
+  const { status, id, loading, reload, stopInboxPlacementTest } = props;
   const [modalVisible, setModalVisible] = useState(false);
 
   const toggleModalVisibility = () => {
     setModalVisible(!modalVisible);
   };
+
+  const stopTest = useCallback(() => {
+    stopInboxPlacementTest(id).then(reload);
+  }, [id, reload, stopInboxPlacementTest]);
 
   if (status !== STATUS.RUNNING) {
     return null;
@@ -24,7 +31,7 @@ const StopTest = ({ status, onStop, loading }) => {
           stopping.
         </p>
       }
-      onConfirm={onStop}
+      onConfirm={stopTest}
       onCancel={toggleModalVisibility}
       confirming={loading}
       isPending={loading}
@@ -35,4 +42,10 @@ const StopTest = ({ status, onStop, loading }) => {
   </>);
 };
 
-export default StopTest;
+function mapStateToProps(state) {
+  return {
+    loading: state.inboxPlacement.stopTestPending
+  };
+}
+
+export default connect(mapStateToProps, { stopInboxPlacementTest })(StopTest);

--- a/src/pages/inboxPlacement/components/tests/AllMessagesCollection.test.js
+++ b/src/pages/inboxPlacement/components/tests/AllMessagesCollection.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import cases from 'jest-in-case';
+
+import AllMessagesCollection, { passFail } from '../AllMessagesCollection';
+
+describe('Component: AllMessagesCollection', () => {
+  const subject = ({ ...props }) => shallow(<AllMessagesCollection data={[]} {...props}/>);
+
+  it('renders correctly with no data', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('renders correctly with data', () => {
+    const data = [
+      {
+        email_address: 'fido@dogmail.com',
+        folder: 'spam',
+        tab: null,
+        dkim: 'pass',
+        spf: 'pass',
+        dmarc: 'pass'
+      },
+      {
+        email_address: 'sparky@gmail.com',
+        folder: 'inbox',
+        tab: 'promotion',
+        dkim: 'pass',
+        spf: null,
+        dmarc: 'fail'
+      }
+    ];
+
+    expect(subject({ data })).toMatchSnapshot();
+  });
+
+  describe('helper: passFail function', () => {
+    const testCases = [
+      { name: 'Pass', input: 'pass' },
+      { name: 'Fail', input: 'fail' },
+      { name: 'null', input: null },
+      { name: 'other results', input: 'foofoo' }
+    ];
+
+    cases('returns correct value for an input of', ({ input }) => {
+      expect(passFail(input)).toMatchSnapshot();
+    }, testCases);
+  });
+
+});

--- a/src/pages/inboxPlacement/components/tests/InfoBlock.test.js
+++ b/src/pages/inboxPlacement/components/tests/InfoBlock.test.js
@@ -14,4 +14,9 @@ describe('Component: InfoBlock', () => {
     expect(subject({ columnProps: { md: 5 }}).prop('md')).toEqual(5);
   });
 
+  it('renders correctly with custom classname', () => {
+    expect(subject({ className: 'cool' }).find('div').first()).toHaveProp('className', 'cool');
+    expect(subject({ className: 'cool' }).find('div').last()).toHaveProp('className', 'cool');
+  });
+
 });

--- a/src/pages/inboxPlacement/components/tests/InfoBlock.test.js
+++ b/src/pages/inboxPlacement/components/tests/InfoBlock.test.js
@@ -15,8 +15,9 @@ describe('Component: InfoBlock', () => {
   });
 
   it('renders correctly with custom classname', () => {
-    expect(subject({ className: 'cool' }).find('div').first()).toHaveProp('className', 'cool');
-    expect(subject({ className: 'cool' }).find('div').last()).toHaveProp('className', 'cool');
+    const wrapper = subject({ labelClassName: 'foo', valueClassName: 'bar' });
+    expect(wrapper.find('div').first()).toHaveProp('className', 'foo');
+    expect(wrapper.find('div').last()).toHaveProp('className', 'bar');
   });
 
 });

--- a/src/pages/inboxPlacement/components/tests/StopTest.test.js
+++ b/src/pages/inboxPlacement/components/tests/StopTest.test.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import StopTest from '../StopTest';
+import { StopTest } from '../StopTest';
 
 describe('Component: StopTest', () => {
+  const mockStopTest = jest.fn(() => Promise.resolve());
+  const mockReload = jest.fn();
+  const id = 0;
   const subject = ({ ...props }) => {
     const defaults = {
+      id,
       status: 'running',
-      onStop: jest.fn(),
+      stopInboxPlacementTest: mockStopTest,
+      reload: mockReload,
       loading: false
     };
     return shallow(<StopTest {...defaults} {...props}/>);
@@ -44,5 +49,12 @@ describe('Component: StopTest', () => {
     //close modal
     wrapper.find('ConfirmationModal').prop('onCancel')();
     expect(wrapper.find('ConfirmationModal').prop('open')).toBe(false);
+  });
+
+  it('confirming stop test stops the test and reloads the current data', async () => {
+    const wrapper = subject();
+    await wrapper.find('ConfirmationModal').prop('onConfirm')();
+    expect(mockStopTest).toHaveBeenCalledWith(id);
+    expect(mockReload).toHaveBeenCalled();
   });
 });

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/AllMessagesCollection.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/AllMessagesCollection.test.js.snap
@@ -16,7 +16,13 @@ exports[`Component: AllMessagesCollection helper: passFail function returns corr
 
 exports[`Component: AllMessagesCollection helper: passFail function returns correct value for an input of null 1`] = `"---"`;
 
-exports[`Component: AllMessagesCollection helper: passFail function returns correct value for an input of other results 1`] = `"---"`;
+exports[`Component: AllMessagesCollection helper: passFail function returns correct value for an input of other results 1`] = `
+<span
+  className="Fail"
+>
+  Foofoo
+</span>
+`;
 
 exports[`Component: AllMessagesCollection renders correctly with data 1`] = `
 <TableCollection

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/AllMessagesCollection.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/AllMessagesCollection.test.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: AllMessagesCollection helper: passFail function returns correct value for an input of Fail 1`] = `
+<span
+  className="Fail"
+>
+  Fail
+</span>
+`;
+
+exports[`Component: AllMessagesCollection helper: passFail function returns correct value for an input of Pass 1`] = `
+<CheckCircle
+  className="Pass"
+/>
+`;
+
+exports[`Component: AllMessagesCollection helper: passFail function returns correct value for an input of null 1`] = `"---"`;
+
+exports[`Component: AllMessagesCollection helper: passFail function returns correct value for an input of other results 1`] = `"---"`;
+
+exports[`Component: AllMessagesCollection renders correctly with data 1`] = `
+<TableCollection
+  defaultSortColumn={null}
+  defaultSortDirection="asc"
+  headerComponent={[Function]}
+  pagination={true}
+  rowComponent={[Function]}
+  rows={
+    Array [
+      Object {
+        "dkim": "pass",
+        "dmarc": "pass",
+        "email_address": "fido@dogmail.com",
+        "folder": "spam",
+        "spf": "pass",
+        "tab": null,
+      },
+      Object {
+        "dkim": "pass",
+        "dmarc": "fail",
+        "email_address": "sparky@gmail.com",
+        "folder": "inbox",
+        "spf": null,
+        "tab": "promotion",
+      },
+    ]
+  }
+  saveCsv={false}
+  wrapperComponent={[Function]}
+/>
+`;
+
+exports[`Component: AllMessagesCollection renders correctly with no data 1`] = `
+<TableCollection
+  defaultSortColumn={null}
+  defaultSortDirection="asc"
+  headerComponent={[Function]}
+  pagination={true}
+  rowComponent={[Function]}
+  rows={Array []}
+  saveCsv={false}
+  wrapperComponent={[Function]}
+/>
+`;

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/InfoBlock.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/InfoBlock.test.js.snap
@@ -2,16 +2,15 @@
 
 exports[`Component: InfoBlock renders correctly 1`] = `
 <Grid.Column>
-  <span
+  <div
     className="InfoLabel"
   >
     Foo
-  </span>
-  <br />
-  <span
+  </div>
+  <div
     className="InfoValue"
   >
     bar
-  </span>
+  </div>
 </Grid.Column>
 `;

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/ProvidersBreakdown.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/ProvidersBreakdown.test.js.snap
@@ -10,7 +10,6 @@ exports[`Component: ProvidersBreakdown SubComponent: GroupPercentage renders per
 
 exports[`Component: ProvidersBreakdown renders correctly with data 1`] = `
 <TableCollection
-  className="ProvidersBreakdownTable"
   defaultSortColumn="placement.inbox_pct"
   defaultSortDirection="desc"
   headerComponent={[Function]}
@@ -53,7 +52,6 @@ exports[`Component: ProvidersBreakdown renders correctly with data 1`] = `
 
 exports[`Component: ProvidersBreakdown renders correctly with no data 1`] = `
 <TableCollection
-  className="ProvidersBreakdownTable"
   defaultSortColumn="placement.inbox_pct"
   defaultSortDirection="desc"
   headerComponent={[Function]}

--- a/src/pages/inboxPlacement/index.js
+++ b/src/pages/inboxPlacement/index.js
@@ -1,9 +1,11 @@
 import SeedListPage from './SeedListPage';
 import TestListPage from './TestListPage';
 import TestDetailsPage from './TestDetailsPage';
+import AllMessagesPage from './AllMessagesPage';
 
 export default {
   SeedListPage,
   TestListPage,
-  TestDetailsPage
+  TestDetailsPage,
+  AllMessagesPage
 };

--- a/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
+++ b/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
@@ -1,0 +1,81 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import { AllMessagesPage } from '../AllMessagesPage';
+import { StopTest } from '../components/StopTest';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+
+describe('Page: All Inbox Placement Messages Test', () => {
+  const subject = ({ ...props }) => {
+    const defaults = {
+      getAllInboxPlacementMessages: jest.fn(),
+      getInboxPlacementByProviders: jest.fn(),
+      id: 0,
+      loading: false,
+      sent: 100,
+      placement: {
+        inbox_pct: 1,
+        missing_pct: 0,
+        spam_pct: 0
+      },
+      authentication: {
+        spf_pct: 1,
+        dkim_pct: 1,
+        dmarc_pct: 1
+      },
+      error: false,
+      history: {
+        replace: jest.fn()
+      }
+    };
+
+    return shallow(<AllMessagesPage {...defaults} {...props} />);
+  };
+
+  it('renders page correctly with defaults', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('calls getInboxPlacementTest on load', () => {
+    const getAllInboxPlacementMessages = jest.fn().mockReturnValue({});
+    const getInboxPlacementByProviders = jest.fn().mockReturnValue({});
+
+    mount(
+      <Router>
+        <AllMessagesPage
+          filterType={'mailbox-providers'}
+          filterName={'gmail.com'}
+          status={'completed'}
+          messages={[]}
+          sent={100}
+          placement={{}}
+          authentication={{}}
+          getAllInboxPlacementMessages={getAllInboxPlacementMessages}
+          getInboxPlacementByProviders={getInboxPlacementByProviders}
+          id={101}
+          history={{ replace: jest.fn() }}
+          StopTestComponent={StopTest}/>
+      </Router>);
+
+    expect(getAllInboxPlacementMessages).toHaveBeenCalled();
+    expect(getInboxPlacementByProviders).toHaveBeenCalled();
+  });
+
+  it('renders loading', () => {
+    const wrapper = subject({ loading: true });
+    expect(wrapper.find('Loading')).toExist();
+    expect(wrapper.find('Page')).not.toExist();
+  });
+
+  it('handles errors', () => {
+    const wrapper = subject();
+    wrapper.setProps({
+      error: {
+        message: 'You dun goofed'
+      }
+    });
+    expect(wrapper.find('RedirectAndAlert')).toMatchSnapshot();
+    expect(wrapper.find('Page')).not.toExist();
+  });
+});
+

--- a/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
+++ b/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
@@ -36,11 +36,12 @@ describe('Page: All Inbox Placement Messages Test', () => {
     expect(subject()).toMatchSnapshot();
   });
 
-  it('calls getInboxPlacementTest on load', () => {
+  describe('useEffect hook', () => {
+
     const getAllInboxPlacementMessages = jest.fn().mockReturnValue({});
     const getInboxPlacementByProviders = jest.fn().mockReturnValue({});
-
-    mount(
+    const resetState = jest.fn().mockReturnValue({});
+    const subjectMounted = ({ ...props }) => mount(
       <Router>
         <AllMessagesPage
           filterType={'mailbox-provider'}
@@ -52,13 +53,25 @@ describe('Page: All Inbox Placement Messages Test', () => {
           authentication={{}}
           getAllInboxPlacementMessages={getAllInboxPlacementMessages}
           getInboxPlacementByProviders={getInboxPlacementByProviders}
+          resetState={resetState}
           id={101}
           history={{ replace: jest.fn() }}
-          StopTestComponent={StopTest}/>
+          error={null}
+          StopTestComponent={StopTest}
+          {...props}/>
       </Router>);
 
-    expect(getAllInboxPlacementMessages).toHaveBeenCalled();
-    expect(getInboxPlacementByProviders).toHaveBeenCalled();
+    it('calls getInboxPlacementTest on load', () => {
+      subjectMounted();
+      expect(getAllInboxPlacementMessages).toHaveBeenCalled();
+      expect(getInboxPlacementByProviders).toHaveBeenCalled();
+    });
+
+    it('calls resetState on unmount', () => {
+      const wrapper = subjectMounted();
+      wrapper.unmount();
+      expect(resetState).toHaveBeenCalled();
+    });
   });
 
   it('renders loading', () => {

--- a/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
+++ b/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
@@ -43,7 +43,7 @@ describe('Page: All Inbox Placement Messages Test', () => {
     mount(
       <Router>
         <AllMessagesPage
-          filterType={'mailbox-providers'}
+          filterType={'mailbox-provider'}
           filterName={'gmail.com'}
           status={'completed'}
           messages={[]}

--- a/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
@@ -1,6 +1,8 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { TestDetailsPage } from '../TestDetailsPage';
+import { StopTest } from '../components/StopTest';
+
 
 describe('Page: Single Inbox Placement Test', () => {
   const subject = ({ ...props }) => {
@@ -37,7 +39,8 @@ describe('Page: Single Inbox Placement Test', () => {
       getInboxPlacementTestContent={getInboxPlacementTestContent}
       id={101}
       tabIndex={1} //not working nicely with tabIndex=0; TestDetails component
-      history={{ replace: jest.fn() }}/>);
+      history={{ replace: jest.fn() }}
+      StopTestComponent={StopTest}/>);
 
     expect(getInboxPlacementTest).toHaveBeenCalled();
     expect(getInboxPlacementByProviders).toHaveBeenCalled();
@@ -83,6 +86,7 @@ describe('Page: Single Inbox Placement Test', () => {
       getInboxPlacementTest={jest.fn()}
       getInboxPlacementByProviders={jest.fn()}
       getInboxPlacementTestContent={jest.fn()}
+      StopTestComponent={StopTest}
     />);
     wrapper.find('Tab').last().simulate('click');
     expect(mockHistory.replace).toHaveBeenCalled();

--- a/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
@@ -52,44 +52,48 @@ exports[`Page: All Inbox Placement Messages Test renders page correctly with def
             className="Panel"
           >
             <InfoBlock
-              className="Deliverability"
               columnProps={
                 Object {
                   "md": 3,
                 }
               }
               label="Sent"
+              labelClassName="DeliverabilityHeader"
               value={100}
+              valueClassName="DeliverabilityValue"
             />
             <InfoBlock
-              className="Deliverability"
               columnProps={
                 Object {
                   "md": 3,
                 }
               }
               label="Inbox"
+              labelClassName="DeliverabilityHeader"
               value={100}
+              valueClassName="DeliverabilityValue"
             />
             <InfoBlock
-              className="Deliverability"
               columnProps={
                 Object {
                   "md": 3,
                 }
               }
               label="Spam"
+              labelClassName="DeliverabilityHeader"
               value={0}
+              valueClassName="DeliverabilityValue"
             />
             <InfoBlock
-              className="Deliverability"
               columnProps={
                 Object {
                   "md": 3,
                 }
               }
               label="Missing"
+              labelClassName="DeliverabilityHeader"
               value={0}
+              valueClassName="DeliverabilityValue"
             />
           </Grid>
         </div>
@@ -107,34 +111,37 @@ exports[`Page: All Inbox Placement Messages Test renders page correctly with def
           className="Panel"
         >
           <InfoBlock
-            className="Authentication"
             columnProps={
               Object {
                 "md": 4,
               }
             }
             label="SPF"
+            labelClassName="AuthenticationHeader"
             value="100%"
+            valueClassName="AuthenticationValue"
           />
           <InfoBlock
-            className="Authentication"
             columnProps={
               Object {
                 "md": 4,
               }
             }
             label="DKIM"
+            labelClassName="AuthenticationHeader"
             value="100%"
+            valueClassName="AuthenticationValue"
           />
           <InfoBlock
-            className="Authentication"
             columnProps={
               Object {
                 "md": 4,
               }
             }
             label="DMARC"
+            labelClassName="AuthenticationHeader"
             value="100%"
+            valueClassName="AuthenticationValue"
           />
         </Grid>
       </Grid.Column>

--- a/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
@@ -37,7 +37,8 @@ exports[`Page: All Inbox Placement Messages Test renders page correctly with def
     </Panel.Section>
     <Grid>
       <Grid.Column
-        md={7}
+        lg={7}
+        md={12}
       >
         <div
           className="Divider"
@@ -47,95 +48,95 @@ exports[`Page: All Inbox Placement Messages Test renders page correctly with def
           >
             Deliverability
           </h5>
-          <div
-            className="Delivery"
-          >
-            <Grid
-              className="Panel"
-            >
-              <InfoBlock
-                columnProps={
-                  Object {
-                    "md": 3,
-                  }
-                }
-                label="Sent"
-                value={100}
-              />
-              <InfoBlock
-                columnProps={
-                  Object {
-                    "md": 3,
-                  }
-                }
-                label="Inbox"
-                value={100}
-              />
-              <InfoBlock
-                columnProps={
-                  Object {
-                    "md": 3,
-                  }
-                }
-                label="Spam"
-                value={0}
-              />
-              <InfoBlock
-                columnProps={
-                  Object {
-                    "md": 3,
-                  }
-                }
-                label="Missing"
-                value={0}
-              />
-            </Grid>
-          </div>
-        </div>
-      </Grid.Column>
-      <Grid.Column
-        md={5}
-      >
-        <div
-          className="Divider"
-        >
-          <h5
-            className="Title"
-          >
-            Authentication
-          </h5>
           <Grid
             className="Panel"
           >
             <InfoBlock
+              className="Deliverability"
               columnProps={
                 Object {
-                  "md": 4,
+                  "md": 3,
                 }
               }
-              label="SPF"
-              value="100%"
+              label="Sent"
+              value={100}
             />
             <InfoBlock
+              className="Deliverability"
               columnProps={
                 Object {
-                  "md": 4,
+                  "md": 3,
                 }
               }
-              label="DKIM"
-              value="100%"
+              label="Inbox"
+              value={100}
             />
             <InfoBlock
+              className="Deliverability"
               columnProps={
                 Object {
-                  "md": 4,
+                  "md": 3,
                 }
               }
-              label="DMARC"
-              value="100%"
+              label="Spam"
+              value={0}
+            />
+            <InfoBlock
+              className="Deliverability"
+              columnProps={
+                Object {
+                  "md": 3,
+                }
+              }
+              label="Missing"
+              value={0}
             />
           </Grid>
         </div>
+      </Grid.Column>
+      <Grid.Column
+        lg={5}
+        md={12}
+      >
+        <h5
+          className="Title"
+        >
+          Authentication
+        </h5>
+        <Grid
+          className="Panel"
+        >
+          <InfoBlock
+            className="Authentication"
+            columnProps={
+              Object {
+                "md": 4,
+              }
+            }
+            label="SPF"
+            value="100%"
+          />
+          <InfoBlock
+            className="Authentication"
+            columnProps={
+              Object {
+                "md": 4,
+              }
+            }
+            label="DKIM"
+            value="100%"
+          />
+          <InfoBlock
+            className="Authentication"
+            columnProps={
+              Object {
+                "md": 4,
+              }
+            }
+            label="DMARC"
+            value="100%"
+          />
+        </Grid>
       </Grid.Column>
     </Grid>
   </Panel>

--- a/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page: All Inbox Placement Messages Test handles errors 1`] = `
+<RedirectAndAlert
+  alert={
+    Object {
+      "message": "You dun goofed",
+      "type": "error",
+    }
+  }
+  to="/inbox-placement/details/0"
+/>
+`;
+
+exports[`Page: All Inbox Placement Messages Test renders page correctly with defaults 1`] = `
+<Page
+  breadcrumbAction={
+    Object {
+      "content": "Inbox Placement Results",
+      "onClick": [Function],
+    }
+  }
+  empty={Object {}}
+  primaryArea={
+    <Connect(StopTest)
+      id={0}
+      reload={[Function]}
+    />
+  }
+  title="Inbox Placement"
+>
+  <Panel>
+    <Panel.Section>
+      <h3>
+        Diagnostics
+      </h3>
+    </Panel.Section>
+    <Grid>
+      <Grid.Column
+        md={7}
+      >
+        <div
+          className="Divider"
+        >
+          <h5
+            className="Title"
+          >
+            Deliverability
+          </h5>
+          <div
+            className="Delivery"
+          >
+            <Grid
+              className="Panel"
+            >
+              <InfoBlock
+                columnProps={
+                  Object {
+                    "md": 3,
+                  }
+                }
+                label="Sent"
+                value={100}
+              />
+              <InfoBlock
+                columnProps={
+                  Object {
+                    "md": 3,
+                  }
+                }
+                label="Inbox"
+                value={100}
+              />
+              <InfoBlock
+                columnProps={
+                  Object {
+                    "md": 3,
+                  }
+                }
+                label="Spam"
+                value={0}
+              />
+              <InfoBlock
+                columnProps={
+                  Object {
+                    "md": 3,
+                  }
+                }
+                label="Missing"
+                value={0}
+              />
+            </Grid>
+          </div>
+        </div>
+      </Grid.Column>
+      <Grid.Column
+        md={5}
+      >
+        <div
+          className="Divider"
+        >
+          <h5
+            className="Title"
+          >
+            Authentication
+          </h5>
+          <Grid
+            className="Panel"
+          >
+            <InfoBlock
+              columnProps={
+                Object {
+                  "md": 4,
+                }
+              }
+              label="SPF"
+              value="100%"
+            />
+            <InfoBlock
+              columnProps={
+                Object {
+                  "md": 4,
+                }
+              }
+              label="DKIM"
+              value="100%"
+            />
+            <InfoBlock
+              columnProps={
+                Object {
+                  "md": 4,
+                }
+              }
+              label="DMARC"
+              value="100%"
+            />
+          </Grid>
+        </div>
+      </Grid.Column>
+    </Grid>
+  </Panel>
+  <Panel
+    title="Seed Diagnostics"
+  >
+    <AllMessagesCollectiom />
+  </Panel>
+</Page>
+`;

--- a/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
@@ -143,7 +143,7 @@ exports[`Page: All Inbox Placement Messages Test renders page correctly with def
   <Panel
     title="Seed Diagnostics"
   >
-    <AllMessagesCollectiom />
+    <AllMessagesCollection />
   </Panel>
 </Page>
 `;

--- a/src/pages/inboxPlacement/tests/__snapshots__/TestDetailsPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/TestDetailsPage.test.js.snap
@@ -22,8 +22,9 @@ exports[`Page: Single Inbox Placement Test renders page correctly with defaults 
   }
   empty={Object {}}
   primaryArea={
-    <StopTest
-      onStop={[Function]}
+    <Connect(StopTest)
+      id={0}
+      reload={[Function]}
     />
   }
   subtitle="Results"

--- a/src/reducers/inboxPlacement.js
+++ b/src/reducers/inboxPlacement.js
@@ -4,7 +4,9 @@ const initialState = {
   seeds: [],
   testsPending: true,
   tests: [],
-  stopTestPending: false
+  stopTestPending: false,
+  placementsByProvider: [],
+  allMessages: []
 };
 
 export default (state = initialState, { type, payload }) => {
@@ -50,6 +52,13 @@ export default (state = initialState, { type, payload }) => {
       return { ...state, getTestContentPending: false, currentTestContent: payload, getTestContentError: null };
     case 'GET_INBOX_PLACEMENT_TEST_CONTENT_FAIL':
       return { ...state, getTestContentPending: false, getTestContentError: payload };
+
+    case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_PENDING':
+      return { ...state, getAllMessagesPending: true, getAllMessagesError: null };
+    case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_SUCCESS':
+      return { ...state, getAllMessagesPending: false, allMessages: payload, getAllMessagesError: null };
+    case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_FAIL':
+      return { ...state, getAllMessagesPending: false, getAllMessagesError: payload };
 
     default:
       return state;

--- a/src/reducers/inboxPlacement.js
+++ b/src/reducers/inboxPlacement.js
@@ -54,11 +54,14 @@ export default (state = initialState, { type, payload }) => {
       return { ...state, getTestContentPending: false, getTestContentError: payload };
 
     case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_PENDING':
-      return { ...state, getAllMessagesPending: true, getAllMessagesError: null };
+      return { ...state, getAllMessagesPending: true, getAllMessagesError: null, allMessages: []};
     case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_SUCCESS':
       return { ...state, getAllMessagesPending: false, allMessages: payload, getAllMessagesError: null };
     case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_FAIL':
       return { ...state, getAllMessagesPending: false, getAllMessagesError: payload };
+
+    case 'RESET_STATE':
+      return { state: initialState };
 
     default:
       return state;

--- a/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
+++ b/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
@@ -251,3 +251,18 @@ Object {
   "testsPending": false,
 }
 `;
+
+exports[`Inbox Placement Reducer resets State 1`] = `
+Object {
+  "state": Object {
+    "allMessages": Array [],
+    "currentTestDetails": Object {},
+    "placementsByProvider": Array [],
+    "seeds": Array [],
+    "seedsPending": false,
+    "stopTestPending": false,
+    "tests": Array [],
+    "testsPending": true,
+  },
+}
+`;

--- a/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
+++ b/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
@@ -1,10 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Inbox Placement Reducer get all inbox placement test messages fail 1`] = `
+Object {
+  "allMessages": Array [],
+  "currentTestDetails": Object {},
+  "getAllMessagesError": Object {
+    "errors": Array [
+      Object {
+        "message": "Some error occurred",
+      },
+    ],
+  },
+  "getAllMessagesPending": false,
+  "placementsByProvider": Array [],
+  "seeds": Array [],
+  "seedsPending": false,
+  "stopTestPending": false,
+  "tests": Array [],
+  "testsPending": true,
+}
+`;
+
+exports[`Inbox Placement Reducer get all inbox placement test messages pending 1`] = `
+Object {
+  "allMessages": Array [],
+  "currentTestDetails": Object {},
+  "getAllMessagesError": null,
+  "getAllMessagesPending": true,
+  "placementsByProvider": Array [],
+  "seeds": Array [],
+  "seedsPending": false,
+  "stopTestPending": false,
+  "tests": Array [],
+  "testsPending": true,
+}
+`;
+
+exports[`Inbox Placement Reducer get all inbox placement test messages success 1`] = `
+Object {
+  "allMessages": Object {
+    "fakeData": true,
+  },
+  "currentTestDetails": Object {},
+  "getAllMessagesError": null,
+  "getAllMessagesPending": false,
+  "placementsByProvider": Array [],
+  "seeds": Array [],
+  "seedsPending": false,
+  "stopTestPending": false,
+  "tests": Array [],
+  "testsPending": true,
+}
+`;
+
 exports[`Inbox Placement Reducer get specific inbox placement test content pending 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
   "getTestContentError": null,
   "getTestContentPending": true,
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -15,6 +70,7 @@ Object {
 
 exports[`Inbox Placement Reducer get specific inbox placement test content pending fail 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
   "getTestContentError": Object {
     "errors": Array [
@@ -24,6 +80,7 @@ Object {
     ],
   },
   "getTestContentPending": false,
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -34,12 +91,14 @@ Object {
 
 exports[`Inbox Placement Reducer get specific inbox placement test content success 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestContent": Object {
     "fakeData": true,
   },
   "currentTestDetails": Object {},
   "getTestContentError": null,
   "getTestContentPending": false,
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -50,9 +109,11 @@ Object {
 
 exports[`Inbox Placement Reducer get specific inbox placement test pending 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
   "getTestError": null,
   "getTestPending": true,
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -63,6 +124,7 @@ Object {
 
 exports[`Inbox Placement Reducer get specific inbox placement test pending fail 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
   "getTestError": Object {
     "errors": Array [
@@ -72,6 +134,7 @@ Object {
     ],
   },
   "getTestPending": false,
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -82,11 +145,13 @@ Object {
 
 exports[`Inbox Placement Reducer get specific inbox placement test success 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {
     "fakeData": true,
   },
   "getTestError": null,
   "getTestPending": false,
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -97,7 +162,9 @@ Object {
 
 exports[`Inbox Placement Reducer list seeds fail 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsError": undefined,
   "seedsPending": false,
@@ -109,7 +176,9 @@ Object {
 
 exports[`Inbox Placement Reducer list seeds pending 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsError": null,
   "seedsPending": true,
@@ -121,7 +190,9 @@ Object {
 
 exports[`Inbox Placement Reducer list seeds success 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
+  "placementsByProvider": Array [],
   "seeds": undefined,
   "seedsError": null,
   "seedsPending": false,
@@ -133,7 +204,9 @@ Object {
 
 exports[`Inbox Placement Reducer list tests fail 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -151,7 +224,9 @@ Object {
 
 exports[`Inbox Placement Reducer list tests pending 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,
@@ -163,7 +238,9 @@ Object {
 
 exports[`Inbox Placement Reducer list tests success 1`] = `
 Object {
+  "allMessages": Array [],
   "currentTestDetails": Object {},
+  "placementsByProvider": Array [],
   "seeds": Array [],
   "seedsPending": false,
   "stopTestPending": false,

--- a/src/reducers/tests/inboxPlacement.test.js
+++ b/src/reducers/tests/inboxPlacement.test.js
@@ -43,6 +43,17 @@ const TEST_CASES = {
   'get specific inbox placement test content pending fail': {
     payload: { errors: [ { message: 'Some error occurred' }]},
     type: 'GET_INBOX_PLACEMENT_TEST_CONTENT_FAIL'
+  },
+  'get all inbox placement test messages pending': {
+    type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES_PENDING'
+  },
+  'get all inbox placement test messages success': {
+    payload: { fakeData: true },
+    type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES_SUCCESS'
+  },
+  'get all inbox placement test messages fail': {
+    payload: { errors: [ { message: 'Some error occurred' }]},
+    type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES_FAIL'
   }
 };
 

--- a/src/reducers/tests/inboxPlacement.test.js
+++ b/src/reducers/tests/inboxPlacement.test.js
@@ -54,6 +54,9 @@ const TEST_CASES = {
   'get all inbox placement test messages fail': {
     payload: { errors: [ { message: 'Some error occurred' }]},
     type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES_FAIL'
+  },
+  'resets State': {
+    type: 'RESET_STATE'
   }
 };
 


### PR DESCRIPTION

### What Changed
 - Update StopTest component to be more independent. Moved the dispatched calls into the component rather than being passed as a prop.
 - Updated the InfoBox component to have custom css styling. Also removed the break tag as it didn't seem to affect the current implementations. 
 - Added new routes and action/reducers for the all messages page /endpoint. 
 - Created the all messages page. Currently only supports mailbox-providers but code for future sending ip support is included. 
 - Added link to the all messages page in the details page in the breakdown by mailbox provider section

### How To Test
 - Go to /inbox-placement. Click on any (real) test. On the details page, scroll down and click on one of the mailbox-providers. Verify that the new page looks like the mocks. 

### To Do
- [ ] UX feedback
