### PR TITLE
TR-1948 - Resolve bug with updating an existing template from the draft state to the published state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3261,52 +3261,61 @@
       "integrity": "sha512-bG5+UzROp4y57xrfTRbjz6cr3kNHOnn6CibPCwzV/dG3zmvDkfZPM8uumU5rdllxbzU4sid4sQ3skcZJ7Qu1LA=="
     },
     "@sparkpost/matchbox": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-3.7.2.tgz",
-      "integrity": "sha512-p5MCWL1TtfCeM0z6GyvAGquZWdJvHfdzT8tjESGZK2/KoFZy+rEnXZ1fq86gBbHnH8L939cFUPa7cgrj+BOPeg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-3.8.1.tgz",
+      "integrity": "sha512-krGQn/Hcs17H3ll6xgYFy7pq6w3HJZp/r0nkZk3u0SvES3QBw513zODPKA7B+Z0cYOnPZ+B4qTIIW2Mqc+/8Eg==",
       "requires": {
         "@sparkpost/design-tokens": "0.0.4",
-        "@sparkpost/matchbox-icons": "^1.2.0",
+        "@sparkpost/matchbox-icons": "^1.2.1",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.1",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
+        "react-focus-lock": "^2.0.5",
         "react-transition-group": "^2.3.0"
       },
       "dependencies": {
-        "loose-envify": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
+        "focus-lock": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.6.tgz",
+          "integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw=="
         },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+        "react-clientside-effect": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
+          "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
           "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "@babel/runtime": "^7.0.0"
           }
         },
         "react-dom": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-          "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+          "version": "16.11.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
+          "integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "scheduler": "^0.15.0"
+            "scheduler": "^0.17.0"
+          }
+        },
+        "react-focus-lock": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
+          "integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "focus-lock": "^0.6.6",
+            "prop-types": "^15.6.2",
+            "react-clientside-effect": "^1.2.2",
+            "use-callback-ref": "^1.2.1",
+            "use-sidecar": "^1.0.1"
           }
         },
         "scheduler": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-          "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+          "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
@@ -11748,8 +11757,7 @@
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
-      "dev": true
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "detect-port": {
       "version": "1.3.0",
@@ -34569,8 +34577,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -35201,10 +35208,24 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-callback-ref": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.1.tgz",
+      "integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w=="
+    },
     "use-debounce": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.0.1.tgz",
       "integrity": "sha512-uCPUD1BtzNjwJBsMFggtvNRfw5vCsarw75TM6Tcj0kCg58YvMnIAuvcPrl6mA91m4BtVvRfPTajZv1OEQpN+hw=="
+    },
+    "use-sidecar": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
+      "integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
+      "requires": {
+        "detect-node": "^2.0.4",
+        "tslib": "^1.9.3"
+      }
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@sparkpost/boomerang": "^1.0.6",
-    "@sparkpost/matchbox": "^3.7.2",
+    "@sparkpost/matchbox": "^3.8.0",
     "@sparkpost/matchbox-icons": "^1.2.1",
     "axios": "^0.18.0",
     "bowser": "2.1.2",

