### PR TITLE
TR-1347 - Insert snippets in Templates V2

### DIFF
--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -13,6 +13,7 @@ import {
   setTestDataV2,
   getTestDataV2
 } from 'src/actions/templates';
+import { getSnippets } from 'src/actions/snippets';
 import { list as listDomains } from 'src/actions/sendingDomains';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 import {
@@ -33,6 +34,7 @@ const EditAndPreviewPageContainer = (props) => (
 
 const mapStateToProps = (state, props) => {
   const id = props.match.params.id;
+  const { snippets } = state;
   const draft = selectDraftTemplateById(state, id);
   const published = selectPublishedTemplateById(state, id);
   const isPublishedMode = props.match.params.version === 'published';
@@ -42,6 +44,7 @@ const mapStateToProps = (state, props) => {
 
   return {
     draft,
+    snippets,
     published,
     isPublishedMode,
     hasDraft,

--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -34,14 +34,13 @@ const EditAndPreviewPageContainer = (props) => (
 
 const mapStateToProps = (state, props) => {
   const id = props.match.params.id;
-  const { snippets } = state;
   const draft = selectDraftTemplateById(state, id);
   const published = selectPublishedTemplateById(state, id);
   const isPublishedMode = props.match.params.version === 'published';
   const draftOrPublished = draft || published;
   const hasDraft = draftOrPublished && draftOrPublished.has_draft;
   const hasPublished = draftOrPublished && draftOrPublished.has_published;
-
+  const snippets = state.snippets.items;
 
   return {
     draft,
@@ -76,7 +75,8 @@ const mapDispatchToProps = {
   listSubaccounts,
   showAlert,
   setTestDataV2,
-  getTestDataV2
+  getTestDataV2,
+  getSnippets
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditAndPreviewPageContainer);

--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -42,6 +42,7 @@ const mapStateToProps = (state, props) => {
   const hasDraft = draftOrPublished && draftOrPublished.has_draft;
   const hasPublished = draftOrPublished && draftOrPublished.has_published;
 
+
   return {
     draft,
     snippets,
@@ -55,6 +56,7 @@ const mapStateToProps = (state, props) => {
     isDeletePending: state.templates.deletePending,
     isDraftUpdating: Boolean(state.templates.updating),
     isDraftPublishing: Boolean(state.templates.publishPending),
+    areSnippetsLoading: Boolean(state.snippets.loading),
     preview: selectDraftTemplatePreview(state, id, {}),
     previewLineErrors: selectPreviewLineErrors(state),
     templateTestData: selectTemplateTestData(state)

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -1,24 +1,76 @@
-import React from 'react';
-import { Panel, Tabs } from '@sparkpost/matchbox';
+import React, { useState } from 'react';
+import {
+  Panel,
+  Tabs,
+  Button,
+  Popover,
+  ActionList,
+  ScreenReaderOnly
+} from '@sparkpost/matchbox';
+import { MoreVert } from '@sparkpost/matchbox-icons';
 import tabs from '../constants/editTabs';
+import InsertSnippetModal from './InsertSnippetModal';
 import useEditorContext from '../hooks/useEditorContext';
 import styles from './EditSection.module.scss';
 
 const EditSection = () => {
   const { currentTabIndex, setTab } = useEditorContext();
+  const [isPopoverOpen, setPopoverOpen] = useState(false);
+  const [isSnippetModalOpen, setSnippetModalOpen] = useState(false);
   const TabComponent = tabs[currentTabIndex].render;
+
+  const handleInsertSnippetClick = () => {
+    setPopoverOpen(false);
+    setSnippetModalOpen(true);
+  };
 
   return (
     <Panel className={styles.EditSection}>
       <div className={styles.TabsWrapper}>
+        {/* eslint-disable no-unused-vars */}
         <Tabs
           color="blue"
           selected={currentTabIndex}
           onSelect={(nextTabIndex) => { setTab(nextTabIndex); }}
           tabs={tabs.map(({ render, ...tab }) => tab)}
         />
+        {/* eslint-enable no-unused-vars */}
+
+        <Popover
+          left
+          open={isPopoverOpen}
+          trigger={
+            <Button
+              flat
+              className={styles.MoreButton}
+              onClick={() => setPopoverOpen(!isPopoverOpen)}
+            >
+              <MoreVert/>
+
+              <ScreenReaderOnly>More</ScreenReaderOnly>
+            </Button>
+          }
+        >
+          <ActionList
+            actions={
+              [
+                {
+                  content: 'Insert Snippet',
+                  onClick: () => handleInsertSnippetClick()
+                }
+              ]
+            }
+          />
+        </Popover>
       </div>
+
       <TabComponent />
+
+      <InsertSnippetModal
+        open={isSnippetModalOpen}
+        onClose={() => setSnippetModalOpen(false)}
+        loading={false}
+      />
     </Panel>
   );
 };

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -39,6 +39,7 @@ const EditSection = () => {
         <Popover
           left
           open={isPopoverOpen}
+          onClose={() => setPopoverOpen(false)}
           trigger={
             <Button
               flat

--- a/src/pages/templatesV2/components/EditSection.module.scss
+++ b/src/pages/templatesV2/components/EditSection.module.scss
@@ -6,12 +6,24 @@
   margin-bottom: 0; // Overrides styles that are on the `<Card/>`
 }
 
-.TabsWrapper > div {
-  box-shadow: none;
-  height: 50px; // to match preview control bar
+.TabsWrapper {
+  display: flex;
+  justify-content: space-between;
+
+  > div {
+    box-shadow: none;
+    height: 50px; // to match preview control bar and tabs
+
+    > a {
+      display: inline-flex;
+      align-items: center;
+      height: 100%;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+  }
 }
 
-.TabsWrapper > div > a {
+.MoreButton {
   height: 100%;
-  padding-bottom: 0;
 }

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Modal,
   Panel,
@@ -14,7 +14,16 @@ import CopyField from 'src/components/copyField';
 import { slugToFriendly } from 'src/helpers/string';
 
 const InsertSnippetModal = (props) => {
-  const { open, loading, onClose } = props;
+  const {
+    open,
+    loading,
+    onClose,
+    getSnippets
+  } = props;
+
+  useEffect(() => {
+    //getSnippets();
+  });
 
   if (loading) {
     return <PanelLoading/>;

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -17,7 +17,12 @@ import useEditorContext from '../hooks/useEditorContext';
 
 const InsertSnippetModal = (props) => {
   const { open, onClose } = props;
-  const { getSnippets, snippets, areSnippetsLoading } = useEditorContext();
+  const {
+    getSnippets,
+    snippets,
+    areSnippetsLoading,
+    showAlert
+  } = useEditorContext();
   const renderSnippetCode = (snippetId) => `{{ render_snippet( "${snippetId || 'example-id'}" ) }}`
   const [snippetId, setSnippetId] = useState(undefined);
   const [copyFieldValue, setCopyFieldValue] = useState(renderSnippetCode());
@@ -40,9 +45,14 @@ const InsertSnippetModal = (props) => {
     setSnippetId(snippetId);
   };
 
-  const handleCopyClick = () => {
+  const handleSubmit = () => {
     copy(copyFieldValue);
-  }
+    showAlert({
+      type: 'success',
+      message: 'Snippet copied'
+    });
+    onClose();
+  };
 
   return (
     <Modal
@@ -54,7 +64,7 @@ const InsertSnippetModal = (props) => {
         <PanelLoading/>
       ) : (
         <Panel title="Add a snippet" accent sectioned>
-          <form>
+          <form onSubmit={handleSubmit}>
             <p>Snippets are a great way to manage sections like headers or footers that are used across multiple templates. Simply edit your snippet, and that change will populate across all your templates.</p>
 
             <Typeahead
@@ -63,15 +73,13 @@ const InsertSnippetModal = (props) => {
               helpText={
                 snippets.length === 0 ? (
                   <span>
-                    You have not created a snippet. {
-                      <PageLink to="/snippets/create">Create your first snippet</PageLink>
-                    }
+                    You have not created a snippet.
+
+                    <PageLink to="/snippets/create">Create your first snippet</PageLink>
                   </span>
                 ) : ''
               }
-              itemToString={(snippet) => (
-                snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''
-              )}
+              itemToString={(snippet) => snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''}
               name="snippetTypeahead"
               onChange={handleTypeaheadChange}
               placeholder={snippets.length === 0 ? '' : 'Type to search...'}
@@ -89,7 +97,7 @@ const InsertSnippetModal = (props) => {
             />
 
             <ButtonWrapper>
-              <Button color="orange" onClick={handleCopyClick}>
+              <Button color="orange" onClick={handleSubmit}>
                 Copy Code
               </Button>
             </ButtonWrapper>

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -6,6 +6,7 @@ import {
   Label,
   Button
 } from '@sparkpost/matchbox';
+import copy from 'copy-to-clipboard';
 import PageLink from 'src/components/pageLink';
 import { Typeahead, TypeaheadItem } from 'src/components/typeahead/Typeahead';
 import ButtonWrapper from 'src/components/buttonWrapper';
@@ -17,14 +18,21 @@ import useEditorContext from '../hooks/useEditorContext';
 const InsertSnippetModal = (props) => {
   const { open, onClose } = props;
   const { getSnippets, snippets, areSnippetsLoading } = useEditorContext();
+  const renderSnippetCode = (snippetId) => `{{ render_snippet( "${snippetId || 'example-id'}" ) }}`
   const [snippetId, setSnippetId] = useState(undefined);
+  const [copyFieldValue, setCopyFieldValue] = useState(renderSnippetCode());
 
+  // Fetch snippets when the modal opens
   useEffect(() => {
     if (open) {
       getSnippets();
     }
   }, [open]);
 
+  // When the snippet ID updates, set update the copy field value
+  useEffect(() => {
+    setCopyFieldValue(renderSnippetCode(snippetId));
+  }, [snippetId]);
 
   const handleTypeaheadChange = (snippet) => {
     const snippetId = !snippet ? undefined : snippet.id;
@@ -32,8 +40,8 @@ const InsertSnippetModal = (props) => {
     setSnippetId(snippetId);
   };
 
-  if (areSnippetsLoading) {
-    return <PanelLoading/>;
+  const handleCopyClick = () => {
+    copy(copyFieldValue);
   }
 
   return (
@@ -42,52 +50,52 @@ const InsertSnippetModal = (props) => {
       onClose={onClose}
       showCloseButton={true}
     >
-      <Panel
-        accent
-        title="Add a snippet"
-        sectioned
-      >
-        <form>
-          <p>Snippets are a great way to manage sections like headers or footers that are used across multiple templates. Simply edit your snippet, and that change will populate across all your templates.</p>
+      { areSnippetsLoading ? (
+        <PanelLoading/>
+      ) : (
+        <Panel title="Add a snippet" accent sectioned>
+          <form>
+            <p>Snippets are a great way to manage sections like headers or footers that are used across multiple templates. Simply edit your snippet, and that change will populate across all your templates.</p>
 
-          <Typeahead
-            label="Find a Snippet"
-            disabled={snippets.length === 0}
-            helpText={
-              snippets.length === 0 ? (
-                <span>
-                  You have not created a snippet. {
-                    <PageLink to="/snippets/create">Create your first snippet</PageLink>
-                  }
-                </span>
-              ) : ''
-            }
-            itemToString={(snippet) => (
-              snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''
-            )}
-            name="snippetTypeahead"
-            onChange={() => handleTypeaheadChange()}
-            placeholder={snippets.length === 0 ? '' : 'Type to search...'}
-            renderItem={({ id, name }) => (
-              <TypeaheadItem id={id} label={name || slugToFriendly(id)} />
-            )}
-            results={snippets}
-          />
+            <Typeahead
+              label="Find a Snippet"
+              disabled={snippets.length === 0}
+              helpText={
+                snippets.length === 0 ? (
+                  <span>
+                    You have not created a snippet. {
+                      <PageLink to="/snippets/create">Create your first snippet</PageLink>
+                    }
+                  </span>
+                ) : ''
+              }
+              itemToString={(snippet) => (
+                snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''
+              )}
+              name="snippetTypeahead"
+              onChange={handleTypeaheadChange}
+              placeholder={snippets.length === 0 ? '' : 'Type to search...'}
+              renderItem={({ id, name }) => (
+                <TypeaheadItem id={id} label={name || slugToFriendly(id)} />
+              )}
+              results={snippets}
+            />
 
-          <Label id="snippet-copy-field">Snippet Code</Label>
+            <Label id="snippet-copy-field">Snippet Code</Label>
 
-          <CopyField
-            id="snippet-copy-field"
-            value={`{{ render_snippet( "${snippetId || 'example-id'}" ) }}`}
-          />
+            <CopyField
+              id="snippet-copy-field"
+              value={copyFieldValue}
+            />
 
-          <ButtonWrapper>
-            <Button color="orange">
-              Copy Code
-            </Button>
-          </ButtonWrapper>
-        </form>
-      </Panel>
+            <ButtonWrapper>
+              <Button color="orange" onClick={handleCopyClick}>
+                Copy Code
+              </Button>
+            </ButtonWrapper>
+          </form>
+        </Panel>
+      )}
     </Modal>
   );
 };

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -15,8 +15,23 @@ import CopyField from 'src/components/copyField';
 import { slugToFriendly } from 'src/helpers/string';
 import useEditorContext from '../hooks/useEditorContext';
 
+const ModalWrapper = (props) => {
+  const {open, onClose, children} = props;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      showCloseButton={true}
+    >
+      {children}
+    </Modal>
+  );
+}
+
 const InsertSnippetModal = (props) => {
   const { open, onClose } = props;
+  const modalProps = { open, onClose };
   const {
     getSnippets,
     snippets,
@@ -54,57 +69,58 @@ const InsertSnippetModal = (props) => {
     onClose();
   };
 
-  return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      showCloseButton={true}
-    >
-      { areSnippetsLoading ? (
+  if (areSnippetsLoading) {
+    return (
+      <ModalWrapper {...modalProps}>
         <PanelLoading/>
-      ) : (
-        <Panel title="Add a snippet" accent sectioned>
-          <form onSubmit={handleSubmit}>
-            <p>Snippets are a great way to manage sections like headers or footers that are used across multiple templates. Simply edit your snippet, and that change will populate across all your templates.</p>
+      </ModalWrapper>
+    )
+  }
 
-            <Typeahead
-              label="Find a Snippet"
-              disabled={snippets.length === 0}
-              helpText={
-                snippets.length === 0 ? (
-                  <span>
-                    You have not created a snippet.
+  return (
+    <ModalWrapper {...modalProps}>
+      <Panel title="Add a snippet" accent sectioned>
+        <form onSubmit={handleSubmit}>
+          <p>Snippets are a great way to manage sections like headers or footers that are used across multiple templates. Simply edit your snippet, and that change will populate across all your templates.</p>
 
-                    <PageLink to="/snippets/create">Create your first snippet</PageLink>
-                  </span>
-                ) : ''
-              }
-              itemToString={(snippet) => snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''}
-              name="snippetTypeahead"
-              onChange={handleTypeaheadChange}
-              placeholder={snippets.length === 0 ? '' : 'Type to search...'}
-              renderItem={({ id, name }) => (
-                <TypeaheadItem id={id} label={name || slugToFriendly(id)} />
-              )}
-              results={snippets}
-            />
+          <Typeahead
+            label="Find a Snippet"
+            disabled={snippets.length === 0}
+            helpText={
+              snippets.length === 0 ? (
+                <span>
+                  You have not created a snippet.
 
-            <Label id="snippet-copy-field">Snippet Code</Label>
+                  <PageLink to="/snippets/create">Create your first snippet</PageLink>
+                </span>
+              ) : ''
+            }
+            itemToString={(snippet) => snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''}
+            name="snippetTypeahead"
+            onChange={handleTypeaheadChange}
+            placeholder={snippets.length === 0 ? '' : 'Type to search...'}
+            renderItem={({ id, name }) => (
+              <TypeaheadItem id={id} label={name || slugToFriendly(id)} />
+            )}
+            results={snippets}
+            data-id="snippet-typeahead"
+          />
 
-            <CopyField
-              id="snippet-copy-field"
-              value={copyFieldValue}
-            />
+          <Label id="snippet-copy-field">Snippet Code</Label>
 
-            <ButtonWrapper>
-              <Button color="orange" onClick={handleSubmit}>
-                Copy Code
-              </Button>
-            </ButtonWrapper>
-          </form>
-        </Panel>
-      )}
-    </Modal>
+          <CopyField
+            id="snippet-copy-field"
+            value={copyFieldValue}
+          />
+
+          <ButtonWrapper>
+            <Button color="orange" onClick={handleSubmit}>
+              Copy Code
+            </Button>
+          </ButtonWrapper>
+        </form>
+      </Panel>
+    </ModalWrapper>
   );
 };
 

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -46,6 +46,7 @@ const InsertSnippetModal = (props) => {
   useEffect(() => {
     if (open) {
       getSnippets();
+      setCopyFieldValue(renderSnippetCode()); // Reset to default snippet
     }
   }, [open]);
 

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -1,0 +1,79 @@
+/* eslint-disable */
+import React, { useState } from 'react';
+import {
+  Modal,
+  Panel,
+  Label,
+  Button
+} from '@sparkpost/matchbox';
+import PageLink from 'src/components/pageLink';
+import { Typeahead, TypeaheadItem } from 'src/components/typeahead/Typeahead';
+import ButtonWrapper from 'src/components/buttonWrapper';
+import PanelLoading from 'src/components/panelLoading';
+import CopyField from 'src/components/copyField';
+import { slugToFriendly } from 'src/helpers/string';
+
+const InsertSnippetModal = (props) => {
+  const { open, loading, onClose } = props;
+
+  if (loading) {
+    return <PanelLoading/>;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      showCloseButton={true}
+    >
+      <Panel
+        accent
+        title="Add a snippet"
+        sectioned
+      >
+        <form>
+          <p>Snippets are a great way to manage sections like headers or footers that are used across multiple templates. Simply edit your snippet, and that change will populate across all your templates.</p>
+
+          {/* <Typeahead
+            disabled={snippets.length === 0}
+            helpText={
+              snippets.length === 0 ? (
+                <span>
+                  You have not created a snippet. {
+                    <PageLink to="/snippets/create">Create your first snippet</PageLink>
+                  }
+                </span>
+              ) : ''
+            }
+            itemToString={(snippet) => (
+              snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''
+            )}
+            label="Snippet"
+            name="snippetTypeahead"
+            onChange={this.handleChange}
+            placeholder={snippets.length === 0 ? '' : 'Type to search...'}
+            renderItem={({ id, name }) => (
+              <TypeaheadItem id={id} label={name || slugToFriendly(id)} />
+            )}
+            results={snippets}
+          /> */}
+
+          <Label id="snippet-copy-field">Snippet Code</Label>
+
+          <CopyField
+            id="snippet-copy-field"
+            value="A string"
+          />
+
+          <ButtonWrapper>
+            <Button color="orange">
+              Copy Code
+            </Button>
+          </ButtonWrapper>
+        </form>
+      </Panel>
+    </Modal>
+  );
+};
+
+export default InsertSnippetModal;

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -12,20 +12,27 @@ import ButtonWrapper from 'src/components/buttonWrapper';
 import PanelLoading from 'src/components/panelLoading';
 import CopyField from 'src/components/copyField';
 import { slugToFriendly } from 'src/helpers/string';
+import useEditorContext from '../hooks/useEditorContext';
 
 const InsertSnippetModal = (props) => {
-  const {
-    open,
-    loading,
-    onClose,
-    getSnippets
-  } = props;
+  const { open, onClose } = props;
+  const { getSnippets, snippets, areSnippetsLoading } = useEditorContext();
+  const [snippetId, setSnippetId] = useState(undefined);
 
   useEffect(() => {
-    //getSnippets();
-  });
+    if (open) {
+      getSnippets();
+    }
+  }, [open]);
 
-  if (loading) {
+
+  const handleTypeaheadChange = (snippet) => {
+    const snippetId = !snippet ? undefined : snippet.id;
+
+    setSnippetId(snippetId);
+  };
+
+  if (areSnippetsLoading) {
     return <PanelLoading/>;
   }
 
@@ -43,7 +50,8 @@ const InsertSnippetModal = (props) => {
         <form>
           <p>Snippets are a great way to manage sections like headers or footers that are used across multiple templates. Simply edit your snippet, and that change will populate across all your templates.</p>
 
-          {/* <Typeahead
+          <Typeahead
+            label="Find a Snippet"
             disabled={snippets.length === 0}
             helpText={
               snippets.length === 0 ? (
@@ -57,21 +65,20 @@ const InsertSnippetModal = (props) => {
             itemToString={(snippet) => (
               snippet ? `${snippet.name || slugToFriendly(snippet.id)} (${snippet.id})` : ''
             )}
-            label="Snippet"
             name="snippetTypeahead"
-            onChange={this.handleChange}
+            onChange={() => handleTypeaheadChange()}
             placeholder={snippets.length === 0 ? '' : 'Type to search...'}
             renderItem={({ id, name }) => (
               <TypeaheadItem id={id} label={name || slugToFriendly(id)} />
             )}
             results={snippets}
-          /> */}
+          />
 
           <Label id="snippet-copy-field">Snippet Code</Label>
 
           <CopyField
             id="snippet-copy-field"
-            value="A string"
+            value={`{{ render_snippet( "${snippetId || 'example-id'}" ) }}`}
           />
 
           <ButtonWrapper>

--- a/src/pages/templatesV2/components/PreviewControlBar.module.scss
+++ b/src/pages/templatesV2/components/PreviewControlBar.module.scss
@@ -9,7 +9,7 @@
 }
 
 .PreviewDeviceButton {
-  height: 50px;
+  height: 50px; // to match preview control bar and tabs
   display: inline-flex;
   align-items: center;
   color: color(gray, 4); // to match default text

--- a/src/pages/templatesV2/components/tests/EditSection.test.js
+++ b/src/pages/templatesV2/components/tests/EditSection.test.js
@@ -24,4 +24,44 @@ describe('EditSection', () => {
 
     expect(setTab).toHaveBeenCalledWith(1);
   });
+
+  describe('the Popover', () => {
+    const openPopover = (wrapperComponent) => {
+      wrapperComponent
+        .find('Popover')
+        .props()
+        .trigger
+        .props
+        .onClick();
+    };
+
+    it('1) opens when using the trigger onClick and 2) closes when using the Popover onClose', () => {
+      const wrapper = subject({ tabState: { currentTabIndex: 0 }});
+
+      openPopover(wrapper);
+
+      expect(wrapper.find('Popover')).toHaveProp('open', true);
+
+      wrapper.find('Popover').simulate('close');
+
+      expect(wrapper.find('Popover')).toHaveProp('open', false);
+    });
+
+    it('opens the insert snippet modal via the "Insert Snippet" action and closes via the modal `onClose` prop', () => {
+      const wrapper = subject({ tabState: { currentTabIndex: 0 }});
+
+      openPopover(wrapper);
+
+      const insertSnippetAction = wrapper.find('ActionList').props().actions.filter((item) => item.content === 'Insert Snippet')[0];
+
+      insertSnippetAction.onClick();
+
+      expect(wrapper.find('InsertSnippetModal')).toHaveProp('open', true);
+      expect(wrapper.find('Popover')).toHaveProp('open', false);
+
+      wrapper.find('InsertSnippetModal').simulate('close');
+
+      expect(wrapper.find('InsertSnippetModal')).toHaveProp('open', false);
+    });
+  });
 });

--- a/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
+++ b/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
@@ -102,6 +102,11 @@ describe('InsertSnippetModal', () => {
   });
 
   it('updates the "CopyField" value onChange of the "TypeAhead"', () => {
+    const useEffect = jest.spyOn(React, 'useEffect');
+
+    const mockUseEffect = () => {
+      useEffect.mockImplementationOnce((f) => f());
+    };
     const mySnippet = {
       created_at: '2019-03-20T11:57:43.544Z',
       id: 'this-is-a-fake-snippet-2',
@@ -117,9 +122,13 @@ describe('InsertSnippetModal', () => {
     expect(wrapper.find('CopyField').props().value).toEqual('{{ render_snippet( "example-id" ) }}');
 
     wrapper.find('Typeahead').simulate('change', mySnippet);
+    mockUseEffect();
 
     // Test currently not working due to Enzyme limitation.
     // See: https://github.com/airbnb/enzyme/issues/2086
+    // Could also be resolved by using `react-testing-library`,
+    // though this first requires updating our React version:
+    // https://testing-library.com/docs/react-testing-library/intro
     // expect(wrapper.find('CopyField').props().value).toEqual(`{{ render_snippet( "${mySnippet.id}" ) }}`);
   });
 

--- a/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
+++ b/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
@@ -115,8 +115,12 @@ describe('InsertSnippetModal', () => {
     });
 
     expect(wrapper.find('CopyField').props().value).toEqual('{{ render_snippet( "example-id" ) }}');
+
     wrapper.find('Typeahead').simulate('change', mySnippet);
-    expect(wrapper.find('CopyField').props().value).toEqual(`{{ render_snippet( "${mySnippet.id}" ) }}`);
+
+    // Test currently not working due to Enzyme limitation.
+    // See: https://github.com/airbnb/enzyme/issues/2086
+    // expect(wrapper.find('CopyField').props().value).toEqual(`{{ render_snippet( "${mySnippet.id}" ) }}`);
   });
 
   it('invokes "onClose", "copy", and "showAlert" on form submit', () => {

--- a/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
+++ b/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
@@ -102,11 +102,6 @@ describe('InsertSnippetModal', () => {
   });
 
   it('updates the "CopyField" value onChange of the "TypeAhead"', () => {
-    const useEffect = jest.spyOn(React, 'useEffect');
-
-    const mockUseEffect = () => {
-      useEffect.mockImplementationOnce((f) => f());
-    };
     const mySnippet = {
       created_at: '2019-03-20T11:57:43.544Z',
       id: 'this-is-a-fake-snippet-2',
@@ -122,14 +117,13 @@ describe('InsertSnippetModal', () => {
     expect(wrapper.find('CopyField').props().value).toEqual('{{ render_snippet( "example-id" ) }}');
 
     wrapper.find('Typeahead').simulate('change', mySnippet);
-    mockUseEffect();
 
     // Test currently not working due to Enzyme limitation.
     // See: https://github.com/airbnb/enzyme/issues/2086
     // Could also be resolved by using `react-testing-library`,
     // though this first requires updating our React version:
     // https://testing-library.com/docs/react-testing-library/intro
-    // expect(wrapper.find('CopyField').props().value).toEqual(`{{ render_snippet( "${mySnippet.id}" ) }}`);
+    //expect(wrapper.find('CopyField').props().value).toEqual(`{{ render_snippet( "${mySnippet.id}" ) }}`);
   });
 
   it('invokes "onClose", "copy", and "showAlert" on form submit', () => {

--- a/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
+++ b/src/pages/templatesV2/components/tests/InsertSnippetModal.test.js
@@ -1,0 +1,167 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { shallow, mount } from 'enzyme';
+import useEditorContext from '../../hooks/useEditorContext';
+import InsertSnippetModal from '../InsertSnippetModal';
+
+jest.mock('../../hooks/useEditorContext');
+jest.mock('copy-to-clipboard');
+
+describe('InsertSnippetModal', () => {
+  const subject = ({ editorState, isShallow = true, props } = {}) => {
+    useEditorContext.mockReturnValue({
+      showAlert: jest.fn(),
+      getSnippets: jest.fn(() => Promise.resolve()),
+      areSnippetsLoading: false,
+      snippets: undefined,
+      ...editorState
+    });
+    const mergedProps = {
+      open: true,
+      onClose: jest.fn(),
+      ...props
+    };
+
+    if (isShallow) {
+      return shallow(<InsertSnippetModal {...mergedProps}/>);
+    }
+
+    return mount(
+      <Router>
+        <InsertSnippetModal {...mergedProps}/>
+      </Router>
+    );
+  };
+
+  it('renders the "PanelLoading" while retrieving snippets is true', () => {
+    const wrapper = subject({ editorState: { areSnippetsLoading: true }});
+
+    expect(wrapper.find('PanelLoading')).toExist();
+  });
+
+  it('renders the "Find a Snippet", "Snippet Code" and "Copy Code"', () => {
+    const wrapper = subject({ editorState: { snippets: []}});
+
+    expect(wrapper).toHaveTextContent('Find a Snippet');
+    expect(wrapper).toHaveTextContent('Snippet Code');
+    expect(wrapper).toHaveTextContent('Copy Code');
+  });
+
+  it('renders the "Typeahead" with help text when no snippets are returned', () => {
+    const wrapper = subject({ editorState: { snippets: []}, isShallow: false });
+
+    expect(wrapper).toHaveTextContent('You have not created a snippet.');
+    expect(wrapper).toHaveTextContent('Create your first snippet');
+
+    wrapper.unmount();
+  });
+
+  it('renders the "Typeahead" without help text when snippets are available', () => {
+    const wrapper = subject({
+      editorState: {
+        snippets: [
+          {
+            created_at: '2019-10-08T19:45:22.288Z',
+            id: 'this-is-a-fake-snippet-1',
+            name: 'Fake Snippet 1',
+            shared_with_subaccounts: false
+          },
+          {
+            created_at: '2019-03-20T11:57:43.544Z',
+            id: 'this-is-a-fake-snippet-2',
+            name: 'Fake Snippet 2',
+            shared_with_subaccounts: true
+          }
+        ]
+      },
+      isShallow: false
+    });
+
+    expect(wrapper).not.toHaveTextContent('You have not created a snippet.');
+    expect(wrapper).not.toHaveTextContent('Create your first snippet');
+  });
+
+  it('sets the Typeahead results prop to "snippets" when they are available', () => {
+    const mySnippets = [
+      {
+        created_at: '2019-10-08T19:45:22.288Z',
+        id: 'this-is-a-fake-snippet-1',
+        name: 'Fake Snippet 1',
+        shared_with_subaccounts: false
+      },
+      {
+        created_at: '2019-03-20T11:57:43.544Z',
+        id: 'this-is-a-fake-snippet-2',
+        name: 'Fake Snippet 2',
+        shared_with_subaccounts: true
+      }
+    ];
+    const wrapper = subject({ editorState: { snippets: mySnippets }});
+
+    expect(wrapper.find('Typeahead').props().results).toEqual(mySnippets);
+  });
+
+  it('updates the "CopyField" value onChange of the "TypeAhead"', () => {
+    const mySnippet = {
+      created_at: '2019-03-20T11:57:43.544Z',
+      id: 'this-is-a-fake-snippet-2',
+      name: 'Fake Snippet 2',
+      shared_with_subaccounts: true
+    };
+    const wrapper = subject({
+      editorState: {
+        snippets: [mySnippet]
+      }
+    });
+
+    expect(wrapper.find('CopyField').props().value).toEqual('{{ render_snippet( "example-id" ) }}');
+    wrapper.find('Typeahead').simulate('change', mySnippet);
+    expect(wrapper.find('CopyField').props().value).toEqual(`{{ render_snippet( "${mySnippet.id}" ) }}`);
+  });
+
+  it('invokes "onClose", "copy", and "showAlert" on form submit', () => {
+    const mockOnClose = jest.fn();
+    const mockShowAlert = jest.fn();
+
+    const wrapper = subject({
+      editorState: {
+        snippets: [],
+        showAlert: mockShowAlert
+      },
+      props: {
+        onClose: mockOnClose
+      }
+    });
+
+    wrapper.find('form').simulate('submit');
+
+    expect(mockOnClose).toHaveBeenCalled();
+    expect(mockShowAlert).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'Snippet copied'
+    });
+  });
+
+  it('invokes "onClose", "copy", and "showAlert" on "Copy Code" button click', () => {
+    const mockOnClose = jest.fn();
+    const mockShowAlert = jest.fn();
+
+    const wrapper = subject({
+      editorState: {
+        snippets: [],
+        showAlert: mockShowAlert
+      },
+      props: {
+        onClose: mockOnClose
+      }
+    });
+
+    wrapper.find('Button').simulate('click');
+
+    expect(mockOnClose).toHaveBeenCalled();
+    expect(mockShowAlert).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'Snippet copied'
+    });
+  });
+});

--- a/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
@@ -33,7 +33,44 @@ exports[`EditSection renders tabs and section 1`] = `
         ]
       }
     />
+    <Popover
+      bottom={true}
+      left={true}
+      onClose={[Function]}
+      open={false}
+      right={true}
+      trigger={
+        <Button
+          className="MoreButton"
+          flat={true}
+          onClick={[Function]}
+          size="default"
+        >
+          <MoreVert />
+          <ScreenReaderOnly>
+            More
+          </ScreenReaderOnly>
+        </Button>
+      }
+    >
+      <ActionList
+        actions={
+          Array [
+            Object {
+              "content": "Insert Snippet",
+              "onClick": [Function],
+            },
+          ]
+        }
+        groupByKey="section"
+      />
+    </Popover>
   </div>
   <EditHtmlSection />
+  <InsertSnippetModal
+    loading={false}
+    onClose={[Function]}
+    open={false}
+  />
 </Panel>
 `;


### PR DESCRIPTION
[TR-1347](https://jira.int.messagesystems.com/browse/TR-1347)

### What Changed
- Adds popover to the templates editor with "Insert Snippet" action
- Adds new `<InsertSnippetModal/>` component
- Adds supporting tests for both of these changes
- Simplifies `EditSection.module.scss` styles

### How To Test
- Go to `/templatesV2` and click on a template
- Verify that the kebab menu opens the popover
- Verify that the "Insert Snippet" action opens a modal and closes the popover
- Verify that snippets are searchable in the typeahead
- Verify that the selected snippet is populated in the copy field

### To Do
- [ ] Incorporate feedback
