### PR TITLE
SA-1002: Add inbox placement messages filtered by region

### DIFF
--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { Grid, Page, Panel } from '@sparkpost/matchbox';
+import _ from 'lodash';
 
 import { Loading } from 'src/components';
 import { getInboxPlacementByProviders, getInboxPlacementByRegions, getAllInboxPlacementMessages, resetState } from 'src/actions/inboxPlacement';
@@ -87,7 +88,7 @@ export const AllMessagesPage = ({
         to: `/inbox-placement/details/${id}`
       }}
       title='Inbox Placement'
-      subtitle={filterName}
+      subtitle={(filterType === PLACEMENT_FILTER_TYPES.REGION) ? _.startCase(filterName) : filterName}
       primaryArea={<StopTestComponent status={status} id={id} reload={loadMessages} />}
     >
       <Panel title="Diagnostics">

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -13,6 +13,7 @@ import InfoBlock from './components/InfoBlock';
 import styles from './AllMessagesPage.module.scss';
 import { formatPercent } from 'src/helpers/units';
 import { PLACEMENT_FILTER_TYPES } from './constants/types';
+import { selectSinglePlacementResult } from 'src/selectors/inboxPlacement';
 
 export const AllMessagesPage = ({
   id,
@@ -124,26 +125,20 @@ export const AllMessagesPage = ({
 
 function mapStateToProps(state, props) {
   const { id, filterType, filterName } = props.match.params;
-  //Runs an inline function that returns a value from a switch statement
-  const result = (() => {
-    switch (filterType) {
-      case PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER:
-        return state.inboxPlacement.placementsByProvider.find(({ mailbox_provider }) => mailbox_provider === filterName);
-      case PLACEMENT_FILTER_TYPES.REGION:
-        return state.inboxPlacement.placementsByRegion.find(({ region }) => region === filterName);
-      default:
-        return {};
-    }
-  })() || {};
+  const {
+    status,
+    seedlist_count = 0,
+    placement = {},
+    authentication = {}} = selectSinglePlacementResult(state, props) || {};
 
   return {
     id,
     filterType,
     filterName,
-    status: result.status,
-    sent: result.seedlist_count || 0,
-    placement: result.placement || {},
-    authentication: result.authentication || {},
+    status,
+    sent: seedlist_count,
+    placement,
+    authentication,
     stopTestLoading: state.inboxPlacement.stopTestPending,
     messages: state.inboxPlacement.allMessages,
     loading: state.inboxPlacement.getAllMessagesPending,

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { Grid, Page, Panel } from '@sparkpost/matchbox';
-import _ from 'lodash';
 
 import { Loading } from 'src/components';
 import { getInboxPlacementByProviders, getInboxPlacementByRegions, getAllInboxPlacementMessages, resetState } from 'src/actions/inboxPlacement';
@@ -14,6 +13,7 @@ import styles from './AllMessagesPage.module.scss';
 import { formatPercent } from 'src/helpers/units';
 import { PLACEMENT_FILTER_TYPES } from './constants/types';
 import { selectSinglePlacementResult } from 'src/selectors/inboxPlacement';
+import formatFilterName from './helpers/formatFilterName';
 
 export const AllMessagesPage = ({
   id,
@@ -89,7 +89,7 @@ export const AllMessagesPage = ({
         to: `/inbox-placement/details/${id}`
       }}
       title='Inbox Placement'
-      subtitle={(filterType === PLACEMENT_FILTER_TYPES.REGION) ? _.startCase(filterName) : filterName}
+      subtitle={formatFilterName(filterType, filterName)}
       primaryArea={<StopTestComponent status={status} id={id} reload={loadMessages} />}
     >
       <Panel title="Diagnostics">

--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Grid, Page, Panel } from '@sparkpost/matchbox';
 
 import { Loading } from 'src/components';
-import { getInboxPlacementByProviders, getAllInboxPlacementMessages, resetState } from 'src/actions/inboxPlacement';
+import { getInboxPlacementByProviders, getInboxPlacementByRegions, getAllInboxPlacementMessages, resetState } from 'src/actions/inboxPlacement';
 import { RedirectAndAlert } from 'src/components/globalAlert';
 import PageLink from 'src/components/pageLink';
 import StopTest from './components/StopTest';
@@ -11,6 +11,7 @@ import AllMessagesCollection from './components/AllMessagesCollection';
 import InfoBlock from './components/InfoBlock';
 import styles from './AllMessagesPage.module.scss';
 import { formatPercent } from 'src/helpers/units';
+import { PLACEMENT_FILTER_TYPES } from './constants/types';
 
 export const AllMessagesPage = ({
   id,
@@ -24,16 +25,32 @@ export const AllMessagesPage = ({
   authentication,
   error,
   getInboxPlacementByProviders,
+  getInboxPlacementByRegions,
   getAllInboxPlacementMessages,
   resetState,
   StopTestComponent = StopTest,
   AllMessagesCollectionComponent = AllMessagesCollection
 }) => {
+
   const loadMessages = useCallback(() => {
-    const filters = { [filterType]: filterName };
-    filterType === 'mailbox-provider' ? getInboxPlacementByProviders(id) : undefined; //TODO add sending ip request
+    //Will be useful for SA-1033
+    const filterTypeToQueryParamMap = {
+      [PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER]: 'mailbox-provider',
+      [PLACEMENT_FILTER_TYPES.REGION]: 'regions'
+    };
+    const filters = { [filterTypeToQueryParamMap[filterType]]: filterName };
+
+    switch (filterType) {
+      case PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER:
+        getInboxPlacementByProviders(id);
+        break;
+      case PLACEMENT_FILTER_TYPES.REGION:
+        getInboxPlacementByRegions(id);
+        break;
+      default:
+    }
     getAllInboxPlacementMessages(id, filters);
-  }, [filterName, filterType, getAllInboxPlacementMessages, getInboxPlacementByProviders, id]);
+  }, [filterName, filterType, getAllInboxPlacementMessages, getInboxPlacementByProviders, getInboxPlacementByRegions, id]);
 
   useEffect(() => {
     loadMessages();
@@ -106,10 +123,17 @@ export const AllMessagesPage = ({
 
 function mapStateToProps(state, props) {
   const { id, filterType, filterName } = props.match.params;
-  const result = ((filterType === 'mailbox-provider')
-    ? state.inboxPlacement.placementsByProvider.find(({ mailbox_provider }) => mailbox_provider === filterName)
-    : undefined) || //TODO add sending ip
-    {};
+  //Runs an inline function that returns a value from a switch statement
+  const result = (() => {
+    switch (filterType) {
+      case PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER:
+        return state.inboxPlacement.placementsByProvider.find(({ mailbox_provider }) => mailbox_provider === filterName);
+      case PLACEMENT_FILTER_TYPES.REGION:
+        return state.inboxPlacement.placementsByRegion.find(({ region }) => region === filterName);
+      default:
+        return {};
+    }
+  })() || {};
 
   return {
     id,
@@ -126,4 +150,4 @@ function mapStateToProps(state, props) {
   };
 }
 
-export default connect(mapStateToProps, { getInboxPlacementByProviders, getAllInboxPlacementMessages, resetState })(AllMessagesPage);
+export default connect(mapStateToProps, { getInboxPlacementByProviders, getInboxPlacementByRegions, getAllInboxPlacementMessages, resetState })(AllMessagesPage);

--- a/src/pages/inboxPlacement/components/PlacementBreakdown.js
+++ b/src/pages/inboxPlacement/components/PlacementBreakdown.js
@@ -7,6 +7,7 @@ import { formatPercent } from 'src/helpers/units';
 import styles from './PlacementBreakdown.module.scss';
 import PageLink from 'src/components/pageLink/PageLink';
 import { PLACEMENT_FILTER_TYPES } from '../constants/types';
+import formatFilterName from '../helpers/formatFilterName.js';
 
 export const GroupPercentage = ({ value }) => <span className={styles.GroupValue}>{formatPercent(value * 100)}</span>;
 
@@ -31,35 +32,37 @@ const WrapperComponent = ({ children }) => (<div>
   <Table>{children}</Table>
 </div>);
 
-const getPlacementNameByType = (type, { id, mailbox_provider, region }) => {
+const getPlacementNameByType = (type, { mailbox_provider, region }) => {
   switch (type) {
     case PLACEMENT_FILTER_TYPES.REGION:
-      return (
-        <PageLink to={`/inbox-placement/details/${id}/${PLACEMENT_FILTER_TYPES.REGION}/${region}`}>
-          <strong>{_.startCase(region)}</strong>
-        </PageLink>);
+      return region;
+    case PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER:
+      return mailbox_provider;
     default:
-      return (
-        <PageLink to={`/inbox-placement/details/${id}/${PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER}/${mailbox_provider}`}>
-          <strong>{mailbox_provider}</strong>
-        </PageLink>);
+      return '';
   }
 };
 
-export const RowComponent = ({ id, mailbox_provider, placement, authentication, type, region }) => (<Table.Row className={styles.DataRow}>
-  <Table.Cell className={styles.PlacementNameCell}>
-    {getPlacementNameByType(type, { id, mailbox_provider, region })}
-  </Table.Cell>
-  {type !== PLACEMENT_FILTER_TYPES.REGION && <Table.Cell className={styles.RegionCell}>
-    {_.startCase(region)}
-  </Table.Cell>}
-  <Table.Cell className={styles.Placement}><GroupPercentage value={placement.inbox_pct}/></Table.Cell>
-  <Table.Cell className={styles.Placement}><GroupPercentage value={placement.spam_pct}/></Table.Cell>
-  <Table.Cell className={styles.Placement}><GroupPercentage value={placement.missing_pct}/></Table.Cell>
-  <Table.Cell className={cx(styles.Authentication, styles.divider)}><GroupPercentage value={authentication.spf_pct}/></Table.Cell>
-  <Table.Cell className={styles.Authentication}><GroupPercentage value={authentication.dkim_pct}/></Table.Cell>
-  <Table.Cell className={styles.Authentication}><GroupPercentage value={authentication.dmarc_pct}/></Table.Cell>
-</Table.Row>);
+export const RowComponent = ({ id, mailbox_provider, placement, authentication, type, region }) => {
+  const name = getPlacementNameByType(type, { mailbox_provider, region });
+  return (
+    <Table.Row className={styles.DataRow}>
+      <Table.Cell className={styles.PlacementNameCell}>
+        <PageLink to={`/inbox-placement/details/${id}/${type}/${name}`}>
+          <strong>{formatFilterName(type, name)}</strong>
+        </PageLink>
+      </Table.Cell>
+      {type !== PLACEMENT_FILTER_TYPES.REGION && <Table.Cell className={styles.RegionCell}>
+        {_.startCase(region)}
+      </Table.Cell>}
+      <Table.Cell className={styles.Placement}><GroupPercentage value={placement.inbox_pct}/></Table.Cell>
+      <Table.Cell className={styles.Placement}><GroupPercentage value={placement.spam_pct}/></Table.Cell>
+      <Table.Cell className={styles.Placement}><GroupPercentage value={placement.missing_pct}/></Table.Cell>
+      <Table.Cell className={cx(styles.Authentication, styles.divider)}><GroupPercentage value={authentication.spf_pct}/></Table.Cell>
+      <Table.Cell className={styles.Authentication}><GroupPercentage value={authentication.dkim_pct}/></Table.Cell>
+      <Table.Cell className={styles.Authentication}><GroupPercentage value={authentication.dmarc_pct}/></Table.Cell>
+    </Table.Row>);
+};
 
 const getRowWrapper = _.memoize((type) => (
   (props) => <RowComponent {...props} type={type} />

--- a/src/pages/inboxPlacement/components/PlacementBreakdown.js
+++ b/src/pages/inboxPlacement/components/PlacementBreakdown.js
@@ -34,9 +34,15 @@ const WrapperComponent = ({ children }) => (<div>
 const getPlacementNameByType = (type, { id, mailbox_provider, region }) => {
   switch (type) {
     case PLACEMENT_FILTER_TYPES.REGION:
-      return <strong>{_.startCase(region)}</strong>;
+      return (
+        <PageLink to={`/inbox-placement/details/${id}/${PLACEMENT_FILTER_TYPES.REGION}/${region}`}>
+          <strong>{_.startCase(region)}</strong>
+        </PageLink>);
     default:
-      return <PageLink to={`/inbox-placement/details/${id}/mailbox-provider/${mailbox_provider}`}><strong>{mailbox_provider}</strong></PageLink>;
+      return (
+        <PageLink to={`/inbox-placement/details/${id}/${PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER}/${mailbox_provider}`}>
+          <strong>{mailbox_provider}</strong>
+        </PageLink>);
   }
 };
 

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/PlacementBreakdown.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/PlacementBreakdown.test.js.snap
@@ -119,9 +119,13 @@ exports[`Component: PlacementBreakdown RowComponent renders region correctly 1`]
   <Table.Cell
     className="PlacementNameCell"
   >
-    <strong>
-      North America
-    </strong>
+    <PageLink
+      to="/inbox-placement/details/1/region/north america"
+    >
+      <strong>
+        North America
+      </strong>
+    </PageLink>
   </Table.Cell>
   <Table.Cell
     className="Placement"

--- a/src/pages/inboxPlacement/helpers/formatFilterName.js
+++ b/src/pages/inboxPlacement/helpers/formatFilterName.js
@@ -1,0 +1,19 @@
+import { PLACEMENT_FILTER_TYPES } from '../constants/types';
+import _ from 'lodash';
+
+export const formatFilterName = (filterType, filterName) => {
+  switch (filterType) {
+    case PLACEMENT_FILTER_TYPES.REGION:
+      return formatRegion(filterName);
+    case PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER:
+      return formatMailboxProvider(filterName);
+    default:
+      return '';
+  }
+};
+
+const formatMailboxProvider = (name) => name;
+
+const formatRegion = (name) => _.startCase(name);
+
+export default formatFilterName;

--- a/src/pages/inboxPlacement/helpers/tests/formatFilterName.test.js
+++ b/src/pages/inboxPlacement/helpers/tests/formatFilterName.test.js
@@ -1,0 +1,13 @@
+import formatFilterName from '../formatFilterName';
+import { PLACEMENT_FILTER_TYPES } from '../../constants/types';
+
+
+describe('Format Display of Inbox Placement Results Breakdown Group By Name', () => {
+  it('should format mailbox providers correctly', () => {
+    expect(formatFilterName(PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER, 'gmail')).toEqual('gmail');
+  });
+
+  it('should format regions correctly', () => {
+    expect(formatFilterName(PLACEMENT_FILTER_TYPES.REGION, 'north america')).toEqual('North America');
+  });
+});

--- a/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
+++ b/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
@@ -4,6 +4,8 @@ import { AllMessagesPage } from '../AllMessagesPage';
 import { StopTest } from '../components/StopTest';
 import { AllMessagesCollection } from '../components/AllMessagesCollection';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { PLACEMENT_FILTER_TYPES } from '../constants/types';
+
 
 
 describe('Page: All Inbox Placement Messages Test', () => {
@@ -11,6 +13,7 @@ describe('Page: All Inbox Placement Messages Test', () => {
     const defaults = {
       getAllInboxPlacementMessages: jest.fn(),
       getInboxPlacementByProviders: jest.fn(),
+      getInboxPlacementByRegions: jest.fn(),
       id: 0,
       loading: false,
       sent: 100,
@@ -42,11 +45,12 @@ describe('Page: All Inbox Placement Messages Test', () => {
 
     const getAllInboxPlacementMessages = jest.fn().mockReturnValue({});
     const getInboxPlacementByProviders = jest.fn().mockReturnValue({});
+    const getInboxPlacementByRegions = jest.fn().mockReturnValue({});
     const resetState = jest.fn().mockReturnValue({});
     const subjectMounted = ({ ...props }) => mount(
       <Router>
         <AllMessagesPage
-          filterType={'mailbox-provider'}
+          filterType={PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER}
           filterName={'gmail.com'}
           status={'completed'}
           messages={[]}
@@ -55,6 +59,7 @@ describe('Page: All Inbox Placement Messages Test', () => {
           authentication={{}}
           getAllInboxPlacementMessages={getAllInboxPlacementMessages}
           getInboxPlacementByProviders={getInboxPlacementByProviders}
+          getInboxPlacementByRegions={getInboxPlacementByRegions}
           resetState={resetState}
           id={101}
           history={{ replace: jest.fn() }}
@@ -64,10 +69,16 @@ describe('Page: All Inbox Placement Messages Test', () => {
           {...props}/>
       </Router>);
 
-    it('calls getInboxPlacementTest on load', () => {
+    it('calls getInboxPlacementTest & getInboxPlacementByProviders on load for mailbox-providers', () => {
       subjectMounted();
       expect(getAllInboxPlacementMessages).toHaveBeenCalled();
       expect(getInboxPlacementByProviders).toHaveBeenCalled();
+    });
+
+    it('calls getInboxPlacementTest & getInboxPlacementByRegions on load for mailbox-providers', () => {
+      subjectMounted({ filterType: PLACEMENT_FILTER_TYPES.REGION, filterName: 'europe' });
+      expect(getAllInboxPlacementMessages).toHaveBeenCalled();
+      expect(getInboxPlacementByRegions).toHaveBeenCalled();
     });
 
     it('calls resetState on unmount', () => {

--- a/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
+++ b/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
@@ -11,6 +11,8 @@ import { PLACEMENT_FILTER_TYPES } from '../constants/types';
 describe('Page: All Inbox Placement Messages Test', () => {
   const subject = ({ ...props }) => {
     const defaults = {
+      filterType: PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER,
+      filterName: 'gmail',
       getAllInboxPlacementMessages: jest.fn(),
       getInboxPlacementByProviders: jest.fn(),
       getInboxPlacementByRegions: jest.fn(),

--- a/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
+++ b/src/pages/inboxPlacement/tests/__snapshots__/AllMessagesPage.test.js.snap
@@ -28,6 +28,7 @@ exports[`Page: All Inbox Placement Messages Test renders page correctly with def
       reload={[Function]}
     />
   }
+  subtitle="gmail"
   title="Inbox Placement"
 >
   <Panel

--- a/src/selectors/inboxPlacement.js
+++ b/src/selectors/inboxPlacement.js
@@ -1,7 +1,12 @@
 import { createSelector } from 'reselect';
 import endsWith from 'lodash/endsWith';
+import { PLACEMENT_FILTER_TYPES } from '../pages/inboxPlacement/constants/types';
 
 export const getSeeds = (state) => state.inboxPlacement.seeds;
+
+const getFilters = (state,props) => props.match.params;
+const getInboxPlacementByMailbox = (state) => state.inboxPlacement.placementsByProvider;
+const getInboxPlacementByRegion = (state) => state.inboxPlacement.placementsByRegion;
 
 export const selectReferenceSeed = createSelector(
   [getSeeds], (seeds) => seeds.find((seed) => endsWith(seed, '@seed.sparkpost.com')));
@@ -15,3 +20,17 @@ export const selectTestDetailsPageError = createSelector(
 export const selectTestDetailsPageLoading = createSelector(
   [getInboxPlacement], (inboxPlacement) => inboxPlacement.getTestPending || inboxPlacement.getByProviderPending || inboxPlacement.getByRegionPending || inboxPlacement.getTestContentPending
 );
+
+export const selectSinglePlacementResult = createSelector(
+  [getInboxPlacementByMailbox, getInboxPlacementByRegion, getFilters],
+  (inboxPlacementByMailbox, inboxPlacementByRegion, { filterType, filterName }) => {
+    switch (filterType) {
+      case PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER:
+        return inboxPlacementByMailbox.find(({ mailbox_provider }) => mailbox_provider === filterName);
+      case PLACEMENT_FILTER_TYPES.REGION:
+        return inboxPlacementByRegion.find(({ region }) => region === filterName);
+      default:
+        return {};
+    }
+  });
+

--- a/src/selectors/tests/inboxPlacement.test.js
+++ b/src/selectors/tests/inboxPlacement.test.js
@@ -1,4 +1,7 @@
-import { selectReferenceSeed, selectTestDetailsPageError, selectTestDetailsPageLoading } from '../inboxPlacement';
+import { selectReferenceSeed,
+  selectTestDetailsPageError,
+  selectTestDetailsPageLoading,
+  selectSinglePlacementResult } from '../inboxPlacement';
 
 describe('Selectors: Inbox Placement', () => {
   describe('selectReferenceSeed', () => {
@@ -84,6 +87,35 @@ describe('Selectors: Inbox Placement', () => {
       state.inboxPlacement.getByRegionPending = true;
       state.inboxPlacement.getTestContentPending = true;
       expect(selectTestDetailsPageLoading(state)).toBe(true);
+    });
+  });
+
+  describe('selectSinglePlacementResult', () => {
+    let state;
+    beforeEach(() => {
+      state = {
+        inboxPlacement: {
+          placementsByProvider: [
+            { id: 0,
+              mailbox_provider: 'gmail',
+              region: 'north america' }
+          ],
+          placementsByRegion: [
+            { id: 0,
+              region: 'europe' }
+          ]
+        }
+      };
+    });
+
+    it('returns mailbox provider', () => {
+      const props = { match: { params: { filterType: 'mailbox-provider', filterName: 'gmail' }}};
+      expect(selectSinglePlacementResult(state, props)).toEqual(state.inboxPlacement.placementsByProvider[0]);
+    });
+
+    it('returns region', () => {
+      const props = { match: { params: { filterType: 'region', filterName: 'europe' }}};
+      expect(selectSinglePlacementResult(state, props)).toEqual(state.inboxPlacement.placementsByRegion[0]);
     });
   });
 });


### PR DESCRIPTION
### What Changed
 - Added all messages filtered by region

### How To Test
 - To to /inbox-placement and click on any tests to access the details page
 - Switch dropdown to region. 
 - Click on any of the regions.
 - The all messages page should load. Verify that filtering is correct by checking that the number sent matches the number of messages in the table.