### PR TITLE
SE-379: List incidents on alert details page

### DIFF
--- a/src/actions/alerts.js
+++ b/src/actions/alerts.js
@@ -66,3 +66,14 @@ export function getAlert({ id }) {
     }
   });
 }
+
+export function getIncidents({ id }) {
+  return sparkpostApiRequest({
+    type: 'GET_ALERT_INCIDENTS',
+    meta: {
+      method: 'GET',
+      url: `/v1/alerts/${id}/incidents`,
+      showErrorAlert: false
+    }
+  });
+}

--- a/src/config/navItems/index.js
+++ b/src/config/navItems/index.js
@@ -119,7 +119,6 @@ export default [
   {
     label: 'Alerts',
     to: '/alerts',
-    tag: 'new',
     icon: NotificationsActive
   },
   inboxPlacementNavItems,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -20,6 +20,7 @@ export const FORMATS = {
 
   DATETIME: 'MMM Do h:mma',
   LONG_DATETIME: 'MMM Do YYYY h:mma',
+  LONG_DATETIME_ALT: 'MMM DD, YYYY [at] h:mma',
 
   INPUT_DATES: ['YYYY-MM-DD'],
   INPUT_TIMES: ['h:mma', 'H:mm', 'H:mma'],

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -135,8 +135,8 @@ export function formatTime(time, FORMAT = config.timeFormat) {
   return moment(time).format(FORMAT);
 }
 
-export function formatDateTime(datetime) {
-  return `${formatDate(datetime)}, ${formatTime(datetime)}`;
+export function formatDateTime(datetime, FORMAT) {
+  return FORMAT ? moment(datetime).format(FORMAT) : `${formatDate(datetime)}, ${formatTime(datetime)}`;
 }
 
 // format as ISO 8601 timestamp to match SP API

--- a/src/pages/alerts/DetailsPage.js
+++ b/src/pages/alerts/DetailsPage.js
@@ -5,6 +5,7 @@ import { Delete, ContentCopy } from '@sparkpost/matchbox-icons';
 import { DeleteModal, Loading } from 'src/components';
 import withAlert from './containers/DetailsPage.container';
 import { AlertDetails } from './components/AlertDetails';
+import AlertIncidents from './components/AlertIncidents';
 import RedirectAndAlert from 'src/components/globalAlert/RedirectAndAlert';
 import styles from './DetailsPage.module.scss';
 import _ from 'lodash';
@@ -15,8 +16,9 @@ export class DetailsPage extends Component {
   };
 
   componentDidMount() {
-    const { id, getAlert, hasSubaccounts, listSubaccounts } = this.props;
+    const { id, getAlert, hasSubaccounts, listSubaccounts, getIncidents } = this.props;
     getAlert({ id });
+    getIncidents({ id });
     if (hasSubaccounts) {
       listSubaccounts();
     }
@@ -54,7 +56,7 @@ export class DetailsPage extends Component {
   };
 
   render() {
-    const { loading, deletePending, alert = {}, error, id, hasSubaccounts } = this.props;
+    const { loading, deletePending, alert = {}, error, id, hasSubaccounts, incidents } = this.props;
     const { isDeleteModalOpen } = this.state;
     const { name } = alert;
 
@@ -83,6 +85,11 @@ export class DetailsPage extends Component {
         {!_.isEmpty(alert) &&
           <AlertDetails alert={alert} id={id} subaccountIdToString={this.subaccountIdToString} hasSubaccounts={hasSubaccounts}/>
         }
+        <AlertIncidents
+          alert={alert}
+          incidents={incidents}
+          subaccountIdToString={this.subaccountIdToString}
+        />
         <DeleteModal
           open={isDeleteModalOpen}
           title='Are you sure you want to delete this alert?'

--- a/src/pages/alerts/components/AlertIncidents.js
+++ b/src/pages/alerts/components/AlertIncidents.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Panel, Table, Tag } from '@sparkpost/matchbox';
+import { TableCollection, Empty } from 'src/components';
+import { METRICS, FILTERS_FRIENDLY_NAMES } from '../constants/formConstants';
+import { getEvaluatorOptions } from '../helpers/alertForm';
+import { roundToPlaces } from 'src/helpers/units';
+import moment from 'moment';
+import _ from 'lodash';
+import styles from './AlertIncidents.module.scss';
+
+const formatDateTime = (timestamp) => moment(timestamp).format('MMM DD, YYYY [at] h:mma');
+
+const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
+
+  const { metric, source } = alert;
+  const { suffix } = getEvaluatorOptions(metric, source);
+
+  const columns = [
+    { label: 'Triggered', sortKey: 'first_fired' },
+    { label: 'Resolved', sortKey: 'last_fired' },
+    { label: 'For' },
+    { label: METRICS[metric], sortKey: 'triggered_value', width: '20%' }
+  ];
+
+  const getRowData = (props) => {
+    const { first_fired, last_fired, status, triggered_value, filters } = props;
+
+
+    const renderTags = () => {
+      const { subaccount_id, ...rest } = filters;
+
+      const subaccountTag = subaccount_id &&
+      <span key='subaccounts'>
+        <h6 className={styles.BoldInline}>Subaccounts</h6>
+        &nbsp;
+        <Tag>{subaccountIdToString(subaccount_id)}</Tag>
+      </span>;
+
+      const otherTags = _.map(rest, (value, key) => {
+        const finalValue = value === 'NULL' ? null : value;
+        return (
+          finalValue &&
+          <span key={key}>
+            <h6 className={styles.BoldInline}>{FILTERS_FRIENDLY_NAMES[key]}</h6>
+            &nbsp;
+            <Tag>{finalValue}</Tag>
+          </span>
+        );
+      });
+
+      return (
+        [
+          subaccountTag,
+          otherTags.length > 0 ? ' and ' : null,
+          ...otherTags
+        ]
+      );
+    };
+
+    return [
+      <div>{formatDateTime(first_fired)}</div>,
+      <div>{status === 'Active' ? <Tag color='yellow'>Active</Tag> : formatDateTime(last_fired)}</div>,
+      <div>{renderTags()}</div>,
+      <div className={styles.paddedCell}>{roundToPlaces(triggered_value, 3)}{suffix}</div>
+    ];
+  };
+
+  const TableWrapper = (props) => (
+    <>
+      <div>
+        <Table>{props.children}</Table>
+      </div>
+    </>
+  );
+
+  return (
+    <Panel title='Alert Incidents'>
+      {incidents.length <= 0
+        ? <Empty message='No incidents'/>
+        : <TableCollection
+          wrapperComponent={TableWrapper}
+          rows={incidents}
+          columns={columns}
+          getRowData={getRowData}
+          pagination
+          defaultSortColumn='first_fired'
+          defaultSortDirection='desc'
+        />
+      }
+
+    </Panel>
+  );
+};
+
+export default AlertIncidents;

--- a/src/pages/alerts/components/AlertIncidents.js
+++ b/src/pages/alerts/components/AlertIncidents.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Panel, Table, Tag } from '@sparkpost/matchbox';
 import { TableCollection, Empty } from 'src/components';
 import { FORMATS } from 'src/constants';
+import { formatDateTime } from 'src/helpers/date';
 import { METRICS, FILTERS_FRIENDLY_NAMES } from '../constants/formConstants';
 import { MAILBOX_PROVIDERS } from 'src/constants';
 import { getEvaluatorOptions } from '../helpers/alertForm';
@@ -9,8 +10,6 @@ import { roundToPlaces } from 'src/helpers/units';
 import moment from 'moment';
 import _ from 'lodash';
 import styles from './AlertIncidents.module.scss';
-
-const formatDateTime = (timestamp) => moment(timestamp).format(FORMATS.LONG_DATETIME_ALT);
 
 const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
 
@@ -66,7 +65,7 @@ const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
 
     return [
       <div>{formatDateTime(first_fired)}</div>,
-      <div>{status === 'Open' ? <Tag color='yellow'>Active</Tag> : formatDateTime(moment(last_fired).add(45, 'minutes'))}</div>,
+      <div>{status === 'Open' ? <Tag color='yellow'>Active</Tag> : formatDateTime(moment(last_fired).add(45, 'minutes'), FORMATS.LONG_DATETIME_ALT)}</div>,
       <div className={styles.IncidentFilters}>{renderTags()}</div>,
       <div className={styles.rightAlign}>{roundToPlaces(triggered_value, 3)}{suffix}</div>
     ];

--- a/src/pages/alerts/components/AlertIncidents.js
+++ b/src/pages/alerts/components/AlertIncidents.js
@@ -64,7 +64,7 @@ const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
     };
 
     return [
-      <div>{formatDateTime(first_fired)}</div>,
+      <div>{formatDateTime(first_fired, FORMATS.LONG_DATETIME_ALT)}</div>,
       <div>{status === 'Open' ? <Tag color='yellow'>Active</Tag> : formatDateTime(moment(last_fired).add(45, 'minutes'), FORMATS.LONG_DATETIME_ALT)}</div>,
       <div className={styles.IncidentFilters}>{renderTags()}</div>,
       <div className={styles.rightAlign}>{roundToPlaces(triggered_value, 3)}{suffix}</div>

--- a/src/pages/alerts/components/AlertIncidents.js
+++ b/src/pages/alerts/components/AlertIncidents.js
@@ -65,7 +65,7 @@ const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
 
     return [
       <div>{formatDateTime(first_fired)}</div>,
-      <div>{status === 'Active' ? <Tag color='yellow'>Active</Tag> : formatDateTime(last_fired)}</div>,
+      <div>{status === 'Open' ? <Tag color='yellow'>Active</Tag> : formatDateTime(moment(last_fired).add(45, 'minutes'))}</div>,
       <div className={styles.IncidentFilters}>{renderTags()}</div>,
       <div className={styles.rightAlign}>{roundToPlaces(triggered_value, 3)}{suffix}</div>
     ];

--- a/src/pages/alerts/components/AlertIncidents.js
+++ b/src/pages/alerts/components/AlertIncidents.js
@@ -20,12 +20,10 @@ const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
     { label: 'Triggered', sortKey: 'first_fired' },
     { label: 'Resolved', sortKey: 'last_fired' },
     { label: 'For' },
-    { label: METRICS[metric], sortKey: 'triggered_value', width: '20%' }
+    { label: METRICS[metric], sortKey: 'triggered_value', className: styles.rightAlign }
   ];
 
-  const getRowData = (props) => {
-    const { first_fired, last_fired, status, triggered_value, filters } = props;
-
+  const getRowData = ({ first_fired, last_fired, status, triggered_value, filters }) => {
 
     const renderTags = () => {
 
@@ -69,16 +67,12 @@ const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
       <div>{formatDateTime(first_fired)}</div>,
       <div>{status === 'Active' ? <Tag color='yellow'>Active</Tag> : formatDateTime(last_fired)}</div>,
       <div className={styles.IncidentFilters}>{renderTags()}</div>,
-      <div className={styles.paddedCell}>{roundToPlaces(triggered_value, 3)}{suffix}</div>
+      <div className={styles.rightAlign}>{roundToPlaces(triggered_value, 3)}{suffix}</div>
     ];
   };
 
   const TableWrapper = (props) => (
-    <>
-      <div>
-        <Table>{props.children}</Table>
-      </div>
-    </>
+    <Table>{props.children}</Table>
   );
 
   return (

--- a/src/pages/alerts/components/AlertIncidents.js
+++ b/src/pages/alerts/components/AlertIncidents.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Panel, Table, Tag } from '@sparkpost/matchbox';
 import { TableCollection, Empty } from 'src/components';
+import { FORMATS } from 'src/constants';
 import { METRICS, FILTERS_FRIENDLY_NAMES } from '../constants/formConstants';
 import { MAILBOX_PROVIDERS } from 'src/constants';
 import { getEvaluatorOptions } from '../helpers/alertForm';
@@ -9,7 +10,7 @@ import moment from 'moment';
 import _ from 'lodash';
 import styles from './AlertIncidents.module.scss';
 
-const formatDateTime = (timestamp) => moment(timestamp).format('MMM DD, YYYY [at] h:mma');
+const formatDateTime = (timestamp) => moment(timestamp).format(FORMATS.LONG_DATETIME_ALT);
 
 const AlertIncidents = ({ incidents = [], alert, subaccountIdToString }) => {
 

--- a/src/pages/alerts/components/AlertIncidents.module.scss
+++ b/src/pages/alerts/components/AlertIncidents.module.scss
@@ -1,10 +1,14 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 .BoldInline{
-  display: inline;
+  display: inline-block;
 }
 
 .paddedCell {
   padding: spacing(small) spacing();
   text-align: right;
+}
+
+.IncidentFilters {
+  max-width: 25vw;
 }

--- a/src/pages/alerts/components/AlertIncidents.module.scss
+++ b/src/pages/alerts/components/AlertIncidents.module.scss
@@ -4,8 +4,7 @@
   display: inline-block;
 }
 
-.paddedCell {
-  padding: spacing(small) spacing();
+.rightAlign {
   text-align: right;
 }
 

--- a/src/pages/alerts/components/AlertIncidents.module.scss
+++ b/src/pages/alerts/components/AlertIncidents.module.scss
@@ -1,0 +1,10 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.BoldInline{
+  display: inline;
+}
+
+.paddedCell {
+  padding: spacing(small) spacing();
+  text-align: right;
+}

--- a/src/pages/alerts/components/tests/AlertIncidents.test.js
+++ b/src/pages/alerts/components/tests/AlertIncidents.test.js
@@ -30,7 +30,7 @@ describe('Alert Details Component', () => {
     {
       first_fired: '2019-08-06T21:00:00.000Z',
       last_fired: '2019-08-06T21:00:00.000Z',
-      status: 'Active',
+      status: 'Open',
       triggered_value: 30,
       filters: {
         subaccount_id: 3,

--- a/src/pages/alerts/components/tests/AlertIncidents.test.js
+++ b/src/pages/alerts/components/tests/AlertIncidents.test.js
@@ -32,7 +32,11 @@ describe('Alert Details Component', () => {
       last_fired: '2019-08-06T21:00:00.000Z',
       status: 'Active',
       triggered_value: 30,
-      filters: {}
+      filters: {
+        subaccount_id: 3,
+        mailbox_provider: 'gmail',
+        sending_ip: '1.1.1.1'
+      }
     }
   ];
 
@@ -55,6 +59,21 @@ describe('Alert Details Component', () => {
 
   it('renders table with an incident', () => {
     expect(subject().find('TableCollection')).toExist();
+  });
+
+  it('properly renders rows', () => {
+    const getRowData = subject().find('TableCollection').prop('getRowData');
+    expect(getRowData(incidents[0])).toMatchSnapshot();
+  });
+
+  it('renders the active status tag', () => {
+    const getRowData = subject().find('TableCollection').prop('getRowData');
+    expect(shallow(getRowData(incidents[1])[1]).find('Tag')).toExist();
+  });
+
+  it('renders tags', () => {
+    const getRowData = subject().find('TableCollection').prop('getRowData');
+    expect(getRowData(incidents[1])[2]).toMatchSnapshot();
   });
 
 });

--- a/src/pages/alerts/components/tests/AlertIncidents.test.js
+++ b/src/pages/alerts/components/tests/AlertIncidents.test.js
@@ -1,0 +1,60 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import AlertIncidents from '../AlertIncidents';
+
+describe('Alert Details Component', () => {
+
+  const alert = {
+    name: 'My Alert Name',
+    metric: 'health_score',
+    channels: {
+      emails: ['Myemail@email.com', 'email@ddress.com'],
+      slack: { target: 'https://hooks.slack.com/services/X' },
+      webhook: { target: 'target.com/200' }
+    },
+    filters: [{ filter_type: 'mailbox_provider', filter_values: ['gmail']}],
+    threshold_evaluator: { source: 'raw', operator: 'lt', value: 80 },
+    subaccounts: [-1],
+    any_subaccount: false,
+    muted: false
+  };
+
+  const incidents = [
+    {
+      first_fired: '2019-08-06T21:00:00.000Z',
+      last_fired: '2019-08-06T21:00:00.000Z',
+      status: 'Resovled',
+      triggered_value: 30,
+      filters: {}
+    },
+    {
+      first_fired: '2019-08-06T21:00:00.000Z',
+      last_fired: '2019-08-06T21:00:00.000Z',
+      status: 'Active',
+      triggered_value: 30,
+      filters: {}
+    }
+  ];
+
+  const defaultProps = {
+    alert,
+    incidents,
+    subaccountIdToString: jest.fn((a) => a)
+  };
+
+  const subject = (props = {}) => shallow(
+    <AlertIncidents
+      {...defaultProps}
+      {...props}
+    />
+  );
+
+  it('renders empty when no incidents', () => {
+    expect(subject({ incidents: []}).find('Empty')).toExist();
+  });
+
+  it('renders table with an incident', () => {
+    expect(subject().find('TableCollection')).toExist();
+  });
+
+});

--- a/src/pages/alerts/components/tests/__snapshots__/AlertIncidents.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertIncidents.test.js.snap
@@ -6,7 +6,7 @@ Array [
     Aug 06, 2019 at 5:00pm
   </div>,
   <div>
-    Aug 06, 2019 at 5:00pm
+    Aug 06, 2019 at 5:45pm
   </div>,
   <div
     className="IncidentFilters"

--- a/src/pages/alerts/components/tests/__snapshots__/AlertIncidents.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertIncidents.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alert Details Component properly renders rows 1`] = `
+Array [
+  <div>
+    Aug 06, 2019 at 5:00pm
+  </div>,
+  <div>
+    Aug 06, 2019 at 5:00pm
+  </div>,
+  <div
+    className="IncidentFilters"
+  />,
+  <div
+    className="rightAlign"
+  >
+    30
+    %
+  </div>,
+]
+`;
+
+exports[`Alert Details Component renders tags 1`] = `
+<div
+  className="IncidentFilters"
+>
+  <span>
+    <strong
+      className="BoldInline"
+    >
+      Subaccounts
+    </strong>
+     
+    <Tag>
+      3
+    </Tag>
+  </span>
+  <span>
+     and 
+  </span>
+  <span>
+    <strong
+      className="BoldInline"
+    >
+      Mailbox Provider
+    </strong>
+     
+    <Tag>
+      Gmail
+    </Tag>
+  </span>
+  <span>
+     and 
+  </span>
+  <span>
+    <strong
+      className="BoldInline"
+    >
+      Sending IP
+    </strong>
+     
+    <Tag>
+      1.1.1.1
+    </Tag>
+  </span>
+</div>
+`;

--- a/src/pages/alerts/constants/formConstants.js
+++ b/src/pages/alerts/constants/formConstants.js
@@ -17,7 +17,8 @@ export const FILTERS_FRIENDLY_NAMES = {
   ip_pool: 'IP Pool',
   mailbox_provider: 'Mailbox Provider',
   sending_domain: 'Sending Domain',
-  sending_ip: 'Sending IP'
+  sending_ip: 'Sending IP',
+  subaccount_id: 'Subaccounts'
 };
 
 export const RECOMMENDED_METRIC_VALUE = {

--- a/src/pages/alerts/containers/DetailsPage.container.js
+++ b/src/pages/alerts/containers/DetailsPage.container.js
@@ -1,17 +1,18 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { deleteAlert, getAlert } from 'src/actions/alerts';
+import { deleteAlert, getAlert, getIncidents } from 'src/actions/alerts';
 import { showAlert } from 'src/actions/globalAlert';
 import { getSubaccounts, hasSubaccounts } from 'src/selectors/subaccounts';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 
 
 function withAlert(WrappedComponent) {
-  const mapDispatchToProps = { deleteAlert, getAlert, showUIAlert: showAlert, listSubaccounts };
+  const mapDispatchToProps = { deleteAlert, getAlert, showUIAlert: showAlert, listSubaccounts, getIncidents };
 
   const mapStateToProps = (state, props) => ({
     id: props.match.params.id,
     alert: state.alerts.alert,
+    incidents: state.alerts.alertIncidents,
     error: state.alerts.getError,
     loading: state.alerts.getPending,
     deletePending: state.alerts.deletePending,

--- a/src/pages/alerts/tests/DetailsPage.test.js
+++ b/src/pages/alerts/tests/DetailsPage.test.js
@@ -35,7 +35,7 @@ describe('Page: Alert Details', () => {
   });
 
   it('should attempt to load incidents', () => {
-    wrapper - shallow(<DetailsPage {...props} />);
+    wrapper = shallow(<DetailsPage {...props} />);
     expect(props.getIncidents).toHaveBeenCalledWith({ id: 'alert-id' });
   });
 

--- a/src/pages/alerts/tests/DetailsPage.test.js
+++ b/src/pages/alerts/tests/DetailsPage.test.js
@@ -5,12 +5,14 @@ import { DetailsPage } from '../DetailsPage';
 describe('Page: Alert Details', () => {
   const props = {
     getAlert: jest.fn(),
+    getIncidents: jest.fn(),
     deleteAlert: jest.fn(() => Promise.resolve()),
     showUIAlert: jest.fn(),
     hasSubaccounts: true,
     listSubaccounts: jest.fn(() => Promise.resolve()),
     subaccounts: [{ id: 1, name: 'My Subaccount' }],
     alert: { name: 'My Alert' },
+    incidents: [],
     loading: false,
     id: 'alert-id',
     deletePending: false,
@@ -30,6 +32,11 @@ describe('Page: Alert Details', () => {
   it('should get subaccounts on mount', () => {
     wrapper = shallow(<DetailsPage {...props} />);
     expect(props.listSubaccounts).toHaveBeenCalled();
+  });
+
+  it('should attempt to load incidents', () => {
+    wrapper - shallow(<DetailsPage {...props} />);
+    expect(props.getIncidents).toHaveBeenCalledWith({ id: 'alert-id' });
   });
 
   it('should render loading component when loading data', () => {

--- a/src/pages/alerts/tests/__snapshots__/DetailsPage.test.js.snap
+++ b/src/pages/alerts/tests/__snapshots__/DetailsPage.test.js.snap
@@ -47,6 +47,15 @@ exports[`Page: Alert Details should render Alert Details Page 1`] = `
     id="alert-id"
     subaccountIdToString={[Function]}
   />
+  <AlertIncidents
+    alert={
+      Object {
+        "name": "My Alert",
+      }
+    }
+    incidents={Array []}
+    subaccountIdToString={[Function]}
+  />
   <DeleteModal
     content={
       <p>

--- a/src/pages/inboxPlacement/helpers/formatScheduleLine.js
+++ b/src/pages/inboxPlacement/helpers/formatScheduleLine.js
@@ -1,8 +1,9 @@
 
 import moment from 'moment';
 import { STATUS, DURATION_HOURS } from '../constants/test';
+import { FORMATS } from 'src/constants';
 
-const formatDateTime = (start_time) => moment(start_time).format('MMM DD, YYYY [at] h:mma');
+const formatDateTime = (start_time) => moment(start_time).format(FORMATS.LONG_DATETIME_ALT);
 const getHoursRemaining = (start_time) => moment(start_time).add(DURATION_HOURS, 'hours').diff(moment(), 'hours');
 
 export default function formatScheduleLine(status, start_time, end_time) {

--- a/src/reducers/alerts.js
+++ b/src/reducers/alerts.js
@@ -5,7 +5,8 @@ const initialState = {
   createPending: false,
   updatePending: false,
   deletePending: false,
-  getPending: false
+  getPending: false,
+  incidents: []
 };
 
 export default (state = initialState, { type, payload, meta }) => {
@@ -49,6 +50,15 @@ export default (state = initialState, { type, payload, meta }) => {
 
     case 'GET_ALERT_SUCCESS':
       return { ...state, alert: payload, getPending: false };
+
+    case 'GET_ALERT_INCIDENTS_PENDING':
+      return { ...state, alertIncidents: [], getPending: true, getError: null };
+
+    case 'GET_ALERT_INCIDENTS_FAIL':
+      return { ...state, getPending: false, getError: payload };
+
+    case 'GET_ALERT_INCIDENTS_SUCCESS':
+      return { ...state, alertIncidents: payload, getPending: false };
 
     // UPDATE single list row Muted status
     case 'SET_ALERT_MUTED_STATUS_PENDING':


### PR DESCRIPTION
### What Changed
 - Added alert incidents table
 - Added alert incidents action/reducer

### How To Test
 - Using appteam account (prod works nicely), go to `/alerts`
 - Go to one of the alerts page
 - Check that table is at bottom
    - Check empty state
    - Check that table properly renders active tag


### To Do
- [ ] Address feedback
- [x] Confirm AC with`last_fired + 45 minutes`
- [ ] Error state with not being able to access alert details with too many filters from incidents API  