### PR TITLE
AC-1080 - Sending module guide set

### DIFF
--- a/src/components/card/Card.module.scss
+++ b/src/components/card/Card.module.scss
@@ -1,32 +1,32 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-
 .CardContainer{
-    border-radius: 5px;
-    border: 1px solid color(gray,5);
-    padding: 15px;
+  border-radius: 5px;
+  border: 1px solid color(gray,5);
+  padding: 15px;
+  margin-top: spacing('small')
 }
 .CardTitle{
-    display: block;
-    color: color(gray,3);
-    font-weight: 600;
-    font-size: font-size(500);
+  display: block;
+  color: color(gray,3);
+  font-weight: 600;
+  font-size: font-size(500);
 }
 .CardContent{
-    display: inline-block;
-    margin-top: spacing('small')*2;
-    margin-bottom: spacing('small');
-    font-size: font-size(500);
+  display: inline-block;
+  margin-top: spacing('small')*2;
+  margin-bottom: spacing('small');
+  font-size: font-size(500);
 }
 
 .right {
-    text-align: right;
+  text-align: right;
 }
 
 .center {
-    text-align: center;
+  text-align: center;
 }
 
 .left {
-    text-align: left;
+  text-align: left;
 }

--- a/src/components/card/Card.module.scss
+++ b/src/components/card/Card.module.scss
@@ -15,7 +15,7 @@
 .CardContent{
     display: inline-block;
     margin-top: spacing('small')*2;
-    margin-bottom: spacing('larger');
+    margin-bottom: spacing('small');
     font-size: font-size(500);
 }
 

--- a/src/components/card/Card.module.scss
+++ b/src/components/card/Card.module.scss
@@ -1,7 +1,6 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 
-
 .CardContainer{
     border-radius: 5px;
     border: 1px solid color(gray,5);

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -16,7 +16,6 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   const renderStep = () => {
     switch (stepName) {
       case 'Features':
-      default:
         return <Grid>
           <Grid.Column xs={12}>
             <Card>
@@ -30,6 +29,34 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
             </Card>
           </Grid.Column>
         </Grid>;
+      case 'Sending':
+        return <>
+        <h2 style={{ textAlign: 'center', fontColor: 'gray' }}>Where Would You Like to Begin?</h2>
+        <Grid>
+          <Grid.Column xs={12} md={6}>
+            <Card textAlign='center'>
+              <CardContent>Send you first email in one click and dive right into what SparkPost can do for your email strategy</CardContent>
+              <CardActions>
+                <ButtonWrapper>
+                  <Button color='orange' onClick={() => setStepName('Show Me SparkPost')}>Show Me SparkPost</Button>
+                </ButtonWrapper>
+              </CardActions>
+            </Card>
+          </Grid.Column>
+          <Grid.Column xs={12} md={6}>
+            <Card textAlign='center'>
+              <CardContent>Ready to integrate via SMTP or API?We'll get you set up ASAP so you can start building with SparkPost</CardContent>
+              <CardActions>
+                <ButtonWrapper>
+                  <Button color='orange' onClick={() => setStepName('Let\'s Code')}>Let's Code</Button>
+                </ButtonWrapper>
+              </CardActions>
+            </Card>
+          </Grid.Column>
+        </Grid>
+         </>;
+      default:
+        null;
     }
   };
   return <>

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Panel, Button, Grid } from '@sparkpost/matchbox';
 import { ArrowDownward, Send } from '@sparkpost/matchbox-icons';
 import { Card, CardTitle, CardContent, CardActions } from 'src/components';
@@ -13,12 +13,16 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   }];
   //stepName could be Features,Sending,Show Me Sparkpost, Let's Code
   const [stepName, setStepName] = useState('Features');
