### PR TITLE
SA-1033 - Update query params for all-messages endpoint

### DIFF
--- a/src/pages/inboxPlacement/AllMessagesPage.js
+++ b/src/pages/inboxPlacement/AllMessagesPage.js
@@ -35,9 +35,8 @@ export const AllMessagesPage = ({
 }) => {
 
   const loadMessages = useCallback(() => {
-    //Will be useful for SA-1033
     const filterTypeToQueryParamMap = {
-      [PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER]: 'mailbox-provider',
+      [PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER]: 'mailbox_providers',
       [PLACEMENT_FILTER_TYPES.REGION]: 'regions'
     };
     const filters = { [filterTypeToQueryParamMap[filterType]]: filterName };
@@ -69,7 +68,7 @@ export const AllMessagesPage = ({
       alert={{ type: 'error', message: error.message }}/>;
   }
 
-  const deliveribilityStyleProps = {
+  const deliverabilityStyleProps = {
     columnProps: { md: 3 },
     valueClassName: styles.DeliverabilityValue,
     labelClassName: styles.DeliverabilityHeader
@@ -98,10 +97,10 @@ export const AllMessagesPage = ({
             <div className={styles.Divider} >
               <h5 className={styles.Title}>Deliverability</h5>
               <Grid className={styles.Panel}>
-                <InfoBlock value={sent} label='Sent' {...deliveribilityStyleProps}/>
-                <InfoBlock value={(placement.inbox_pct || 0) * sent} label='Inbox' {...deliveribilityStyleProps}/>
-                <InfoBlock value={(placement.spam_pct || 0) * sent} label='Spam' {...deliveribilityStyleProps}/>
-                <InfoBlock value={(placement.missing_pct || 0) * sent} label='Missing' {...deliveribilityStyleProps}/>
+                <InfoBlock value={sent} label='Sent' {...deliverabilityStyleProps}/>
+                <InfoBlock value={(placement.inbox_pct || 0) * sent} label='Inbox' {...deliverabilityStyleProps}/>
+                <InfoBlock value={(placement.spam_pct || 0) * sent} label='Spam' {...deliverabilityStyleProps}/>
+                <InfoBlock value={(placement.missing_pct || 0) * sent} label='Missing' {...deliverabilityStyleProps}/>
               </Grid>
             </div>
           </Grid.Column>

--- a/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
+++ b/src/pages/inboxPlacement/tests/AllMessagesPage.test.js
@@ -73,13 +73,13 @@ describe('Page: All Inbox Placement Messages Test', () => {
 
     it('calls getInboxPlacementTest & getInboxPlacementByProviders on load for mailbox-providers', () => {
       subjectMounted();
-      expect(getAllInboxPlacementMessages).toHaveBeenCalled();
+      expect(getAllInboxPlacementMessages).toHaveBeenCalledWith(101, { mailbox_providers: 'gmail.com' });
       expect(getInboxPlacementByProviders).toHaveBeenCalled();
     });
 
     it('calls getInboxPlacementTest & getInboxPlacementByRegions on load for mailbox-providers', () => {
       subjectMounted({ filterType: PLACEMENT_FILTER_TYPES.REGION, filterName: 'europe' });
-      expect(getAllInboxPlacementMessages).toHaveBeenCalled();
+      expect(getAllInboxPlacementMessages).toHaveBeenCalledWith(101, { regions: 'europe' });
       expect(getInboxPlacementByRegions).toHaveBeenCalled();
     });
 


### PR DESCRIPTION

### What Changed
 - Updated query param from `mailbox-provider` to `mailbox_providers`.
 - Fixed typo in variable name
 - Improved tests

### How To Test
 - Go to '/inbox-placement`.
 - Click on any test.
 - Click on an email domain in the table.
 - Verify that the api call uses `mailbox_providers` and that filtering still works. IE: The aggregate
results show 10 responses so there should be 10 messages in the table.
