### PR TITLE
FE-762 Removed override for Tag styles from Matchbox bug that is now fixed

### DIFF
--- a/src/pages/alerts/components/AlertDetails.module.scss
+++ b/src/pages/alerts/components/AlertDetails.module.scss
@@ -16,32 +16,20 @@
   text-align: center;
 }
 
-.Tags {
+.Tags, .FirstTag, .TagsWithIcon {
   margin: 0 rem(5) rem(10);
-  position: relative;
-  top: rem(-1);
 }
 
 .FirstTag {
-  margin: 0 rem(5) rem(10) 0;
-  position: relative;
-  top: rem(-1);
+  margin-left: 0;
 }
 
 .TagsWithIcon {
-  margin: 0 rem(5) rem(10);
-  position: relative;
-  top: rem(-1);
-
   .Icon {
     height: rem(20);
     width: rem(20);
-    position: relative;
-    top: rem(4);
   }
   .TagText {
     margin: 0 0 0 rem(5);
-    position: relative;
-    top: rem(-2);
   }
 }


### PR DESCRIPTION
### What Changed
 - Removed manual alignment for matchbox Tag component

### How To Test
 - Create an alert (or view an existing one) that has an icon in a Tag (slack/webbook notify).
 - Ensure the icon is vertically aligned.

Note: I searched through the rest of the code base for instances where we override the styles of the matchbox Tag component and this is the only one that interfered with the alignment. All others were margin related.
