### PR TITLE
TR-1374 - List Page duplication fix

### DIFF
--- a/src/pages/templatesV2/ListPage.js
+++ b/src/pages/templatesV2/ListPage.js
@@ -57,6 +57,7 @@ export default class ListPage extends Component {
         .then((res) => {
           this.setState({
             templateToDuplicate: res,
+            testDataToDuplicate: getTestDataV2({ id: res.id, mode: 'published' }),
             showDuplicateModal: !this.state.showDuplicateModal
           });
         });
@@ -66,7 +67,7 @@ export default class ListPage extends Component {
       .then((res) => {
         this.setState({
           templateToDuplicate: res,
-          testDataToDuplicate: getTestDataV2({ id: res.id, mode: res.published ? 'published' : 'draft' }),
+          testDataToDuplicate: getTestDataV2({ id: res.id, mode: 'draft' }),
           showDuplicateModal: !this.state.showDuplicateModal
         });
       });

--- a/src/pages/templatesV2/tests/ListPage.test.js
+++ b/src/pages/templatesV2/tests/ListPage.test.js
@@ -96,29 +96,25 @@ describe('ListPage', () => {
   });
 
   it('invokes `getPublished()` when the template is in published mode when toggling the duplicate modal', () => {
-    const mockGetPublished = jest.fn(() => Promise.resolve());
-    const mockGetDraft = jest.fn(() => Promise.resolve());
+    const mockGetPublished = jest.fn(() => Promise.resolve({ id: 'foo' }));
     const wrapper = subject({
       getPublished: mockGetPublished,
-      getDraft: mockGetDraft
+      getTestDataV2: jest.fn()
     });
 
     wrapper.instance().toggleDuplicateModal({ published: true });
     expect(mockGetPublished).toHaveBeenCalled();
-    expect(mockGetDraft).not.toHaveBeenCalled();
   });
 
   it('invokes `getDraft()` when the template is NOT in published mode when toggling the duplicate modal', () => {
-    const mockGetPublished = jest.fn(() => Promise.resolve());
-    const mockGetDraft = jest.fn(() => Promise.resolve());
+    const mockGetDraft = jest.fn(() => Promise.resolve({ id: 'foo' }));
     const wrapper = subject({
-      getPublished: mockGetPublished,
-      getDraft: mockGetDraft
+      getDraft: mockGetDraft,
+      getTestDataV2: jest.fn()
     });
 
     wrapper.instance().toggleDuplicateModal({ published: false });
     expect(mockGetDraft).toHaveBeenCalled();
-    expect(mockGetPublished).not.toHaveBeenCalled();
   });
 
   it('shows an alert after duplication and refreshes the list', async () => {


### PR DESCRIPTION
TR-1374 - Resolve test data duplication persistence issue

### What Changed
- Resolves issue with test data not persisting for published templates on the list page

### How To Test
- Go to `/templatesV2`
- Find a published template with test data
- Duplicate that template and verify that the same test data exists in the copy
- Double check that drafts duplicate in a similar manner

### To Do
- [x] Incorporate feedback
