### PR TITLE
TR-1958 - Add links to RecentActivity section

### DIFF
--- a/src/pages/templatesV2/components/RecentActivity.js
+++ b/src/pages/templatesV2/components/RecentActivity.js
@@ -3,7 +3,10 @@ import _ from 'lodash';
 import { Panel } from '@sparkpost/matchbox';
 import { FileEdit, CheckCircle } from '@sparkpost/matchbox-icons';
 import { formatDate } from 'src/helpers/date';
+import { setSubaccountQuery } from 'src/helpers/subaccounts';
+import PageLink from 'src/components/pageLink';
 import { DuplicateAction, DeleteAction } from './ListComponents';
+import { routeNamespace } from '../constants/routes';
 import styles from './RecentActivity.module.scss';
 
 const RecentActivity = (props) => {
@@ -24,6 +27,8 @@ const RecentActivity = (props) => {
 
       <div className={styles.RecentActivity} role="list">
         {descendingSortedTemplates.map((template, index) => {
+          const version = template.list_status === 'draft' ? 'draft' : 'published';
+
           { /* Render only the first four items */ }
           if (index <= 3) {
             return (
@@ -47,7 +52,11 @@ const RecentActivity = (props) => {
                     </Panel.Section>
 
                     <Panel.Section className={styles.RecentActivitySection}>
-                      <strong>{template.name}</strong>
+                      <strong>
+                        <PageLink to={`/${routeNamespace}/edit/${template.id}/${version}/content${setSubaccountQuery(template.subaccount_id)}`}>
+                          {template.name}
+                        </PageLink>
+                      </strong>
                     </Panel.Section>
 
                     <div className={styles.RecentActivityMeta}>

--- a/src/pages/templatesV2/components/tests/RecentActivity.test.js
+++ b/src/pages/templatesV2/components/tests/RecentActivity.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
 import RecentActivity from '../RecentActivity';
 
@@ -34,17 +33,15 @@ describe('RecentActivity', () => {
     }
 
     return mount(
-      <Router>
-        <RecentActivity
-          onToggleDeleteModal={jest.fn()}
-          onToggleDuplicateModal={jest.fn()}
-          {...props}
-        />
-      </Router>
+      <RecentActivity
+        onToggleDeleteModal={jest.fn()}
+        onToggleDuplicateModal={jest.fn()}
+        {...props}
+      />
     );
   };
 
-  it('renders an empty fragment when fewer than 2 templates are present', () => {
+  it('renders an empty fragment when fewer than 2 templates are present', function () {
     const wrapper = subject({
       templates: [
         publishedTemplate,
@@ -55,7 +52,7 @@ describe('RecentActivity', () => {
     expect(wrapper).not.toHaveTextContent('Recent Activity');
   });
 
-  it('renders a list of templates with relevant links when there are more than 2 templates', () => {
+  it('renders a list of templates with relevant links when there are more than 2 templates', function () {
     const wrapper = subject({
       templates: [
         publishedWithDraftTemplate,
@@ -73,7 +70,7 @@ describe('RecentActivity', () => {
     expect(wrapper.find('PageLink').at(2)).toHaveProp('to', `/templatesv2/edit/${draftTemplate.id}/draft/content`);
   });
 
-  it('renders a maximum of four templates when more than four are present', () => {
+  it('renders a maximum of four templates when more than four are present', function () {
     const wrapper = subject({
       templates: [
         publishedWithDraftTemplate,
@@ -87,7 +84,7 @@ describe('RecentActivity', () => {
     expect(wrapper.find('Panel').length).toBe(4);
   });
 
-  it('invokes the `onToggleDuplicateModal` propr when `DuplicateAction` is clicked', () => {
+  it('invokes the `onToggleDuplicateModal` propr when `DuplicateAction` is clicked', function () {
     const mockToggleDeleteModal = jest.fn();
     const mockToggleDuplicateModal = jest.fn();
 

--- a/src/pages/templatesV2/components/tests/RecentActivity.test.js
+++ b/src/pages/templatesV2/components/tests/RecentActivity.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { shallow, mount } from 'enzyme';
 import RecentActivity from '../RecentActivity';
 
@@ -33,11 +34,13 @@ describe('RecentActivity', () => {
     }
 
     return mount(
-      <RecentActivity
-        onToggleDeleteModal={jest.fn()}
-        onToggleDuplicateModal={jest.fn()}
-        {...props}
-      />
+      <Router>
+        <RecentActivity
+          onToggleDeleteModal={jest.fn()}
+          onToggleDuplicateModal={jest.fn()}
+          {...props}
+        />
+      </Router>
     );
   };
 
@@ -52,7 +55,7 @@ describe('RecentActivity', () => {
     expect(wrapper).not.toHaveTextContent('Recent Activity');
   });
 
-  it('renders when there are more than 2 templates', () => {
+  it('renders a list of templates with relevant links when there are more than 2 templates', () => {
     const wrapper = subject({
       templates: [
         publishedWithDraftTemplate,
@@ -63,8 +66,11 @@ describe('RecentActivity', () => {
 
     expect(wrapper).toHaveTextContent('Recent Activity');
     expect(wrapper).toHaveTextContent(publishedWithDraftTemplate.name);
+    expect(wrapper.find('PageLink').at(0)).toHaveProp('to', `/templatesv2/edit/${publishedWithDraftTemplate.id}/published/content`);
     expect(wrapper).toHaveTextContent(publishedTemplate.name);
+    expect(wrapper.find('PageLink').at(1)).toHaveProp('to', `/templatesv2/edit/${publishedTemplate.id}/published/content`);
     expect(wrapper).toHaveTextContent(draftTemplate.name);
+    expect(wrapper.find('PageLink').at(2)).toHaveProp('to', `/templatesv2/edit/${draftTemplate.id}/draft/content`);
   });
 
   it('renders a maximum of four templates when more than four are present', () => {


### PR DESCRIPTION
[TR-1958](https://jira.int.messagesystems.com/browse/TR-1958)

### What Changed
- Incorporated `<PageLink/>` component in to `<RecentActivity/>` component
- Added supporting unit tests

### How To Test
- Go to `/templatesV2` and verify that each Panel links to a the relevant template

### To Do
- [ ] Incorporate feedback
