### PR TITLE
TR-1849 - Add insert AMP boilerplate modal

### DIFF
--- a/cypress/tests/templates/templates.js
+++ b/cypress/tests/templates/templates.js
@@ -64,8 +64,12 @@ describe('Templates', () => {
           .then(($iframe) => {
             const $body = $iframe.contents().find('body');
 
-            cy.wrap($body.find(selector))
-              .should('contain', content);
+            if (selector.length) {
+              cy.wrap($body.find(selector))
+                .should('contain', content);
+            } else {
+              cy.wrap($body).should('contain', content);
+            }
           });
       };
 
@@ -84,6 +88,13 @@ describe('Templates', () => {
         .type('<h1>This is some AMP HTML. Cypress is {{qualifier}}.', { parseSpecialCharSequences: false });
 
       testPreviewContent('h1', 'This is some AMP HTML. Cypress is .');
+
+      cy.get('[data-id="popover-trigger-more"]').click();
+      cy.findByText('Insert AMP Boilerplate').click();
+      cy.findByText('Are you sure you want to insert the AMP Email Boilerplate?').should('be.visible');
+      cy.findByText('Insert').click();
+
+      testPreviewContent('', 'Hello, world');
 
       // Text editing
       cy.findByText('Text').click();

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -139,9 +139,9 @@ const EditSection = () => {
 
       <ConfirmationModal
         open={isAMPModalOpen}
-        title='Are you sure you want to insert the AMP boilerplate?'
+        title='Are you sure you want to insert the AMP Email Boilerplate?'
         content={<p>Any existing markup in the AMP tab will be lost.</p>}
-        confirmVerb='Insert AMP Boilerplate'
+        confirmVerb='Insert'
         onCancel={() => setAMPModalOpen(false)}
         onConfirm={handleAMPConfirmClick}
       />

--- a/src/pages/templatesV2/components/EditSection.js
+++ b/src/pages/templatesV2/components/EditSection.js
@@ -9,24 +9,81 @@ import {
   Tag
 } from '@sparkpost/matchbox';
 import { MoreHoriz } from '@sparkpost/matchbox-icons';
+import ConfirmationModal from 'src/components/modals/ConfirmationModal';
 import tabs from '../constants/editTabs';
 import InsertSnippetModal from './InsertSnippetModal';
 import useEditorContext from '../hooks/useEditorContext';
 import styles from './EditSection.module.scss';
 
 const EditSection = () => {
-  const { currentTabIndex, setTab, isPublishedMode } = useEditorContext();
+  const {
+    currentTabIndex,
+    currentTabKey,
+    setTab,
+    setContent,
+    content,
+    isPublishedMode
+  } = useEditorContext();
   const [isPopoverOpen, setPopoverOpen] = useState(false);
   const [isSnippetModalOpen, setSnippetModalOpen] = useState(false);
+  const [isAMPModalOpen, setAMPModalOpen] = useState(false);
 
   const currentTab = tabs[currentTabIndex];
   const TabComponent = currentTab.render;
   const hasReadOnlyTag = isPublishedMode && (currentTab.key === 'html' || currentTab.key === 'amp_html' || currentTab.key === 'text');
   const hasPopover = !isPublishedMode;
+  const AMPBoilerplate = `
+<!DOCTYPE html>
+<html ⚡4email>
+  <head>
+    <meta charset="utf-8" />
+    <style amp4email-boilerplate>
+      body {
+        visibility: hidden;
+      }
+    </style>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+  </head>
+  <body>
+    Hello, world.
+  </body>
+</html>
+  `.trim(); // Tabbing is weird here to ensure no extra tabs are rendered in the editor
+  const popoverActions = [
+    {
+      content: 'Insert Snippet',
+      onClick: () => handleInsertSnippetClick(),
+      role: 'button',
+      href: 'javascript:void(0);',
+      title: 'Opens a dialog',
+      'data-id': 'popover-action-insert-snippet'
+    },
+    currentTabKey === 'amp_html' && {
+      content: 'Insert AMP Boilerplate',
+      onClick: () => handleInsertAMPClick(),
+      role: 'button',
+      href: 'javascript:void(0);',
+      title: 'Opens a dialog',
+      'data-id': 'popover-action-insert-amp-boilerplate'
+    }
+  ].filter(Boolean); // Removes empty items from the array
 
   const handleInsertSnippetClick = () => {
     setPopoverOpen(false);
     setSnippetModalOpen(true);
+  };
+
+  const handleInsertAMPClick = () => {
+    setPopoverOpen(false);
+    setAMPModalOpen(true);
+  };
+
+  const handleAMPConfirmClick = () => {
+    setAMPModalOpen(false);
+    setContent({
+      ...content,
+      amp_html: AMPBoilerplate
+    });
   };
 
   return (
@@ -67,19 +124,7 @@ const EditSection = () => {
               </Button>
             }
           >
-            <ActionList
-              actions={
-                [
-                  {
-                    content: 'Insert Snippet',
-                    onClick: () => handleInsertSnippetClick(),
-                    role: 'button',
-                    href: 'javascript:void(0);',
-                    'data-id': 'popover-action-insert-snippet'
-                  }
-                ]
-              }
-            />
+            <ActionList actions={popoverActions}/>
           </Popover>
         }
       </div>
@@ -90,6 +135,15 @@ const EditSection = () => {
         open={isSnippetModalOpen}
         onClose={() => setSnippetModalOpen(false)}
         loading={false}
+      />
+
+      <ConfirmationModal
+        open={isAMPModalOpen}
+        title='Are you sure you want to insert the AMP boilerplate?'
+        content={<p>Any existing markup in the AMP tab will be lost.</p>}
+        confirmVerb='Insert AMP Boilerplate'
+        onCancel={() => setAMPModalOpen(false)}
+        onConfirm={handleAMPConfirmClick}
       />
     </Panel>
   );

--- a/src/pages/templatesV2/components/tests/EditSection.test.js
+++ b/src/pages/templatesV2/components/tests/EditSection.test.js
@@ -84,5 +84,25 @@ describe('EditSection', () => {
 
       expect(wrapper.find('Popover')).not.toExist();
     });
+
+    it('opens the insert amp confirmation modal via the "Insert AMP Boilerplate" action', () => {
+      const wrapper = subject({
+        currentTabIndex: 1,
+        currentTabKey: 'amp_html'
+      });
+
+      openPopover(wrapper);
+
+      const insertAMPAction = wrapper.find('ActionList').props().actions.filter((item) => item.content === 'Insert AMP Boilerplate')[0];
+
+      insertAMPAction.onClick();
+
+      expect(wrapper.find('ConfirmationModal')).toHaveProp('open', true);
+      expect(wrapper.find('Popover')).toHaveProp('open', false);
+
+      wrapper.find('ConfirmationModal').simulate('cancel');
+
+      expect(wrapper.find('ConfirmationModal')).toHaveProp('open', false);
+    });
   });
 });

--- a/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/EditSection.test.js.snap
@@ -75,6 +75,7 @@ exports[`EditSection renders tabs and section 1`] = `
               "href": "javascript:void(0);",
               "onClick": [Function],
               "role": "button",
+              "title": "Opens a dialog",
             },
           ]
         }
@@ -87,6 +88,18 @@ exports[`EditSection renders tabs and section 1`] = `
     loading={false}
     onClose={[Function]}
     open={false}
+  />
+  <ConfirmationModal
+    confirmVerb="Insert"
+    content={
+      <p>
+        Any existing markup in the AMP tab will be lost.
+      </p>
+    }
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    open={false}
+    title="Are you sure you want to insert the AMP Email Boilerplate?"
   />
 </Panel>
 `;


### PR DESCRIPTION
[TR-1849](https://jira.int.messagesystems.com/browse/TR-1849)

### What Changed
- Adds AMP Boilerplate modal to control insertion of AMP boilerplate in to the AMP HTML editor tab

### How To Test
1. Go to `/templatesV2`
1. Create a new template
1. Go to the 'AMP HTML' tab and click on the popover trigger kebab in top right, then 'Insert AMP Boilerplate'
1. Confirm!
1. Verify that there are no typos in my content and that it makes sense!
1. Verify that the AMP boilerplate was inserted appropriately

### To Do
- [x] Add supporting tests
- [ ] Incorporate feedback
