### PR TITLE
TR-1850 - Replace use of array sort with Lodash orderBy for consisten…

### DIFF
--- a/src/pages/templatesV2/components/RecentActivity.js
+++ b/src/pages/templatesV2/components/RecentActivity.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import { Panel } from '@sparkpost/matchbox';
 import { FileEdit, CheckCircle } from '@sparkpost/matchbox-icons';
 import { formatDate } from 'src/helpers/date';
@@ -11,7 +12,7 @@ const RecentActivity = (props) => {
     onToggleDeleteModal,
     onToggleDuplicateModal
   } = props;
-  const descendingSortedTemplates = templates.sort((a, b) => new Date(b.last_update_time) - new Date(a.last_update_time));
+  const descendingSortedTemplates = _.orderBy(templates, 'last_update_time', 'desc');
 
   if (templates.length < 3) {
     return;


### PR DESCRIPTION
[TR-1850](https://jira.int.messagesystems.com/browse/TR-1850)

### What Changed
- Replaced use of `Array.prototype.sort` with `_.orderBy` for consistency with TableCollection

### How To Test
- Verify that recent activity panels show the same first four results as the table collection

### To Do
- [x] Incorporate feedback
