### PR TITLE
TR-2010 - Updates delete template modal styles to be much *much* scarier 

### DIFF
--- a/cypress/tests/templates/templates.js
+++ b/cypress/tests/templates/templates.js
@@ -60,23 +60,23 @@ describe('Templates', () => {
       const testPreviewContent = (selector, content) => {
         cy.wait('@contentPreviewer');
 
-        cy.get('iframe')
-          .then(($iframe) => {
-            const $body = $iframe.contents().find('body');
+        cy.get('iframe').then($iframe => {
+          const $body = $iframe.contents().find('body');
 
-            if (selector.length) {
-              cy.wrap($body.find(selector))
-                .should('contain', content);
-            } else {
-              cy.wrap($body).should('contain', content);
-            }
-          });
+          if (selector.length) {
+            cy.wrap($body.find(selector)).should('contain', content);
+          } else {
+            cy.wrap($body).should('contain', content);
+          }
+        });
       };
 
       // HTML editing
       cy.get(editorSelector)
         .focus()
-        .type('<h1>This is some HTML. Cypress is {{qualifier}}.', { parseSpecialCharSequences: false }); // See: https://docs.cypress.io/api/commands/type.html#Syntax
+        .type('<h1>This is some HTML. Cypress is {{qualifier}}.', {
+          parseSpecialCharSequences: false,
+        }); // See: https://docs.cypress.io/api/commands/type.html#Syntax
 
       testPreviewContent('h1', 'This is some HTML. Cypress is .');
 
@@ -85,13 +85,17 @@ describe('Templates', () => {
 
       cy.get(editorSelector)
         .focus()
-        .type('<h1>This is some AMP HTML. Cypress is {{qualifier}}.', { parseSpecialCharSequences: false });
+        .type('<h1>This is some AMP HTML. Cypress is {{qualifier}}.', {
+          parseSpecialCharSequences: false,
+        });
 
       testPreviewContent('h1', 'This is some AMP HTML. Cypress is .');
 
       cy.get('[data-id="popover-trigger-more"]').click();
       cy.findByText('Insert AMP Boilerplate').click();
-      cy.findByText('Are you sure you want to insert the AMP Email Boilerplate?').should('be.visible');
+      cy.findByText('Are you sure you want to insert the AMP Email Boilerplate?').should(
+        'be.visible',
+      );
       cy.findByText('Insert').click();
 
       testPreviewContent('', 'Hello, world');
@@ -101,7 +105,9 @@ describe('Templates', () => {
 
       cy.get(editorSelector)
         .focus()
-        .type('This is some plain text. Cypress is {{qualifier}}.', { parseSpecialCharSequences: false });
+        .type('This is some plain text. Cypress is {{qualifier}}.', {
+          parseSpecialCharSequences: false,
+        });
 
       testPreviewContent('p', 'This is some plain text. Cypress is .');
 
@@ -111,15 +117,15 @@ describe('Templates', () => {
         options: {},
         metadata: {},
         substitution_data: {
-          qualifier: 'excelente'
-        }
+          qualifier: 'excelente',
+        },
       };
       const altExampleTestData = {
         options: {},
         metadata: {},
         substitution_data: {
-          qualifier: 'pretty darn great'
-        }
+          qualifier: 'pretty darn great',
+        },
       };
 
       cy.get(editorSelector)
@@ -141,10 +147,15 @@ describe('Templates', () => {
       cy.findByText('Save and Publish').click();
       cy.get('#modal-portal').within(() => cy.findByText('Save and Publish').click());
 
-      cy.wait(['@templatesPut','@templatesGet']);
+      cy.wait(['@templatesPut', '@templatesGet']);
 
       cy.findByText('Template published').should('be.visible');
-      cy.get('#alert-portal').within(() => cy.findAllByRole('button').first().click()); // Close the Snackbar component such that other elements are visible to Cypress
+      cy.get('#alert-portal').within(() =>
+        cy
+          .findAllByRole('button')
+          .first()
+          .click(),
+      ); // Close the Snackbar component such that other elements are visible to Cypress
 
       cy.findByText('Saved').should('be.visible');
       cy.findByText('Unsaved Changes').should('not.be.visible');
@@ -165,9 +176,11 @@ describe('Templates', () => {
 
     it('allows duplication from the list page view', () => {
       cy.get('table').within(() => {
-        cy.findByText(templateTitle).closest('tr').within(() => {
-          cy.findByText('Duplicate Template').click({ force: true });
-        });
+        cy.findByText(templateTitle)
+          .closest('tr')
+          .within(() => {
+            cy.findByText('Duplicate Template').click({ force: true });
+          });
       });
 
       cy.findByText('Duplicate').click();
@@ -179,12 +192,14 @@ describe('Templates', () => {
 
     it('allows deletion from the list page view', () => {
       cy.get('table').within(() => {
-        cy.findByText(templateTitle).closest('tr').within(() => {
-          cy.findByText('Delete Template').click({ force: true });
-        });
+        cy.findByText(templateTitle)
+          .closest('tr')
+          .within(() => {
+            cy.findByText('Delete Template').click({ force: true });
+          });
       });
 
-      cy.findByText('Delete').click();
+      cy.findByText('Delete All Versions').click();
 
       cy.wait('@templatesDelete');
       cy.findByText(templateTitle).should('not.be.visible');
@@ -192,12 +207,14 @@ describe('Templates', () => {
 
     it('cleans up test data.', () => {
       cy.get('table').within(() => {
-        cy.findByText(`${templateTitle} (COPY)`).closest('tr').within(() => {
-          cy.findByText('Delete Template').click({ force: true });
-        });
+        cy.findByText(`${templateTitle} (COPY)`)
+          .closest('tr')
+          .within(() => {
+            cy.findByText('Delete Template').click({ force: true });
+          });
       });
 
-      cy.findByText('Delete').click();
+      cy.findByText('Delete All Versions').click();
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22319,28 +22319,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -22351,14 +22351,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -22369,42 +22369,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -22414,28 +22414,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -22445,14 +22445,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -22469,7 +22469,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -22484,14 +22484,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -22501,7 +22501,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -22511,7 +22511,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -22522,21 +22522,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -22546,14 +22546,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -22563,14 +22563,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -22581,7 +22581,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -22591,7 +22591,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -22601,14 +22601,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "dev": true,
           "optional": true,
@@ -22620,7 +22620,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "dev": true,
           "optional": true,
@@ -22639,7 +22639,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -22650,14 +22650,14 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "dev": true,
           "optional": true,
@@ -22668,7 +22668,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -22681,21 +22681,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -22705,21 +22705,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -22730,21 +22730,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -22757,7 +22757,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -22766,7 +22766,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -22782,7 +22782,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -22792,49 +22792,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -22846,7 +22846,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -22856,7 +22856,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -22866,14 +22866,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -22889,14 +22889,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -22906,14 +22906,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true

--- a/src/__testHelpers__/renderWithRedux.js
+++ b/src/__testHelpers__/renderWithRedux.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+
+// Lovingly adapted from:
+// https://testing-library.com/docs/example-react-redux by @kentcdodds
+const renderWithRedux = ({ component, reducer, initialState }) => {
+  const store = createStore(reducer, initialState);
+
+  return {
+    ...render(<Provider store={store}>{component}</Provider>),
+    // adding `store` to the returned utilities to allow us
+    // to reference it in our tests (just try to avoid using
+    // this to test implementation details).
+    store
+  };
+};
+
+export default renderWithRedux;

--- a/src/pages/templates/ListPage.js
+++ b/src/pages/templates/ListPage.js
@@ -1,13 +1,14 @@
 /* eslint-disable max-lines */
 import React, { Component } from 'react';
 import { Page } from '@sparkpost/matchbox';
-import { ApiErrorBanner, DeleteModal, Loading, TableCollection } from 'src/components';
+import { ApiErrorBanner, Loading, TableCollection } from 'src/components';
 import { Templates } from 'src/components/images';
 import PageLink from 'src/components/pageLink';
 import { resolveTemplateStatus } from 'src/helpers/templates';
 import RecentActivity from './components/RecentActivity';
 import { DeleteAction, DuplicateAction, LastUpdated, Name, Status } from './components/ListComponents';
 import DuplicateTemplateModal from './components/editorActions/DuplicateTemplateModal';
+import DeleteTemplateModal from './components/editorActions/DeleteTemplateModal';
 import { routeNamespace } from './constants/routes';
 import styles from './ListPage.module.scss';
 
@@ -23,23 +24,6 @@ export default class ListPage extends Component {
   componentDidMount() {
     this.props.listTemplates();
   }
-
-  deleteTemplate = () => {
-    const {
-      deleteTemplate,
-      listTemplates,
-      showAlert
-    } = this.props;
-    const { id, name, subaccount_id } = this.state.templateToDelete;
-
-    return deleteTemplate({ id, subaccountId: subaccount_id })
-      .then(() => {
-        showAlert({ type: 'success', message: `Template ${name} deleted` });
-        this.toggleDeleteModal();
-
-        return listTemplates();
-      });
-  };
 
   toggleDeleteModal = (template) => {
     this.setState({
@@ -82,6 +66,20 @@ export default class ListPage extends Component {
     showAlert({
       type: 'success',
       message: `Template ${template.name} duplicated`
+    });
+
+    return listTemplates();
+  };
+
+  handleDeleteSuccess = () => {
+    const { listTemplates, showAlert } = this.props;
+    const template = this.state.templateToDelete;
+
+    this.toggleDeleteModal();
+
+    showAlert({
+      type: 'success',
+      message: `Template ${template.name} deleted`
     });
 
     return listTemplates();
@@ -213,13 +211,13 @@ export default class ListPage extends Component {
               saveCsv={false}
             />
 
-            <DeleteModal
+            <DeleteTemplateModal
               open={this.state.showDeleteModal}
-              title="Are you sure you want to delete this template?"
-              content={<p>Both the draft and published versions of this template will be deleted.</p>}
-              onCancel={this.toggleDeleteModal}
-              onDelete={this.deleteTemplate}
-              isPending={isDeletePending}
+              onClose={this.toggleDeleteModal}
+              template={this.state.templateToDelete}
+              deleteTemplate={this.props.deleteTemplate}
+              successCallback={this.handleDeleteSuccess}
+              isLoading={isDeletePending}
             />
 
             <DuplicateTemplateModal

--- a/src/pages/templates/components/editorActions/DeleteTemplateModal.js
+++ b/src/pages/templates/components/editorActions/DeleteTemplateModal.js
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
+import { Modal, Panel, Button } from '@sparkpost/matchbox';
+import ButtonWrapper from 'src/components/buttonWrapper';
+import PanelLoading from 'src/components/panelLoading';
 import useEditorContext from '../../hooks/useEditorContext';
-import { DeleteModal } from 'src/components';
 import { RedirectAndAlert } from 'src/components/globalAlert';
 import { routeNamespace } from '../../constants/routes';
+import styles from './DeleteTemplateModal.module.scss';
 
 const DeleteTemplateModal = (props) => {
   const { open, onCancel } = props;
@@ -29,14 +32,37 @@ const DeleteTemplateModal = (props) => {
         />
       }
 
-      <DeleteModal
+      <Modal
         open={open}
-        title="Are you sure you want to delete this template?"
-        content={<p>Both the draft and published versions of this template will be deleted.</p>}
-        onCancel={onCancel}
-        onDelete={handleDelete}
-        isPending={isDeletePending}
-      />
+        showCloseButton
+        onClose={onCancel}
+      >
+        {isDeletePending && <PanelLoading/>}
+
+        {!isDeletePending && (
+          <Panel title="Are you sure you want to delete your template?">
+            <Panel.Section>
+              <p>If so, the <strong className={styles.WarningText}>published version and any drafts</strong> will all be deleted.</p>
+
+              <ButtonWrapper>
+                <Button
+                  destructive
+                  onClick={handleDelete}
+                >
+                  Delete All Versions
+                </Button>
+
+                <Button
+                  className={styles.CancelButton}
+                  onClick={onCancel}
+                >
+                  Keep Editing
+                </Button>
+              </ButtonWrapper>
+            </Panel.Section>
+          </Panel>
+        )}
+      </Modal>
     </>
   );
 };

--- a/src/pages/templates/components/editorActions/DeleteTemplateModal.js
+++ b/src/pages/templates/components/editorActions/DeleteTemplateModal.js
@@ -1,23 +1,31 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Modal, Panel, Button } from '@sparkpost/matchbox';
 import ButtonWrapper from 'src/components/buttonWrapper';
 import PanelLoading from 'src/components/panelLoading';
-import useEditorContext from '../../hooks/useEditorContext';
 import { RedirectAndAlert } from 'src/components/globalAlert';
 import { routeNamespace } from '../../constants/routes';
 import styles from './DeleteTemplateModal.module.scss';
 
 const DeleteTemplateModal = (props) => {
-  const { open, onCancel } = props;
   const {
+    open,
+    onClose,
+    template,
     deleteTemplate,
-    isDeletePending,
-    template
-  } = useEditorContext();
+    isLoading,
+    successCallback
+  } = props;
   const [hasSuccessRedirect, setSuccessRedirect] = useState(false);
   const handleDelete = () => {
     deleteTemplate({ id: template.id, subaccountId: template.subaccount_id })
-      .then(() => setSuccessRedirect(true));
+      .then(() => {
+        if (successCallback) {
+          successCallback();
+        } else {
+          setSuccessRedirect(true);
+        }
+      });
   };
 
   return (
@@ -35,27 +43,20 @@ const DeleteTemplateModal = (props) => {
       <Modal
         open={open}
         showCloseButton
-        onClose={onCancel}
+        onClose={onClose}
       >
-        {isDeletePending && <PanelLoading/>}
-
-        {!isDeletePending && (
+        {isLoading ? <PanelLoading minHeight="190px"/> : (
           <Panel title="Are you sure you want to delete your template?">
             <Panel.Section>
-              <p>If so, the <strong className={styles.WarningText}>published version and any drafts</strong> will all be deleted.</p>
+              {/* The <span>s are used here to avoid the bare JSX string problem */}
+              <p><span>If so, the </span><strong className={styles.WarningText}>published version and any drafts</strong><span> will all be deleted.</span></p>
 
               <ButtonWrapper>
-                <Button
-                  destructive
-                  onClick={handleDelete}
-                >
+                <Button destructive onClick={handleDelete}>
                   Delete All Versions
                 </Button>
 
-                <Button
-                  className={styles.CancelButton}
-                  onClick={onCancel}
-                >
+                <Button className={styles.CancelButton} onClick={onClose}>
                   Keep Editing
                 </Button>
               </ButtonWrapper>
@@ -65,6 +66,15 @@ const DeleteTemplateModal = (props) => {
       </Modal>
     </>
   );
+};
+
+DeleteTemplateModal.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  template: PropTypes.object,
+  deleteTemplate: PropTypes.func,
+  isLoading: PropTypes.bool,
+  successCallback: PropTypes.func
 };
 
 export default DeleteTemplateModal;

--- a/src/pages/templates/components/editorActions/DeleteTemplateModal.js
+++ b/src/pages/templates/components/editorActions/DeleteTemplateModal.js
@@ -7,49 +7,43 @@ import { RedirectAndAlert } from 'src/components/globalAlert';
 import { routeNamespace } from '../../constants/routes';
 import styles from './DeleteTemplateModal.module.scss';
 
-const DeleteTemplateModal = (props) => {
-  const {
-    open,
-    onClose,
-    template,
-    deleteTemplate,
-    isLoading,
-    successCallback
-  } = props;
+const DeleteTemplateModal = props => {
+  const { open, onClose, template, deleteTemplate, isLoading, successCallback } = props;
   const [hasSuccessRedirect, setSuccessRedirect] = useState(false);
   const handleDelete = () => {
-    deleteTemplate({ id: template.id, subaccountId: template.subaccount_id })
-      .then(() => {
-        if (successCallback) {
-          successCallback();
-        } else {
-          setSuccessRedirect(true);
-        }
-      });
+    deleteTemplate({ id: template.id, subaccountId: template.subaccount_id }).then(() => {
+      if (successCallback) {
+        successCallback();
+      } else {
+        setSuccessRedirect(true);
+      }
+    });
   };
 
   return (
     <>
-      {hasSuccessRedirect &&
+      {hasSuccessRedirect && (
         <RedirectAndAlert
           to={`/${routeNamespace}`}
           alert={{
             type: 'success',
-            message: 'Template deleted'
+            message: 'Template deleted',
           }}
         />
-      }
+      )}
 
-      <Modal
-        open={open}
-        showCloseButton
-        onClose={onClose}
-      >
-        {isLoading ? <PanelLoading minHeight="190px"/> : (
+      <Modal open={open} showCloseButton onClose={onClose}>
+        {isLoading ? (
+          <PanelLoading minHeight="190px" />
+        ) : (
           <Panel title="Are you sure you want to delete your template?">
             <Panel.Section>
               {/* The <span>s are used here to avoid the bare JSX string problem */}
-              <p><span>If so, the </span><strong className={styles.WarningText}>published version and any drafts</strong><span> will all be deleted.</span></p>
+              <p>
+                <span>If so, the </span>
+                <strong className={styles.WarningText}>published version and any drafts</strong>
+                <span> will all be deleted.</span>
+              </p>
 
               <ButtonWrapper>
                 <Button destructive onClick={handleDelete}>
@@ -74,7 +68,7 @@ DeleteTemplateModal.propTypes = {
   template: PropTypes.object,
   deleteTemplate: PropTypes.func,
   isLoading: PropTypes.bool,
-  successCallback: PropTypes.func
+  successCallback: PropTypes.func,
 };
 
 export default DeleteTemplateModal;

--- a/src/pages/templates/components/editorActions/DeleteTemplateModal.js
+++ b/src/pages/templates/components/editorActions/DeleteTemplateModal.js
@@ -51,7 +51,7 @@ const DeleteTemplateModal = props => {
                 </Button>
 
                 <Button className={styles.CancelButton} onClick={onClose}>
-                  Keep Editing
+                  Cancel
                 </Button>
               </ButtonWrapper>
             </Panel.Section>

--- a/src/pages/templates/components/editorActions/DeleteTemplateModal.module.scss
+++ b/src/pages/templates/components/editorActions/DeleteTemplateModal.module.scss
@@ -1,0 +1,9 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.WarningText {
+  color: color(red, base);
+}
+
+.CancelButton {
+  margin-left: spacing();
+}

--- a/src/pages/templates/components/editorActions/DraftModeActions.js
+++ b/src/pages/templates/components/editorActions/DraftModeActions.js
@@ -17,11 +17,13 @@ const DraftModeActions = () => {
     hasPublished,
     draft,
     createTemplate,
+    deleteTemplate,
     showAlert,
     content,
     isPublishedMode,
     testData,
-    isCreatePending
+    isCreatePending,
+    isDeletePending
   } = useEditorContext();
 
   // State
@@ -119,7 +121,10 @@ const DraftModeActions = () => {
 
         <DeleteTemplateModal
           open={isDeleteModalOpen}
-          onCancel={handleModalClose}
+          onClose={handleModalClose}
+          template={draft}
+          isLoading={isDeletePending}
+          deleteTemplate={deleteTemplate}
         />
 
         <SaveAndPublishConfirmationModal

--- a/src/pages/templates/components/editorActions/PublishedModeActions.js
+++ b/src/pages/templates/components/editorActions/PublishedModeActions.js
@@ -16,11 +16,13 @@ const PublishedModeActions = () => {
     template,
     published,
     createTemplate,
+    deleteTemplate,
     showAlert,
     content,
     isPublishedMode,
     testData,
-    isCreatePending
+    isCreatePending,
+    isDeletePending
   } = useEditorContext();
   const editDraftTo = `/${routeNamespace}/edit/${template.id}/draft/content${setSubaccountQuery(template.subaccount_id)}`;
 
@@ -114,7 +116,10 @@ const PublishedModeActions = () => {
 
         <DeleteTemplateModal
           open={isDeleteModalOpen}
-          onCancel={handleModalClose}
+          onClose={handleModalClose}
+          template={published}
+          isLoading={isDeletePending}
+          deleteTemplate={deleteTemplate}
         />
       </div>
     </Button.Group>

--- a/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
+++ b/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
@@ -1,25 +1,47 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { BrowserRouter as Router } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
 import DeleteTemplateModal from '../DeleteTemplateModal';
 import useEditorContext from '../../../hooks/useEditorContext';
+import globalAlert from 'src/reducers/globalAlert';
+import renderWithRedux from 'src/__testHelpers__/renderWithRedux';
 jest.mock('../../../hooks/useEditorContext');
+jest.mock('../../../../../../src/components/globalAlert'); // Mocks `RedirectAndAlert` component
 
 describe('DeleteTemplateModal', () => {
-  it('invokes "deleteTemplate" when deleting', () => {
-    const mockDeleteTemplate = jest.fn(() => Promise.resolve());
-    const subject = () => {
-      useEditorContext.mockReturnValue({
-        isDeletePending: false,
-        deleteTemplate: mockDeleteTemplate,
-        template: {
-          id: 'hello',
-          subaccount_id: 'world'
-        }
-      });
-      return shallow(<DeleteTemplateModal />);
+  const subject = (editorContext) => {
+    useEditorContext.mockReturnValue({
+      isDeletePending: false,
+      template: {
+        id: 'hello',
+        subaccount_id: 'world'
+      },
+      ...editorContext
+    });
+    const initialState = {
+      alerts: [],
+      showBanner: true
     };
 
-    subject().find('DeleteModal').simulate('delete');
+    return renderWithRedux({
+      reducer: globalAlert,
+      initialState,
+      component: (
+        <Router>
+          <DeleteTemplateModal/>
+        </Router>
+      )
+    });
+  };
+
+  it('invokes "deleteTemplate" when clicking "Delete All Versions"', () => {
+    const mockDeleteTemplate = jest.fn(() => Promise.resolve());
+
+    const { getByText, debug } = subject({ deleteTemplate: mockDeleteTemplate });
+
+    userEvent.click(getByText('Delete All Versions'));
+
+    debug();
 
     expect(mockDeleteTemplate).toHaveBeenCalledWith({ id: 'hello', subaccountId: 'world' });
   });

--- a/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
+++ b/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
@@ -7,10 +7,10 @@ import renderWithRedux from 'src/__testHelpers__/renderWithRedux';
 jest.mock('../../../../../../src/components/globalAlert'); // Mocks `RedirectAndAlert` component
 
 describe('DeleteTemplateModal', () => {
-  const subject = (props) => {
+  const subject = props => {
     const initialState = {
       alerts: [],
-      showBanner: true
+      showBanner: true,
     };
 
     return renderWithRedux({
@@ -22,13 +22,13 @@ describe('DeleteTemplateModal', () => {
             open={true}
             template={{
               id: 'hello',
-              subaccount_id: 'world'
+              subaccount_id: 'world',
             }}
             isLoading={false}
             {...props}
           />
         </Router>
-      )
+      ),
     });
   };
 

--- a/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
+++ b/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
@@ -2,22 +2,12 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import DeleteTemplateModal from '../DeleteTemplateModal';
-import useEditorContext from '../../../hooks/useEditorContext';
 import globalAlert from 'src/reducers/globalAlert';
 import renderWithRedux from 'src/__testHelpers__/renderWithRedux';
-jest.mock('../../../hooks/useEditorContext');
 jest.mock('../../../../../../src/components/globalAlert'); // Mocks `RedirectAndAlert` component
 
 describe('DeleteTemplateModal', () => {
-  const subject = (editorContext) => {
-    useEditorContext.mockReturnValue({
-      isDeletePending: false,
-      template: {
-        id: 'hello',
-        subaccount_id: 'world'
-      },
-      ...editorContext
-    });
+  const subject = (props) => {
     const initialState = {
       alerts: [],
       showBanner: true
@@ -28,7 +18,15 @@ describe('DeleteTemplateModal', () => {
       initialState,
       component: (
         <Router>
-          <DeleteTemplateModal/>
+          <DeleteTemplateModal
+            open={true}
+            template={{
+              id: 'hello',
+              subaccount_id: 'world'
+            }}
+            isLoading={false}
+            {...props}
+          />
         </Router>
       )
     });

--- a/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
+++ b/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import DeleteTemplateModal from '../DeleteTemplateModal';
 import globalAlert from 'src/reducers/globalAlert';
 import renderWithRedux from 'src/__testHelpers__/renderWithRedux';
-jest.mock('../../../../../../src/components/globalAlert'); // Mocks `RedirectAndAlert` component
+jest.mock('src/components/globalAlert'); // Mocks `RedirectAndAlert` component
 
 describe('DeleteTemplateModal', () => {
   const subject = props => {

--- a/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
+++ b/src/pages/templates/components/editorActions/tests/DeleteTemplateModal.test.js
@@ -35,11 +35,9 @@ describe('DeleteTemplateModal', () => {
   it('invokes "deleteTemplate" when clicking "Delete All Versions"', () => {
     const mockDeleteTemplate = jest.fn(() => Promise.resolve());
 
-    const { getByText, debug } = subject({ deleteTemplate: mockDeleteTemplate });
+    const { getByText } = subject({ deleteTemplate: mockDeleteTemplate });
 
     userEvent.click(getByText('Delete All Versions'));
-
-    debug();
 
     expect(mockDeleteTemplate).toHaveBeenCalledWith({ id: 'hello', subaccountId: 'world' });
   });

--- a/src/pages/templates/components/editorActions/tests/DraftModeActions.test.js
+++ b/src/pages/templates/components/editorActions/tests/DraftModeActions.test.js
@@ -73,9 +73,9 @@ describe('DraftModeActions', () => {
       expect(wrapper.find('Popover')).toHaveProp('open', false);
     });
 
-    it('sets the `open` prop to `false` when invoking the `onCancel` prop', () => {
+    it('sets the `open` prop to `false` when invoking the `onClose` prop', () => {
       wrapper.find('DeleteTemplate').simulate('click');
-      wrapper.find('DeleteTemplateModal').prop('onCancel')();
+      wrapper.find('DeleteTemplateModal').prop('onClose')();
 
       expect(wrapper.find('DeleteTemplateModal')).toHaveProp('open', false);
     });

--- a/src/pages/templates/components/editorActions/tests/PublishedModeActions.test.js
+++ b/src/pages/templates/components/editorActions/tests/PublishedModeActions.test.js
@@ -51,9 +51,9 @@ describe('PublishedModeActions', () => {
       expect(wrapper.find('Popover')).toHaveProp('open', false);
     });
 
-    it('sets the `open` prop to `false` when invoking the `onCancel` prop', () => {
+    it('sets the `open` prop to `false` when invoking the `onClose` prop', () => {
       wrapper.find('DeleteTemplate').simulate('click');
-      wrapper.find('DeleteTemplateModal').prop('onCancel')();
+      wrapper.find('DeleteTemplateModal').prop('onClose')();
 
       expect(wrapper.find('DeleteTemplateModal')).toHaveProp('open', false);
     });

--- a/src/pages/templates/components/editorActions/tests/__snapshots__/DraftModeActions.test.js.snap
+++ b/src/pages/templates/components/editorActions/tests/__snapshots__/DraftModeActions.test.js.snap
@@ -71,8 +71,14 @@ exports[`DraftModeActions renders draft actions 1`] = `
       }
     />
     <DeleteTemplateModal
-      onCancel={[Function]}
+      onClose={[Function]}
       open={false}
+      template={
+        Object {
+          "id": "a-random-id-123",
+          "subaccount_id": "some-subaccount-id",
+        }
+      }
     />
     <SaveAndPublishConfirmationModal
       onCancel={[Function]}

--- a/src/pages/templates/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
+++ b/src/pages/templates/components/editorActions/tests/__snapshots__/PublishedModeActions.test.js.snap
@@ -77,8 +77,14 @@ exports[`PublishedModeActions renders published actions 1`] = `
       }
     />
     <DeleteTemplateModal
-      onCancel={[Function]}
+      onClose={[Function]}
       open={false}
+      template={
+        Object {
+          "id": "123",
+          "subaccount_id": "abcd",
+        }
+      }
     />
   </div>
 </Button.Group>

--- a/src/pages/templates/tests/ListPage.test.js
+++ b/src/pages/templates/tests/ListPage.test.js
@@ -67,30 +67,32 @@ describe('ListPage', () => {
   it('renders delete modal visible', () => {
     const wrapper = subject();
     wrapper.setState({ showDeleteModal: true });
-    expect(wrapper.find('DeleteModal').prop('open')).toBe(true);
+    expect(wrapper.find('DeleteTemplateModal').prop('open')).toBe(true);
   });
 
   it('renders delete modal hidden', () => {
     const wrapper = subject();
     wrapper.setState({ showDeleteModal: false });
-    expect(wrapper.find('DeleteModal').prop('open')).toBe(false);
+    expect(wrapper.find('DeleteTemplateModal').prop('open')).toBe(false);
   });
 
   it('deletes template upon confirmation', async () => {
     const delFn = jest.fn(() => Promise.resolve());
     const wrapper = subject({ deleteTemplate: delFn });
     wrapper.setState({ showDeleteModal: true, templateToDelete: { id: 'foo', name: 'Bar', subaccount_id: 123 }});
-    await wrapper.find('DeleteModal').prop('onDelete')();
-    expect(delFn).toHaveBeenCalledWith({ id: 'foo', subaccountId: 123 });
+    await wrapper.find('DeleteTemplateModal').prop('deleteTemplate')();
+    expect(delFn).toHaveBeenCalled();
   });
 
   it('shows alert after delete and refreshes list', async () => {
-    const delFn = jest.fn(() => Promise.resolve());
     const alertFn = jest.fn();
     const listTemplateFn = jest.fn();
-    const wrapper = subject({ deleteTemplate: delFn, showAlert: alertFn, listTemplates: listTemplateFn });
+    const wrapper = subject({
+      showAlert: alertFn,
+      listTemplates: listTemplateFn
+    });
     wrapper.setState({ showDeleteModal: true, templateToDelete: { id: 'foo', name: 'Bar' }});
-    await wrapper.find('DeleteModal').prop('onDelete')();
+    await wrapper.find('DeleteTemplateModal').prop('successCallback')();
     expect(alertFn).toHaveBeenCalledWith({ type: 'success', message: 'Template Bar deleted' });
     expect(listTemplateFn).toHaveBeenCalled();
   });

--- a/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/templates/tests/__snapshots__/ListPage.test.js.snap
@@ -122,17 +122,12 @@ exports[`ListPage renders correctly 1`] = `
     }
     saveCsv={false}
   />
-  <DeleteModal
-    content={
-      <p>
-        Both the draft and published versions of this template will be deleted.
-      </p>
-    }
-    isPending={false}
-    onCancel={[Function]}
-    onDelete={[Function]}
+  <DeleteTemplateModal
+    isLoading={false}
+    onClose={[Function]}
     open={false}
-    title="Are you sure you want to delete this template?"
+    successCallback={[Function]}
+    template={null}
   />
   <DuplicateTemplateModal
     contentToDuplicate={null}


### PR DESCRIPTION
[TR-2010](https://jira.int.messagesystems.com/browse/TR-2010)

### What Changed
- Refactored delete template modal to use pure props instead of editor context
- Updated styles for the delete template modal to be a lot scarier (matching the very frightening mocks)
- Refactored delete template modal tests to use React Testing Library
- Updated some old Enzyme tests to match the new implementation
- ...it maybe goes without saying, but some Prettier reformatting going on here

#### Before

![Screen Shot 2019-11-25 at 10 45 17 AM](https://user-images.githubusercontent.com/3613392/69655908-88ac4300-1045-11ea-9f7d-9a75dec42002.png)

#### After

![Screen Shot 2019-11-26 at 9 20 11 AM](https://user-images.githubusercontent.com/3613392/69655914-8b0e9d00-1045-11ea-84f7-419230f69abd.png)

### How To Test
- Go to `/templates` and delete a template from the 'Recent Activity' section and the `<table/>` - verify that the new styles are present *and* that deleting works as expected
- Click on a template in draft mode and use the editor actions in the top right and delete the template. Verify that the new styles are present and that deleting occurs as expected.
- Click on a template in published mode and use the editor actions in the top right and delete the template. Verify that the new styles are present and that deleting occurs as expected.
- Run Cypress tests for templates locally - `npm run test-e2e`

### To Do
- [ ] Incorporate feedback
