### PR TITLE
TR-2005 - Implement saving test data in published mode before sending a template preview

### DIFF
--- a/src/pages/templates/EditAndPreviewPage.container.js
+++ b/src/pages/templates/EditAndPreviewPage.container.js
@@ -10,7 +10,7 @@ import {
   deleteTemplate,
   create as createTemplate,
   sendPreview,
-  setTestData,
+  setTestData as setTestDataAction, // A method to update the editor content is also called `setTestData` - this method updates
   getTestData
 } from 'src/actions/templates';
 import { getSnippets } from 'src/actions/snippets';
@@ -76,7 +76,7 @@ const mapDispatchToProps = {
   listDomains,
   listSubaccounts,
   showAlert,
-  setTestData,
+  setTestDataAction,
   getTestData,
   getSnippets
 };

--- a/src/pages/templates/components/SendTestEmailButton.js
+++ b/src/pages/templates/components/SendTestEmailButton.js
@@ -19,6 +19,7 @@ const SendTestEmailButton = () => {
     sendPreview,
     template,
     showAlert,
+    setTestDataAction,
     parsedTestData,
     updateDraft,
     setHasSaved
@@ -65,6 +66,14 @@ const SendTestEmailButton = () => {
           setModalLoading(false);
           setHasSaved(true);
         });
+    }
+
+    if (isPublishedMode) {
+      setTestDataAction({
+        id: templateId,
+        mode: 'published',
+        data: parsedTestData
+      });
     }
   };
 

--- a/src/pages/templates/components/tests/SendTestEmailButton.test.js
+++ b/src/pages/templates/components/tests/SendTestEmailButton.test.js
@@ -158,5 +158,33 @@ describe('SendTestEmailButton', () => {
         });
       });
     });
+
+    it('invokes the set test data action (without updating the template otherwise) when the template is in published mode', () => {
+      const mockSetTestData = jest.fn();
+      const mockUpdateDraft = jest.fn();
+      const mockParsedTestData = {
+        options: {},
+        substitution_data: {
+          foo: 'bar'
+        },
+        metadata: {}
+      };
+
+      const { getByText } = subject({
+        isPublishedMode: true,
+        updateDraft: mockUpdateDraft,
+        parsedTestData: mockParsedTestData,
+        setTestDataAction: mockSetTestData
+      });
+
+      userEvent.click(getByText('Send a Test'));
+
+      expect(mockUpdateDraft).not.toHaveBeenCalled();
+      expect(mockSetTestData).toHaveBeenCalledWith({
+        id: '123456',
+        mode: 'published',
+        data: mockParsedTestData
+      });
+    });
   });
 });


### PR DESCRIPTION
[TR-2005](https://jira.int.messagesystems.com/browse/TR-2005)

### What Changed
- Renamed import of `setTestData` action to fix issue with duplicate function names in editor context
- Invoke the `setTestData` action when the user opens the send preview modal in published mode
- Added supporting test

### How To Test
1. Go to `/templates`
1. Make a new template, add some substitution data and use the substitution data in your template with curly braces, e.g. `{{ data }}`
1. Click "Save and Publish"
1. When in published mode, edit the test data and click "Send a Test"
1. Send a preview email to your email address and verify that the new data is present
1. Additionally, leave the currently opened, published template, then  open it again from the list page
1. Verify that the new test data persisted.

### To Do
- [ ] Incorporate feedback