### PR TITLE
FE-754 Do Not Trigger Keyboard on iOS for Select a Plan Dropdown

### DIFF
--- a/src/components/planPicker/PlanPicker.js
+++ b/src/components/planPicker/PlanPicker.js
@@ -85,7 +85,7 @@ export class PlanPicker extends Component {
         <div className={cx(styles.PlanContainer)}>
           {PLAN_TIERS[selectedItem.tier] && <div className={cx(styles.DropdownLabel)}>{PLAN_TIERS[selectedItem.tier]}</div>}
           <Plan {...triggerProps} className={triggerClasses} planPriceProps={planPriceProps}/>
-          <input {...getInputProps()} ref={(input) => this.input = input} className={styles.Input} />
+          <input {...getInputProps()} ref={(input) => this.input = input} className={styles.Input} readOnly />
           <div className={listClasses}>{items}</div>
         </div>
         <div className={cx(styles.TierPlansInfo)}>

--- a/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
+++ b/src/components/planPicker/tests/__snapshots__/PlanPicker.test.js.snap
@@ -48,6 +48,7 @@ exports[`Plan Picker:  Render Function renders 1`] = `
     />
     <input
       className="Input"
+      readOnly={true}
     />
     <div
       className="List"


### PR DESCRIPTION
### What Changed
 - The keyboard in iOS does not open when you use the "custom select" when selecting a plan on the /onboarding/plan page.

### How To Test
 - Use the device simulator from xcode and navigate to the /onboarding/plan page. (Turns out you can go directly there without making a new account)
 - Press the "Select a Plan" dropdown and see that the keyboard does not trigger itself open (Note: You need to have the simulator set up to not use the hardware keyboard for the on-screen keyboard to pop up to begin with).
 - Ensure that choosing an option besides the default indeed changes the value