--- a/src/actions/templates.js
+++ b/src/actions/templates.js
@@ -198,7 +198,7 @@ export function publishV2(data, subaccountId) {
     dispatch({ type: 'PUBLISH_ACTION_PENDING' });
 
     try {
-      await dispatch(update(data, subaccountId));
+      await dispatch(updateV2(data, subaccountId));
       dispatch(setTestDataV2({ id, mode: 'published', data: parsedTestData }));
 
       await dispatch(sparkpostApiRequest({

--- a/src/actions/tests/__snapshots__/templates.test.js.snap
+++ b/src/actions/tests/__snapshots__/templates.test.js.snap
@@ -137,6 +137,13 @@ Array [
           "reply_to": undefined,
           "text": undefined,
         },
+        "testData": Object {
+          "metadata": Object {},
+          "options": Object {},
+          "substitution_data": Object {
+            "hello": "world",
+          },
+        },
       },
       "headers": Object {
         "x-msys-subaccount": 123,
@@ -146,9 +153,6 @@ Array [
       "url": "/v1/templates/foo",
     },
     "type": "UPDATE_TEMPLATE",
-  },
-  Object {
-    "type": "SET_TEMPLATE_TEST_DATA",
   },
   Object {
     "meta": Object {

--- a/src/pages/templatesV2/EditAndPreviewPage.container.js
+++ b/src/pages/templatesV2/EditAndPreviewPage.container.js
@@ -37,15 +37,16 @@ const mapStateToProps = (state, props) => {
   const draft = selectDraftTemplateById(state, id);
   const published = selectPublishedTemplateById(state, id);
   const isPublishedMode = props.match.params.version === 'published';
-  const draftOrPublished = draft || published;
-  const hasDraft = draftOrPublished && draftOrPublished.has_draft;
-  const hasPublished = draftOrPublished && draftOrPublished.has_published;
+  const template = draft || published;
+  const hasDraft = template && template.has_draft;
+  const hasPublished = template && template.has_published;
   const snippets = state.snippets.items;
 
   return {
     draft,
-    snippets,
     published,
+    template,
+    snippets,
     isPublishedMode,
     hasDraft,
     hasPublished,
@@ -65,8 +66,8 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {
   getDraft,
-  getPreview,
   getPublished,
+  getPreview,
   deleteTemplateV2,
   createTemplateV2,
   updateDraftV2,

--- a/src/pages/templatesV2/components/ListComponents.js
+++ b/src/pages/templatesV2/components/ListComponents.js
@@ -34,25 +34,32 @@ export const Name = ({ list_name: name, id, subaccount_id, ...rowData }) => {
 };
 
 export const Status = (rowData) => {
-  const listStatus = rowData.list_status;
-
+  const { list_status } = rowData;
   const PublishedIcon = <CheckCircle className={styles.PublishedIconColor}/>;
 
-  if (listStatus === 'published') {
-    return <Tag className={styles.published}>{PublishedIcon} Published</Tag>;
+  if (list_status === 'published') {
+    return (
+      <Tag className={styles.published}>
+        {PublishedIcon}&nbsp;<span>Published</span>
+      </Tag>
+    );
   }
 
-  if (listStatus === 'published_with_draft') {
+  if (list_status === 'published_with_draft') {
     return (
       <Tooltip dark content='Contains unpublished changes'>
         <Tag className={styles.PublishedWithChanges}>
-          {PublishedIcon} Published
+          {PublishedIcon}&nbsp;<span>Published</span>
         </Tag>
       </Tooltip>
     );
   }
 
-  return <Tag><Edit/> Draft</Tag>;
+  return (
+    <Tag>
+      <Edit/>&nbsp;<span>Draft</span>
+    </Tag>
+  );
 };
 
 export const DeleteAction = ({ onClick, ...props }) => (

--- a/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
+++ b/src/pages/templatesV2/components/editorActions/PublishedModeActions.js
@@ -13,8 +13,7 @@ import DuplicateTemplateModal from './DuplicateTemplateModal';
 
 const PublishedModeActions = () => {
   const {
-    hasDraft,
-    draft,
+    template,
     createTemplateV2,
     showAlert,
     content,
@@ -22,8 +21,7 @@ const PublishedModeActions = () => {
     testData,
     isCreatePending
   } = useEditorContext();
-  const draftText = hasDraft ? 'Edit Draft' : 'Save as Draft';
-  const editDraftTo = `/${routeNamespace}/edit/${draft.id}/draft/content${setSubaccountQuery(draft.subaccount_id)}`;
+  const editDraftTo = `/${routeNamespace}/edit/${template.id}/draft/content${setSubaccountQuery(template.subaccount_id)}`;
 
   // State
   const [isPopoverOpen, setPopoverOpen] = useState(false);
@@ -54,7 +52,7 @@ const PublishedModeActions = () => {
         role="button"
         data-id="button-edit-draft"
       >
-        <strong>{draftText}</strong>
+        <strong>Edit Draft</strong>
       </Button>
 
       <div className={styles.Actions}>
@@ -83,7 +81,7 @@ const PublishedModeActions = () => {
               >
                 <FileEdit/>
 
-                {draftText}
+                <span>Edit Draft</span>
               </PageLink>
             </div>
 
@@ -104,7 +102,7 @@ const PublishedModeActions = () => {
         <DuplicateTemplateModal
           open={isDuplicateModalOpen}
           onClose={handleModalClose}
-          template={draft}
+          template={template}
           contentToDuplicate={content}
           testDataToDuplicate={testData}
           createTemplate={createTemplateV2}

--- a/src/pages/templatesV2/components/editorActions/SaveAndPublishConfirmationModal.js
+++ b/src/pages/templatesV2/components/editorActions/SaveAndPublishConfirmationModal.js
@@ -19,7 +19,7 @@ const SaveAndPublishConfirmationModal = (props) => {
 
   const handleConfirm = () => {
     publishDraftV2({
-      ...draft,
+      id: draft.id,
       content,
       parsedTestData
     }, draft.subaccount_id)

--- a/src/pages/templatesV2/components/editorActions/tests/PublishedModeActions.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/PublishedModeActions.test.js
@@ -9,7 +9,7 @@ describe('PublishedModeActions', () => {
   const subject = (editorState) => {
     useEditorContext.mockReturnValue({
       hasDraft: true,
-      draft: {
+      template: {
         id: 'a-random-id-123',
         subaccount_id: 'some-subaccount-id'
       },
@@ -20,7 +20,7 @@ describe('PublishedModeActions', () => {
   };
 
   it('renders published actions', () => {
-    expect(subject({ draft: { id: '123', subaccount_id: 'abcd' }})).toMatchSnapshot();
+    expect(subject({ template: { id: '123', subaccount_id: 'abcd' }})).toMatchSnapshot();
   });
 
   describe('the DuplicateTemplateModal', () => {

--- a/src/pages/templatesV2/components/editorActions/tests/SaveAndPublishConfirmationModal.test.js
+++ b/src/pages/templatesV2/components/editorActions/tests/SaveAndPublishConfirmationModal.test.js
@@ -71,7 +71,7 @@ describe('SaveAndPublishConfirmationModal', () => {
 
     expect(publishDraftV2).toHaveBeenCalledWith(
       {
-        ...draft,
+        id: draft.id,
         content,
         parsedTestData
       },

--- a/src/pages/templatesV2/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
+++ b/src/pages/templatesV2/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
@@ -48,7 +48,9 @@ exports[`PublishedModeActions renders published actions 1`] = `
             to="/templatesv2/edit/123/draft/content?subaccount=abcd"
           >
             <FileEdit />
-            Edit Draft
+            <span>
+              Edit Draft
+            </span>
           </PageLink>
         </div>
         <hr

--- a/src/pages/templatesV2/components/tests/__snapshots__/ListComponents.test.js.snap
+++ b/src/pages/templatesV2/components/tests/__snapshots__/ListComponents.test.js.snap
@@ -60,7 +60,10 @@ exports[`Template List Components Name should render 1`] = `
 exports[`Template List Components Status should render draft 1`] = `
 <Tag>
   <Edit />
-   Draft
+   
+  <span>
+    Draft
+  </span>
 </Tag>
 `;
 
@@ -71,7 +74,10 @@ exports[`Template List Components Status should render published 1`] = `
   <CheckCircle
     className="PublishedIconColor"
   />
-   Published
+   
+  <span>
+    Published
+  </span>
 </Tag>
 `;
 
@@ -98,7 +104,10 @@ exports[`Template List Components Status should render unpublished changes 1`] =
     <CheckCircle
       className="PublishedIconColor"
     />
-     Published
+     
+    <span>
+      Published
+    </span>
   </Tag>
 </Tooltip>
 `;

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -103,14 +103,24 @@ export const selectTemplatesForListTable = createSelector(
   [selectTemplates], (templates) => {
     const templatesForListing = [];
     templates.forEach((template) => {
+      const isPublished = template.published;
       const hasPublished = template.has_published;
       const hasDraft = template.has_draft;
 
       if (hasPublished) {
-        templatesForListing.push({ ...template, list_name: template.name, list_status: hasDraft ? 'published_with_draft' : 'published' });
+        templatesForListing.push({
+          ...template,
+          list_name: template.name,
+          list_status: (hasDraft && !isPublished) ? 'published_with_draft' : 'published'
+        });
       }
-      if (hasDraft) {
-        templatesForListing.push({ ...template, list_name: hasPublished ? `${template.name} (DRAFT)` : template.name, list_status: 'draft' });
+
+      if (!isPublished) {
+        templatesForListing.push({
+          ...template,
+          list_name: hasPublished ? `${template.name} (DRAFT)` : template.name,
+          list_status: 'draft'
+        });
       }
     });
     return templatesForListing;

--- a/src/selectors/tests/__snapshots__/templates.test.js.snap
+++ b/src/selectors/tests/__snapshots__/templates.test.js.snap
@@ -205,6 +205,15 @@ Array [
 exports[`Templates selectors selectTemplatesForListTable returns template(s) correctly having both published and draft version 1`] = `
 Array [
   Object {
+    "has_published": false,
+    "list_name": "unpublished",
+    "list_status": "draft",
+    "name": "unpublished",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+    "subaccount_name": "sub 1",
+  },
+  Object {
     "has_published": true,
     "list_name": "publishedSubaccount",
     "list_status": "published",
@@ -214,21 +223,19 @@ Array [
     "subaccount_name": "sub 1",
   },
   Object {
-    "has_draft": true,
     "has_published": true,
-    "list_name": "publishedMaster",
-    "list_status": "published_with_draft",
-    "name": "publishedMaster",
-    "published": true,
+    "list_name": "publishedSubaccount (DRAFT)",
+    "list_status": "draft",
+    "name": "publishedSubaccount",
     "shared_with_subaccounts": false,
-    "subaccount_id": 0,
-    "subaccount_name": null,
+    "subaccount_id": 101,
+    "subaccount_name": "sub 1",
   },
   Object {
     "has_draft": true,
     "has_published": true,
-    "list_name": "publishedMaster (DRAFT)",
-    "list_status": "draft",
+    "list_name": "publishedMaster",
+    "list_status": "published",
     "name": "publishedMaster",
     "published": true,
     "shared_with_subaccounts": false,
@@ -244,11 +251,29 @@ Array [
     "subaccount_id": 0,
     "subaccount_name": null,
   },
+  Object {
+    "has_published": true,
+    "list_name": "publishedShared (DRAFT)",
+    "list_status": "draft",
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+    "subaccount_name": null,
+  },
 ]
 `;
 
 exports[`Templates selectors selectTemplatesForListTable returns template(s) with draft version only 1`] = `
 Array [
+  Object {
+    "has_published": false,
+    "list_name": "unpublished",
+    "list_status": "draft",
+    "name": "unpublished",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+    "subaccount_name": "sub 1",
+  },
   Object {
     "has_draft": true,
     "has_published": false,
@@ -259,15 +284,42 @@ Array [
     "subaccount_id": 101,
     "subaccount_name": "sub 1",
   },
+  Object {
+    "has_published": false,
+    "list_name": "publishedShared",
+    "list_status": "draft",
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+    "subaccount_name": null,
+  },
 ]
 `;
 
 exports[`Templates selectors selectTemplatesForListTable returns template(s) with published version only 1`] = `
 Array [
   Object {
+    "has_published": false,
+    "list_name": "unpublished",
+    "list_status": "draft",
+    "name": "unpublished",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+    "subaccount_name": "sub 1",
+  },
+  Object {
     "has_published": true,
     "list_name": "publishedSubaccount",
     "list_status": "published",
+    "name": "publishedSubaccount",
+    "shared_with_subaccounts": false,
+    "subaccount_id": 101,
+    "subaccount_name": "sub 1",
+  },
+  Object {
+    "has_published": true,
+    "list_name": "publishedSubaccount (DRAFT)",
+    "list_status": "draft",
     "name": "publishedSubaccount",
     "shared_with_subaccounts": false,
     "subaccount_id": 101,
@@ -287,6 +339,15 @@ Array [
     "has_published": true,
     "list_name": "publishedShared",
     "list_status": "published",
+    "name": "publishedShared",
+    "shared_with_subaccounts": true,
+    "subaccount_id": 0,
+    "subaccount_name": null,
+  },
+  Object {
+    "has_published": true,
+    "list_name": "publishedShared (DRAFT)",
+    "list_status": "draft",
     "name": "publishedShared",
     "shared_with_subaccounts": true,
     "subaccount_id": 0,


### PR DESCRIPTION
[TR-1948](https://jira.int.messagesystems.com/browse/TR-1948)

### What Changed
- Updated Matchbox version to get a11y updates
- Updated `publishV2` to use `updateV2` instead of `update`
- Renamed some variables for clarity's sake
- Updated markup for rendering status on the list page
- Removed unnecessary spreading of data on the `SaveAndPublishConfirmationModal`
- Updated templates selector to accurately reflect the template's current status

### How To Test
1. Go to `/templatesV2`
1. Create a new template
1. Go back to the list page and verify that the template is marked as a 'Draft'
1. Open that template and publish it
1. Go back to the list page and verify that the template is marked as 'Published'
1. Open the template and click 'Edit Draft'
1. Make a change to the draft and click 'Save and Publish'
1. Verify that the changes that you made were preserved
1. Click 'Edit Draft' and make any change to the template
1. Using the menu in the top right, click 'Save Draft'
1. Return to the list page
1. Verify that there are now two templates in the list, one with 'Draft' and one with 'Published' - the published draft should indicate that there are unpublished changes in the draft.
1. Take a break because that was a lot of work 😩

### To Do
- [ ] Incorporate feedback
