### PR TITLE
TR-1750: AMP enabled Test Emails Sent in-app always send with open tracking enabled

### DIFF
--- a/src/pages/templates/CreatePage.container.js
+++ b/src/pages/templates/CreatePage.container.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import { create, getDraft } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 
-// Selectors
+import { selectDefaultTemplateOptions } from 'src/selectors/accessConditionState';
 import { selectAndCloneDraftById, selectDefaultTestData } from 'src/selectors/templates';
 
 import CreatePage from './CreatePage';
@@ -24,6 +24,7 @@ const mapStateToProps = (state, props) => ({
   formName: FORM_NAME,
   initialValues: {
     assignTo: 'master',
+    options: selectDefaultTemplateOptions(state),
     testData: selectDefaultTestData(),
     ...selectAndCloneDraftById(state, props.match.params.id)
   }

--- a/src/pages/templates/CreatePage.container.js
+++ b/src/pages/templates/CreatePage.container.js
@@ -8,7 +8,7 @@ import { create, getDraft } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 
 // Selectors
-import { selectClonedTemplate, selectDefaultTestData } from 'src/selectors/templates';
+import { selectAndCloneDraftById, selectDefaultTestData } from 'src/selectors/templates';
 
 import CreatePage from './CreatePage';
 
@@ -25,7 +25,7 @@ const mapStateToProps = (state, props) => ({
   initialValues: {
     assignTo: 'master',
     testData: selectDefaultTestData(),
-    ...selectClonedTemplate(state, props)
+    ...selectAndCloneDraftById(state, props.match.params.id)
   }
 });
 

--- a/src/pages/templates/CreatePage.container.js
+++ b/src/pages/templates/CreatePage.container.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import { create, getDraft } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 
-import { selectDefaultTemplateOptions } from 'src/selectors/accessConditionState';
+import { selectDefaultTemplateOptions } from 'src/selectors/account';
 import { selectAndCloneDraftById, selectDefaultTestData } from 'src/selectors/templates';
 
 import CreatePage from './CreatePage';

--- a/src/pages/templates/EditPage.container.js
+++ b/src/pages/templates/EditPage.container.js
@@ -5,7 +5,7 @@ import { getFormValues, isValid, reduxForm } from 'redux-form';
 import { getDraft, update, deleteTemplate, publish, getTestData, setTestData } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 import { hasGrants } from 'src/helpers/conditions';
-import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
+import { selectDraftTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, hasSubaccounts, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 
 import EditPage from './EditPage';
@@ -13,7 +13,7 @@ import EditPage from './EditPage';
 const FORM_NAME = 'templateEdit';
 
 const mapStateToProps = (state, props) => {
-  const template = selectTemplateById(state, props).draft;
+  const template = selectDraftTemplateById(state, props.match.params.id);
   const canModify = hasGrants('templates/modify')(state);
   const canSend = hasGrants('transmissions/modify')(state);
 

--- a/src/pages/templates/PreviewDraftPage.container.js
+++ b/src/pages/templates/PreviewDraftPage.container.js
@@ -3,7 +3,7 @@ import { withRouter } from 'react-router-dom';
 
 import { showAlert } from 'src/actions/globalAlert';
 import { getDraftAndPreview, sendPreview } from 'src/actions/templates';
-import { selectDraftTemplate, selectDraftTemplatePreview } from 'src/selectors/templates';
+import { selectDraftTemplateById, selectDraftTemplatePreview } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery } from 'src/selectors/subaccounts';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { hasGrants } from 'src/helpers/conditions';
@@ -17,7 +17,7 @@ export const mapStateToProps = (state, props) => {
     canSendEmail: hasGrants('transmissions/modify')(state),
     returnPath: `/templates/edit/${props.match.params.id}${setSubaccountQuery(subaccountId)}`,
     preview: selectDraftTemplatePreview(state, props.match.params.id),
-    template: selectDraftTemplate(state, props.match.params.id),
+    template: selectDraftTemplateById(state, props.match.params.id),
     subaccountId
   };
 };

--- a/src/pages/templates/PreviewPublishedPage.container.js
+++ b/src/pages/templates/PreviewPublishedPage.container.js
@@ -3,7 +3,7 @@ import { withRouter } from 'react-router-dom';
 
 import { showAlert } from 'src/actions/globalAlert';
 import { getPublishedAndPreview, sendPreview } from 'src/actions/templates';
-import { selectPublishedTemplate, selectPublishedTemplatePreview } from 'src/selectors/templates';
+import { selectPublishedTemplateById, selectPublishedTemplatePreview } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery } from 'src/selectors/subaccounts';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { hasGrants } from 'src/helpers/conditions';
@@ -17,7 +17,7 @@ export const mapStateToProps = (state, props) => {
     canSendEmail: hasGrants('transmissions/modify')(state),
     returnPath: `/templates/edit/${props.match.params.id}/published${setSubaccountQuery(subaccountId)}`,
     preview: selectPublishedTemplatePreview(state, props.match.params.id),
-    template: selectPublishedTemplate(state, props.match.params.id),
+    template: selectPublishedTemplateById(state, props.match.params.id),
     subaccountId
   };
 };

