### PR TITLE
TR-1900 - Adds `data-id` attributes to various interactive elements in the new templates editor

### DIFF
--- a/src/pages/templatesV2/ListPage.js
+++ b/src/pages/templatesV2/ListPage.js
@@ -124,9 +124,15 @@ export default class ListPage extends Component {
       {
         component: (template) => (
           <span className={styles.Actions}>
-            <DuplicateAction onClick={() => this.toggleDuplicateModal(template)}/>
+            <DuplicateAction
+              onClick={() => this.toggleDuplicateModal(template)}
+              data-id="table-button-duplicate"
+            />
 
-            <DeleteAction onClick={() => this.toggleDeleteModal(template)}/>
+            <DeleteAction
+              onClick={() => this.toggleDeleteModal(template)}
+              data-id="table-button-delete"
+            />
           </span>
         ),
         header: {

--- a/src/pages/templatesV2/components/EditNavigation.js
+++ b/src/pages/templatesV2/components/EditNavigation.js
@@ -25,6 +25,7 @@ const EditNavigation = ({ primaryArea }) => {
             onClick={() => { setNavigation(key); }}
             to="javascript:void(0)"
             role="button"
+            data-id={`subnav-link-${key}`}
           >
             {content}
           </UnstyledLink>

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -58,7 +58,10 @@ const EditSection = () => {
               [
                 {
                   content: 'Insert Snippet',
-                  onClick: () => handleInsertSnippetClick()
+                  onClick: () => handleInsertSnippetClick(),
+                  role: 'button',
+                  href: 'javascript:void(0);',
+                  'data-id': 'popover-action-insert-snippet'
                 }
               ]
             }

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -45,6 +45,7 @@ const EditSection = () => {
               flat
               className={styles.MoreButton}
               onClick={() => setPopoverOpen(!isPopoverOpen)}
+              data-id="popover-trigger-more"
             >
               <MoreVert/>
 

--- a/src/pages/templatesV2/components/ListComponents.js
+++ b/src/pages/templatesV2/components/ListComponents.js
@@ -57,6 +57,7 @@ export const Status = (rowData) => {
 
 export const DeleteAction = ({ onClick, ...props }) => (
   <Button
+    {...props}
     className={styles.Action}
     flat
     onClick={() => onClick(props)}
@@ -69,6 +70,7 @@ export const DeleteAction = ({ onClick, ...props }) => (
 
 export const DuplicateAction = ({ onClick, ...props }) => (
   <Button
+    {...props}
     className={styles.Action}
     flat
     onClick={() => onClick(props)}

--- a/src/pages/templatesV2/components/PreviewControlBar.js
+++ b/src/pages/templatesV2/components/PreviewControlBar.js
@@ -18,6 +18,7 @@ const PreviewControlBar = () => {
           onClick={() => setPreviewDevice('desktop')}
           to="javascript:void(0);"
           role="button"
+          data-id="button-desktop-preview"
         >
           <DesktopWindows size={24} />
 
@@ -30,6 +31,7 @@ const PreviewControlBar = () => {
           onClick={() => setPreviewDevice('mobile')}
           to="javascript:void(0);"
           role="button"
+          data-id="button-mobile-preview"
         >
           <PhoneAndroid size={24} />
 

--- a/src/pages/templatesV2/components/RecentActivity.js
+++ b/src/pages/templatesV2/components/RecentActivity.js
@@ -63,11 +63,13 @@ const RecentActivity = (props) => {
                         <DuplicateAction
                           className={styles.RecentActivityAction}
                           onClick={() => onToggleDuplicateModal(template)}
+                          data-id="recent-activity-button-duplicate"
                         />
 
                         <DeleteAction
                           className={styles.RecentActivityAction}
                           onClick={() => onToggleDeleteModal(template)}
+                          data-id="recent-activity-button-delete"
                         />
                       </div>
                     </div>

--- a/src/pages/templatesV2/components/SendTestEmailButton.js
+++ b/src/pages/templatesV2/components/SendTestEmailButton.js
@@ -108,6 +108,7 @@ const SendTestEmailButton = () => {
         size="small"
         title="Opens a dialog"
         onClick={handleModalOpen}
+        data-id="button-send-a-test"
       >
         Send a Test
       </Button>
@@ -152,6 +153,7 @@ const SendTestEmailButton = () => {
                   type="email"
                   disabled
                   value={fromEmail}
+                  data-id="textfield-from-email"
                 />
 
                 <TextField
@@ -161,11 +163,13 @@ const SendTestEmailButton = () => {
                   type="email"
                   disabled
                   value={subject}
+                  data-id="textfield-email-subject"
                 />
 
                 <Button
                   color="orange"
                   type="submit"
+                  data-id="button-send-email"
                 >
                   Send Email
                 </Button>

--- a/src/pages/templatesV2/components/editorActions/DeleteTemplate.js
+++ b/src/pages/templatesV2/components/editorActions/DeleteTemplate.js
@@ -12,6 +12,7 @@ const DeleteTemplate = (props) => {
         onClick={onClick}
         role="button"
         to="javascript:void(0);"
+        data-id="action-delete"
       >
         <Delete/>
 

--- a/src/pages/templatesV2/components/editorActions/DraftModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/DraftModeActions.js
@@ -70,6 +70,7 @@ const DraftModeActions = () => {
             <Button
               onClick={() => setPopoverOpen(!isPopoverOpen)}
               aria-expanded={isPopoverOpen ? 'true' : 'false'}
+              data-id="popover-actions-trigger"
             >
               <ArrowDropDown/>
 

--- a/src/pages/templatesV2/components/editorActions/DuplicateTemplate.js
+++ b/src/pages/templatesV2/components/editorActions/DuplicateTemplate.js
@@ -11,6 +11,7 @@ const DuplicateTemplate = (props) => {
         onClick={onClick}
         role="button"
         to="javascript:void(0);"
+        data-id="action-duplicate"
       >
         <ContentCopy/>
 

--- a/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
+++ b/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
@@ -128,6 +128,7 @@ const DuplicateTemplateModal = (props) => {
             value={draftName}
             error={hasNameError ? 'Please enter a template name.' : undefined}
             onChange={handleNameChange}
+            data-id="textfield-template-name"
           />
 
           <TextField
@@ -138,10 +139,15 @@ const DuplicateTemplateModal = (props) => {
             value={draftId}
             error={hasIdError ? 'Please enter a unique template ID.' : undefined}
             onChange={handleIdChange}
+            data-id="textfield-template-id"
           />
 
           <ButtonWrapper>
-            <Button color="orange" submit>
+            <Button
+              color="orange"
+              submit
+              data-id="button-duplicate"
+            >
               Duplicate
             </Button>
           </ButtonWrapper>

--- a/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
@@ -61,7 +61,7 @@ const PublishedModeActions = () => {
             <Button
               onClick={() => setPopoverOpen(!isPopoverOpen)}
               aria-expanded={isPopoverOpen ? 'true' : 'false'}
-              data-id="popover-editor-actions"
+              data-id="popover-trigger-editor-actions"
             >
               <ArrowDropDown/>
 

--- a/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
@@ -48,7 +48,12 @@ const PublishedModeActions = () => {
 
   return (
     <Button.Group>
-      <Button to={editDraftTo} className={styles.Actions}>
+      <Button
+        to={editDraftTo}
+        className={styles.Actions}
+        role="button"
+        data-id="button-edit-draft"
+      >
         <strong>{draftText}</strong>
       </Button>
 

--- a/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
@@ -61,6 +61,7 @@ const PublishedModeActions = () => {
             <Button
               onClick={() => setPopoverOpen(!isPopoverOpen)}
               aria-expanded={isPopoverOpen ? 'true' : 'false'}
+              data-id="popover-editor-actions"
             >
               <ArrowDropDown/>
 

--- a/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
@@ -76,7 +76,11 @@ const PublishedModeActions = () => {
         >
           <div className={styles.ActionsBody}>
             <div className={styles.ActionItem}>
-              <PageLink to={editDraftTo}>
+              <PageLink
+                to={editDraftTo}
+                data-id="action-edit-draft"
+                role="button"
+              >
                 <FileEdit/>
 
                 {draftText}

--- a/src/pages/templatesV2/components/editorActions/SaveAndPublish.js
+++ b/src/pages/templatesV2/components/editorActions/SaveAndPublish.js
@@ -15,6 +15,7 @@ const SaveAndPublish = (props) => {
         <Button
           onClick={onClick}
           title="Opens a dialog"
+          data-id="action-save-and-publish"
         >
           {children}
         </Button>
@@ -26,6 +27,7 @@ const SaveAndPublish = (props) => {
           role="button"
           to="javascript:void(0);"
           title="Opens a dialog"
+          data-id="action-save-and-publish"
         >
           <CheckCircleOutline/>
 

--- a/src/pages/templatesV2/components/editorActions/SaveDraft.js
+++ b/src/pages/templatesV2/components/editorActions/SaveDraft.js
@@ -36,7 +36,12 @@ const SaveDraft = (props) => {
 
   return (
     <div className={className}>
-      <UnstyledLink onClick={handleClick} to="javascript:void(0);" role="button">
+      <UnstyledLink
+        onClick={handleClick}
+        to="javascript:void(0);"
+        role="button"
+        data-id="action-save-draft"
+      >
         <FileEdit/>
 
         <span>Save Draft</span>

--- a/src/pages/templatesV2/components/editorActions/ViewPublished.js
+++ b/src/pages/templatesV2/components/editorActions/ViewPublished.js
@@ -10,10 +10,15 @@ export default ({ className }) => {
 
   const publishedPath = `/${routeNamespace}/edit/${draft.id}/published/content${setSubaccountQuery(draft.subaccount_id)}`;
 
-  return (<div className={className}>
-    <UnstyledLink onClick={() => history.push(publishedPath)}>
-      <RemoveRedEye/>View Published
-    </UnstyledLink>
-  </div>);
-
+  return (
+    <div className={className}>
+      <UnstyledLink
+        to="javascript:void(0);"
+        onClick={() => history.push(publishedPath)}
+        data-id="action-view-published"
+      >
+        <RemoveRedEye/>View Published
+      </UnstyledLink>
+    </div>
+  );
 };

--- a/src/pages/templatesV2/components/editorActions/ViewPublished.js
+++ b/src/pages/templatesV2/components/editorActions/ViewPublished.js
@@ -17,7 +17,9 @@ export default ({ className }) => {
         onClick={() => history.push(publishedPath)}
         data-id="action-view-published"
       >
-        <RemoveRedEye/>View Published
+        <RemoveRedEye/>
+
+        <span>View Published</span>
       </UnstyledLink>
     </div>
   );

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DraftModeActions.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DraftModeActions.test.js.snap
@@ -22,6 +22,7 @@ exports[`DraftModeActions renders draft actions 1`] = `
       trigger={
         <Button
           aria-expanded="false"
+          data-id="popover-actions-trigger"
           onClick={[Function]}
           size="default"
         >

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DuplicateTemplateModal.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DuplicateTemplateModal.test.js.snap
@@ -15,6 +15,7 @@ exports[`DuplicateTemplateModal renders with default props and some data from th
       onSubmit={[Function]}
     >
       <TextField
+        data-id="textfield-template-name"
         id="template-name"
         label="Template Name"
         name="templateName"
@@ -25,6 +26,7 @@ exports[`DuplicateTemplateModal renders with default props and some data from th
         value=""
       />
       <TextField
+        data-id="textfield-template-id"
         id="template-id"
         label="Template ID"
         name="templateId"
@@ -37,6 +39,7 @@ exports[`DuplicateTemplateModal renders with default props and some data from th
       <ButtonWrapper>
         <Button
           color="orange"
+          data-id="button-duplicate"
           size="default"
           submit={true}
         >

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
@@ -4,6 +4,8 @@ exports[`PublishedModeActions renders published actions 1`] = `
 <Button.Group>
   <Button
     className="Actions"
+    data-id="button-edit-draft"
+    role="button"
     size="default"
     to="/templatesv2/edit/123/draft/content?subaccount=abcd"
   >
@@ -23,6 +25,7 @@ exports[`PublishedModeActions renders published actions 1`] = `
       trigger={
         <Button
           aria-expanded="false"
+          data-id="popover-trigger-editor-actions"
           onClick={[Function]}
           size="default"
         >
@@ -40,6 +43,8 @@ exports[`PublishedModeActions renders published actions 1`] = `
           className="ActionItem"
         >
           <PageLink
+            data-id="action-edit-draft"
+            role="button"
             to="/templatesv2/edit/123/draft/content?subaccount=abcd"
           >
             <FileEdit />

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveAndPublish.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveAndPublish.test.js.snap
@@ -3,6 +3,7 @@
 exports[`SaveAndPublish Renders and icon and default content when no children are supplied 1`] = `
 <div>
   <UnstyledLink
+    data-id="action-save-and-publish"
     role="button"
     title="Opens a dialog"
     to="javascript:void(0);"
@@ -20,6 +21,7 @@ exports[`SaveAndPublish renders SaveAndPublish action 1`] = `
   className="Foo"
 >
   <UnstyledLink
+    data-id="action-save-and-publish"
     role="button"
     title="Opens a dialog"
     to="javascript:void(0);"

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveDraft.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/SaveDraft.test.js.snap
@@ -5,6 +5,7 @@ exports[`SaveDraft renders save draft action 1`] = `
   className="Foo"
 >
   <UnstyledLink
+    data-id="action-save-draft"
     onClick={[Function]}
     role="button"
     to="javascript:void(0);"

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/ViewPublished.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/ViewPublished.test.js.snap
@@ -5,10 +5,14 @@ exports[`ViewPublished renders ViewPublished action 1`] = `
   className="Foo"
 >
   <UnstyledLink
+    data-id="action-view-published"
     onClick={[Function]}
+    to="javascript:void(0);"
   >
     <RemoveRedEye />
-    View Published
+    <span>
+      View Published
+    </span>
   </UnstyledLink>
 </div>
 `;

--- a/src/pages/templatesV2/components/tests/__snapshots__/EditNavigation.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/EditNavigation.test.js.snap
@@ -9,6 +9,7 @@ exports[`EditNavigation renders navigation with primary area 1`] = `
   >
     <UnstyledLink
       className="NavigationLink"
+      data-id="subnav-link-content"
       key="content"
       onClick={[Function]}
       role="button"
@@ -18,6 +19,7 @@ exports[`EditNavigation renders navigation with primary area 1`] = `
     </UnstyledLink>
     <UnstyledLink
       className="NavigationLink"
+      data-id="subnav-link-settings"
       key="settings"
       onClick={[Function]}
       role="button"

--- a/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
@@ -16,19 +16,31 @@ exports[`EditSection renders tabs and section 1`] = `
         Array [
           Object {
             "content": "HTML",
+            "data-id": "tab-html",
             "key": "html",
+            "role": "button",
+            "to": "javascript:void(0);",
           },
           Object {
             "content": "AMP HTML",
+            "data-id": "tab-amp-html",
             "key": "amp_html",
+            "role": "button",
+            "to": "javascript:void(0);",
           },
           Object {
             "content": "Text",
+            "data-id": "tab-text",
             "key": "text",
+            "role": "button",
+            "to": "javascript:void(0);",
           },
           Object {
             "content": "Test Data",
+            "data-id": "tab-test-data",
             "key": "test_data",
+            "role": "button",
+            "to": "javascript:void(0);",
           },
         ]
       }
@@ -42,6 +54,7 @@ exports[`EditSection renders tabs and section 1`] = `
       trigger={
         <Button
           className="MoreButton"
+          data-id="popover-trigger-more"
           flat={true}
           onClick={[Function]}
           size="default"
@@ -58,7 +71,10 @@ exports[`EditSection renders tabs and section 1`] = `
           Array [
             Object {
               "content": "Insert Snippet",
+              "data-id": "popover-action-insert-snippet",
+              "href": "javascript:void(0);",
               "onClick": [Function],
+              "role": "button",
             },
           ]
         }

--- a/src/pages/templatesV2/components/tests/__snapshots__/PreviewControlBar.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/PreviewControlBar.test.js.snap
@@ -9,6 +9,7 @@ exports[`PreviewControlBar renders control bar 1`] = `
   >
     <UnstyledLink
       className="PreviewDeviceButton active"
+      data-id="button-desktop-preview"
       id="preview-content-desktop-button"
       onClick={[Function]}
       role="button"
@@ -23,6 +24,7 @@ exports[`PreviewControlBar renders control bar 1`] = `
     </UnstyledLink>
     <UnstyledLink
       className="PreviewDeviceButton"
+      data-id="button-mobile-preview"
       id="preview-content-mobile-button"
       onClick={[Function]}
       role="button"

--- a/src/pages/templatesV2/constants/editTabs.js
+++ b/src/pages/templatesV2/constants/editTabs.js
@@ -7,22 +7,34 @@ const editTabs = [
   {
     content: 'HTML',
     key: 'html',
-    render: EditHtmlSection
+    render: EditHtmlSection,
+    role: 'button',
+    to: 'javascript:void(0);',
+    ['data-id']: 'tab-html'
   },
   {
     content: 'AMP HTML',
     key: 'amp_html',
-    render: EditAmpSection
+    render: EditAmpSection,
+    role: 'button',
+    to: 'javascript:void(0);',
+    ['data-id']: 'tab-amp-html'
   },
   {
     content: 'Text',
     key: 'text',
-    render: EditTextSection
+    render: EditTextSection,
+    role: 'button',
+    to: 'javascript:void(0);',
+    ['data-id']: 'tab-text'
   },
   {
     content: 'Test Data',
     key: 'test_data',
-    render: EditTestDataSection
+    render: EditTestDataSection,
+    role: 'button',
+    to: 'javascript:void(0);',
+    ['data-id']: 'tab-test-data'
   }
 ];
 

--- a/src/pages/templatesV2/constants/editTabs.js
+++ b/src/pages/templatesV2/constants/editTabs.js
@@ -10,7 +10,7 @@ const editTabs = [
     render: EditHtmlSection,
     role: 'button',
     to: 'javascript:void(0);',
-    ['data-id']: 'tab-html'
+    'data-id': 'tab-html'
   },
   {
     content: 'AMP HTML',
@@ -18,7 +18,7 @@ const editTabs = [
     render: EditAmpSection,
     role: 'button',
     to: 'javascript:void(0);',
-    ['data-id']: 'tab-amp-html'
+    'data-id': 'tab-amp-html'
   },
   {
     content: 'Text',
@@ -26,7 +26,7 @@ const editTabs = [
     render: EditTextSection,
     role: 'button',
     to: 'javascript:void(0);',
-    ['data-id']: 'tab-text'
+    'data-id': 'tab-text'
   },
   {
     content: 'Test Data',
@@ -34,7 +34,7 @@ const editTabs = [
     render: EditTestDataSection,
     role: 'button',
     to: 'javascript:void(0);',
-    ['data-id']: 'tab-test-data'
+    'data-id': 'tab-test-data'
   }
 ];
 


### PR DESCRIPTION
[TR-1900](https://jira.int.messagesystems.com/browse/TR-1900)

### What Changed
- Added `data-id` attributes to interactive elements within the templates editor.
- Added some missing ARIA roles
- Updated relevant snapshots

### How To Test
Verify `data-id` attributes exist on the following elements:

- The duplicate and delete buttons on the table collection
- The subnavigation items
- The edit section popover trigger
- The desktop and mobile preview buttons on the preview panel
- The duplicate and delete buttons in the 'Recent Activity' section on the list page
- The 'Send a Test' button on the preview panel
- The text fields within the 'Send a Test' modal
- The 'Delete' button within the delete template modal
- The editor actions popover trigger in the top right of the view
- Each action in the editor actions popover in the top right of the view
- The editor tabs

### To Do
- [ ] Incorporate feedback
