### PR TITLE
TR-1895 - Remove unnecessary extra request on mount

### DIFF
--- a/src/pages/templatesV2/context/EditorContext.js
+++ b/src/pages/templatesV2/context/EditorContext.js
@@ -33,9 +33,12 @@ export const EditorContextProvider = ({ children, value: {
 
   useEffect(() => {
     getDraft(requestParams.id, requestParams.subaccount);
-    getPublished(requestParams.id, requestParams.subaccount);
     listDomains();
     listSubaccounts();
+
+    if (requestParams.version === 'published') {
+      getPublished(requestParams.id, requestParams.subaccount);
+    }
   },
   [
     listSubaccounts,

--- a/src/pages/templatesV2/context/tests/EditorContext.test.js
+++ b/src/pages/templatesV2/context/tests/EditorContext.test.js
@@ -7,8 +7,14 @@ jest.mock('src/hooks/useRouter');
 
 describe('EditorContext', () => {
   describe('EditorContextProvider', () => {
-    const subject = ({ render = shallow, value = {}} = {}) => {
-      useRouter.mockReturnValue({ requestParams: { id: 'test-template', subaccount: '123' }});
+    const subject = ({ render = shallow, value = {}, routerParams = {}} = {}) => {
+      useRouter.mockReturnValue({
+        requestParams: {
+          id: 'test-template',
+          subaccount: '123',
+          ...routerParams
+        }
+      });
 
       return render(
         <EditorContextProvider
@@ -36,7 +42,7 @@ describe('EditorContext', () => {
       expect(wrapper).toHaveProp('value', expect.objectContaining(value));
     });
 
-    it('calls getDraft and getPublished on mount', () => {
+    it('calls getDraft, listDomains, and listSubaccounts on mount', () => {
       const getDraft = jest.fn();
       const getPublished = jest.fn();
       const listDomains = jest.fn();
@@ -53,9 +59,31 @@ describe('EditorContext', () => {
       });
 
       expect(getDraft).toHaveBeenCalledWith('test-template', '123');
-      expect(getPublished).toHaveBeenCalledWith('test-template', '123');
+      expect(getPublished).not.toHaveBeenCalled();
       expect(listDomains).toHaveBeenCalled();
       expect(listSubaccounts).toHaveBeenCalled();
+    });
+
+    it('calls getPublished when the route param version is "published"', () => {
+      const getDraft = jest.fn();
+      const getPublished = jest.fn();
+      const listDomains = jest.fn();
+      const listSubaccounts = jest.fn();
+
+      subject({
+        render: mount,
+        value: {
+          getDraft,
+          getPublished,
+          listDomains,
+          listSubaccounts
+        },
+        routerParams: {
+          version: 'published'
+        }
+      });
+
+      expect(getPublished).toHaveBeenCalledWith('test-template', '123');
     });
   });
 });


### PR DESCRIPTION
[TR-1895](https://jira.int.messagesystems.com/browse/TR-1895)

### What Changed
- Added check for which version of the template is currently being viewed before retrieving 

### How To Test
- Go to `/templatesV2`
- Go to the details page of any template in draft mode and check in the console for any 404s related to a request for the published draft
- Update relevant tests to match updated implementation

### To Do
- [x] Incorporate feedback