### PR TITLE
AC-1081 - Breadcrumbs for the modules

### DIFF
--- a/src/components/breadcrumbs/BreadCrumbs.js
+++ b/src/components/breadcrumbs/BreadCrumbs.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from './BreadCrumbs.module.scss';
+import classNames from 'classnames';
+export const BreadCrumbs = ({ children }) => (
+  <div className={styles.BreadCrumbContainer}>
+    {React.Children.map(children, (child, index) => (
+  <>
+  &nbsp; {child} &nbsp; {index + 1 !== React.Children.count(children) && '>'}
+  </>
+    ))}
+  </div>
+);
+
+
+export const BreadCrumbsItem = ({ children, active, onClick }) => (
+  <span onClick={onClick} className={classNames(!active && styles.InActiveItem, styles.BreadCrumbItem)}>{children} </span>
+);

--- a/src/components/breadcrumbs/BreadCrumbs.js
+++ b/src/components/breadcrumbs/BreadCrumbs.js
@@ -5,7 +5,7 @@ export const BreadCrumbs = ({ children }) => (
   <div className={styles.BreadCrumbContainer}>
     {React.Children.map(children, (child, index) => (
   <>
-  &nbsp; {child} &nbsp; {index + 1 !== React.Children.count(children) && <div className={styles.Arrow}>></div>}
+  {child} {index + 1 !== React.Children.count(children) && <div className={styles.Arrow}>&nbsp;>&nbsp;</div>}
   </>
     ))}
   </div>

--- a/src/components/breadcrumbs/BreadCrumbs.js
+++ b/src/components/breadcrumbs/BreadCrumbs.js
@@ -5,7 +5,7 @@ export const BreadCrumbs = ({ children }) => (
   <div className={styles.BreadCrumbContainer}>
     {React.Children.map(children, (child, index) => (
   <>
-  &nbsp; {child} &nbsp; {index + 1 !== React.Children.count(children) && '>'}
+  &nbsp; {child} &nbsp; {index + 1 !== React.Children.count(children) && <div className={styles.Arrow}>></div>}
   </>
     ))}
   </div>

--- a/src/components/breadcrumbs/BreadCrumbs.module.scss
+++ b/src/components/breadcrumbs/BreadCrumbs.module.scss
@@ -1,0 +1,14 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.InActiveItem{
+  color: color(gray,4);
+}
+
+.BreadCrumbItem{
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.BreadCrumbContainer{
+  padding: 0 spacing(small) spacing(large) 0
+}

--- a/src/components/breadcrumbs/BreadCrumbs.module.scss
+++ b/src/components/breadcrumbs/BreadCrumbs.module.scss
@@ -6,7 +6,7 @@
 
 .BreadCrumbItem{
   font-weight: 500;
-  font-size: font-size(600);
+  font-size: font-size(500);
   cursor: pointer;
 }
 

--- a/src/components/breadcrumbs/BreadCrumbs.module.scss
+++ b/src/components/breadcrumbs/BreadCrumbs.module.scss
@@ -5,10 +5,18 @@
 }
 
 .BreadCrumbItem{
-  font-weight: 600;
+  font-weight: 500;
+  font-size: font-size(600);
   cursor: pointer;
 }
 
+.Arrow{
+  display: inline-block;
+  font-size: font-size(900);
+  transform: translateY(3px);
+  color: color(gray,4);
+}
+
 .BreadCrumbContainer{
-  padding: 0 spacing(small) spacing(large) 0
+  padding: 0 spacing(small) spacing(large) 0;
 }

--- a/src/components/breadcrumbs/index.js
+++ b/src/components/breadcrumbs/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from './BreadCrumbs.module.scss';
+import classNames from 'classnames';
+export const BreadCrumbs = ({ children }) => (
+  <div className={styles.BreadCrumbContainer}>
+    {React.Children.map(children, (child, index) => (
+  <>
+  &nbsp; {child} &nbsp; {index + 1 !== React.Children.count(children) && '>'}
+  </>
+    ))}
+  </div>
+);
+
+
+export const BreadCrumbsItem = ({ children, active, onClick }) => (
+  <span onClick={onClick} className={classNames(!active && styles.InActiveItem, styles.BreadCrumbItem)}>{children} </span>
+);

--- a/src/components/breadcrumbs/index.js
+++ b/src/components/breadcrumbs/index.js
@@ -1,17 +1,1 @@
-import React from 'react';
-import styles from './BreadCrumbs.module.scss';
-import classNames from 'classnames';
-export const BreadCrumbs = ({ children }) => (
-  <div className={styles.BreadCrumbContainer}>
-    {React.Children.map(children, (child, index) => (
-  <>
-  &nbsp; {child} &nbsp; {index + 1 !== React.Children.count(children) && '>'}
-  </>
-    ))}
-  </div>
-);
-
-
-export const BreadCrumbsItem = ({ children, active, onClick }) => (
-  <span onClick={onClick} className={classNames(!active && styles.InActiveItem, styles.BreadCrumbItem)}>{children} </span>
-);
+export { BreadCrumbs, BreadCrumbsItem } from './BreadCrumbs';

--- a/src/components/breadcrumbs/tests/BreadCrumbs.test.js
+++ b/src/components/breadcrumbs/tests/BreadCrumbs.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { BreadCrumbs, BreadCrumbsItem } from '../BreadCrumbs';
+
+describe('BreadCrumbs', () => {
+
+  const defaultProps = {
+    children: [
+      <BreadCrumbsItem onClick={jest.fn()} active={false}>A</BreadCrumbsItem>,
+      <BreadCrumbsItem onClick={jest.fn()} active={false}>B</BreadCrumbsItem>,
+      <BreadCrumbsItem onClick={jest.fn()} active={false}>C</BreadCrumbsItem>
+    ]
+  };
+
+  const subject = (props) => (shallow(<BreadCrumbs {...defaultProps} {...props}/>));
+
+  it('should not render > after the last breadCrumb ' , () => {
+    const instance = subject();
+    expect(instance.find('div').children().last().text()).not.toBe('>');
+  });
+});

--- a/src/components/breadcrumbs/tests/BreadCrumbs.test.js
+++ b/src/components/breadcrumbs/tests/BreadCrumbs.test.js
@@ -16,6 +16,6 @@ describe('BreadCrumbs', () => {
 
   it('should not render > after the last breadCrumb ' , () => {
     const instance = subject();
-    expect(instance.find('div').children().last().text()).not.toBe('>');
+    expect(instance.find('div').at(0).children().last()).not.toBe('>');
   });
 });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -29,6 +29,7 @@ export { default as CookieConsent } from './cookieConsent/CookieConsent';
 export { default as PageLink } from './pageLink/PageLink';
 export { default as Subaccount } from './labels/Subaccount';
 
+export * from './breadcrumbs';
 export * from './collection';
 export * from './formatters';
 export * from './loading/Loading';

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -4,8 +4,15 @@ import { ArrowDownward, Send } from '@sparkpost/matchbox-icons';
 import { Card, CardTitle, CardContent, CardActions } from 'src/components';
 import ButtonWrapper from 'src/components/buttonWrapper';
 import styles from './GettingStartedGuide.module.scss';
+import { BreadCrumbs, BreadCrumbsItem } from '../../../components';
 
 export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
+  const breadCrumbsItems = {
+    'Features': ['Features'],
+    'Sending': ['Features', 'Sending'],
+    'Show Me SparkPost': ['Features', 'Sending', 'Show Me SparkPost'],
+    'Let\'s Code': ['Features', 'Sending', 'Let\'s Code']
+  };
   const actions = isGuideAtBottom ? null : [{
     content: <span> Move to Bottom <ArrowDownward size='20'/> </span>,
     color: 'blue',
@@ -67,7 +74,14 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   };
   return <>
         <Panel title='Getting Started' actions={actions} sectioned >
-          <p><strong> Features</strong> </p>
+          <BreadCrumbs>
+            {breadCrumbsItems[stepName].map((item) => (
+              <BreadCrumbsItem
+                key={item}
+                onClick={() => setStepName(item)}
+                active={stepName === item}>{item}</BreadCrumbsItem>
+            ))}
+          </BreadCrumbs>
           {renderStep()}
         </Panel>
         </>;

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -4,7 +4,7 @@ import { ArrowDownward, Send } from '@sparkpost/matchbox-icons';
 import { Card, CardTitle, CardContent, CardActions } from 'src/components';
 import ButtonWrapper from 'src/components/buttonWrapper';
 import styles from './GettingStartedGuide.module.scss';
-import { BreadCrumbs, BreadCrumbsItem } from '../../../components';
+import { BreadCrumbs, BreadCrumbsItem } from 'src/components';
 
 export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   const breadCrumbsItems = {

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -24,4 +24,23 @@ describe('GettingStartedGuide', () => {
     expect(instance).toHaveTextContent('Show Me SparkPost');
     expect(instance).toHaveTextContent('Let&#39;s Code');
   });
+
+  it('should render the corresponding step when breadcrumb is clicked', () => {
+
+    const instance = subject();
+    instance.find('Button').simulate('click');
+    instance.find({ children: 'Show Me SparkPost' }).simulate('click');
+    instance.find('BreadCrumbsItem').at(1).simulate('click');
+    expect(instance).toHaveTextContent('Show Me SparkPost');
+    expect(instance).toHaveTextContent('Let&#39;s Code');
+
+  });
+
+  it('should render the BreadCrumbItem as active corresponding to the Step', () => {
+    const instance = subject();
+    instance.find('Button').simulate('click');
+    instance.find({ children: 'Show Me SparkPost' }).simulate('click');
+    expect(instance.find({ active: true })).toHaveTextContent('Show Me SparkPost');
+
+  });
 });


### PR DESCRIPTION
AC-1081 - Breadcrumbs for the modules

### What Changed
 - Added a shared components to display BreadCrumbs.
 - Added breadCrumbs to the GettingStartedGuide

### How To Test
 - Enable "messaging_onboarding" ui option for the account.
 - Navigate to /dashboard.
 - check if breadcrumbs are similar to [mocks](https://sparkpost.invisionapp.com/share/DHULLYL45GB#/screens/390961094)

### To Do
- [x] Address Feedback.
