### PR TITLE
FE-733 -  Reduce API key shortcode font size

### DIFF
--- a/src/components/shortKeyCode/ShortKeyCode.js
+++ b/src/components/shortKeyCode/ShortKeyCode.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const ShortKeyCode = ({ shortKey }) => (
-  <code>{shortKey}••••••••</code>
+  <>{shortKey}••••••••</>
 );
 
 export default ShortKeyCode;


### PR DESCRIPTION
FE-733 -  Reduce API key shortcode font size

### What Changed
 - changed the  API key shortcode font size to be consistent with our other fonts

### How To Test
 - Navigate to /account/api-keys and check key columns font-size.
### To Do
- [ ] Address Feedback.
