### PR TITLE
TR-1901 - When updating the draft from the template settings view, the updated state of the template content should be saved

### DIFF
--- a/src/pages/templatesV2/components/settings/SettingsForm.js
+++ b/src/pages/templatesV2/components/settings/SettingsForm.js
@@ -18,8 +18,11 @@ export default class SettingsForm extends React.Component {
       updateDraftV2,
       parsedTestData,
       subaccountId,
-      showAlert
+      showAlert,
+      content
     } = this.props;
+
+    values.content = content;
 
     return updateDraftV2({
       id: draft.id,

--- a/src/pages/templatesV2/components/settings/SettingsForm.js
+++ b/src/pages/templatesV2/components/settings/SettingsForm.js
@@ -22,12 +22,11 @@ export default class SettingsForm extends React.Component {
       content
     } = this.props;
 
-    values.content = content;
-
     return updateDraftV2({
       id: draft.id,
       parsedTestData,
-      ...values
+      ...values,
+      content
     }, subaccountId)
       .then(() => {
         showAlert({ type: 'success', message: 'Template settings updated.' });

--- a/src/pages/templatesV2/components/settings/SettingsForm.js
+++ b/src/pages/templatesV2/components/settings/SettingsForm.js
@@ -23,9 +23,9 @@ export default class SettingsForm extends React.Component {
       setHasSaved
     } = this.props;
 
-    const { text , html } = content;
+    const { subject: _subject, from: _from, reply_to: _reply_to, ...rest } = content; //content object has updated values for html, text etc, provided by useEditorContext
 
-    values.content = { ...values.content , text, html };
+    values.content = { ...values.content , ...rest };
 
     return updateDraftV2({
       id: draft.id,

--- a/src/pages/templatesV2/components/settings/SettingsForm.js
+++ b/src/pages/templatesV2/components/settings/SettingsForm.js
@@ -12,23 +12,28 @@ import styles from './SettingsForm.module.scss';
 import { emailOrSubstitution } from '../validation';
 
 export default class SettingsForm extends React.Component {
-  updateSettings = (values) => {
+  updateSettings = (values = {}) => {
     const {
       draft,
       updateDraftV2,
       parsedTestData,
       subaccountId,
       showAlert,
-      content
+      content,
+      setHasSaved
     } = this.props;
+
+    const { text , html } = content;
+
+    values.content = { ...values.content , text, html };
 
     return updateDraftV2({
       id: draft.id,
       parsedTestData,
-      ...values,
-      content
+      ...values
     }, subaccountId)
       .then(() => {
+        setHasSaved(true);
         showAlert({ type: 'success', message: 'Template settings updated.' });
       });
   };

--- a/src/pages/templatesV2/components/settings/tests/SettingsForm.test.js
+++ b/src/pages/templatesV2/components/settings/tests/SettingsForm.test.js
@@ -16,9 +16,17 @@ describe('SettingsForm', () => {
       domainsLoading: false,
       hasSubaccounts: false,
       canViewSubaccount: false,
+      content: {
+        html: '<p>Hello</p>',
+        text: ''
+      },
+      values: {
+        content: {}
+      },
       isPublishedMode: false,
       handleSubmit: jest.fn((func) => func),
-      showAlert: jest.fn()
+      showAlert: jest.fn(),
+      setHasSaved: jest.fn()
     };
 
     return shallow(<SettingsForm {...defaultProps} {...props} />);
@@ -109,17 +117,24 @@ describe('SettingsForm', () => {
         some: 'data'
       };
       const mockAlert = jest.fn();
+      const mockSetHasSaved = jest.fn();
       const wrapper = subject({
         valid: true,
         pristine: false,
         updateDraftV2: mockUpdateDraft,
         parsedTestData,
         draft: { id: 'foo' },
-        showAlert: mockAlert
+        showAlert: mockAlert,
+        setHasSaved: mockSetHasSaved
       });
       await wrapper.find('form').simulate('submit');
-      expect(mockUpdateDraft).toHaveBeenCalledWith({ id: 'foo', parsedTestData }, undefined);
+      expect(mockUpdateDraft).toHaveBeenCalledWith({ id: 'foo', parsedTestData,
+        content: {
+          'html': '<p>Hello</p>',
+          'text': ''
+        }}, undefined);
       expect(mockAlert).toHaveBeenCalledWith({ type: 'success', message: 'Template settings updated.' });
+      expect(mockSetHasSaved).toHaveBeenCalledWith(true);
     });
 
     it('updates settings with subaccount', () => {
@@ -132,7 +147,10 @@ describe('SettingsForm', () => {
         subaccountId: 101
       });
       wrapper.find('form').simulate('submit');
-      expect(mockUpdateDraft).toHaveBeenCalledWith({ id: 'foo' }, 101);
+      expect(mockUpdateDraft).toHaveBeenCalledWith({ id: 'foo', content: {
+        'html': '<p>Hello</p>',
+        'text': ''
+      }}, 101);
     });
   });
 });


### PR DESCRIPTION
TR-1901 - When updating the draft from the template settings view, the updated state of the template content should be saved

### What Changed
 - updated state of template is now being saved when switching tabs and when settings are updated.

### How To Test
 - Make changes to the HTML tab of the editor
 - Swap to "Template Settings"
 - Save those settings
 - Saved Indicator changes to SAVED
 - Return to the HTML tab and verify that the content stays the same

### To Do
- [ ] Address feedback
