### PR TITLE
FE-732: Make form labels consistent with recipients list

### DIFF
--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -68,28 +68,26 @@ export class RecipientListForm extends Component {
     }
 
     return <div>
-      { error && this.renderCsvErrors() }
+      {error && this.renderCsvErrors()}
       <form onSubmit={handleSubmit(this.preSubmit)}>
         <Panel>
           <Panel.Section>
             <Field
               name='name'
-              label='Label'
+              label='Name'
               placeholder='My favorite recipients'
               validate={[required, maxLength(64)]}
               disabled={submitting}
               component={TextFieldWrapper}
-              required
             />
-            { ! editMode && <Field
+            {!editMode && <Field
               name='id'
-              label='Identifier'
+              label='ID'
               placeholder='my-favorite-recipients'
               validate={[required, maxLength(64)]}
               disabled={submitting}
               component={TextFieldWrapper}
-              required
-            /> }
+            />}
             <Field
               name='description'
               label='Description'
@@ -112,7 +110,6 @@ export class RecipientListForm extends Component {
               label={uploadHint}
               name="csv"
               validate={uploadValidators}
-              required
             />
           </Panel.Section>
           <Panel.Section>

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
@@ -7,10 +7,9 @@ exports[`RecipientListForm defaults to create mode 1`] = `
       <Panel.Section>
         <Field
           component={[Function]}
-          label="Label"
+          label="Name"
           name="name"
           placeholder="My favorite recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -20,10 +19,9 @@ exports[`RecipientListForm defaults to create mode 1`] = `
         />
         <Field
           component={[Function]}
-          label="Identifier"
+          label="ID"
           name="id"
           placeholder="my-favorite-recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -58,7 +56,6 @@ exports[`RecipientListForm defaults to create mode 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
-          required={true}
           validate={
             Array [
               [Function],
@@ -103,10 +100,9 @@ exports[`RecipientListForm renders CSV errors 1`] = `
       <Panel.Section>
         <Field
           component={[Function]}
-          label="Label"
+          label="Name"
           name="name"
           placeholder="My favorite recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -116,10 +112,9 @@ exports[`RecipientListForm renders CSV errors 1`] = `
         />
         <Field
           component={[Function]}
-          label="Identifier"
+          label="ID"
           name="id"
           placeholder="my-favorite-recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -154,7 +149,6 @@ exports[`RecipientListForm renders CSV errors 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
-          required={true}
           validate={
             Array [
               [Function],
@@ -186,10 +180,9 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
       <Panel.Section>
         <Field
           component={[Function]}
-          label="Label"
+          label="Name"
           name="name"
           placeholder="My favorite recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -199,10 +192,9 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
         />
         <Field
           component={[Function]}
-          label="Identifier"
+          label="ID"
           name="id"
           placeholder="my-favorite-recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -237,7 +229,6 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
-          required={true}
           validate={
             Array [
               [Function],
@@ -269,10 +260,9 @@ exports[`RecipientListForm renders correctly in edit mode 1`] = `
       <Panel.Section>
         <Field
           component={[Function]}
-          label="Label"
+          label="Name"
           name="name"
           placeholder="My favorite recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -307,7 +297,6 @@ exports[`RecipientListForm renders correctly in edit mode 1`] = `
           }
           label="Optional: Upload a CSV file of recipients to replace the existing recipients in this list"
           name="csv"
-          required={true}
           validate={
             Array [
               [Function],
@@ -339,10 +328,9 @@ exports[`RecipientListForm should disable form elements on submit 1`] = `
         <Field
           component={[Function]}
           disabled={true}
-          label="Label"
+          label="Name"
           name="name"
           placeholder="My favorite recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -353,10 +341,9 @@ exports[`RecipientListForm should disable form elements on submit 1`] = `
         <Field
           component={[Function]}
           disabled={true}
-          label="Identifier"
+          label="ID"
           name="id"
           placeholder="my-favorite-recipients"
-          required={true}
           validate={
             Array [
               [Function],
@@ -393,7 +380,6 @@ exports[`RecipientListForm should disable form elements on submit 1`] = `
           }
           label="Upload a CSV file of recipients"
           name="csv"
-          required={true}
           validate={
             Array [
               [Function],


### PR DESCRIPTION
### What Changed
 - Changed "Label" to "Name" and "Identifier" to "ID" in the recipient list form for consistency with the list page.
- Removed the `required` prop from the fields in the form for consistency with other forms.

### How To Test
 - Ensure the labels are changed on /lists/recipient-lists/create and /lists/recipient-lists/edit
 - Ensure the labels do not have the `*` at the end of the field label anymore 
