### PR TITLE
TR-1888 Default account options to empty object for selectDefaultTemplateOptions

### DIFF
--- a/src/selectors/account.js
+++ b/src/selectors/account.js
@@ -23,10 +23,10 @@ export const selectDefaultTemplateOptions = createSelector(
   [getAccount],
   ({
     options: {
-      click_tracking,
-      rest_tracking_default,
-      transactional_default
-    }
+      click_tracking = true,
+      rest_tracking_default = true,
+      transactional_default = false
+    } = {} // need to be defensive, not all user roles provide access to options
   }) => ({
     click_tracking: click_tracking || rest_tracking_default,
     open_tracking: rest_tracking_default,

--- a/src/selectors/tests/account.test.js
+++ b/src/selectors/tests/account.test.js
@@ -94,13 +94,7 @@ describe('Account Selectors', () => {
 
   it('returns default template options', () => {
     const state = {
-      account: {
-        options: {
-          click_tracking: true,
-          rest_tracking_default: true,
-          transactional_default: false
-        }
-      }
+      account: {}
     };
 
     expect(accountSelectors.selectDefaultTemplateOptions(state)).toEqual({


### PR DESCRIPTION
[TR-1888](https://jira.int.messagesystems.com/browse/)

### What Changed
- Guard against account options being undefined

### How To Test
- Create a subaccount
- Create a template assigned to that subaccount
- Create a subaccount reporting user 
- Open the template (was displaying sorry page, now should load editor as expected)