### PR TITLE
FE-734: Make Cancellation Button Destructive

### DIFF
--- a/src/pages/account/components/CancellationPanel.js
+++ b/src/pages/account/components/CancellationPanel.js
@@ -75,7 +75,7 @@ export class CancellationPanel extends React.Component {
             config={config.brightback.cancelConfig}
             condition={true}
             render={({ to, enabled }) => (
-              <Button color='orange' to={enabled ? to : ACCOUNT_CANCEL_LINK} component={enabled ? null : Link}>Cancel Account</Button>
+              <Button destructive to={enabled ? to : ACCOUNT_CANCEL_LINK} component={enabled ? null : Link}>Cancel Account</Button>
             )}
           />
         </div>

--- a/src/pages/account/components/tests/CancellationPanel.test.js
+++ b/src/pages/account/components/tests/CancellationPanel.test.js
@@ -14,7 +14,7 @@ describe('CancellationPanel', () => {
     fetchAccount = {() => {}}
     {...props}/>);
 
-  const getButton = ({ wrapper = subject(), enabled = false, to = '' }) => wrapper
+  const getButton = ({ wrapper = subject(), enabled = false, to = '' } = {}) => wrapper
     .find(Brightback)
     .renderProp('render')({ enabled, to });
 

--- a/src/pages/account/components/tests/CancellationPanel.test.js
+++ b/src/pages/account/components/tests/CancellationPanel.test.js
@@ -37,6 +37,10 @@ describe('CancellationPanel', () => {
     expect(getButton({ enabled: true, to: bbUrl }).prop('to')).toEqual(bbUrl);
   });
 
+  it('cancellation button is destructive variant', () => {
+    expect(getButton().prop('destructive')).toBeTruthy();
+  });
+
   it('refresh button renews account and retrieves new account state', async () => {
     const renewAccount = jest.fn(() => Promise.resolve());
     const showAlert = jest.fn();


### PR DESCRIPTION
### What Changed
 - The button on the account cancellation pane (/account/settings at bottom) is now using the "destructive" variant of Matchbox's Button

### How To Test
 - Go to /account/settings, scroll to bottom, ensure button for "Cancel Account" is like this one: https://sparkpost.github.io/matchbox/?selectedKind=Action%7CButton&selectedStory=Destructive

