### PR TITLE
TR-1899 - Add  style to editor tabs that are in read only mode

### DIFF
--- a/src/pages/templatesV2/components/EditHtmlSection.js
+++ b/src/pages/templatesV2/components/EditHtmlSection.js
@@ -13,15 +13,6 @@ const EditHtmlSection = () => {
       onChange={(value) => { setContent({ html: value }); }}
       value={content.html}
       readOnly={isPublishedMode}
-      editorProps={{
-        $cursor: {
-          element: {
-            style: {
-              opacity: 0
-            }
-          }
-        }
-      }}
     />
   );
 };

--- a/src/pages/templatesV2/components/EditHtmlSection.js
+++ b/src/pages/templatesV2/components/EditHtmlSection.js
@@ -13,6 +13,15 @@ const EditHtmlSection = () => {
       onChange={(value) => { setContent({ html: value }); }}
       value={content.html}
       readOnly={isPublishedMode}
+      editorProps={{
+        $cursor: {
+          element: {
+            style: {
+              opacity: 0
+            }
+          }
+        }
+      }}
     />
   );
 };

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -5,19 +5,24 @@ import {
   Button,
   Popover,
   ActionList,
-  ScreenReaderOnly
+  ScreenReaderOnly,
+  Tag
 } from '@sparkpost/matchbox';