--- a/src/pages/templates/PublishedPage.container.js
+++ b/src/pages/templates/PublishedPage.container.js
@@ -4,7 +4,7 @@ import { reduxForm } from 'redux-form';
 
 import { getPublished, getTestData, setTestData } from 'src/actions/templates';
 import { hasGrants } from 'src/helpers/conditions';
-import { selectTemplateById, selectTemplateTestData } from 'src/selectors/templates';
+import { selectPublishedTemplateById, selectTemplateTestData } from 'src/selectors/templates';
 import { selectSubaccountIdFromQuery, selectSubaccountFromQuery } from 'src/selectors/subaccounts';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 import { showAlert } from 'src/actions/globalAlert';
@@ -14,12 +14,11 @@ import PublishedPage from './PublishedPage';
 const FORM_NAME = 'templatePublished';
 
 const mapStateToProps = (state, props) => {
-  const template = selectTemplateById(state, props).published;
+  const template = selectPublishedTemplateById(state, props.match.params.id);
 
   return {
     loading: state.templates.getPublishedLoading,
     getPublishedError: state.templates.getPublishedError,
-    template,
     canModify: hasGrants('templates/modify')(state),
     subaccountId: selectSubaccountIdFromQuery(state, props),
     hasSubaccounts: hasSubaccounts(state),

--- a/src/pages/templatesV2/CreatePage.container.js
+++ b/src/pages/templatesV2/CreatePage.container.js
@@ -6,19 +6,21 @@ import _ from 'lodash';
 import { create, getDraft } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 import { list as listDomains } from 'src/actions/sendingDomains';
+import { selectDefaultTemplateOptions } from 'src/selectors/accessConditionState';
 
 import CreatePage from './CreatePage';
 
 const formName = 'templateCreate';
 const selector = formValueSelector(formName);
 
-const mapStateToProps = (state, props) => ({
+const mapStateToProps = (state) => ({
   id: selector(state, 'id'),
   loading: state.templates.getDraftLoading,
   subaccountId: _.get(selector(state, 'subaccount'), 'id'),
   formName: formName,
   initialValues: {
-    assignTo: 'master'
+    assignTo: 'master',
+    options: selectDefaultTemplateOptions(state) // not visible to users, but needed
   }
 });
 

--- a/src/pages/templatesV2/CreatePage.container.js
+++ b/src/pages/templatesV2/CreatePage.container.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { create, getDraft } from 'src/actions/templates';
 import { showAlert } from 'src/actions/globalAlert';
 import { list as listDomains } from 'src/actions/sendingDomains';
-import { selectDefaultTemplateOptions } from 'src/selectors/accessConditionState';
+import { selectDefaultTemplateOptions } from 'src/selectors/account';
 
 import CreatePage from './CreatePage';
 

--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -14,10 +14,10 @@ import {
 import { list as listDomains } from 'src/actions/sendingDomains';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 import {
-  selectDraftTemplate,
+  selectDraftTemplateById,
   selectDraftTemplatePreview,
   selectPreviewLineErrors,
-  selectPublishedTemplate
+  selectPublishedTemplateById
 } from 'src/selectors/templates';
 import { EditorContextProvider } from './context/EditorContext';
 import EditAndPreviewPage from './EditAndPreviewPage';
@@ -30,8 +30,8 @@ const EditAndPreviewPageContainer = (props) => (
 
 const mapStateToProps = (state, props) => {
   const id = props.match.params.id;
-  const draft = selectDraftTemplate(state, id);
-  const published = selectPublishedTemplate(state, id);
+  const draft = selectDraftTemplateById(state, id);
+  const published = selectPublishedTemplateById(state, id);
   const isPublishedMode = props.match.params.version === 'published';
   const draftOrPublished = draft || published;
   const hasDraft = draftOrPublished && draftOrPublished.has_draft;

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -11,6 +11,21 @@ export const getCurrentAccountPlan = createSelector(
   (account, plans) => plans.find((plan) => plan.code === account.subscription.code) || {}
 );
 
+export const selectDefaultTemplateOptions = createSelector(
+  [getAccount],
+  ({
+    options: {
+      click_tracking,
+      rest_tracking_default,
+      transactional_default
+    }
+  }) => ({
+    click_tracking: click_tracking,
+    open_tracking: rest_tracking_default,
+    transactional: transactional_default
+  })
+);
+
 const selectAccessConditionState = createSelector(
   [getAccount, getUser, getPlans, getCurrentAccountPlan, getACReady],
   (account, currentUser, plans, accountPlan, ready) => ({
@@ -33,4 +48,3 @@ export default selectAccessConditionState;
  */
 
 export const selectCondition = (condition) => createSelector([selectAccessConditionState], condition);
-

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -11,21 +11,6 @@ export const getCurrentAccountPlan = createSelector(
   (account, plans) => plans.find((plan) => plan.code === account.subscription.code) || {}
 );
 
-export const selectDefaultTemplateOptions = createSelector(
-  [getAccount],
-  ({
-    options: {
-      click_tracking,
-      rest_tracking_default,
-      transactional_default
-    }
-  }) => ({
-    click_tracking: click_tracking,
-    open_tracking: rest_tracking_default,
-    transactional: transactional_default
-  })
-);
-
 const selectAccessConditionState = createSelector(
   [getAccount, getUser, getPlans, getCurrentAccountPlan, getACReady],
   (account, currentUser, plans, accountPlan, ready) => ({

--- a/src/selectors/account.js
+++ b/src/selectors/account.js
@@ -3,6 +3,8 @@ import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
 import { getCurrentAccountPlan, selectCondition } from 'src/selectors/accessConditionState';
 import getConfig from 'src/helpers/getConfig';
 
+const getAccount = (state) => state.account;
+
 export const hasAutoVerifyEnabledSelector = createSelector(
   getCurrentAccountPlan,
   selectCondition(hasAccountOptionEnabled('auto_verify_domains')),
@@ -15,3 +17,19 @@ export const selectHasAnyoneAtDomainVerificationEnabled = accountOptionWithFallb
 export const selectTrackingDomainCname = accountOptionWithFallback('tracking_domain_cname', 'trackingDomains.cnameValue');
 export const selectAllowDefaultBounceDomains = accountOptionWithFallback('allow_default_bounce_domain', 'bounceDomains.allowDefault');
 export const selectAllSubaccountDefaultBounceDomains = accountOptionWithFallback('allow_subaccount_default_bounce_domain', 'bounceDomains.allowSubaccountDefault');
+
+// note, the default template options derive from account options
+export const selectDefaultTemplateOptions = createSelector(
+  [getAccount],
+  ({
+    options: {
+      click_tracking,
+      rest_tracking_default,
+      transactional_default
+    }
+  }) => ({
+    click_tracking: click_tracking || rest_tracking_default,
+    open_tracking: rest_tracking_default,
+    transactional: transactional_default
+  })
+);

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -24,15 +24,14 @@ export const selectPreviewLineErrors = (state) => (
 export const selectDefaultTestData = () => JSON.stringify(config.templates.testData, null, 2);
 export const selectTemplateTestData = (state) => JSON.stringify(state.templates.testData || config.templates.testData, null, 2);
 
-export const cloneTemplate = (template) => Object.assign({ ...template }, { name: `${template.name} Copy`, id: `${template.id}-copy` });
-
-export const selectClonedTemplate = (state, props) => {
-  const template = selectTemplateById(state, props);
-
-  if (_.get(props, 'match.params.id') && !_.isEmpty(template.draft)) {
-    return cloneTemplate(template.draft);
+export const selectAndCloneDraftById = createSelector(
+  [selectDraftTemplate],
+  (draft) => {
+    if (!_.isEmpty(draft)) {
+      return { ...draft, name: `${draft.name} Copy`, id: `${draft.id}-copy` };
+    }
   }
-};
+);
 
 // Selects sending domains for From Email typeahead
 export const selectDomainsBySubaccount = createSelector(

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import config from 'src/config';
 import { createSelector } from 'reselect';
-import { selectDefaultTemplateOptions } from 'src/selectors/accessConditionState';
+import { selectDefaultTemplateOptions } from 'src/selectors/account';
 import { getDomains, isVerified } from 'src/selectors/sendingDomains';
 import { hasSubaccounts, selectSubaccountIdFromProps } from 'src/selectors/subaccounts';
 import { filterTemplatesBySubaccount } from 'src/helpers/templates';

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -12,9 +12,6 @@ export const getPublishedTemplateById = (state, id) => _.get(state, ['templates'
 export const selectTemplates = (state) => state.templates.list;
 export const selectPublishedTemplates = (state) => _.filter(state.templates.list, (template) => template.has_published);
 
-export const selectDraftTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'draft']);
-export const selectPublishedTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);
-
 const createTemplateSelector = (getter) => createSelector(
   [getter, selectDefaultTemplateOptions],
   (template, defaultOptions) => {

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -16,13 +16,15 @@ export const selectTemplateById = (state, props) => state.templates.byId[props.m
 export const selectDraftTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'draft']);
 export const selectPublishedTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);
 
-export const selectDraftTemplateById = createSelector(
-  [getDraftTemplateById, selectDefaultTemplateOptions],
-  (draft, defaultOptions) => {
-    if (!draft) { return; }
-    return { ...draft, options: { ...defaultOptions, ...draft.options }};
+const createTemplateSelector = (getter) => createSelector(
+  [getter, selectDefaultTemplateOptions],
+  (template, defaultOptions) => {
+    if (!template) { return; }
+    return { ...template, options: { ...defaultOptions, ...template.options }};
   }
 );
+export const selectDraftTemplateById = createTemplateSelector(getDraftTemplateById);
+export const selectPublishedTemplateById = createTemplateSelector(getPublishedTemplateById);
 
 export const selectDraftTemplatePreview = (state, id, defaultValue) => (
   state.templates.contentPreview.draft[id] || defaultValue

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -1,9 +1,13 @@
 import _ from 'lodash';
 import config from 'src/config';
 import { createSelector } from 'reselect';
+import { selectDefaultTemplateOptions } from 'src/selectors/accessConditionState';
 import { getDomains, isVerified } from 'src/selectors/sendingDomains';
 import { hasSubaccounts, selectSubaccountIdFromProps } from 'src/selectors/subaccounts';
 import { filterTemplatesBySubaccount } from 'src/helpers/templates';
+
+export const getDraftTemplateById = (state, id) => _.get(state, ['templates', 'byId', id, 'draft']);
+export const getPublishedTemplateById = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);
 
 export const selectTemplates = (state) => state.templates.list;
 export const selectPublishedTemplates = (state) => _.filter(state.templates.list, (template) => template.has_published);
@@ -11,6 +15,15 @@ export const selectTemplateById = (state, props) => state.templates.byId[props.m
 
 export const selectDraftTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'draft']);
 export const selectPublishedTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);
+
+export const selectDraftTemplateById = createSelector(
+  [getDraftTemplateById, selectDefaultTemplateOptions],
+  (draft, defaultOptions) => {
+    if (!draft) { return; }
+    return { ...draft, options: { ...defaultOptions, ...draft.options }};
+  }
+);
+
 export const selectDraftTemplatePreview = (state, id, defaultValue) => (
   state.templates.contentPreview.draft[id] || defaultValue
 );
@@ -25,11 +38,10 @@ export const selectDefaultTestData = () => JSON.stringify(config.templates.testD
 export const selectTemplateTestData = (state) => JSON.stringify(state.templates.testData || config.templates.testData, null, 2);
 
 export const selectAndCloneDraftById = createSelector(
-  [selectDraftTemplate],
+  [selectDraftTemplateById],
   (draft) => {
-    if (!_.isEmpty(draft)) {
-      return { ...draft, name: `${draft.name} Copy`, id: `${draft.id}-copy` };
-    }
+    if (!draft) { return; }
+    return { ...draft, name: `${draft.name} Copy`, id: `${draft.id}-copy` };
   }
 );
 

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -11,7 +11,6 @@ export const getPublishedTemplateById = (state, id) => _.get(state, ['templates'
 
 export const selectTemplates = (state) => state.templates.list;
 export const selectPublishedTemplates = (state) => _.filter(state.templates.list, (template) => template.has_published);
-export const selectTemplateById = (state, props) => state.templates.byId[props.match.params.id] || { draft: {}, published: {}};
 
 export const selectDraftTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'draft']);
 export const selectPublishedTemplate = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -56,16 +56,6 @@ Object {
 }
 `;
 
-exports[`Templates selectors selectAndCloneDraftById should clone template if :id exist in state 1`] = `
-Object {
-  "id": "ape-copy",
-  "name": "Ape Copy",
-  "published": false,
-}
-`;
-
-exports[`Templates selectors selectAndCloneDraftById should not clone template if :id does not exist 1`] = `undefined`;
-
 exports[`Templates selectors selectDefaultTestData should return default test data 1`] = `
 "{
   \\"substitution_data\\": {},

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Templates selectors .selectDraftTemplate returns draft template 1`] = `
-Object {
-  "id": "ape",
-  "name": "Ape",
-  "published": false,
-}
-`;
-
-exports[`Templates selectors .selectDraftTemplate returns undefined when unknown 1`] = `undefined`;
-
 exports[`Templates selectors .selectDraftTemplatePreview returns default value when unknown 1`] = `Object {}`;
 
 exports[`Templates selectors .selectDraftTemplatePreview returns preview of draft template 1`] = `
@@ -20,16 +10,6 @@ Object {
 `;
 
 exports[`Templates selectors .selectDraftTemplatePreview returns undefined when unknown 1`] = `undefined`;
-
-exports[`Templates selectors .selectPublishedTemplate returns published template 1`] = `
-Object {
-  "id": "ape",
-  "name": "Ape",
-  "published": true,
-}
-`;
-
-exports[`Templates selectors .selectPublishedTemplate returns undefined when unknown 1`] = `undefined`;
 
 exports[`Templates selectors .selectPublishedTemplatePreview returns default value when unknown 1`] = `Object {}`;
 

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -56,16 +56,7 @@ Object {
 }
 `;
 
-exports[`Templates selectors cloneTemplate clones template 1`] = `
-Object {
-  "content": Object {},
-  "id": "test-template-copy",
-  "name": "Test Template Copy",
-  "published": false,
-}
-`;
-
-exports[`Templates selectors getClonedTemplate should clone template if :id exist in state 1`] = `
+exports[`Templates selectors selectAndCloneDraftById should clone template if :id exist in state 1`] = `
 Object {
   "id": "ape-copy",
   "name": "Ape Copy",
@@ -73,7 +64,7 @@ Object {
 }
 `;
 
-exports[`Templates selectors getClonedTemplate should not clone template if :id does not exist 1`] = `undefined`;
+exports[`Templates selectors selectAndCloneDraftById should not clone template if :id does not exist 1`] = `undefined`;
 
 exports[`Templates selectors selectDefaultTestData should return default test data 1`] = `
 "{

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -42,20 +42,6 @@ Object {
 
 exports[`Templates selectors .selectPublishedTemplatePreview returns undefined when unknown 1`] = `undefined`;
 
-exports[`Templates selectors Templates by id Selector returns empty draft and published 1`] = `
-Object {
-  "draft": Object {},
-  "published": Object {},
-}
-`;
-
-exports[`Templates selectors Templates by id Selector returns template 1`] = `
-Object {
-  "draft": Object {},
-  "published": Object {},
-}
-`;
-
 exports[`Templates selectors selectDefaultTestData should return default test data 1`] = `
 "{
   \\"substitution_data\\": {},

--- a/src/selectors/tests/accessConditionState.test.js
+++ b/src/selectors/tests/accessConditionState.test.js
@@ -1,4 +1,7 @@
-import selectAccessCondtionState, { selectCondition } from '../accessConditionState';
+import selectAccessCondtionState, {
+  selectCondition,
+  selectDefaultTemplateOptions
+} from '../accessConditionState';
 
 jest.mock('src/helpers/conditions/account');
 
@@ -10,6 +13,11 @@ describe('Selector: Access Condition State', () => {
   beforeEach(() => {
     testState = {
       account: {
+        options: {
+          click_tracking: true,
+          rest_tracking_default: true,
+          transactional_default: false
+        },
         subscription: {
           code: 'plan2'
         }
@@ -44,4 +52,11 @@ describe('Selector: Access Condition State', () => {
     expect(testCondition).toHaveBeenCalledWith(testAccessConditionState);
   });
 
+  test('returns default template options', () => {
+    expect(selectDefaultTemplateOptions(testState)).toEqual({
+      click_tracking: true,
+      open_tracking: true,
+      transactional: false
+    });
+  });
 });

--- a/src/selectors/tests/accessConditionState.test.js
+++ b/src/selectors/tests/accessConditionState.test.js
@@ -1,7 +1,4 @@
-import selectAccessCondtionState, {
-  selectCondition,
-  selectDefaultTemplateOptions
-} from '../accessConditionState';
+import selectAccessCondtionState, { selectCondition } from '../accessConditionState';
 
 jest.mock('src/helpers/conditions/account');
 
@@ -13,11 +10,6 @@ describe('Selector: Access Condition State', () => {
   beforeEach(() => {
     testState = {
       account: {
-        options: {
-          click_tracking: true,
-          rest_tracking_default: true,
-          transactional_default: false
-        },
         subscription: {
           code: 'plan2'
         }
@@ -50,13 +42,5 @@ describe('Selector: Access Condition State', () => {
     const testCondition = jest.fn(() => true);
     expect(selectCondition(testCondition)(testState)).toEqual(true);
     expect(testCondition).toHaveBeenCalledWith(testAccessConditionState);
-  });
-
-  test('returns default template options', () => {
-    expect(selectDefaultTemplateOptions(testState)).toEqual({
-      click_tracking: true,
-      open_tracking: true,
-      transactional: false
-    });
   });
 });

--- a/src/selectors/tests/account.test.js
+++ b/src/selectors/tests/account.test.js
@@ -91,4 +91,22 @@ describe('Account Selectors', () => {
       expect(subject()).toEqual('this.example.com');
     });
   });
+
+  it('returns default template options', () => {
+    const state = {
+      account: {
+        options: {
+          click_tracking: true,
+          rest_tracking_default: true,
+          transactional_default: false
+        }
+      }
+    };
+
+    expect(accountSelectors.selectDefaultTemplateOptions(state)).toEqual({
+      click_tracking: true,
+      open_tracking: true,
+      transactional: false
+    });
+  });
 });

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -149,20 +149,6 @@ describe('Templates selectors', () => {
     });
   });
 
-  cases('.selectDraftTemplate', ({ id }) => {
-    expect(selector.selectDraftTemplate(store, id)).toMatchSnapshot();
-  }, {
-    'returns draft template': { id: 'ape' },
-    'returns undefined when unknown': { id: 'unknown' }
-  });
-
-  cases('.selectPublishedTemplate', ({ id }) => {
-    expect(selector.selectPublishedTemplate(store, id)).toMatchSnapshot();
-  }, {
-    'returns published template': { id: 'ape' },
-    'returns undefined when unknown': { id: 'unknown' }
-  });
-
   describe('selectDraftTemplateById', () => {
     it('returns template', () => {
       expect(selector.selectDraftTemplateById(store, 'lion')).toEqual({

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -134,28 +134,13 @@ describe('Templates selectors', () => {
     'returns default value when unknown': { id: 'unknown', defaultValue: {}}
   });
 
-  describe('cloneTemplate', () => {
-    const template = {
-      name: 'Test Template',
-      id: 'test-template',
-      published: false,
-      content: {}
-    };
-
-    it('clones template', () => {
-      expect(selector.cloneTemplate(template)).toMatchSnapshot();
-    });
-  });
-
-  describe('getClonedTemplate', () => {
+  describe('selectAndCloneDraftById', () => {
     it('should clone template if :id exist in state', () => {
-      const props = { match: { params: { id: 'ape' }}};
-      expect(selector.selectClonedTemplate(store, props)).toMatchSnapshot();
+      expect(selector.selectAndCloneDraftById(store, 'ape')).toMatchSnapshot();
     });
 
     it('should not clone template if :id does not exist', () => {
-      const props = { match: { params: { id: 'Nope' }}};
-      expect(selector.selectClonedTemplate(store, props)).toMatchSnapshot();
+      expect(selector.selectAndCloneDraftById(store, 'Nope')).toMatchSnapshot();
     });
   });
 

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -5,6 +5,13 @@ describe('Templates selectors', () => {
   let store;
   beforeEach(() => {
     store = {
+      account: { // yuck
+        options: {
+          click_tracking: true,
+          rest_tracking_default: true,
+          transactional_default: false
+        }
+      },
       templates: {
         list: [
           {
@@ -45,6 +52,18 @@ describe('Templates selectors', () => {
               name: 'Ape',
               id: 'ape',
               published: true
+            }
+          },
+          lion: {
+            draft: {
+              id: 'lion',
+              name: 'Lion',
+              published: false,
+              options: {
+                click_tracking: false,
+                open_tracking: false,
+                transactional: false
+              }
             }
           }
         },
@@ -92,6 +111,34 @@ describe('Templates selectors', () => {
     };
   });
 
+  describe('getDraftTemplateById', () => {
+    it('returns draft template', () => {
+      expect(selector.getDraftTemplateById(store, 'ape')).toEqual({
+        name: 'Ape',
+        id: 'ape',
+        published: false
+      });
+    });
+
+    it('returns undefined when not present', () => {
+      expect(selector.getDraftTemplateById(store, 'unknown')).toBeUndefined();
+    });
+  });
+
+  describe('getPublishedTemplateById', () => {
+    it('returns draft template', () => {
+      expect(selector.getPublishedTemplateById(store, 'ape')).toEqual({
+        name: 'Ape',
+        id: 'ape',
+        published: true
+      });
+    });
+
+    it('returns undefined when not present', () => {
+      expect(selector.getPublishedTemplateById(store, 'unknown')).toBeUndefined();
+    });
+  });
+
   describe('Templates by id Selector', () => {
     it('returns template', () => {
       const props = { match: { params: { id: 'Ape' }}};
@@ -118,6 +165,38 @@ describe('Templates selectors', () => {
     'returns undefined when unknown': { id: 'unknown' }
   });
 
+  describe('selectDraftTemplateById', () => {
+    it('returns draft', () => {
+      expect(selector.selectDraftTemplateById(store, 'ape')).toEqual({
+        id: 'ape',
+        name: 'Ape',
+        options: {
+          click_tracking: true,
+          open_tracking: true,
+          transactional: false
+        },
+        published: false
+      });
+    });
+
+    it('returns draft with default options', () => {
+      expect(selector.selectDraftTemplateById(store, 'lion')).toEqual({
+        id: 'lion',
+        name: 'Lion',
+        options: {
+          click_tracking: false,
+          open_tracking: false,
+          transactional: false
+        },
+        published: false
+      });
+    });
+
+    it('returns undefined when draft is not present', () => {
+      expect(selector.selectDraftTemplateById(store, 'unknown')).toBeUndefined();
+    });
+  });
+
   cases('.selectDraftTemplatePreview', ({ defaultValue, id }) => {
     expect(selector.selectDraftTemplatePreview(store, id, defaultValue)).toMatchSnapshot();
   }, {
@@ -135,12 +214,21 @@ describe('Templates selectors', () => {
   });
 
   describe('selectAndCloneDraftById', () => {
-    it('should clone template if :id exist in state', () => {
-      expect(selector.selectAndCloneDraftById(store, 'ape')).toMatchSnapshot();
+    it('returns clone of draft with updated name and id', () => {
+      expect(selector.selectAndCloneDraftById(store, 'ape')).toEqual({
+        id: 'ape-copy',
+        name: 'Ape Copy',
+        options: {
+          click_tracking: true,
+          open_tracking: true,
+          transactional: false
+        },
+        published: false
+      });
     });
 
-    it('should not clone template if :id does not exist', () => {
-      expect(selector.selectAndCloneDraftById(store, 'Nope')).toMatchSnapshot();
+    it('returns undefined when draft is not present', () => {
+      expect(selector.selectAndCloneDraftById(store, 'unknown')).toBeUndefined();
     });
   });
 

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -64,6 +64,16 @@ describe('Templates selectors', () => {
                 open_tracking: false,
                 transactional: false
               }
+            },
+            published: {
+              id: 'lion',
+              name: 'Lion',
+              published: true,
+              options: {
+                click_tracking: false,
+                open_tracking: false,
+                transactional: false
+              }
             }
           }
         },
@@ -166,20 +176,7 @@ describe('Templates selectors', () => {
   });
 
   describe('selectDraftTemplateById', () => {
-    it('returns draft', () => {
-      expect(selector.selectDraftTemplateById(store, 'ape')).toEqual({
-        id: 'ape',
-        name: 'Ape',
-        options: {
-          click_tracking: true,
-          open_tracking: true,
-          transactional: false
-        },
-        published: false
-      });
-    });
-
-    it('returns draft with default options', () => {
+    it('returns template', () => {
       expect(selector.selectDraftTemplateById(store, 'lion')).toEqual({
         id: 'lion',
         name: 'Lion',
@@ -192,8 +189,53 @@ describe('Templates selectors', () => {
       });
     });
 
-    it('returns undefined when draft is not present', () => {
+    it('returns template with default options', () => {
+      expect(selector.selectDraftTemplateById(store, 'ape')).toEqual({
+        id: 'ape',
+        name: 'Ape',
+        options: {
+          click_tracking: true,
+          open_tracking: true,
+          transactional: false
+        },
+        published: false
+      });
+    });
+
+    it('returns undefined when template is not present', () => {
       expect(selector.selectDraftTemplateById(store, 'unknown')).toBeUndefined();
+    });
+  });
+
+  describe('selectPublishedTemplateById', () => {
+    it('returns template', () => {
+      expect(selector.selectPublishedTemplateById(store, 'lion')).toEqual({
+        id: 'lion',
+        name: 'Lion',
+        options: {
+          click_tracking: false,
+          open_tracking: false,
+          transactional: false
+        },
+        published: true
+      });
+    });
+
+    it('returns template with default options', () => {
+      expect(selector.selectPublishedTemplateById(store, 'ape')).toEqual({
+        id: 'ape',
+        name: 'Ape',
+        options: {
+          click_tracking: true,
+          open_tracking: true,
+          transactional: false
+        },
+        published: true
+      });
+    });
+
+    it('returns undefined when template is not present', () => {
+      expect(selector.selectPublishedTemplateById(store, 'unknown')).toBeUndefined();
     });
   });
 

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -149,18 +149,6 @@ describe('Templates selectors', () => {
     });
   });
 
-  describe('Templates by id Selector', () => {
-    it('returns template', () => {
-      const props = { match: { params: { id: 'Ape' }}};
-      expect(selector.selectTemplateById(store, props)).toMatchSnapshot();
-    });
-
-    it('returns empty draft and published', () => {
-      const props = { match: { params: { id: 'Nope' }}};
-      expect(selector.selectTemplateById(store, props)).toMatchSnapshot();
-    });
-  });
-
   cases('.selectDraftTemplate', ({ id }) => {
     expect(selector.selectDraftTemplate(store, id)).toMatchSnapshot();
   }, {


### PR DESCRIPTION
Refer to [TR-1750](https://jira.int.messagesystems.com/browse/TR-1750)

### What Changed
 - If template options are not define for a template, they should be initialized with default account options for both new and old editors 

### How To Test

Must test all template actions in both old and new template editors.  The expectation is if the template options are not set, they will use the account option defaults.

- Create
- Duplicate
- Edit
- Publish
- Preview
- Send Test
