### PR TITLE
TR-1946 - Resolve issue with RecentActivity component returning nothing when fewer than 3 templates are present

### DIFF
--- a/src/pages/templatesV2/components/RecentActivity.js
+++ b/src/pages/templatesV2/components/RecentActivity.js
@@ -15,7 +15,7 @@ const RecentActivity = (props) => {
   const descendingSortedTemplates = _.orderBy(templates, 'last_update_time', 'desc');
 
   if (templates.length < 3) {
-    return;
+    return null;
   }
 
   return (

--- a/src/pages/templatesV2/components/tests/RecentActivity.test.js
+++ b/src/pages/templatesV2/components/tests/RecentActivity.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import RecentActivity from '../RecentActivity';
 
 describe('RecentActivity', () => {
@@ -21,13 +21,25 @@ describe('RecentActivity', () => {
     last_update_time: '2019-10-18T17:30:49+00:00',
     list_status: 'draft'
   };
-  const subject = (props) => shallow(
-    <RecentActivity
-      onToggleDeleteModal={jest.fn()}
-      onToggleDuplicateModal={jest.fn()}
-      {...props}
-    />
-  );
+  const subject = (props, isShallow = true) => {
+    if (isShallow) {
+      return shallow(
+        <RecentActivity
+          onToggleDeleteModal={jest.fn()}
+          onToggleDuplicateModal={jest.fn()}
+          {...props}
+        />
+      );
+    }
+
+    return mount(
+      <RecentActivity
+        onToggleDeleteModal={jest.fn()}
+        onToggleDuplicateModal={jest.fn()}
+        {...props}
+      />
+    );
+  };
 
   it('renders an empty fragment when fewer than 2 templates are present', () => {
     const wrapper = subject({
@@ -35,7 +47,7 @@ describe('RecentActivity', () => {
         publishedTemplate,
         draftTemplate
       ]
-    });
+    }, false);
 
     expect(wrapper).not.toHaveTextContent('Recent Activity');
   });


### PR DESCRIPTION
[TR-1946](https://jira.int.messagesystems.com/browse/TR-1946)

### What Changed
- When fewer than three templates are present, `null` is returned instead of nothing
- Updated tests to fail by using a full `mount`, then verified that the fix addressed the issue

### How To Test
- With a new account (or any account with fewer than 3 templates), go to `/templatesV2` and verify that no Recent Activity component renders *and* the app does not render the error boundary UI

### To Do
- [x] Incorporate feedback
