### PR TITLE
Sa 1000 - Add region column to Inbox Placement by Mailbox Providers

### DIFF
--- a/src/pages/inboxPlacement/components/ProvidersBreakdown.js
+++ b/src/pages/inboxPlacement/components/ProvidersBreakdown.js
@@ -8,7 +8,7 @@ import PageLink from 'src/components/pageLink/PageLink';
 
 export const GroupPercentage = ({ value }) => <span className={styles.GroupValue}>{formatPercent(value * 100)}</span>;
 
-const HeaderComponent = () => (<thead>
+export const HeaderComponent = () => (<thead>
   <Table.Row className={styles.HeaderRow}>
     <Table.HeaderCell className={styles.MailboxProviderCell}>Mailbox Provider</Table.HeaderCell>
     <Table.HeaderCell className={styles.RegionCell}>Region</Table.HeaderCell>
@@ -25,7 +25,7 @@ const WrapperComponent = ({ children }) => (<div>
   <Table>{children}</Table>
 </div>);
 
-const RowComponent = ({ id, mailbox_provider, region, placement, authentication }) => (<Table.Row className={styles.DataRow}>
+export const RowComponent = ({ id, mailbox_provider, region, placement, authentication }) => (<Table.Row className={styles.DataRow}>
   <Table.Cell className={styles.MailboxProviderCell}>
     <PageLink to={`/inbox-placement/details/${id}/mailbox-provider/${mailbox_provider}`}><strong>{mailbox_provider}</strong></PageLink>
   </Table.Cell>

--- a/src/pages/inboxPlacement/components/ProvidersBreakdown.js
+++ b/src/pages/inboxPlacement/components/ProvidersBreakdown.js
@@ -10,7 +10,8 @@ export const GroupPercentage = ({ value }) => <span className={styles.GroupValue
 
 const HeaderComponent = () => (<thead>
   <Table.Row className={styles.HeaderRow}>
-    <Table.HeaderCell className={styles.ProviderCell}>Mailbox Provider</Table.HeaderCell>
+    <Table.HeaderCell className={styles.MailboxProviderCell}>Mailbox Provider</Table.HeaderCell>
+    <Table.HeaderCell className={styles.RegionCell}>Region</Table.HeaderCell>
     <Table.HeaderCell className={styles.Placement}>Inbox</Table.HeaderCell>
     <Table.HeaderCell className={styles.Placement}>Spam</Table.HeaderCell>
     <Table.HeaderCell className={styles.Placement}>Missing</Table.HeaderCell>
@@ -24,9 +25,12 @@ const WrapperComponent = ({ children }) => (<div>
   <Table>{children}</Table>
 </div>);
 
-const RowComponent = ({ id, mailbox_provider, placement, authentication }) => (<Table.Row className={styles.DataRow}>
-  <Table.Cell className={styles.ProviderCell}>
+const RowComponent = ({ id, mailbox_provider, region, placement, authentication }) => (<Table.Row className={styles.DataRow}>
+  <Table.Cell className={styles.MailboxProviderCell}>
     <PageLink to={`/inbox-placement/details/${id}/mailbox-provider/${mailbox_provider}`}><strong>{mailbox_provider}</strong></PageLink>
+  </Table.Cell>
+  <Table.Cell className={styles.RegionCell}>
+    {region}
   </Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.inbox_pct}/></Table.Cell>
   <Table.Cell className={styles.Placement}><GroupPercentage value={placement.spam_pct}/></Table.Cell>

--- a/src/pages/inboxPlacement/components/ProvidersBreakdown.module.scss
+++ b/src/pages/inboxPlacement/components/ProvidersBreakdown.module.scss
@@ -10,9 +10,15 @@
   border-bottom: 0px;
 }
 
-.ProviderCell {
+.MailboxProviderCell {
+  width: 20%;
+  font-weight: normal;
+}
+
+.RegionCell {
   border-right: 1px solid color(gray, 8);
-  width: 40%;
+  width: 15%;
+  word-break: normal;
   font-weight: normal;
 }
 

--- a/src/pages/inboxPlacement/components/tests/ProvidersBreakdown.test.js
+++ b/src/pages/inboxPlacement/components/tests/ProvidersBreakdown.test.js
@@ -1,9 +1,41 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import ProvidersBreakdown, { GroupPercentage } from '../ProvidersBreakdown';
+import ProvidersBreakdown, { GroupPercentage, HeaderComponent, RowComponent } from '../ProvidersBreakdown';
 
 describe('Component: ProvidersBreakdown', () => {
+
+  const data = [
+    {
+      mailbox_provider: 'dogmail.com',
+      region: 'north america',
+      placement: {
+        inbox_pct: 0,
+        spam_pct: 0,
+        missing_pct: 1
+      },
+      authentication: {
+        spf_pct: 0,
+        dkim_pct: 0,
+        dmarc_pct: 1
+      }
+    },
+    {
+      mailbox_provider: 'doghouseinbox.com',
+      region: 'europe',
+      placement: {
+        inbox_pct: 0.8,
+        spam_pct: 0.1,
+        missing_pct: 0.1
+      },
+      authentication: {
+        spf_pct: 0.8,
+        dkim_pct: 0.1,
+        dmarc_pct: 0.1
+      }
+    }
+  ];
+
   const subject = ({ ...props }) => shallow(<ProvidersBreakdown data={[]} {...props}/>);
 
   it('renders correctly with no data', () => {
@@ -11,41 +43,33 @@ describe('Component: ProvidersBreakdown', () => {
   });
 
   it('renders correctly with data', () => {
-    const data = [
-      {
-        'mailbox_provider': 'dogmail.com',
-        'placement': {
-          'inbox_pct': 0,
-          'spam_pct': 0,
-          'missing_pct': 1
-        },
-        'authentication': {
-          'spf_pct': 0,
-          'dkim_pct': 0,
-          'dmarc_pct': 1
-        }
-      },
-      {
-        'mailbox_provider': 'doghouseinbox.com',
-        'placement': {
-          'inbox_pct': 0.8,
-          'spam_pct': 0.1,
-          'missing_pct': 0.1
-        },
-        'authentication': {
-          'spf_pct': 0.8,
-          'dkim_pct': 0.1,
-          'dmarc_pct': 0.1
-        }
-      }
-    ];
-
     expect(subject({ data })).toMatchSnapshot();
   });
+
 
   describe('SubComponent: GroupPercentage', () => {
     it('renders percentage correctly', () => {
       expect(shallow(<GroupPercentage value={0.2}/>)).toMatchSnapshot();
+    });
+  });
+
+  describe('RowComponent', () => {
+    const { mailbox_provider, region, placement, authentication } = data[0];
+    it('renders correctly', () => {
+      expect(shallow(
+        <RowComponent
+          id={1}
+          mailbox_provider={mailbox_provider}
+          region={region}
+          placement={placement}
+          authentication={authentication}
+        />)).toMatchSnapshot();
+    });
+  });
+
+  describe('HeaderComponent', () => {
+    it('renders correctly', () => {
+      expect(shallow(<HeaderComponent/>)).toMatchSnapshot();
     });
   });
 

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/ProvidersBreakdown.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/ProvidersBreakdown.test.js.snap
@@ -1,5 +1,119 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Component: ProvidersBreakdown HeaderComponent renders correctly 1`] = `
+<thead>
+  <Table.Row
+    className="HeaderRow"
+  >
+    <Table.HeaderCell
+      className="MailboxProviderCell"
+    >
+      Mailbox Provider
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      className="RegionCell"
+    >
+      Region
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      className="Placement"
+    >
+      Inbox
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      className="Placement"
+    >
+      Spam
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      className="Placement"
+    >
+      Missing
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      className="Authentication divider"
+    >
+      SPF
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      className="Authentication"
+    >
+      DKIM
+    </Table.HeaderCell>
+    <Table.HeaderCell
+      className="Authentication"
+    >
+      DMARC
+    </Table.HeaderCell>
+  </Table.Row>
+</thead>
+`;
+
+exports[`Component: ProvidersBreakdown RowComponent renders correctly 1`] = `
+<Table.Row
+  className="DataRow"
+>
+  <Table.Cell
+    className="MailboxProviderCell"
+  >
+    <PageLink
+      to="/inbox-placement/details/1/mailbox-provider/dogmail.com"
+    >
+      <strong>
+        dogmail.com
+      </strong>
+    </PageLink>
+  </Table.Cell>
+  <Table.Cell
+    className="RegionCell"
+  >
+    north america
+  </Table.Cell>
+  <Table.Cell
+    className="Placement"
+  >
+    <GroupPercentage
+      value={0}
+    />
+  </Table.Cell>
+  <Table.Cell
+    className="Placement"
+  >
+    <GroupPercentage
+      value={0}
+    />
+  </Table.Cell>
+  <Table.Cell
+    className="Placement"
+  >
+    <GroupPercentage
+      value={1}
+    />
+  </Table.Cell>
+  <Table.Cell
+    className="Authentication divider"
+  >
+    <GroupPercentage
+      value={0}
+    />
+  </Table.Cell>
+  <Table.Cell
+    className="Authentication"
+  >
+    <GroupPercentage
+      value={0}
+    />
+  </Table.Cell>
+  <Table.Cell
+    className="Authentication"
+  >
+    <GroupPercentage
+      value={1}
+    />
+  </Table.Cell>
+</Table.Row>
+`;
+
 exports[`Component: ProvidersBreakdown SubComponent: GroupPercentage renders percentage correctly 1`] = `
 <span
   className="GroupValue"
@@ -29,6 +143,7 @@ exports[`Component: ProvidersBreakdown renders correctly with data 1`] = `
           "missing_pct": 1,
           "spam_pct": 0,
         },
+        "region": "north america",
       },
       Object {
         "authentication": Object {
@@ -42,6 +157,7 @@ exports[`Component: ProvidersBreakdown renders correctly with data 1`] = `
           "missing_pct": 0.1,
           "spam_pct": 0.1,
         },
+        "region": "europe",
       },
     ]
   }


### PR DESCRIPTION

### What Changed
 - Added a region column to inbox placement test details page in the placement breakdown chart. 

### How To Test
 - Go to `/inbox-placement`
 - Click on any of the tests. 
 - Verify that the region column exists.
 - Prod account 108 would be the best to use.
