### PR TITLE
FE-735: Fix 2fa column name

### DIFF
--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -15,11 +15,12 @@ import { hasSubaccounts } from 'src/selectors/subaccounts';
 import { Subaccount, Loading, ApiErrorBanner, DeleteModal, TableCollection, ActionPopover } from 'src/components';
 import User from './components/User';
 
+const tfaColumnLabel = <abbr title='Two Factor Authentication'>2FA</abbr>;
 
 const COLUMNS = [
   { label: 'User', sortKey: 'name' },
   { label: 'Role', sortKey: 'roleLabel' },
-  { label: 'Two Factor Auth', sortKey: 'tfa_enabled' },
+  { label: tfaColumnLabel, sortKey: 'tfa_enabled' },
   { label: 'Last Login', sortKey: 'last_login' },
   null
 ];
@@ -28,7 +29,7 @@ const SUB_COLUMN = [
   { label: 'User', sortKey: 'name', width: '40%' },
   { label: 'Role', sortKey: 'roleLabel', width: '11%' },
   { label: 'Subaccount', sortKey: 'subaccount_id', width: '15%' },
-  { label: 'Two Factor Auth', sortKey: 'tfa_enabled', width: '8%' },
+  { label: tfaColumnLabel, sortKey: 'tfa_enabled', width: '10%' },
   { label: 'Last Login', sortKey: 'last_login', width: '14%' },
   null
 ];

--- a/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/ListPage.test.js.snap
@@ -57,7 +57,11 @@ exports[`Page: Users List should render correctly by default 1`] = `
             "sortKey": "roleLabel",
           },
           Object {
-            "label": "Two Factor Auth",
+            "label": <abbr
+              title="Two Factor Authentication"
+            >
+              2FA
+            </abbr>,
             "sortKey": "tfa_enabled",
           },
           Object {
@@ -219,7 +223,11 @@ exports[`Page: Users List should show a delete modal 1`] = `
             "sortKey": "roleLabel",
           },
           Object {
-            "label": "Two Factor Auth",
+            "label": <abbr
+              title="Two Factor Authentication"
+            >
+              2FA
+            </abbr>,
             "sortKey": "tfa_enabled",
           },
           Object {


### PR DESCRIPTION
### What Changed
 - Use abbreviation for Two factor authentication column label.

### How To Test
 - Go to `/account/users`. Verify that the 2fa column is on one line and hovering over shows the unabbreviated word.