-import { MoreVert } from '@sparkpost/matchbox-icons';
+import { MoreHoriz } from '@sparkpost/matchbox-icons';
 import tabs from '../constants/editTabs';
 import InsertSnippetModal from './InsertSnippetModal';
 import useEditorContext from '../hooks/useEditorContext';
 import styles from './EditSection.module.scss';
 
 const EditSection = () => {
-  const { currentTabIndex, setTab } = useEditorContext();
+  const { currentTabIndex, setTab, isPublishedMode } = useEditorContext();
   const [isPopoverOpen, setPopoverOpen] = useState(false);
   const [isSnippetModalOpen, setSnippetModalOpen] = useState(false);
-  const TabComponent = tabs[currentTabIndex].render;
+
+  const currentTab = tabs[currentTabIndex];
+  const TabComponent = currentTab.render;
+  const hasReadOnlyTag = isPublishedMode && (currentTab.key === 'html' || currentTab.key === 'amp_html' || currentTab.key === 'text');
+  const hasPopover = !isPublishedMode;
 
   const handleInsertSnippetClick = () => {
     setPopoverOpen(false);
@@ -36,37 +41,44 @@ const EditSection = () => {
         />
         {/* eslint-enable no-unused-vars */}
 
-        <Popover
-          left
-          open={isPopoverOpen}
-          onClose={() => setPopoverOpen(false)}
-          trigger={
-            <Button
-              flat
-              className={styles.MoreButton}
-              onClick={() => setPopoverOpen(!isPopoverOpen)}
-              data-id="popover-trigger-more"
-            >
-              <MoreVert/>
+        {hasReadOnlyTag &&
+          <div className={styles.TagWrapper}>
+            <Tag color="yellow">
+              <span>Read Only</span>
+            </Tag>
+          </div>
+        }
 
-              <ScreenReaderOnly>More</ScreenReaderOnly>
-            </Button>
-          }
-        >
-          <ActionList
-            actions={
-              [
-                {
-                  content: 'Insert Snippet',
-                  onClick: () => handleInsertSnippetClick(),
-                  role: 'button',
-                  href: 'javascript:void(0);',
-                  'data-id': 'popover-action-insert-snippet'
-                }
-              ]
+        {hasPopover &&
+          <Popover
+            left
+            open={isPopoverOpen}
+            onClose={() => setPopoverOpen(false)}
+            trigger={
+              <Button
+                flat
+                className={styles.MoreButton}
+                onClick={() => setPopoverOpen(!isPopoverOpen)}
+                data-id="popover-trigger-more"
+              >
+                <MoreHoriz/>
+
+                <ScreenReaderOnly>More</ScreenReaderOnly>
+              </Button>
             }
-          />
-        </Popover>
+          >
+            <ActionList
+              actions={
+                [
+                  {
+                    content: 'Insert Snippet',
+                    onClick: () => handleInsertSnippetClick()
+                  }
+                ]
+              }
+            />
+          </Popover>
+        }
       </div>
 
       <TabComponent />

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -72,7 +72,10 @@ const EditSection = () => {
                 [
                   {
                     content: 'Insert Snippet',
-                    onClick: () => handleInsertSnippetClick()
+                    onClick: () => handleInsertSnippetClick(),
+                    role: 'button',
+                    href: 'javascript:void(0);',
+                    'data-id': 'popover-action-insert-snippet'
                   }
                 ]
               }

--- a/src/pages/templatesV2/components/EditSection.module.scss
+++ b/src/pages/templatesV2/components/EditSection.module.scss
@@ -24,6 +24,13 @@
   }
 }
 
-.MoreButton {
+.MoreButton,
+.TagWrapper {
   height: 100%;
+}
+
+.TagWrapper {
+  display: flex;
+  align-items: center;
+  padding: 0 spacing();
 }

--- a/src/pages/templatesV2/components/Editor.js
+++ b/src/pages/templatesV2/components/Editor.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import AceEditor from 'react-ace';
 import useEditor from '../hooks/useEditor';
 import 'brace/ext/searchbox';
@@ -12,14 +13,16 @@ const Editor = ({
   mode = 'text',
   setOptions = {},
   value = '',
+  readOnly,
   ...props
 }) => {
   const { setAnnotations, setEditor } = useEditor({ inlineErrors });
 
   return (
-    <div className={styles.EditorWrapper}>
+    <div className={classNames(styles.EditorWrapper, readOnly && styles.ReadOnly)}>
       <AceEditor
         {...props}
+        readOnly={readOnly}
         annotations={[]} // do not use, see useEditor
         cursorStart={1}
         editorProps={{

--- a/src/pages/templatesV2/components/Editor.module.scss
+++ b/src/pages/templatesV2/components/Editor.module.scss
@@ -11,4 +11,13 @@
     background: linear-gradient(to right, #ff594d 5px, transparent 5px) !important;
     color: inherit !important;
   }
+
+  &.ReadOnly {
+    opacity: 0.75;
+  }
+
+  &.ReadOnly,
+  &.ReadOnly :global(.ace_content) {
+    cursor: not-allowed;
+  }
 }

--- a/src/pages/templatesV2/components/Editor.module.scss
+++ b/src/pages/templatesV2/components/Editor.module.scss
@@ -12,12 +12,15 @@
     color: inherit !important;
   }
 
-  &.ReadOnly {
-    opacity: 0.75;
-  }
-
   &.ReadOnly,
   &.ReadOnly :global(.ace_content) {
     cursor: not-allowed;
+    user-select: none;
+  }
+
+   // Visually hide the cursor when in read only mode
+  &.ReadOnly :global(.ace_cursor) {
+    opacity: 0;
+    visibility: hidden;
   }
 }

--- a/src/pages/templatesV2/components/tests/EditSection.test.js
+++ b/src/pages/templatesV2/components/tests/EditSection.test.js
@@ -6,23 +6,35 @@ import EditSection from '../EditSection';
 jest.mock('../../hooks/useEditorContext');
 
 describe('EditSection', () => {
-  const subject = ({ tabState }) => {
-    useEditorContext.mockReturnValue(tabState);
+  const subject = (editorState) => {
+    useEditorContext.mockReturnValue(editorState);
     return shallow(<EditSection />);
   };
 
   it('renders tabs and section', () => {
-    const wrapper = subject({ tabState: { currentTabIndex: 0 }});
+    const wrapper = subject({ currentTabIndex: 0 });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('sets tab on select', () => {
     const setTab = jest.fn();
-    const wrapper = subject({ tabState: { currentTabIndex: 0, setTab }});
+    const wrapper = subject({ currentTabIndex: 0, setTab });
 
     wrapper.find('Tabs').simulate('select', 1);
 
     expect(setTab).toHaveBeenCalledWith(1);
+  });
+
+  it('renders a "Read Only" tag in published mode for the "HTML", "AMP HTML", and "Text" tabs', () => {
+    const wrapper = subject({ currentTabIndex: 0, isPublishedMode: true });
+
+    expect(wrapper).toHaveTextContent('Read Only');
+  });
+
+  it('does not render a "Read Only" tag in published mode for the "Test Data" tab', () => {
+    const wrapper = subject({ currentTabIndex: 3, isPublishedMode: true });
+
+    expect(wrapper).not.toHaveTextContent('Read Only');
   });
 
   describe('the Popover', () => {
@@ -36,7 +48,7 @@ describe('EditSection', () => {
     };
 
     it('1) opens when using the trigger onClick and 2) closes when using the Popover onClose', () => {
-      const wrapper = subject({ tabState: { currentTabIndex: 0 }});
+      const wrapper = subject({ currentTabIndex: 0 });
 
       openPopover(wrapper);
 
@@ -48,7 +60,7 @@ describe('EditSection', () => {
     });
 
     it('opens the insert snippet modal via the "Insert Snippet" action and closes via the modal `onClose` prop', () => {
-      const wrapper = subject({ tabState: { currentTabIndex: 0 }});
+      const wrapper = subject({ currentTabIndex: 0 });
 
       openPopover(wrapper);
 
@@ -62,6 +74,15 @@ describe('EditSection', () => {
       wrapper.find('InsertSnippetModal').simulate('close');
 
       expect(wrapper.find('InsertSnippetModal')).toHaveProp('open', false);
+    });
+
+    it('does not render when not in published mode', () => {
+      const wrapper = subject({
+        currentTabIndex: 0,
+        isPublishedMode: true
+      });
+
+      expect(wrapper.find('Popover')).not.toExist();
     });
   });
 });

--- a/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
@@ -59,7 +59,7 @@ exports[`EditSection renders tabs and section 1`] = `
           onClick={[Function]}
           size="default"
         >
-          <MoreVert />
+          <MoreHoriz />
           <ScreenReaderOnly>
             More
           </ScreenReaderOnly>


### PR DESCRIPTION
[TR-1899](https://jira.int.messagesystems.com/browse/TR-1899)

### What Changed
- Add `<Tag/>` component instance for editor tabs when in published mode:

![Screen Shot 2019-10-31 at 1 28 29 PM](https://user-images.githubusercontent.com/3613392/67970996-5ba17780-fbe2-11e9-8f6e-7d83f8e2496f.png)

- Swap vertical kebab with horizontal kebab after chat with UX
- Added conditional rendering to the popover
- Updated editor styles when in read only mode

### How To Test
- Go to `/templatesV2` and click on a template in draft mode
- Click 'Save and Publish' in the top right
- Verify that the Popover is no longer available on the editor tabs
- Verify that the `<Tag/>` renders for the HTML, AMP HTML, and Text tabs but *not* for the Test Data tab

### To Do
- [x] Add supporting tests
- [ ] Incorporate feedback
