### PR TITLE
FE-740: Set Container Height of SparkPost Logo For Safari

### DIFF
--- a/src/components/navigation/components/Top.module.scss
+++ b/src/components/navigation/components/Top.module.scss
@@ -28,6 +28,7 @@
 .MobileLogo {
   flex: 1 0 0;
   padding: rem(6) spacing() rem(18);
+  height: 100%;
   text-align: center;
 }
 


### PR DESCRIPTION
### What Changed
 - Set the height of the container of the icon so that safari can determine the height of the logo 

### How To Test
 - Check the SparkPost logo at the top on the mobile (small viewport) view of the app in:
   - Chrome
   - Safari 
   - Firefox
 - Ensure they all have the same look and feel
