### PR TITLE
TR-1897 - Add loading state while DuplicateTemplateModal is fetching a template

### DIFF
--- a/src/components/panelLoading/PanelLoading.js
+++ b/src/components/panelLoading/PanelLoading.js
@@ -3,14 +3,23 @@ import styles from './PanelLoading.module.scss';
 import { Panel } from '@sparkpost/matchbox';
 import { Loading } from 'src/components/loading/Loading';
 
-const PanelLoading = ({ minHeight }) => (
-  <Panel className={styles.Loading} style={{ minHeight }}>
-    <Loading />
-  </Panel>
-);
+const PanelLoading = (props) => {
+  const { minHeight, accent } = props;
+
+  return (
+    <Panel
+      className={styles.Loading}
+      style={{ minHeight }}
+      accent={accent}
+    >
+      <Loading />
+    </Panel>
+  );
+};
 
 PanelLoading.defaultProps = {
-  minHeight: '400px'
+  minHeight: '400px',
+  accent: false
 };
 
 export default PanelLoading;

--- a/src/components/panelLoading/tests/__snapshots__/PanelLoading.test.js.snap
+++ b/src/components/panelLoading/tests/__snapshots__/PanelLoading.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Panel Loading render 1`] = `
 <Panel
+  accent={false}
   className="Loading"
   style={
     Object {

--- a/src/components/usageReport/tests/__snapshots__/UsageReport.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/UsageReport.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`UsageReport Component should render null without props 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/account/components/EnforceTfaPanel/tests/__snapshots__/EnforceTfaPanel.test.js.snap
+++ b/src/pages/account/components/EnforceTfaPanel/tests/__snapshots__/EnforceTfaPanel.test.js.snap
@@ -74,6 +74,7 @@ exports[`Component: EnforceTfaPanel renders fully after loading 1`] = `
 
 exports[`Component: EnforceTfaPanel renders loading state 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/account/components/SingleSignOnPanel/tests/__snapshots__/SingleSignOnPanel.test.js.snap
+++ b/src/pages/account/components/SingleSignOnPanel/tests/__snapshots__/SingleSignOnPanel.test.js.snap
@@ -15,6 +15,7 @@ exports[`SingleSignOnPanel renders with panel loading 1`] = `
   title="Single Sign-On"
 >
   <PanelLoading
+    accent={false}
     minHeight="130px"
   />
 </Panel>

--- a/src/pages/profile/components/tests/__snapshots__/TfaManager.test.js.snap
+++ b/src/pages/profile/components/tests/__snapshots__/TfaManager.test.js.snap
@@ -115,6 +115,7 @@ exports[`EnableTfaModal tests should show a message about 0 codes 1`] = `
 
 exports[`EnableTfaModal tests should show panel loading while status unknown 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="100px"
 />
 `;

--- a/src/pages/register/tests/__snapshots__/RegisterPage.test.js.snap
+++ b/src/pages/register/tests/__snapshots__/RegisterPage.test.js.snap
@@ -42,6 +42,7 @@ exports[`Page: RegisterPage loading 1`] = `
     title="Set Password"
   >
     <PanelLoading
+      accent={false}
       minHeight="400px"
     />
   </Panel>

--- a/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
+++ b/src/pages/reports/bounce/tests/__snapshots__/BouncePage.test.js.snap
@@ -10,6 +10,7 @@ exports[`BouncePage:  should display loading panel on top level metrics when agg
     searchOptions={Object {}}
   />
   <PanelLoading
+    accent={false}
     minHeight="115px"
   />
   <Tabs
@@ -569,6 +570,7 @@ exports[`BouncePage:  should show loading panel when table is loading 1`] = `
   />
   <hr />
   <PanelLoading
+    accent={false}
     minHeight="400px"
   />
 </Page>

--- a/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
+++ b/src/pages/reports/delays/tests/__snapshots__/DelayPage.test.js.snap
@@ -67,6 +67,7 @@ exports[`DelayPage:  should show loading indicator when loading table 1`] = `
     title="Delayed Messages"
   >
     <PanelLoading
+      accent={false}
       minHeight="400px"
     />
   </Panel>
@@ -80,6 +81,7 @@ exports[`DelayPage:  should show loading panel when aggregates are still loading
 >
   <withRouter(Connect(ReportOptions)) />
   <PanelLoading
+    accent={false}
     minHeight="115px"
   />
   <Panel

--- a/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
+++ b/src/pages/reports/engagement/components/async/tests/__snapshots__/EngagementChart.test.js.snap
@@ -198,6 +198,7 @@ exports[`EngagementChart renders engagement chart 1`] = `
 
 exports[`EngagementChart renders loading 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/reports/engagement/components/tests/__snapshots__/EngagementSummary.test.js.snap
+++ b/src/pages/reports/engagement/components/tests/__snapshots__/EngagementSummary.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`EngagementSummary renders loading panel 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="115px"
 />
 `;

--- a/src/pages/reports/engagement/components/tests/__snapshots__/EngagementTable.test.js.snap
+++ b/src/pages/reports/engagement/components/tests/__snapshots__/EngagementTable.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`EngagementTable when loading 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
@@ -26,6 +26,7 @@ exports[`Page: Message Events tests should only render loading component while l
 >
   <withRouter(Connect(MessageEventsSearch)) />
   <PanelLoading
+    accent={false}
     minHeight="400px"
   />
 </Page>

--- a/src/pages/reports/rejection/tests/__snapshots__/RejectionPage.test.js.snap
+++ b/src/pages/reports/rejection/tests/__snapshots__/RejectionPage.test.js.snap
@@ -23,6 +23,7 @@ exports[`RejectionPage:  renders correctly when loading 1`] = `
   </Connect(MetricsSummary)>
   <hr />
   <PanelLoading
+    accent={false}
     minHeight="400px"
   />
 </Page>
@@ -37,6 +38,7 @@ exports[`RejectionPage:  renders loading pannel when aggregates are still loadin
     reportLoading={false}
   />
   <PanelLoading
+    accent={false}
     minHeight="115px"
   />
   <hr />

--- a/src/pages/sendingDomains/components/tests/__snapshots__/AssignTrackingDomain.test.js.snap
+++ b/src/pages/sendingDomains/components/tests/__snapshots__/AssignTrackingDomain.test.js.snap
@@ -176,6 +176,7 @@ exports[`Component: AssignTrackingDomain form should render panel loading compon
   </Left>
   <Right>
     <PanelLoading
+      accent={false}
       minHeight="400px"
     />
   </Right>

--- a/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/EngagementRecencyPreview.test.js.snap
@@ -172,6 +172,7 @@ exports[`Signals EngagementRecencyPreview Component renders error correctly 1`] 
 
 exports[`Signals EngagementRecencyPreview Component renders loading correctly 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="170px"
 />
 `;

--- a/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/HealthScorePreview.test.js.snap
@@ -129,6 +129,7 @@ exports[`Signals HealthScorePreview Component renders error correctly 1`] = `
 
 exports[`Signals HealthScorePreview Component renders loading correctly 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="170px"
 />
 `;

--- a/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
+++ b/src/pages/signals/components/previews/tests/__snapshots__/SpamTrapsPreview.test.js.snap
@@ -142,6 +142,7 @@ exports[`Signals SpamTrapsPreview Component renders error correctly 1`] = `
 
 exports[`Signals SpamTrapsPreview Component renders loading correctly 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="170px"
 />
 `;

--- a/src/pages/subaccounts/components/test/__snapshots__/ApiKeysTab.test.js.snap
+++ b/src/pages/subaccounts/components/test/__snapshots__/ApiKeysTab.test.js.snap
@@ -27,6 +27,7 @@ exports[`ApiKeysTab empty 1`] = `
 
 exports[`ApiKeysTab loading 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/subaccounts/components/test/__snapshots__/EditTab.test.js.snap
+++ b/src/pages/subaccounts/components/test/__snapshots__/EditTab.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`EditTab Render loading 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/subaccounts/components/test/__snapshots__/SendingDomainsTab.test.js.snap
+++ b/src/pages/subaccounts/components/test/__snapshots__/SendingDomainsTab.test.js.snap
@@ -86,6 +86,7 @@ exports[`SendingDomainsTab should show empty message when 0 domains exist 1`] = 
 
 exports[`SendingDomainsTab should show panel loading while loading domains 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/suppressions/components/tests/__snapshots__/Results.test.js.snap
+++ b/src/pages/suppressions/components/tests/__snapshots__/Results.test.js.snap
@@ -217,6 +217,7 @@ exports[`Results renders correctly on initial loading 1`] = `
 
 exports[`Results renders correctly when list is loading 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/templates/components/tests/__snapshots__/ImportSnippetPanel.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/ImportSnippetPanel.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`ImportSnippetPanel renders loading panel 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;

--- a/src/pages/templatesV2/ListPage.container.js
+++ b/src/pages/templatesV2/ListPage.container.js
@@ -26,7 +26,9 @@ function mapStateToProps(state) {
     error: state.templates.listError,
     canModify,
     isDeletePending: Boolean(state.templates.deletePending),
-    isCreatePending: Boolean(state.templates.createPending)
+    isCreatePending: Boolean(state.templates.createPending),
+    draftPending: Boolean(state.templates.getDraftLoading),
+    publishedPending: Boolean(state.templates.getPublishedLoading)
   };
 }
 

--- a/src/pages/templatesV2/ListPage.container.js
+++ b/src/pages/templatesV2/ListPage.container.js
@@ -27,8 +27,8 @@ function mapStateToProps(state) {
     canModify,
     isDeletePending: Boolean(state.templates.deletePending),
     isCreatePending: Boolean(state.templates.createPending),
-    draftPending: Boolean(state.templates.getDraftLoading),
-    publishedPending: Boolean(state.templates.getPublishedLoading)
+    isDraftPending: Boolean(state.templates.getDraftLoading),
+    isPublishedPending: Boolean(state.templates.getPublishedLoading)
   };
 }
 

--- a/src/pages/templatesV2/ListPage.js
+++ b/src/pages/templatesV2/ListPage.js
@@ -157,8 +157,8 @@ export default class ListPage extends Component {
       templates,
       isDeletePending,
       isCreatePending,
-      draftPending,
-      publishedPending
+      isDraftPending,
+      isPublishedPending
     } = this.props;
 
     if (loading) {
@@ -238,7 +238,7 @@ export default class ListPage extends Component {
               contentToDuplicate={this.state.templateToDuplicate && this.state.templateToDuplicate.content}
               testDataToDuplicate={this.state.testDataToDuplicate}
               isPublishedMode={this.state.templateToDuplicate && this.state.templateToDuplicate.published}
-              isLoading={draftPending || publishedPending || isCreatePending}
+              isLoading={isDraftPending || isPublishedPending || isCreatePending}
             />
           </>
         )}

--- a/src/pages/templatesV2/ListPage.js
+++ b/src/pages/templatesV2/ListPage.js
@@ -52,13 +52,14 @@ export default class ListPage extends Component {
     const { getDraft, getPublished, getTestDataV2 } = this.props;
     const isPublished = template.published;
 
+    this.setState({ showDuplicateModal: true });
+
     if (isPublished) {
       return getPublished(template.id)
         .then((res) => {
           this.setState({
             templateToDuplicate: res,
-            testDataToDuplicate: getTestDataV2({ id: res.id, mode: 'published' }),
-            showDuplicateModal: !this.state.showDuplicateModal
+            testDataToDuplicate: getTestDataV2({ id: res.id, mode: 'published' })
           });
         });
     }
@@ -67,8 +68,7 @@ export default class ListPage extends Component {
       .then((res) => {
         this.setState({
           templateToDuplicate: res,
-          testDataToDuplicate: getTestDataV2({ id: res.id, mode: 'draft' }),
-          showDuplicateModal: !this.state.showDuplicateModal
+          testDataToDuplicate: getTestDataV2({ id: res.id, mode: 'draft' })
         });
       });
   }
@@ -155,7 +155,10 @@ export default class ListPage extends Component {
       listTemplates,
       loading,
       templates,
-      isDeletePending
+      isDeletePending,
+      isCreatePending,
+      draftPending,
+      publishedPending
     } = this.props;
 
     if (loading) {
@@ -235,7 +238,7 @@ export default class ListPage extends Component {
               contentToDuplicate={this.state.templateToDuplicate && this.state.templateToDuplicate.content}
               testDataToDuplicate={this.state.testDataToDuplicate}
               isPublishedMode={this.state.templateToDuplicate && this.state.templateToDuplicate.published}
-              isLoading={this.props.isCreatePending}
+              isLoading={draftPending || publishedPending || isCreatePending}
             />
           </>
         )}

--- a/src/pages/templatesV2/components/InsertSnippetModal.js
+++ b/src/pages/templatesV2/components/InsertSnippetModal.js
@@ -73,7 +73,7 @@ const InsertSnippetModal = (props) => {
   if (areSnippetsLoading) {
     return (
       <ModalWrapper {...modalProps}>
-        <PanelLoading/>
+        <PanelLoading accent/>
       </ModalWrapper>
     )
   }

--- a/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
+++ b/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
@@ -102,7 +102,7 @@ const DuplicateTemplateModal = (props) => {
   if (isLoading) {
     return (
       <ModalWrapper {...modalProps}>
-        <PanelLoading minHeight={'325px'}/>
+        <PanelLoading accent minHeight='330px'/>
       </ModalWrapper>
     );
   }

--- a/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
+++ b/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
@@ -13,7 +13,6 @@ const ModalWrapper = (props) => {
   const {
     open,
     onClose,
-    showCloseButton,
     children
   } = props;
 
@@ -21,7 +20,7 @@ const ModalWrapper = (props) => {
     <Modal
       open={open}
       onClose={onClose}
-      showCloseButton={showCloseButton}
+      showCloseButton={true}
     >
       {children}
     </Modal>
@@ -40,11 +39,7 @@ const DuplicateTemplateModal = (props) => {
     showAlert,
     isLoading
   } = props;
-  const modalProps = {
-    open,
-    onClose,
-    showCloseButton: true
-  };
+  const modalProps = { open, onClose };
   const initialDraftName = (template && template.name) ? `${template.name} (COPY)` : '';
   const initialDraftId = (template && template.id) ? `${template.id}-copy` : '';
 

--- a/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
+++ b/src/pages/templatesV2/components/editorActions/DuplicateTemplateModal.js
@@ -102,7 +102,7 @@ const DuplicateTemplateModal = (props) => {
   if (isLoading) {
     return (
       <ModalWrapper {...modalProps}>
-        <PanelLoading minHeight={'300px'}/>
+        <PanelLoading minHeight={'325px'}/>
       </ModalWrapper>
     );
   }

--- a/src/pages/templatesV2/components/editorActions/tests/DuplicateTemplateModal.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/DuplicateTemplateModal.test.js
@@ -20,9 +20,9 @@ describe('DuplicateTemplateModal', () => {
 
   it('has a close button', () => {
     const wrapper = subject();
-    const modalProps = wrapper.find('ModalWrapper').props();
+    const { showCloseButton } = wrapper.find('ModalWrapper').dive().props();
 
-    expect(modalProps.showCloseButton).toBe(true);
+    expect(showCloseButton).toBe(true);
   });
 
   it('renders the loading state when "isLoading" is true', () => {

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DuplicateTemplateModal.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/DuplicateTemplateModal.test.js.snap
@@ -4,7 +4,6 @@ exports[`DuplicateTemplateModal renders with default props and some data from th
 <ModalWrapper
   onClose={[MockFunction]}
   open={false}
-  showCloseButton={true}
 >
   <Panel
     accent={true}

--- a/src/pages/webhooks/components/tests/__snapshots__/BatchTab.test.js.snap
+++ b/src/pages/webhooks/components/tests/__snapshots__/BatchTab.test.js.snap
@@ -78,6 +78,7 @@ exports[`Webhook Component: Batch Status Tab should show button text as Refreshi
     </Button>
   </Panel.Section>
   <PanelLoading
+    accent={false}
     minHeight="400px"
   />
 </Panel>

--- a/src/pages/webhooks/components/tests/__snapshots__/EditTab.test.js.snap
+++ b/src/pages/webhooks/components/tests/__snapshots__/EditTab.test.js.snap
@@ -22,6 +22,7 @@ exports[`Webhooks EditTab should render correctly 1`] = `
 
 exports[`Webhooks EditTab should render loading 1`] = `
 <PanelLoading
+  accent={false}
   minHeight="400px"
 />
 `;


### PR DESCRIPTION
[TR-1897](https://jira.int.messagesystems.com/browse/TR-1897)

### What Changed
- Remove closing modal as part of a Promise chain
- use Redux store to control loading state
- Updated minimum height of loading state to more closely match height of the modal content

### How To Test
- On the `/templatesV2` list page, click on any of the duplicate buttons and verify that a loading state is now present

### To Do
- [ ] Incorporate feedback
