### PR TITLE
AC-1082 : "Show Me SparkPost" list for onboarding

### DIFF
--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -24,4 +24,4 @@ export const hasUiOption = (option) => ({ account }) => _.has(account.options, `
 export const isAccountUiOptionSet = (option, defaultValue) => ({ account }) => Boolean(_.get(account.options, `ui.${option}`, defaultValue));
 export const isSubscriptionPending = ({ account }) => Boolean(account.pending_subscription);
 export const hasAccountOptionEnabled = (option) => ({ account }) => Boolean(_.get(account.options, option, false));
-export const accountUiOption = (option) => ({ account }) => _.get(account.options, `ui.${option}`);
+export const getAccountUiOptionValue = (option) => ({ account }) => _.get(account.options, `ui.${option}`);

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -24,3 +24,4 @@ export const hasUiOption = (option) => ({ account }) => _.has(account.options, `
 export const isAccountUiOptionSet = (option, defaultValue) => ({ account }) => Boolean(_.get(account.options, `ui.${option}`, defaultValue));
 export const isSubscriptionPending = ({ account }) => Boolean(account.pending_subscription);
 export const hasAccountOptionEnabled = (option) => ({ account }) => Boolean(_.get(account.options, option, false));
+export const accountUiOption = (option) => ({ account }) => _.get(account.options, `ui.${option}`);

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -12,7 +12,8 @@ import {
   hasOnlineSupport,
   hasUiOption,
   isAccountUiOptionSet,
-  hasAccountOptionEnabled
+  hasAccountOptionEnabled,
+  getAccountUiOptionValue
 } from '../account';
 
 import cases from 'jest-in-case';
@@ -270,4 +271,25 @@ describe('Condition: hasAccountOptionEnabled', () => {
     state.account.options = null;
     expect(hasAccountOptionEnabled('auto_verify_domains')(state)).toEqual(false);
   });
+});
+
+
+describe('Condition: getAccountUiOptionValue', () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      account: {
+        options: {
+          ui: {
+            stepName: 'Sending'
+          }
+        }
+      }
+    };
+  });
+  it('should return the value of the ui option', () => {
+    expect(getAccountUiOptionValue('stepName')(state)).toEqual('Sending');
+  });
+
 });

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -9,7 +9,7 @@ import VerifyEmailBanner from 'src/components/verifyEmailBanner/VerifyEmailBanne
 import { FreePlanWarningBanner } from 'src/pages/billing/components/Banners';
 /* helpers */
 import { hasGrants } from 'src/helpers/conditions';
-import { isAccountUiOptionSet, accountUiOption } from 'src/helpers/conditions/account';
+import { isAccountUiOptionSet, getAccountUiOptionValue } from 'src/helpers/conditions/account';
 /* actions */
 import { update as updateAccount } from 'src/actions/account';
 