+  const guideHeadingRef = useRef(null);
+  useEffect(() => {
+    if (guideHeadingRef.current) { guideHeadingRef.current.focus(); }
+  }, [stepName]);
   const renderStep = () => {
     switch (stepName) {
       case 'Features':
         return <Grid>
-          <Grid.Column xs={12}>
-            <Card>
+          <Grid.Column xs={12} >
+            <Card >
               <CardTitle><Send size='20' className={styles.SendIcon}/>   &nbsp;Sending with Sparkpost</CardTitle>
               <CardContent><p className={styles.FeaturesCardContent}>Learn how to send emails, integrate our API into your code, and make the most of our powerful analytics.</p></CardContent>
               <CardActions>
@@ -31,9 +35,9 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
         </Grid>;
       case 'Sending':
         return <>
-        <h2 className={styles.SendingStepHeading}>Where Would You Like to Begin?</h2>
+        <p className={styles.SendingStepHeading} role="heading" aria-level="4" ref={guideHeadingRef} tabIndex={-1}>Where Would You Like to Begin?</p>
         <Grid>
-          <Grid.Column xs={12} md={6}>
+          <Grid.Column xs={12} md={6} >
             <Card textAlign='center'>
               <CardContent><p className={styles.FeaturesCardContent}>Send your first email in one click and dive right into what SparkPost can do for your email strategy </p></CardContent>
               <CardActions>

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -35,7 +35,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
         <Grid>
           <Grid.Column xs={12} md={6}>
             <Card textAlign='center'>
-              <CardContent>Send you first email in one click and dive right into what SparkPost can do for your email strategy</CardContent>
+              <CardContent>Send your first email in one click and dive right into what SparkPost can do for your email strategy</CardContent>
               <CardActions>
                 <ButtonWrapper>
                   <Button color='orange' onClick={() => setStepName('Show Me SparkPost')}>Show Me SparkPost</Button>

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -31,30 +31,32 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
         </Grid>;
       case 'Sending':
         return <>
-        <h2 style={{ textAlign: 'center', fontColor: 'gray' }}>Where Would You Like to Begin?</h2>
+        <h2 className={styles.SendingStepHeading}>Where Would You Like to Begin?</h2>
         <Grid>
           <Grid.Column xs={12} md={6}>
             <Card textAlign='center'>
-              <CardContent>Send your first email in one click and dive right into what SparkPost can do for your email strategy</CardContent>
+              <CardContent><p className={styles.FeaturesCardContent}>Send your first email in one click and dive right into what SparkPost can do for your email strategy </p></CardContent>
               <CardActions>
                 <ButtonWrapper>
-                  <Button color='orange' onClick={() => setStepName('Show Me SparkPost')}>Show Me SparkPost</Button>
+                  <Button color='orange' onClick={() => setStepName('Show Me SparkPost')} className={styles.SendingStepButtons}>Show Me SparkPost</Button>
                 </ButtonWrapper>
               </CardActions>
             </Card>
           </Grid.Column>
           <Grid.Column xs={12} md={6}>
             <Card textAlign='center'>
-              <CardContent>Ready to integrate via SMTP or API?We'll get you set up ASAP so you can start building with SparkPost</CardContent>
+              <CardContent><p className={styles.FeaturesCardContent}>Ready to integrate via SMTP or API? We'll get you set up ASAP so you can start building with SparkPost</p></CardContent>
               <CardActions>
                 <ButtonWrapper>
-                  <Button color='orange' onClick={() => setStepName('Let\'s Code')}>Let's Code</Button>
+                  <Button color='orange' onClick={() => setStepName('Let\'s Code')} className={styles.SendingStepButtons}>Let's Code</Button>
                 </ButtonWrapper>
               </CardActions>
             </Card>
           </Grid.Column>
         </Grid>
          </>;
+      case 'Show Me SparkPost':
+      case 'Let\'s Code':
       default:
         null;
     }

--- a/src/pages/dashboard/components/GettingStartedGuide.module.scss
+++ b/src/pages/dashboard/components/GettingStartedGuide.module.scss
@@ -16,4 +16,6 @@
 
 .SendingStepHeading{
     text-align: center;
+    font-size: font-size(600);
+    font-weight: 600;
 }

--- a/src/pages/dashboard/components/GettingStartedGuide.module.scss
+++ b/src/pages/dashboard/components/GettingStartedGuide.module.scss
@@ -7,4 +7,13 @@
 
 .FeaturesCardContent {
     max-width: 450px;
+    margin: 0;
 } 
+
+.SendingStepButtons{
+    min-width: 40%
+}
+
+.SendingStepHeading{
+    text-align: center;
+}

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -21,8 +21,7 @@ describe('GettingStartedGuide', () => {
     const instance = subject();
     instance.find('Button').simulate('click');
     expect(instance.find('Card')).toHaveLength(2);
-    instance.find('Button').forEach((button) => {
-      expect(['Show Me SparkPost', 'Let\'s Code'].findIndex((x) => x === button.children().text()) !== -1).toBeTruthy();
-    });
+    expect(instance).toHaveTextContent('Show Me SparkPost');
+    expect(instance).toHaveTextContent('Let&#39;s Code');
   });
 });

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -3,12 +3,26 @@ import { shallow } from 'enzyme';
 import { GettingStartedGuide } from '../GettingStartedGuide';
 import { ArrowDownward } from '@sparkpost/matchbox-icons';
 
