### PR TITLE
SA-1001: Filter Inbox Placement Tests by Text Field

### DIFF
--- a/src/pages/inboxPlacement/components/TestDetails.js
+++ b/src/pages/inboxPlacement/components/TestDetails.js
@@ -18,9 +18,9 @@ const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
   const [breakdownType, setBreakdownType] = useState(PLACEMENTS_TYPE_OPTIONS[0].value);
   const [searchPlacements, setSearchPlacements] = useState('');
 
-  const onSearchChange = useCallback((e) => {
-    setSearchPlacements(e.target.value);
-  }, []);
+  const debouncedSetSearchPlacements = useCallback(_.debounce((placements) => setSearchPlacements(placements), 300), []);
+
+  const onSearchChange = useCallback((e) => debouncedSetSearchPlacements(e.target.value), [debouncedSetSearchPlacements]);
 
   const onFilterChange = useCallback((e) => {
     setBreakdownType(e.target.value);

--- a/src/pages/inboxPlacement/components/TestDetails.js
+++ b/src/pages/inboxPlacement/components/TestDetails.js
@@ -35,11 +35,11 @@ const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
   switch (breakdownType) {
     case PLACEMENT_FILTER_TYPES.REGION:
       breakdownData = placementsByRegion;
-      textFieldPlaceholder = 'Region';
+      textFieldPlaceholder = PLACEMENT_FILTER_LABELS[breakdownType];
       break;
     default:
       breakdownData = placementsByProvider;
-      textFieldPlaceholder = 'Mailbox Provider or Region';
+      textFieldPlaceholder = `${PLACEMENT_FILTER_LABELS[PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER]} or ${PLACEMENT_FILTER_LABELS[PLACEMENT_FILTER_TYPES.REGION]}`;
       break;
   }
 

--- a/src/pages/inboxPlacement/components/TestDetails.module.scss
+++ b/src/pages/inboxPlacement/components/TestDetails.module.scss
@@ -22,7 +22,16 @@
   }
 }
 
-.PlacementFilter {
+.PlacementFilterContainer {
   padding: spacing(base);
+  display: flex;
+}
+
+.PlacementFilterSelect {
   max-width: 200px;
+}
+
+.PlacementFilterTextField {
+  flex: 1;
+  margin-left: spacing(base);
 }

--- a/src/pages/inboxPlacement/components/tests/TestDetails.test.js
+++ b/src/pages/inboxPlacement/components/tests/TestDetails.test.js
@@ -81,4 +81,98 @@ describe('Component: TestDetails', () => {
     wrapper.find('Select').simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER }});
     expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual(placementsByProvider);
   });
+
+  it('changes placement data when using search bar on providers list', () => {
+    const dogmail = {
+      'mailbox_provider': 'dogmail.net',
+      'region': 'north america',
+      'placement': {
+        'inbox_pct': 0,
+        'spam_pct': 0,
+        'missing_pct': 1
+      }
+    };
+    const gmail = {
+      'mailbox_provider': 'gmail.com',
+      'region': 'europe',
+      'placement': {
+        'inbox_pct': 0,
+        'spam_pct': 0,
+        'missing_pct': 1
+      }
+    };
+    const hotmail = {
+      'mailbox_provider': 'hotmail.com',
+      'region': 'global',
+      'placement': {
+        'inbox_pct': 0,
+        'spam_pct': 0,
+        'missing_pct': 1
+      }
+    };
+    const placementsByProvider = [dogmail, gmail, hotmail];
+
+    const wrapper = subject({ placementsByProvider });
+
+    // Match one result
+    wrapper.find('TextField').simulate('change', { target: { value: 'net' }});
+    expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual([dogmail]);
+
+    // Match more than one result
+    wrapper.find('TextField').simulate('change', { target: { value: 'gmail' }});
+    expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual([dogmail, gmail]);
+
+    // No results
+    wrapper.find('TextField').simulate('change', { target: { value: 'this wont match anything' }});
+    expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual([]);
+
+    // Search by case insensitive region match
+    wrapper.find('TextField').simulate('change', { target: { value: 'america' }});
+    expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual([dogmail]);
+  });
+
+  it('changes placement data when using search bar on regions list', () => {
+    const northAmerica = {
+      'region': 'north america',
+      'placement': {
+        'inbox_pct': 0,
+        'spam_pct': 0,
+        'missing_pct': 1
+      }
+    };
+    const southAmerica = {
+      'region': 'south america',
+      'placement': {
+        'inbox_pct': 0,
+        'spam_pct': 0,
+        'missing_pct': 1
+      }
+    };
+    const europe = {
+      'region': 'europe',
+      'placement': {
+        'inbox_pct': 0,
+        'spam_pct': 0,
+        'missing_pct': 1
+      }
+    };
+    const placementsByRegion = [northAmerica, southAmerica, europe];
+
+    const wrapper = subject({ placementsByRegion });
+
+    // Change to Region list
+    wrapper.find('Select').simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.REGION }});
+
+    // Match one result
+    wrapper.find('TextField').simulate('change', { target: { value: 'north' }});
+    expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual([northAmerica]);
+
+    // Match more than one result
+    wrapper.find('TextField').simulate('change', { target: { value: 'america' }});
+    expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual([northAmerica, southAmerica]);
+
+    // No results
+    wrapper.find('TextField').simulate('change', { target: { value: 'this wont match anything' }});
+    expect(wrapper.find('PlacementBreakdown').prop('data')).toEqual([]);
+  });
 });

--- a/src/pages/inboxPlacement/components/tests/TestDetails.test.js
+++ b/src/pages/inboxPlacement/components/tests/TestDetails.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import TestDetails from '../TestDetails';
 import { PLACEMENT_FILTER_TYPES } from '../../constants/types';
 
+jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
 jest.mock('date-fns', () => ({ format: jest.fn().mockReturnValue('Jul 8th 2019 11:49am') }));
 
 describe('Component: TestDetails', () => {

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/TestDetails.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/TestDetails.test.js.snap
@@ -80,23 +80,38 @@ exports[`Component: TestDetails renders correctly 1`] = `
     }
   >
     <div
-      className="PlacementFilter"
+      className="PlacementFilterContainer"
     >
-      <Select
-        onChange={[Function]}
-        options={
-          Array [
-            Object {
-              "label": "Mailbox Provider",
-              "value": "mailbox-provider",
-            },
-            Object {
-              "label": "Region",
-              "value": "region",
-            },
-          ]
-        }
-      />
+      <div
+        className="PlacementFilterSelect"
+      >
+        <Select
+          onChange={[Function]}
+          options={
+            Array [
+              Object {
+                "label": "Mailbox Provider",
+                "value": "mailbox-provider",
+              },
+              Object {
+                "label": "Region",
+                "value": "region",
+              },
+            ]
+          }
+        />
+      </div>
+      <div
+        className="PlacementFilterTextField"
+      >
+        <TextField
+          onChange={[Function]}
+          placeholder="Mailbox Provider or Region"
+          resize="both"
+          suffix={<Search />}
+          type="text"
+        />
+      </div>
     </div>
     <ProvidersBreakdown
       data={Array []}


### PR DESCRIPTION
### What Changed
 - Added a search bar to the top of the inbox placement details page
 - You can now filter the list by Mailbox Providers by case insensitive text matching of region name or mailbox provider name 
 - You can now filter the list by Region by case insensitive text matching of region name

### How To Test
 - (on 108 account):
 - Search "america" on the mailbox provider's list and you should see at&t and comcast
 - Switch to filtering by region and you should see North America

### To Do
- Debounce the search field 250ms
- Write test for search field