@@ -90,7 +90,7 @@ export class DashboardPage extends Component {
 const mapStateToProps = (state) => ({
   isMessageOnboardingSet: isAccountUiOptionSet('messaging_onboarding')(state),
   isGuideAtBottom: isAccountUiOptionSet('isGuideAtBottom')(state),
-  stepName: accountUiOption('stepName')(state)
+  stepName: getAccountUiOptionValue('stepName')(state)
 });
 
 export default (connect(mapStateToProps, { updateAccount })(DashboardPage));

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -11,7 +11,7 @@ import { FreePlanWarningBanner } from 'src/pages/billing/components/Banners';
 import { hasGrants } from 'src/helpers/conditions';
 import { isAccountUiOptionSet, getAccountUiOptionValue } from 'src/helpers/conditions/account';
 /* actions */
-import { update as updateAccount } from 'src/actions/account';
+import { setAccountOption } from 'src/actions/account';
 
 
 export class DashboardPage extends Component {
@@ -22,29 +22,12 @@ export class DashboardPage extends Component {
     this.setState({ isGuideAtBottom: this.props.isGuideAtBottom });
   }
   moveGuideAtBottom = () => {
-    const updateGuide = {
-      options: {
-        ui: {
-          isGuideAtBottom: true,
-          messaging_onboarding: true
-        }
-      }
-    };
     this.setState({ isGuideAtBottom: true });
-    this.props.updateAccount(updateGuide);
+    this.props.setAccountOption('isGuideAtBottom', true);
   }
 
   storeStepName = (stepName) => {
-    const updateStepName = {
-      options: {
-        ui: {
-          isGuideAtBottom: this.state.isGuideAtBottom,
-          stepName: stepName,
-          messaging_onboarding: true
-        }
-      }
-    };
-    this.props.updateAccount(updateStepName);
+    this.props.setAccountOption('stepName', stepName);
   }
 
   displayGuideAndReport = () => {
@@ -93,4 +76,4 @@ const mapStateToProps = (state) => ({
   stepName: getAccountUiOptionValue('stepName')(state)
 });
 
-export default (connect(mapStateToProps, { updateAccount })(DashboardPage));
+export default (connect(mapStateToProps, { setAccountOption })(DashboardPage));

--- a/src/pages/dashboard/DashboardPage.js
+++ b/src/pages/dashboard/DashboardPage.js
@@ -9,7 +9,7 @@ import VerifyEmailBanner from 'src/components/verifyEmailBanner/VerifyEmailBanne
 import { FreePlanWarningBanner } from 'src/pages/billing/components/Banners';
 /* helpers */
 import { hasGrants } from 'src/helpers/conditions';
-import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { isAccountUiOptionSet, accountUiOption } from 'src/helpers/conditions/account';
 /* actions */
 import { update as updateAccount } from 'src/actions/account';
 
@@ -34,10 +34,30 @@ export class DashboardPage extends Component {
     this.props.updateAccount(updateGuide);
   }
 
+  storeStepName = (stepName) => {
+    const updateStepName = {
+      options: {
+        ui: {
+          isGuideAtBottom: this.state.isGuideAtBottom,
+          stepName: stepName,
+          messaging_onboarding: true
+        }
+      }
+    };
+    this.props.updateAccount(updateStepName);
+  }
+
   displayGuideAndReport = () => {
     const { isGuideAtBottom } = this.state;
     const usageReport = <UsageReport/>;
-    const gettingStartedGuide = <GettingStartedGuide isGuideAtBottom={isGuideAtBottom} moveGuideAtBottom={this.moveGuideAtBottom} />;
+    const gettingStartedGuide = <GettingStartedGuide
+      isGuideAtBottom={isGuideAtBottom}
+      moveGuideAtBottom={this.moveGuideAtBottom}
+      storeStepName={this.storeStepName}
+      stepName={this.props.stepName}
+    />;
+
+
     if (this.props.isMessageOnboardingSet) {
       if (isGuideAtBottom) { return <>{usageReport}{gettingStartedGuide}</>; }
       return <>{gettingStartedGuide}{usageReport}</>;
@@ -69,7 +89,8 @@ export class DashboardPage extends Component {
 }
 const mapStateToProps = (state) => ({
   isMessageOnboardingSet: isAccountUiOptionSet('messaging_onboarding')(state),
-  isGuideAtBottom: isAccountUiOptionSet('isGuideAtBottom')(state)
+  isGuideAtBottom: isAccountUiOptionSet('isGuideAtBottom')(state),
+  stepName: accountUiOption('stepName')(state)
 });
 
 export default (connect(mapStateToProps, { updateAccount })(DashboardPage));

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -28,59 +28,84 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   const renderStep = () => {
     switch (stepName) {
       case 'Features':
-        return <Grid>
-          <Grid.Column xs={12} >
-            <Card >
-              <CardTitle><Send size='20' className={styles.SendIcon}/>   &nbsp;Sending with Sparkpost</CardTitle>
-              <CardContent><p className={styles.FeaturesCardContent}>Learn how to send emails, integrate our API into your code, and make the most of our powerful analytics.</p></CardContent>
-              <CardActions>
-                <ButtonWrapper>
-                  <Button color='orange' onClick={() => setStepName('Sending')}>Start Sending</Button>
-                </ButtonWrapper>
-              </CardActions>
-            </Card>
-          </Grid.Column>
-        </Grid>;
+        return <Panel.Section>
+          <Grid>
+            <Grid.Column xs={12} >
+              <Card >
+                <CardTitle><Send size='20' className={styles.SendIcon}/>   &nbsp;Sending with Sparkpost</CardTitle>
+                <CardContent><p className={styles.FeaturesCardContent}>Learn how to send emails, integrate our API into your code, and make the most of our powerful analytics.</p></CardContent>
+                <CardActions>
+                  <ButtonWrapper>
+                    <Button color='orange' onClick={() => setStepName('Sending')}>Start Sending</Button>
+                  </ButtonWrapper>
+                </CardActions>
+              </Card>
+            </Grid.Column>
+          </Grid>
+        </Panel.Section>
+        ;
       case 'Sending':
-        return <>
-        <p className={styles.SendingStepHeading} role="heading" aria-level="4" ref={guideHeadingRef} tabIndex={-1}>Where Would You Like to Begin?</p>
-        <Grid>
-          <Grid.Column xs={12} md={6} >
-            <Card textAlign='center'>
-              <CardContent><p className={styles.FeaturesCardContent}>Send your first email in one click and dive right into what SparkPost can do for your email strategy </p></CardContent>
-              <CardActions>
-                <ButtonWrapper>
-                  <Button color='orange' onClick={() => setStepName('Show Me SparkPost')} className={styles.SendingStepButtons}>Show Me SparkPost</Button>
-                </ButtonWrapper>
-              </CardActions>
-            </Card>
-          </Grid.Column>
-          <Grid.Column xs={12} md={6}>
-            <Card textAlign='center'>
-              <CardContent><p className={styles.FeaturesCardContent}>Ready to integrate via SMTP or API? We'll get you set up ASAP so you can start building with SparkPost</p></CardContent>
-              <CardActions>
-                <ButtonWrapper>
-                  <Button color='orange' onClick={() => setStepName('Let\'s Code')} className={styles.SendingStepButtons}>Let's Code</Button>
-                </ButtonWrapper>
-              </CardActions>
-            </Card>
-          </Grid.Column>
-        </Grid>
-         </>;
+        return <Panel.Section>
+          <p className={styles.SendingStepHeading} role="heading" aria-level="4" ref={guideHeadingRef} tabIndex={-1}>Where Would You Like to Begin?</p>
+          <Grid>
+            <Grid.Column xs={12} md={6} >
+              <Card textAlign='center'>
+                <CardContent><p className={styles.FeaturesCardContent}>Send your first email in one click and dive right into what SparkPost can do for your email strategy </p></CardContent>
+                <CardActions>
+                  <ButtonWrapper>
+                    <Button color='orange' onClick={() => setStepName('Show Me SparkPost')} className={styles.SendingStepButtons}>Show Me SparkPost</Button>
+                  </ButtonWrapper>
+                </CardActions>
+              </Card>
+            </Grid.Column>
+            <Grid.Column xs={12} md={6}>
+              <Card textAlign='center'>
+                <CardContent><p className={styles.FeaturesCardContent}>Ready to integrate via SMTP or API? We'll get you set up ASAP so you can start building with SparkPost</p></CardContent>
+                <CardActions>
+                  <ButtonWrapper>
+                    <Button color='orange' onClick={() => setStepName('Let\'s Code')} className={styles.SendingStepButtons}>Let's Code</Button>
+                  </ButtonWrapper>
+                </CardActions>
+              </Card>
+            </Grid.Column>
+          </Grid>
+        </Panel.Section>;
       case 'Show Me SparkPost':
-        return <GuideListItem action={{ name: 'Send Test Email', onClick: () => {} }} >
-          <GuideListItemTitle>
+        return <>
+        <Panel.Section>
+          <GuideListItem action={{ name: 'Send Test Email', onClick: () => {} }} >
+            <GuideListItemTitle>
             Send a Test Email
-          </GuideListItemTitle>
-          <GuideListItemDescription>Send a test email using our starter template.</GuideListItemDescription>
-        </GuideListItem>;
+            </GuideListItemTitle>
+            <GuideListItemDescription>Send a test email using our starter template.</GuideListItemDescription>
+          </GuideListItem>
+        </Panel.Section>
+        <Panel.Section>
+          <GuideListItem action={{ name: 'Explore Analytics', onClick: () => {} }} >
+            <GuideListItemTitle>
+            Explore Analytics
+            </GuideListItemTitle>
+            <GuideListItemDescription>Get acquainted with our powerful analytics to make the most of your sending strategy.</GuideListItemDescription>
+          </GuideListItem>
+        </Panel.Section>
+          <Panel.Section>
+            <GuideListItem action={{ name: 'Invite a Collaborator', onClick: () => {} }} >
+              <GuideListItemTitle>
+            Invite Your Team
+              </GuideListItemTitle>
+              <GuideListItemDescription>{'Need help integrating? Pass the ball on to someone else to finish setting up this account.'}<br/>
+                {'Or you can '}<a href='#'>setup email sending now</a>
+              </GuideListItemDescription>
+            </GuideListItem>
+          </Panel.Section>
+        </>;
       case 'Let\'s Code':
       default:
         null;
     }
   };
   return <>
-        <Panel title='Getting Started' actions={actions} sectioned >
+        <Panel title='Getting Started' actions={actions} >
           <BreadCrumbs>
             {breadCrumbsItems[stepName].map((item) => (
               <BreadCrumbsItem

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -5,6 +5,7 @@ import { Card, CardTitle, CardContent, CardActions } from 'src/components';
 import ButtonWrapper from 'src/components/buttonWrapper';
 import styles from './GettingStartedGuide.module.scss';
 import { BreadCrumbs, BreadCrumbsItem } from 'src/components';
+import { GuideListItem, GuideListItemTitle, GuideListItemDescription } from './GuideListItem';
 
 export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   const breadCrumbsItems = {
@@ -67,6 +68,10 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
         </Grid>
          </>;
       case 'Show Me SparkPost':
+        return <GuideListItem action={{ name: 'Send Test Email', onClick: () => {} }}>
+          <GuideListItemTitle> Send a Test Email</GuideListItemTitle>
+          <GuideListItemDescription>Send a test email using our starter template.</GuideListItemDescription>
+        </GuideListItem>;
       case 'Let\'s Code':
       default:
         null;

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -7,7 +7,7 @@ import styles from './GettingStartedGuide.module.scss';
 import { BreadCrumbs, BreadCrumbsItem } from 'src/components';
 import { GuideListItem, GuideListItemTitle, GuideListItemDescription } from './GuideListItem';
 
-export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
+export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom, storeStepName, stepName: storedStepName }) => {
   const breadCrumbsItems = {
     'Features': ['Features'],
     'Sending': ['Features', 'Sending'],
@@ -20,7 +20,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
     onClick: moveGuideAtBottom
   }];
   //stepName could be Features,Sending,Show Me Sparkpost, Let's Code
-  const [stepName, setStepName] = useState('Features');
+  const [stepName, setStepName] = useState(storedStepName || 'Features');
   const guideHeadingRef = useRef(null);
   useEffect(() => {
     if (guideHeadingRef.current) { guideHeadingRef.current.focus(); }
@@ -34,6 +34,11 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
     ))}
   </BreadCrumbs>);
 
+  const setAndStoreStepName = (stepName) => {
+    storeStepName(stepName);
+    setStepName(stepName);
+  };
+
   const renderStep = () => {
     switch (stepName) {
       case 'Features':
@@ -46,7 +51,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
                 <CardContent><p className={styles.FeaturesCardContent}>Learn how to send emails, integrate our API into your code, and make the most of our powerful analytics.</p></CardContent>
                 <CardActions>
                   <ButtonWrapper>
-                    <Button color='orange' onClick={() => setStepName('Sending')}>Start Sending</Button>
+                    <Button color='orange' onClick={() => setAndStoreStepName('Sending')}>Start Sending</Button>
                   </ButtonWrapper>
                 </CardActions>
               </Card>
@@ -65,7 +70,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
                 <CardContent><p className={styles.FeaturesCardContent}>Send your first email in one click and dive right into what SparkPost can do for your email strategy </p></CardContent>
                 <CardActions>
                   <ButtonWrapper>
-                    <Button color='orange' onClick={() => setStepName('Show Me SparkPost')} className={styles.SendingStepButtons}>Show Me SparkPost</Button>
+                    <Button color='orange' onClick={() => setAndStoreStepName('Show Me SparkPost')} className={styles.SendingStepButtons}>Show Me SparkPost</Button>
                   </ButtonWrapper>
                 </CardActions>
               </Card>
@@ -75,7 +80,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
                 <CardContent><p className={styles.FeaturesCardContent}>Ready to integrate via SMTP or API? We'll get you set up ASAP so you can start building with SparkPost</p></CardContent>
                 <CardActions>
                   <ButtonWrapper>
-                    <Button color='orange' onClick={() => setStepName('Let\'s Code')} className={styles.SendingStepButtons}>Let's Code</Button>
+                    <Button color='orange' onClick={() => setAndStoreStepName('Let\'s Code')} className={styles.SendingStepButtons}>Let's Code</Button>
                   </ButtonWrapper>
                 </CardActions>
               </Card>

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -29,7 +29,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom, storeS
     {breadCrumbsItems[stepName].map((item) => (
       <BreadCrumbsItem
         key={item}
-        onClick={() => setStepName(item)}
+        onClick={() => setAndStoreStepName(item)}
         active={stepName === item}>{item}</BreadCrumbsItem>
     ))}
   </BreadCrumbs>);
@@ -121,9 +121,8 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom, storeS
         null;
     }
   };
-  return <>
-        <Panel title='Getting Started' actions={actions} >
-          {renderStep()}
-        </Panel>
-        </>;
+  return <Panel title='Getting Started' actions={actions} >
+    {renderStep()}
+  </Panel>
+  ;
 };

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -99,7 +99,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom, storeS
            </GuideListItem>
          </Panel.Section>
         <Panel.Section>
-          <GuideListItem action={{ name: 'Explore Analytics', onClick: () => {} }} itemCompleted={true}>
+          <GuideListItem action={{ name: 'Explore Analytics', onClick: () => {} }}>
             <GuideListItemTitle>
             Explore Analytics
             </GuideListItemTitle>

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -68,8 +68,10 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
         </Grid>
          </>;
       case 'Show Me SparkPost':
-        return <GuideListItem action={{ name: 'Send Test Email', onClick: () => {} }}>
-          <GuideListItemTitle> Send a Test Email</GuideListItemTitle>
+        return <GuideListItem action={{ name: 'Send Test Email', onClick: () => {} }} >
+          <GuideListItemTitle>
+            Send a Test Email
+          </GuideListItemTitle>
           <GuideListItemDescription>Send a test email using our starter template.</GuideListItemDescription>
         </GuideListItem>;
       case 'Let\'s Code':

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -99,7 +99,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom, storeS
            </GuideListItem>
          </Panel.Section>
         <Panel.Section>
-          <GuideListItem action={{ name: 'Explore Analytics', onClick: () => {} }} >
+          <GuideListItem action={{ name: 'Explore Analytics', onClick: () => {} }} itemCompleted={true}>
             <GuideListItemTitle>
             Explore Analytics
             </GuideListItemTitle>

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -25,10 +25,20 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   useEffect(() => {
     if (guideHeadingRef.current) { guideHeadingRef.current.focus(); }
   }, [stepName]);
+  const renderBreadCrumbs = () => (<BreadCrumbs>
+    {breadCrumbsItems[stepName].map((item) => (
+      <BreadCrumbsItem
+        key={item}
+        onClick={() => setStepName(item)}
+        active={stepName === item}>{item}</BreadCrumbsItem>
+    ))}
+  </BreadCrumbs>);
+
   const renderStep = () => {
     switch (stepName) {
       case 'Features':
         return <Panel.Section>
+          {renderBreadCrumbs()}
           <Grid>
             <Grid.Column xs={12} >
               <Card >
@@ -42,10 +52,12 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
               </Card>
             </Grid.Column>
           </Grid>
-        </Panel.Section>
-        ;
+        </Panel.Section>;
+
+
       case 'Sending':
         return <Panel.Section>
+          {renderBreadCrumbs()}
           <p className={styles.SendingStepHeading} role="heading" aria-level="4" ref={guideHeadingRef} tabIndex={-1}>Where Would You Like to Begin?</p>
           <Grid>
             <Grid.Column xs={12} md={6} >
@@ -72,14 +84,15 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
         </Panel.Section>;
       case 'Show Me SparkPost':
         return <>
-        <Panel.Section>
-          <GuideListItem action={{ name: 'Send Test Email', onClick: () => {} }} >
-            <GuideListItemTitle>
+         <Panel.Section>
+           {renderBreadCrumbs()}
+           <GuideListItem action={{ name: 'Send Test Email', onClick: () => {} }} >
+             <GuideListItemTitle>
             Send a Test Email
-            </GuideListItemTitle>
-            <GuideListItemDescription>Send a test email using our starter template.</GuideListItemDescription>
-          </GuideListItem>
-        </Panel.Section>
+             </GuideListItemTitle>
+             <GuideListItemDescription>Send a test email using our starter template.</GuideListItemDescription>
+           </GuideListItem>
+         </Panel.Section>
         <Panel.Section>
           <GuideListItem action={{ name: 'Explore Analytics', onClick: () => {} }} >
             <GuideListItemTitle>
@@ -97,8 +110,7 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
                 {'Or you can '}<a href='#'>setup email sending now</a>
               </GuideListItemDescription>
             </GuideListItem>
-          </Panel.Section>
-        </>;
+          </Panel.Section></>;
       case 'Let\'s Code':
       default:
         null;
@@ -106,14 +118,6 @@ export const GettingStartedGuide = ({ isGuideAtBottom, moveGuideAtBottom }) => {
   };
   return <>
         <Panel title='Getting Started' actions={actions} >
-          <BreadCrumbs>
-            {breadCrumbsItems[stepName].map((item) => (
-              <BreadCrumbsItem
-                key={item}
-                onClick={() => setStepName(item)}
-                active={stepName === item}>{item}</BreadCrumbsItem>
-            ))}
-          </BreadCrumbs>
           {renderStep()}
         </Panel>
         </>;

--- a/src/pages/dashboard/components/GuideListItem.js
+++ b/src/pages/dashboard/components/GuideListItem.js
@@ -4,17 +4,13 @@ import { Button, Grid } from '@sparkpost/matchbox';
 
 export const GuideListItem = ({ itemCompleted, children, action: { name, onClick }}) => (
   <Grid>
-    <Grid.Column xs={12} md={9}>
-      <Grid>
-        <Grid.Column md={1} xs={12}>
-          {itemCompleted ? <CheckCircleOutline size={36} style={{ color: 'green' }}/> : <RadioButtonUnchecked size={36}/>}
-        </Grid.Column>
-        <Grid.Column md={11} xs={12}>
-          {children}
-        </Grid.Column>
-      </Grid>
+    <Grid.Column md={1} xs={12}>
+      {itemCompleted ? <CheckCircleOutline size={36} style={{ color: 'green' }}/> : <RadioButtonUnchecked size={36}/>}
     </Grid.Column>
-    <Grid.Column xs={12} md={3}>
+    <Grid.Column md={8} xs={12}>
+      {children}
+    </Grid.Column>
+    <Grid.Column md={3} xs={12}>
       <div style={{ float: 'right' }}>
         <Button onClick={onClick} color={!itemCompleted && 'orange'}> {name} </Button>
       </div>

--- a/src/pages/dashboard/components/GuideListItem.js
+++ b/src/pages/dashboard/components/GuideListItem.js
@@ -14,7 +14,7 @@ export const GuideListItem = ({ itemCompleted, children, action: { name, onClick
     </Grid.Column>
     <Grid.Column md={3} xs={12}>
       <div className={styles.ListActionContainer}>
-        <Button onClick={onClick} color={!itemCompleted && 'orange'}> {name} </Button>
+        <Button onClick={onClick} color={(!itemCompleted && 'orange') || null}> {name} </Button>
       </div>
     </Grid.Column>
   </Grid>

--- a/src/pages/dashboard/components/GuideListItem.js
+++ b/src/pages/dashboard/components/GuideListItem.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import { RadioButtonUnchecked, CheckCircleOutline } from '@sparkpost/matchbox-icons';
 import { Button, Grid } from '@sparkpost/matchbox';
-
+import styles from './GuideListItem.module.scss';
 export const GuideListItem = ({ itemCompleted, children, action: { name, onClick }}) => (
   <Grid>
-    <Grid.Column md={1} xs={12}>
-      {itemCompleted ? <CheckCircleOutline size={36} style={{ color: 'green' }}/> : <RadioButtonUnchecked size={36}/>}
-    </Grid.Column>
-    <Grid.Column md={8} xs={12}>
-      {children}
+    <Grid.Column md={9} xs={12}>
+      <div className={styles.CheckBoxContainer}>
+        {itemCompleted ? <CheckCircleOutline size={36} className={styles.CheckCircleIcon}/> : <RadioButtonUnchecked size={36}/>}
+      </div>
+      <div className={styles.ListItemContainer}>
+        {children}
+      </div>
     </Grid.Column>
     <Grid.Column md={3} xs={12}>
-      <div style={{ float: 'right' }}>
+      <div className={styles.ListActionContainer}>
         <Button onClick={onClick} color={!itemCompleted && 'orange'}> {name} </Button>
       </div>
     </Grid.Column>
@@ -19,13 +21,13 @@ export const GuideListItem = ({ itemCompleted, children, action: { name, onClick
 );
 
 export const GuideListItemTitle = ({ children }) => (
-  <div style={{ fontWeight: 600 }}>
+  <div className={styles.GuideListItem}>
     {children}
   </div>
 );
 
 export const GuideListItemDescription = ({ children }) => (
-  <div style={{ paddingTop: '10px' }}>
+  <div className={styles.GuideListItemDescription}>
     {children}
   </div>
 );

--- a/src/pages/dashboard/components/GuideListItem.js
+++ b/src/pages/dashboard/components/GuideListItem.js
@@ -1,20 +1,23 @@
 import React from 'react';
-import ButtonWrapper from 'src/components/buttonWrapper';
 import { PanoramaFishEye, CheckCircleOutline } from '@sparkpost/matchbox-icons';
-import { Button } from '@sparkpost/matchbox';
+import { Button, Grid } from '@sparkpost/matchbox';
 
 export const GuideListItem = ({ itemCompleted, children, action: { name, onClick }}) => (
-  <div>
-    <div>
-      {itemCompleted ? <CheckCircleOutline size={50}/> : <PanoramaFishEye size={10}/>}
-    </div>
-    <div>
-      {children}
-    </div>
-    <ButtonWrapper>
-      <Button onClick={onClick} color={!itemCompleted && 'orange'}> {name} </Button>
-    </ButtonWrapper>
-  </div>
+  <Grid>
+    <Grid.Column xs={12} md={9}>
+      <div style={{ display: 'inline-block' }}>
+        {itemCompleted ? <CheckCircleOutline size={36}/> : <PanoramaFishEye size={36}/>}
+      </div>
+      <div style={{ display: 'inline-block' }}>
+        {children}
+      </div>
+    </Grid.Column>
+    <Grid.Column xs={12} md={3}>
+      <div style={{ float: 'right' }}>
+        <Button onClick={onClick} color={!itemCompleted && 'orange'}> {name} </Button>
+      </div>
+    </Grid.Column>
+  </Grid>
 );
 
 export const GuideListItemTitle = ({ children }) => (

--- a/src/pages/dashboard/components/GuideListItem.js
+++ b/src/pages/dashboard/components/GuideListItem.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import ButtonWrapper from 'src/components/buttonWrapper';
+import { PanoramaFishEye, CheckCircleOutline } from '@sparkpost/matchbox-icons';
+import { Button } from '@sparkpost/matchbox';
+
+export const GuideListItem = ({ itemCompleted, children, action: { name, onClick }}) => (
+  <div>
+    <div>
+      {itemCompleted ? <CheckCircleOutline size={50}/> : <PanoramaFishEye size={10}/>}
+    </div>
+    <div>
+      {children}
+    </div>
+    <ButtonWrapper>
+      <Button onClick={onClick} color={!itemCompleted && 'orange'}> {name} </Button>
+    </ButtonWrapper>
+  </div>
+);
+
+export const GuideListItemTitle = ({ children }) => (
+  <div>
+    {children}
+  </div>
+);
+
+export const GuideListItemDescription = ({ children }) => (
+  <div>
+    {children}
+  </div>
+);

--- a/src/pages/dashboard/components/GuideListItem.js
+++ b/src/pages/dashboard/components/GuideListItem.js
@@ -14,7 +14,7 @@ export const GuideListItem = ({ itemCompleted, children, action: { name, onClick
     </Grid.Column>
     <Grid.Column md={3} xs={12}>
       <div className={styles.ListActionContainer}>
-        <Button onClick={onClick} color={(!itemCompleted && 'orange') || null}> {name} </Button>
+        <Button onClick={onClick} color={(!itemCompleted && 'orange') || null} outline={itemCompleted}> {name} </Button>
       </div>
     </Grid.Column>
   </Grid>

--- a/src/pages/dashboard/components/GuideListItem.js
+++ b/src/pages/dashboard/components/GuideListItem.js
@@ -1,16 +1,18 @@
 import React from 'react';
-import { PanoramaFishEye, CheckCircleOutline } from '@sparkpost/matchbox-icons';
+import { RadioButtonUnchecked, CheckCircleOutline } from '@sparkpost/matchbox-icons';
 import { Button, Grid } from '@sparkpost/matchbox';
 
 export const GuideListItem = ({ itemCompleted, children, action: { name, onClick }}) => (
   <Grid>
     <Grid.Column xs={12} md={9}>
-      <div style={{ display: 'inline-block' }}>
-        {itemCompleted ? <CheckCircleOutline size={36}/> : <PanoramaFishEye size={36}/>}
-      </div>
-      <div style={{ display: 'inline-block' }}>
-        {children}
-      </div>
+      <Grid>
+        <Grid.Column md={1} xs={12}>
+          {itemCompleted ? <CheckCircleOutline size={36} style={{ color: 'green' }}/> : <RadioButtonUnchecked size={36}/>}
+        </Grid.Column>
+        <Grid.Column md={11} xs={12}>
+          {children}
+        </Grid.Column>
+      </Grid>
     </Grid.Column>
     <Grid.Column xs={12} md={3}>
       <div style={{ float: 'right' }}>
@@ -21,13 +23,13 @@ export const GuideListItem = ({ itemCompleted, children, action: { name, onClick
 );
 
 export const GuideListItemTitle = ({ children }) => (
-  <div>
+  <div style={{ fontWeight: 600 }}>
     {children}
   </div>
 );
 
 export const GuideListItemDescription = ({ children }) => (
-  <div>
+  <div style={{ paddingTop: '10px' }}>
     {children}
   </div>
 );

--- a/src/pages/dashboard/components/GuideListItem.module.scss
+++ b/src/pages/dashboard/components/GuideListItem.module.scss
@@ -1,0 +1,35 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.CheckBoxContainer { 
+  width: 40px;
+  float: left;
+  max-height: 40px;
+  @media screen and (min-width: breakpoint(smaller)) {
+    height: 100%;
+  }
+}
+
+.ListItemContainer{
+  float: left;
+  @media screen and (min-width: breakpoint(smaller)) {
+    height: 100%;
+    max-width: 450px;
+  }
+}
+
+.ListActionContainer{
+  float: right;
+}
+
+.CheckCircleIcon{
+  color: green;
+}
+
+.GuideListItem{
+  font-weight: 600;
+}
+
+.GuideListItemDescription{
+  padding-top: 10px;
+
+}

--- a/src/pages/dashboard/components/GuideListItem.module.scss
+++ b/src/pages/dashboard/components/GuideListItem.module.scss
@@ -17,7 +17,6 @@
   padding-left: spacing(small);
   @media screen and (min-width: breakpoint(smaller)) {
     height: 100%;
-    max-width: 450px;
   }
 }
 

--- a/src/pages/dashboard/components/GuideListItem.module.scss
+++ b/src/pages/dashboard/components/GuideListItem.module.scss
@@ -13,6 +13,8 @@
 
 .ListItemContainer{
   float: left;
+  padding-top: spacing(small);
+  padding-left: spacing(small);
   @media screen and (min-width: breakpoint(smaller)) {
     height: 100%;
     max-width: 450px;

--- a/src/pages/dashboard/components/GuideListItem.module.scss
+++ b/src/pages/dashboard/components/GuideListItem.module.scss
@@ -1,4 +1,6 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
+@import 'src/styles/status-color';
+
 
 .CheckBoxContainer { 
   width: 40px;
@@ -22,7 +24,7 @@
 }
 
 .CheckCircleIcon{
-  color: green;
+  color: status-color(success);
 }
 
 .GuideListItem{

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -7,7 +7,8 @@ import { ArrowDownward } from '@sparkpost/matchbox-icons';
 describe('GettingStartedGuide', () => {
   const defaultProps = {
     isGuideAtBottom: false,
-    moveGuideAtBottom: jest.fn()
+    moveGuideAtBottom: jest.fn(),
+    storeStepName: jest.fn()
   };
 
   const subject = (props) => (shallow(<GettingStartedGuide {...defaultProps} {...props} />));

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -42,6 +42,12 @@ describe('GettingStartedGuide', () => {
     instance.find('Button').simulate('click');
     instance.find({ children: 'Show Me SparkPost' }).simulate('click');
     expect(instance.find({ active: true })).toHaveTextContent('Show Me SparkPost');
+  });
 
+  it('should render three list items when on step "Show Me SparkPost" ', () => {
+    const instance = subject();
+    instance.find('Button').simulate('click');
+    instance.find({ children: 'Show Me SparkPost' }).simulate('click');
+    expect(instance.find('GuideListItem')).toHaveLength(3);
   });
 });

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -26,6 +26,13 @@ describe('GettingStartedGuide', () => {
     expect(instance).toHaveTextContent('Let&#39;s Code');
   });
 
+  it('should store the stepName when any CardAction Button is clicked' , () => {
+    const instance = subject();
+    instance.find('CardActions').find('Button').at(0).simulate('click');
+    expect(defaultProps.storeStepName).toHaveBeenCalled();
+
+  });
+
   it('should render the corresponding step when breadcrumb is clicked', () => {
 
     const instance = subject();

--- a/src/pages/dashboard/components/tests/GuideListItem.test.js
+++ b/src/pages/dashboard/components/tests/GuideListItem.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { GuideListItem } from '../GuideListItem';
+
+describe('GettingStartedGuide', () => {
+  const defaultProps = {
+    itemCompleted: true,
+    children: null,
+    action: {
+      name: 'Button',
+      onClick: jest.fn()
+    }
+  };
+
+  const subject = (props) => (shallow(<GuideListItem {...defaultProps} {...props} />));
+
+  it('should render a orange button only when list item is not complete', () => {
+    expect(subject({ itemCompleted: false }).find('Button').prop('color')).toBe('orange');
+    expect(subject({ itemCompleted: true }).find('Button').prop('color')).not.toBe('orange');
+
+  });
+
+  it('should a CheckCircleOutline when the list item is complete and a RadioButton unchecked when it is not complete', () => {
+    expect(subject({ itemCompleted: true }).find('CheckCircleOutline')).toHaveLength(1);
+    expect(subject({ itemCompleted: false }).find('RadioButtonUnchecked')).toHaveLength(1);
+  });
+});

--- a/src/pages/dashboard/components/tests/GuideListItem.test.js
+++ b/src/pages/dashboard/components/tests/GuideListItem.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { GuideListItem } from '../GuideListItem';
+import { Button } from '@sparkpost/matchbox';
 
 describe('GettingStartedGuide', () => {
   const defaultProps = {
@@ -17,7 +18,11 @@ describe('GettingStartedGuide', () => {
   it('should render a orange button only when list item is not complete', () => {
     expect(subject({ itemCompleted: false }).find('Button').prop('color')).toBe('orange');
     expect(subject({ itemCompleted: true }).find('Button').prop('color')).not.toBe('orange');
+  });
 
+  it('should render a Button with outline prop only when the item is complete', () => {
+    expect(subject({ itemCompleted: true }).find(Button).prop('outline')).toBeTruthy();
+    expect(subject({ itemCompleted: false }).find(Button).prop('outline')).not.toBeTruthy();
   });
 
   it('should a CheckCircleOutline when the list item is complete and a RadioButton unchecked when it is not complete', () => {


### PR DESCRIPTION
AC-1082 : "Show Me SparkPost" list for onboarding

### What Changed
- Added the GuideListItem.
- List shows up when Show Me SparkPost button is clicked.
- Breadcrumb includes "Show Me SparkPost".

### How To Test
 - Enable "messaging_onboarding" ui option for the account.
 - Navigate to /dashboard.
 - Click on "Start Sending" and then on "Show Me SparkPost".
 - check if list is similar to [mocks](https://sparkpost.invisionapp.com/share/DHULLYL45GB#/screens/390961095)
- adding itemCompleted={true} to one of the <GuideListItem> and check if it is similar to mocks. 
- List persists as the active list through session until switching off of guide set explicitly.

### To Do
- [ ] Address feedback.
- [x]  Write tests