+
 describe('GettingStartedGuide', () => {
-  const subject = (props) => (shallow(<GettingStartedGuide {...props} />));
+  const defaultProps = {
+    isGuideAtBottom: false,
+    moveGuideAtBottom: jest.fn()
+  };
+
+  const subject = (props) => (shallow(<GettingStartedGuide {...defaultProps} {...props} />));
+
   it('should render correctly when guide is at bottom or when guide is at top', () => {
     expect(subject({ isGuideAtBottom: true }).find('Panel').prop('actions')).toBe(null);
-    expect(subject({ isGuideAtBottom: false }).find('Panel').prop('actions')).toEqual(expect.arrayContaining([{ 'color': 'blue', 'content': <span> Move to Bottom <ArrowDownward size="20" /> </span>, 'onClick': undefined }]));
+    expect(subject({ isGuideAtBottom: false }).find('Panel').prop('actions')).toEqual(expect.arrayContaining([{ 'color': 'blue', 'content': <span> Move to Bottom <ArrowDownward size="20" /> </span>, 'onClick': defaultProps.moveGuideAtBottom }]));
+  });
+
+  it('should render Sending Step when Start Sending Button is clicked', () => {
+    const instance = subject();
+    instance.find('Button').simulate('click');
+    expect(instance.find('Card')).toHaveLength(2);
+    instance.find('Button').forEach((button) => {
+      expect(['Show Me SparkPost', 'Let\'s Code'].findIndex((x) => x === button.children())).toBeTruthy();
+    });
   });
 });
-
-

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -22,7 +22,7 @@ describe('GettingStartedGuide', () => {
     instance.find('Button').simulate('click');
     expect(instance.find('Card')).toHaveLength(2);
     instance.find('Button').forEach((button) => {
-      expect(['Show Me SparkPost', 'Let\'s Code'].findIndex((x) => x === button.children())).toBeTruthy();
+      expect(['Show Me SparkPost', 'Let\'s Code'].findIndex((x) => x === button.children().text()) !== -1).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
AC-1080 - Sending module guide set

### What Changed
- Includes the options for "Show Me SparkPost" guide set and the "Let's Code" guide set
- reduced the margin for CardContent.
- BreadCrumbs are not the part of this ticket.

### How To Test
- Enable "messaging_onboarding" ui option for the account.
- Navigate to /dashboard.
- check if the second step of guide is similar to [mocks](https://sparkpost.invisionapp.com/share/DHULLYL45GB#/screens/390961094)

### To Do
- [ ] Address Feedback
