### PR TITLE
Sa 1078 - Inbox Placement grouped by sending ip

### DIFF
--- a/src/pages/inboxPlacement/TestDetailsPage.js
+++ b/src/pages/inboxPlacement/TestDetailsPage.js
@@ -3,15 +3,24 @@ import { connect } from 'react-redux';
 import { Page, Tabs } from '@sparkpost/matchbox';
 
 import { Loading } from 'src/components';
-import { getInboxPlacementTest, getInboxPlacementByProvider, getInboxPlacementByRegion, getInboxPlacementTestContent } from 'src/actions/inboxPlacement';
-import { selectTestDetailsPageError, selectTestDetailsPageLoading } from 'src/selectors/inboxPlacement';
+import {
+  getInboxPlacementTest,
+  getInboxPlacementByProvider,
+  getInboxPlacementByRegion,
+  getInboxPlacementBySendingIp,
+  getInboxPlacementTestContent,
+} from 'src/actions/inboxPlacement';
+import {
+  selectTestDetailsPageError,
+  selectTestDetailsPageLoading,
+} from 'src/selectors/inboxPlacement';
 import TestDetails from './components/TestDetails';
 import TestContent from './components/TestContent';
 import useTabs from 'src/hooks/useTabs';
 import { RedirectAndAlert } from 'src/components/globalAlert';
 import StopTest from './components/StopTest';
 
-export const TestDetailsPage = (props) => {
+export const TestDetailsPage = props => {
   const {
     history,
     id,
@@ -20,13 +29,15 @@ export const TestDetailsPage = (props) => {
     details,
     placementsByProvider,
     placementsByRegion,
+    placementsBySendingIp,
     content,
     error,
     getInboxPlacementTest,
     getInboxPlacementByProvider,
     getInboxPlacementByRegion,
+    getInboxPlacementBySendingIp,
     getInboxPlacementTestContent,
-    StopTestComponent = StopTest //This is for unit test purposes
+    StopTestComponent = StopTest, //This is for unit test purposes
   } = props;
 
   const [selectedTabIndex, tabs] = useTabs(TABS, tabIndex);
@@ -36,7 +47,15 @@ export const TestDetailsPage = (props) => {
     getInboxPlacementByProvider(id);
     getInboxPlacementTestContent(id);
     getInboxPlacementByRegion(id);
-  }, [getInboxPlacementTest, getInboxPlacementByProvider, getInboxPlacementTestContent, getInboxPlacementByRegion, id]);
+    getInboxPlacementBySendingIp(id);
+  }, [
+    getInboxPlacementTest,
+    getInboxPlacementByProvider,
+    getInboxPlacementTestContent,
+    getInboxPlacementByRegion,
+    getInboxPlacementBySendingIp,
+    id,
+  ]);
 
   useEffect(() => {
     loadTestData();
@@ -50,37 +69,42 @@ export const TestDetailsPage = (props) => {
     const selectedTabKey = tabs[selectedTabIndex].key;
     switch (selectedTabKey) {
       case 'content':
-        return <TestContent content={content} details={details}/>;
+        return <TestContent content={content} details={details} />;
       default:
-        return <TestDetails details={details} placementsByProvider={placementsByProvider} placementsByRegion={placementsByRegion}/>;
+        return (
+          <TestDetails
+            details={details}
+            placementsByProvider={placementsByProvider}
+            placementsByRegion={placementsByRegion}
+            placementsBySendingIp={placementsBySendingIp}
+          />
+        );
     }
   };
 
   if (loading) {
-    return <Loading/>;
+    return <Loading />;
   }
 
   if (error) {
-    return <RedirectAndAlert
-      to='/inbox-placement'
-      alert={{ type: 'error', message: error.message }}/>;
+    return (
+      <RedirectAndAlert to="/inbox-placement" alert={{ type: 'error', message: error.message }} />
+    );
   }
 
   return (
     <Page
       breadcrumbAction={{
         content: 'All Inbox Placement Tests',
-        onClick: () => history.push('/inbox-placement')
+        onClick: () => history.push('/inbox-placement'),
       }}
-      title='Inbox Placement'
-      subtitle='Results'
-      primaryArea={<StopTestComponent status={(details || {}).status} id={id} reload={loadTestData} />}
+      title="Inbox Placement"
+      subtitle="Results"
+      primaryArea={
+        <StopTestComponent status={(details || {}).status} id={id} reload={loadTestData} />
+      }
     >
-      <Tabs
-        selected={selectedTabIndex}
-        connectBelow={true}
-        tabs={tabs}
-      />
+      <Tabs selected={selectedTabIndex} connectBelow={true} tabs={tabs} />
       {renderTabContent(selectedTabIndex)}
     </Page>
   );
@@ -88,7 +112,7 @@ export const TestDetailsPage = (props) => {
 
 const TABS = [
   { content: 'Details', key: 'details' },
-  { content: 'Content', key: 'content' }
+  { content: 'Content', key: 'content' },
 ];
 
 function mapStateToProps(state, props) {
@@ -103,7 +127,8 @@ function mapStateToProps(state, props) {
     details: state.inboxPlacement.currentTestDetails,
     placementsByProvider: state.inboxPlacement.placementsByProvider || [],
     placementsByRegion: state.inboxPlacement.placementsByRegion || [],
-    content: state.inboxPlacement.currentTestContent || {}
+    placementsBySendingIp: state.inboxPlacement.placementsBySendingIp || [],
+    content: state.inboxPlacement.currentTestContent || {},
   };
 }
 
@@ -111,7 +136,8 @@ const mapDispatchToProps = {
   getInboxPlacementTest,
   getInboxPlacementByProvider,
   getInboxPlacementByRegion,
-  getInboxPlacementTestContent
+  getInboxPlacementBySendingIp,
+  getInboxPlacementTestContent,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(TestDetailsPage);

--- a/src/pages/inboxPlacement/components/TestDetails.js
+++ b/src/pages/inboxPlacement/components/TestDetails.js
@@ -13,19 +13,30 @@ import AuthenticationResults from './AuthenticationResults';
 import { Search } from '@sparkpost/matchbox-icons';
 import { PLACEMENT_FILTER_TYPES, PLACEMENT_FILTER_LABELS } from '../constants/types';
 
-//TODO remove in SA-1078
-const { SENDING_IP: _SendingIP, ...placementsMinusSendingIp } = PLACEMENT_FILTER_TYPES;
-const PLACEMENTS_TYPE_OPTIONS = Object.values(placementsMinusSendingIp).map((type) => ({ label: PLACEMENT_FILTER_LABELS[type], value: type }));
+const PLACEMENTS_TYPE_OPTIONS = Object.values(PLACEMENT_FILTER_TYPES).map(type => ({
+  label: PLACEMENT_FILTER_LABELS[type],
+  value: type,
+}));
 
-const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
+const TestDetails = ({
+  details,
+  placementsByProvider,
+  placementsByRegion,
+  placementsBySendingIp,
+}) => {
   const [breakdownType, setBreakdownType] = useState(PLACEMENTS_TYPE_OPTIONS[0].value);
   const [searchPlacements, setSearchPlacements] = useState('');
 
-  const debouncedSetSearchPlacements = useCallback(_.debounce((placements) => setSearchPlacements(placements), 300), []);
+  const debouncedSetSearchPlacements = useCallback(
+    _.debounce(placements => setSearchPlacements(placements), 300),
+    [],
+  );
 
-  const onSearchChange = useCallback((e) => debouncedSetSearchPlacements(e.target.value), [debouncedSetSearchPlacements]);
+  const onSearchChange = useCallback(e => debouncedSetSearchPlacements(e.target.value), [
+    debouncedSetSearchPlacements,
+  ]);
 
-  const onFilterChange = useCallback((e) => {
+  const onFilterChange = useCallback(e => {
     setBreakdownType(e.target.value);
   }, []);
 
@@ -38,9 +49,15 @@ const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
       breakdownData = placementsByRegion;
       textFieldPlaceholder = PLACEMENT_FILTER_LABELS[breakdownType];
       break;
+    case PLACEMENT_FILTER_TYPES.SENDING_IP:
+      breakdownData = placementsBySendingIp;
+      textFieldPlaceholder = PLACEMENT_FILTER_LABELS[breakdownType];
+      break;
     default:
       breakdownData = placementsByProvider;
-      textFieldPlaceholder = `${PLACEMENT_FILTER_LABELS[PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER]} or ${PLACEMENT_FILTER_LABELS[PLACEMENT_FILTER_TYPES.REGION]}`;
+      textFieldPlaceholder = `${
+        PLACEMENT_FILTER_LABELS[PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER]
+      } or ${PLACEMENT_FILTER_LABELS[PLACEMENT_FILTER_TYPES.REGION]}`;
       break;
   }
 
@@ -48,31 +65,43 @@ const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
     const searchRegex = new RegExp(_.escapeRegExp(searchPlacements), 'i');
     switch (breakdownType) {
       case PLACEMENT_FILTER_TYPES.REGION:
-        breakdownData = breakdownData.filter((item) => item.region.match(searchRegex));
+        breakdownData = breakdownData.filter(item => item.region.match(searchRegex));
+        break;
+      case PLACEMENT_FILTER_TYPES.SENDING_IP:
+        breakdownData = breakdownData.filter(item => item.sending_ip.match(searchRegex));
         break;
       default:
-        breakdownData = breakdownData.filter((item) => item.region.match(searchRegex) || item.mailbox_provider.match(searchRegex));
+        breakdownData = breakdownData.filter(
+          item => item.region.match(searchRegex) || item.mailbox_provider.match(searchRegex),
+        );
         break;
     }
   }
 
-  const panelTitle = (<>
-    <h3 className={styles.Inline}>Placement Breakdown</h3>
-    <small
-      className={styles.SeedsCount}>{details.seedlist_count > 1 ? ` | ${details.seedlist_count} Seeds` : ` | ${details.seedlist_count} Seed`}
-    </small>
-  </>);
+  const panelTitle = (
+    <>
+      <h3 className={styles.Inline}>Placement Breakdown</h3>
+      <small className={styles.SeedsCount}>
+        {details.seedlist_count > 1
+          ? ` | ${details.seedlist_count} Seeds`
+          : ` | ${details.seedlist_count} Seed`}
+      </small>
+    </>
+  );
 
-  return (<>
+  return (
+    <>
       <Panel>
         <Panel.Section>
           <h2>{details.subject}</h2>
           <Grid>
-            <InfoBlock value={details.from_address} label='From' columnProps={{ md: 4 }}/>
-            <InfoBlock value={format(details.start_time, FORMATS.LONG_DATETIME)} label='Started'/>
-            <InfoBlock value={details.end_time ? format(details.end_time, FORMATS.LONG_DATETIME) : '--'}
-              label='Finished'/>
-            <InfoBlock value={details.test_name || 'None'} label='Inbox Placement Test Name'/>
+            <InfoBlock value={details.from_address} label="From" columnProps={{ md: 4 }} />
+            <InfoBlock value={format(details.start_time, FORMATS.LONG_DATETIME)} label="Started" />
+            <InfoBlock
+              value={details.end_time ? format(details.end_time, FORMATS.LONG_DATETIME) : '--'}
+              label="Finished"
+            />
+            <InfoBlock value={details.test_name || 'None'} label="Inbox Placement Test Name" />
           </Grid>
         </Panel.Section>
         <Grid>
@@ -80,14 +109,14 @@ const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
             <div className={styles.FolderPlacementBarChart}>
               <Panel.Section>
                 <h3>Folder Placement</h3>
-                <FolderPlacementBarChart placements={placements}/>
+                <FolderPlacementBarChart placements={placements} />
               </Panel.Section>
             </div>
           </Grid.Column>
           <Grid.Column md={12} lg={4}>
             <Panel.Section>
               <h3 className={styles.AuthenticationHeader}>Authentication</h3>
-              <AuthenticationResults data={details.authentication}/>
+              <AuthenticationResults data={details.authentication} />
             </Panel.Section>
           </Grid.Column>
         </Grid>
@@ -98,21 +127,36 @@ const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
             <ScreenReaderOnly>
               <Label id="select-placement-type">Placement Type</Label>
             </ScreenReaderOnly>
-            <Select id="select-placement-type" data-id="select-placement-type" options={PLACEMENTS_TYPE_OPTIONS} onChange={onFilterChange}/>
+            <Select
+              id="select-placement-type"
+              data-id="select-placement-type"
+              options={PLACEMENTS_TYPE_OPTIONS}
+              onChange={onFilterChange}
+            />
           </div>
           <div className={styles.PlacementFilterTextField}>
             <ScreenReaderOnly>
               <Label id="textfield-placement-search">{`Search by ${textFieldPlaceholder}`}</Label>
             </ScreenReaderOnly>
-            <TextField id="textfield-placement-search" data-id="text-field-placement-search" suffix={<Search />} onChange={onSearchChange} placeholder={textFieldPlaceholder} />
+            <TextField
+              id="textfield-placement-search"
+              data-id="text-field-placement-search"
+              suffix={<Search />}
+              onChange={onSearchChange}
+              placeholder={textFieldPlaceholder}
+            />
           </div>
         </div>
-        <PlacementBreakdown data-id="placement-breakdown-table" type={breakdownType} data={breakdownData} />
+        <PlacementBreakdown
+          data-id="placement-breakdown-table"
+          type={breakdownType}
+          data={breakdownData}
+        />
       </Panel>
       <div style={{ clear: 'both' }} />
-      <Panel title='Time to Receive Mail'>
+      <Panel title="Time to Receive Mail">
         <Panel.Section>
-          <TimeToReceiveSection data={details.time_to_receive}/>
+          <TimeToReceiveSection data={details.time_to_receive} />
         </Panel.Section>
       </Panel>
     </>
@@ -120,6 +164,3 @@ const TestDetails = ({ details, placementsByProvider, placementsByRegion }) => {
 };
 
 export default TestDetails;
-
-
-

--- a/src/pages/inboxPlacement/components/tests/PlacementBreakdown.test.js
+++ b/src/pages/inboxPlacement/components/tests/PlacementBreakdown.test.js
@@ -2,102 +2,114 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { PLACEMENT_FILTER_TYPES } from '../../constants/types';
-import PlacementBreakdown, { GroupPercentage, HeaderComponent, RowComponent } from '../PlacementBreakdown';
+import PlacementBreakdown, {
+  GroupPercentage,
+  HeaderComponent,
+  RowComponent,
+} from '../PlacementBreakdown';
+import formatFilterName from '../../helpers/formatFilterName';
 
 describe('Component: PlacementBreakdown', () => {
-
   const data = [
     {
       mailbox_provider: 'dogmail.com',
       region: 'north america',
+      sending_ip: '101.101',
       placement: {
         inbox_pct: 0,
         spam_pct: 0,
-        missing_pct: 1
+        missing_pct: 1,
       },
       authentication: {
         spf_pct: 0,
         dkim_pct: 0,
-        dmarc_pct: 1
-      }
+        dmarc_pct: 1,
+      },
     },
     {
       mailbox_provider: 'doghouseinbox.com',
       region: 'europe',
+      sending_ip: '101.102',
       placement: {
         inbox_pct: 0.8,
         spam_pct: 0.1,
-        missing_pct: 0.1
+        missing_pct: 0.1,
       },
       authentication: {
         spf_pct: 0.8,
         dkim_pct: 0.1,
-        dmarc_pct: 0.1
-      }
-    }
+        dmarc_pct: 0.1,
+      },
+    },
   ];
 
-  const subject = ({ ...props }) => shallow(<PlacementBreakdown data={[]} {...props}/>);
+  const subject = ({ ...props }) => shallow(<PlacementBreakdown data={[]} {...props} />);
 
   it('renders correctly with no data', () => {
     expect(subject()).toMatchSnapshot();
   });
 
   it('matches snapshot with provider data', () => {
-    const data = [
-      {
-        'mailbox_provider': 'dogmail.com',
-        'placement': {
-          'inbox_pct': 0,
-          'spam_pct': 0,
-          'missing_pct': 1
-        },
-        'authentication': {
-          'spf_pct': 0,
-          'dkim_pct': 0,
-          'dmarc_pct': 1
-        }
-      },
-      {
-        'mailbox_provider': 'doghouseinbox.com',
-        'placement': {
-          'inbox_pct': 0.8,
-          'spam_pct': 0.1,
-          'missing_pct': 0.1
-        },
-        'authentication': {
-          'spf_pct': 0.8,
-          'dkim_pct': 0.1,
-          'dmarc_pct': 0.1
-        }
-      }
-    ];
-
     expect(subject({ data })).toMatchSnapshot();
   });
 
   describe('SubComponent: GroupPercentage', () => {
     it('renders percentage correctly', () => {
-      expect(shallow(<GroupPercentage value={0.2}/>)).toMatchSnapshot();
+      expect(shallow(<GroupPercentage value={0.2} />)).toMatchSnapshot();
     });
   });
 
   describe('RowComponent', () => {
-    const { mailbox_provider, region, placement, authentication } = data[0];
+    const { mailbox_provider, region, placement, sending_ip, authentication } = data[0];
+
     it('renders region correctly', () => {
-      expect(shallow(
+      const wrapper = shallow(
         <RowComponent
           id={1}
-          // This is undefined because PLACEMENT_FILTER_TYPES.REGION doesn't have a mailbox_provider in its data
+          // This is undefined because results by region doesn't have a mailbox_provider nor sending ip
           mailbox_provider={undefined}
+          sending_ip={undefined}
           region={region}
           type={PLACEMENT_FILTER_TYPES.REGION}
           placement={placement}
           authentication={authentication}
-        />)).toMatchSnapshot();
+        />,
+      );
+
+      expect(wrapper.find('PageLink')).toHaveProp(
+        'to',
+        '/inbox-placement/details/1/region/north america',
+      );
+      expect(wrapper.find('PageLink').find('strong')).toHaveTextContent(
+        formatFilterName(PLACEMENT_FILTER_TYPES.REGION, 'north america'),
+      );
     });
+
+    it('renders sending ip correctly', () => {
+      const wrapper = shallow(
+        <RowComponent
+          id={1}
+          // This is undefined because results by sending ip doesn't have a mailbox_provider nor region
+          mailbox_provider={undefined}
+          region={undefined}
+          sending_ip={sending_ip}
+          type={PLACEMENT_FILTER_TYPES.SENDING_IP}
+          placement={placement}
+          authentication={authentication}
+        />,
+      );
+
+      expect(wrapper.find('PageLink')).toHaveProp(
+        'to',
+        '/inbox-placement/details/1/sending-ip/101.101',
+      );
+      expect(wrapper.find('PageLink').find('strong')).toHaveTextContent(
+        formatFilterName(PLACEMENT_FILTER_TYPES.SENDING_IP, '101.101'),
+      );
+    });
+
     it('renders mailbox provider correctly', () => {
-      expect(shallow(
+      const wrapper = shallow(
         <RowComponent
           id={1}
           mailbox_provider={mailbox_provider}
@@ -105,14 +117,24 @@ describe('Component: PlacementBreakdown', () => {
           type={PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER}
           placement={placement}
           authentication={authentication}
-        />)).toMatchSnapshot();
+        />,
+      );
+
+      expect(wrapper.find('PageLink')).toHaveProp(
+        'to',
+        '/inbox-placement/details/1/mailbox-provider/dogmail.com',
+      );
+      expect(wrapper.find('PageLink').find('strong')).toHaveTextContent(
+        formatFilterName(PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER, 'dogmail.com'),
+      );
     });
   });
 
   describe('HeaderComponent', () => {
     it('renders correctly', () => {
-      expect(shallow(<HeaderComponent/>)).toMatchSnapshot();
+      expect(
+        shallow(<HeaderComponent type={PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER} />),
+      ).toMatchSnapshot();
     });
   });
-
 });

--- a/src/pages/inboxPlacement/components/tests/TestDetails.test.js
+++ b/src/pages/inboxPlacement/components/tests/TestDetails.test.js
@@ -3,19 +3,24 @@ import { shallow } from 'enzyme';
 import TestDetails from '../TestDetails';
 import { PLACEMENT_FILTER_TYPES } from '../../constants/types';
 
-jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
+jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('date-fns', () => ({ format: jest.fn().mockReturnValue('Jul 8th 2019 11:49am') }));
 
 describe('Component: TestDetails', () => {
+  const samplePlacement = {
+    inbox_pct: 0,
+    spam_pct: 0,
+    missing_pct: 1,
+  };
   const subject = ({ ...props }) => {
     const defaults = {
       details: {
         start_time: '2019-07-08T15:49:56.954Z',
         end_time: null,
         subject: 'Fooo',
-        test_name: 'Baz'
+        test_name: 'Baz',
       },
-      placementsByProvider: []
+      placementsByProvider: [],
     };
     return shallow(<TestDetails {...defaults} {...props} />);
   };
@@ -32,7 +37,7 @@ describe('Component: TestDetails', () => {
     const detailsWithoutName = {
       start_time: '2019-07-08T15:49:56.954Z',
       end_time: null,
-      subject: 'Fooo'
+      subject: 'Fooo',
     };
     const wrapper = subject({ details: detailsWithoutName });
     expect(wrapper.find('InfoBlock').at(3)).toHaveProp('value', 'None');
@@ -41,143 +46,176 @@ describe('Component: TestDetails', () => {
   it('renders providers breakdown correctly', () => {
     const placementsByProvider = [
       {
-        'mailbox_provider': 'dogmail.com',
-        'placement': {
-          'inbox_pct': 0,
-          'spam_pct': 0,
-          'missing_pct': 1
-        }
-      }
+        mailbox_provider: 'dogmail.com',
+        placement: samplePlacement,
+      },
     ];
 
-    expect(subject({ placementsByProvider }).find(placementBreakdownSelector).prop('data')).toEqual(placementsByProvider);
+    expect(
+      subject({ placementsByProvider })
+        .find(placementBreakdownSelector)
+        .prop('data'),
+    ).toEqual(placementsByProvider);
   });
 
   it('changes placement data when changing select', () => {
     const placementsByProvider = [
       {
-        'mailbox_provider': 'dogmail.com',
-        'placement': {
-          'inbox_pct': 0,
-          'spam_pct': 0,
-          'missing_pct': 1
-        }
-      }
+        mailbox_provider: 'dogmail.com',
+        placement: samplePlacement,
+      },
     ];
     const placementsByRegion = [
       {
-        'placement': {
-          'inbox_pct': 0,
-          'spam_pct': 0,
-          'missing_pct': 1
-        },
-        'region': 'north america'
-      }
+        placement: samplePlacement,
+        region: 'north america',
+      },
     ];
-    const wrapper = subject({ placementsByProvider, placementsByRegion });
+    const placementsBySendingIp = [
+      {
+        placement: samplePlacement,
+        sending_ip: '101.101',
+      },
+    ];
+    const wrapper = subject({ placementsByProvider, placementsByRegion, placementsBySendingIp });
     // Default data
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual(placementsByProvider);
 
     // Change to Region Filter
-    wrapper.find(placementTypeSelectSelector).simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.REGION }});
+    wrapper
+      .find(placementTypeSelectSelector)
+      .simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.REGION } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual(placementsByRegion);
 
+    // Change to Sending Ip Filter
+    wrapper
+      .find(placementTypeSelectSelector)
+      .simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.SENDING_IP } });
+    expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual(placementsBySendingIp);
+
     // Change back to Mailbox Provider filter
-    wrapper.find(placementTypeSelectSelector).simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER }});
+    wrapper
+      .find(placementTypeSelectSelector)
+      .simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual(placementsByProvider);
   });
 
   it('changes placement data when using search bar on providers list', () => {
     const dogmail = {
-      'mailbox_provider': 'dogmail.net',
-      'region': 'north america',
-      'placement': {
-        'inbox_pct': 0,
-        'spam_pct': 0,
-        'missing_pct': 1
-      }
+      mailbox_provider: 'dogmail.net',
+      region: 'north america',
+      sending_ip: '101.101',
+      placement: samplePlacement,
     };
     const gmail = {
-      'mailbox_provider': 'gmail.com',
-      'region': 'europe',
-      'placement': {
-        'inbox_pct': 0,
-        'spam_pct': 0,
-        'missing_pct': 1
-      }
+      mailbox_provider: 'gmail.com',
+      region: 'europe',
+      sending_ip: '101.102',
+      placement: samplePlacement,
     };
     const hotmail = {
-      'mailbox_provider': 'hotmail.com',
-      'region': 'global',
-      'placement': {
-        'inbox_pct': 0,
-        'spam_pct': 0,
-        'missing_pct': 1
-      }
+      mailbox_provider: 'hotmail.com',
+      region: 'global',
+      sending_ip: '101.103',
+      placement: samplePlacement,
     };
     const placementsByProvider = [dogmail, gmail, hotmail];
 
     const wrapper = subject({ placementsByProvider });
 
     // Match one result
-    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'net' }});
+    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'net' } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([dogmail]);
 
     // Match more than one result
-    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'gmail' }});
+    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'gmail' } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([dogmail, gmail]);
 
     // No results
-    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'this wont match anything' }});
+    wrapper
+      .find(searchFieldSelector)
+      .simulate('change', { target: { value: 'this wont match anything' } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([]);
 
     // Search by case insensitive region match
-    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'america' }});
+    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'america' } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([dogmail]);
   });
 
   it('changes placement data when using search bar on regions list', () => {
     const northAmerica = {
-      'region': 'north america',
-      'placement': {
-        'inbox_pct': 0,
-        'spam_pct': 0,
-        'missing_pct': 1
-      }
+      region: 'north america',
+      placement: samplePlacement,
     };
     const southAmerica = {
-      'region': 'south america',
-      'placement': {
-        'inbox_pct': 0,
-        'spam_pct': 0,
-        'missing_pct': 1
-      }
+      region: 'south america',
+      placement: samplePlacement,
     };
     const europe = {
-      'region': 'europe',
-      'placement': {
-        'inbox_pct': 0,
-        'spam_pct': 0,
-        'missing_pct': 1
-      }
+      region: 'europe',
+      placement: samplePlacement,
     };
     const placementsByRegion = [northAmerica, southAmerica, europe];
 
     const wrapper = subject({ placementsByRegion });
 
     // Change to Region list
-    wrapper.find(placementTypeSelectSelector).simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.REGION }});
+    wrapper
+      .find(placementTypeSelectSelector)
+      .simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.REGION } });
 
     // Match one result
-    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'north' }});
+    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'north' } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([northAmerica]);
 
     // Match more than one result
-    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'america' }});
-    expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([northAmerica, southAmerica]);
+    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'america' } });
+    expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([
+      northAmerica,
+      southAmerica,
+    ]);
 
     // No results
-    wrapper.find(searchFieldSelector).simulate('change', { target: { value: 'this wont match anything' }});
+    wrapper
+      .find(searchFieldSelector)
+      .simulate('change', { target: { value: 'this wont match anything' } });
+    expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([]);
+  });
+
+  it('changes placement data when using search bar on sending ip list', () => {
+    const ip1 = {
+      sending_ip: '101.101',
+      placement: samplePlacement,
+    };
+    const ip2 = {
+      sending_ip: '101.102',
+      placement: samplePlacement,
+    };
+    const ip3 = {
+      sending_ip: '103.104',
+      placement: samplePlacement,
+    };
+    const placementsBySendingIp = [ip1, ip2, ip3];
+
+    const wrapper = subject({ placementsBySendingIp });
+
+    // Change to Region list
+    wrapper
+      .find(placementTypeSelectSelector)
+      .simulate('change', { target: { value: PLACEMENT_FILTER_TYPES.SENDING_IP } });
+
+    // Match one result
+    wrapper.find(searchFieldSelector).simulate('change', { target: { value: '102' } });
+    expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([ip2]);
+
+    // Match more than one result
+    wrapper.find(searchFieldSelector).simulate('change', { target: { value: '101' } });
+    expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([ip1, ip2]);
+
+    // No results
+    wrapper
+      .find(searchFieldSelector)
+      .simulate('change', { target: { value: 'this wont match anything' } });
     expect(wrapper.find(placementBreakdownSelector).prop('data')).toEqual([]);
   });
 });

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/PlacementBreakdown.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/PlacementBreakdown.test.js.snap
@@ -47,131 +47,6 @@ exports[`Component: PlacementBreakdown HeaderComponent renders correctly 1`] = `
 </thead>
 `;
 
-exports[`Component: PlacementBreakdown RowComponent renders mailbox provider correctly 1`] = `
-<Table.Row
-  className="DataRow"
->
-  <Table.Cell
-    className="PlacementNameCell"
-  >
-    <PageLink
-      to="/inbox-placement/details/1/mailbox-provider/dogmail.com"
-    >
-      <strong>
-        dogmail.com
-      </strong>
-    </PageLink>
-  </Table.Cell>
-  <Table.Cell
-    className="RegionCell"
-  >
-    North America
-  </Table.Cell>
-  <Table.Cell
-    className="Placement"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Placement"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Placement"
-  >
-    <GroupPercentage
-      value={1}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Authentication divider"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Authentication"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Authentication"
-  >
-    <GroupPercentage
-      value={1}
-    />
-  </Table.Cell>
-</Table.Row>
-`;
-
-exports[`Component: PlacementBreakdown RowComponent renders region correctly 1`] = `
-<Table.Row
-  className="DataRow"
->
-  <Table.Cell
-    className="PlacementNameCell"
-  >
-    <PageLink
-      to="/inbox-placement/details/1/region/north america"
-    >
-      <strong>
-        North America
-      </strong>
-    </PageLink>
-  </Table.Cell>
-  <Table.Cell
-    className="Placement"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Placement"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Placement"
-  >
-    <GroupPercentage
-      value={1}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Authentication divider"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Authentication"
-  >
-    <GroupPercentage
-      value={0}
-    />
-  </Table.Cell>
-  <Table.Cell
-    className="Authentication"
-  >
-    <GroupPercentage
-      value={1}
-    />
-  </Table.Cell>
-</Table.Row>
-`;
-
 exports[`Component: PlacementBreakdown SubComponent: GroupPercentage renders percentage correctly 1`] = `
 <span
   className="GroupValue"
@@ -201,6 +76,8 @@ exports[`Component: PlacementBreakdown matches snapshot with provider data 1`] =
           "missing_pct": 1,
           "spam_pct": 0,
         },
+        "region": "north america",
+        "sending_ip": "101.101",
       },
       Object {
         "authentication": Object {
@@ -214,6 +91,8 @@ exports[`Component: PlacementBreakdown matches snapshot with provider data 1`] =
           "missing_pct": 0.1,
           "spam_pct": 0.1,
         },
+        "region": "europe",
+        "sending_ip": "101.102",
       },
     ]
   }

--- a/src/pages/inboxPlacement/components/tests/__snapshots__/TestDetails.test.js.snap
+++ b/src/pages/inboxPlacement/components/tests/__snapshots__/TestDetails.test.js.snap
@@ -106,6 +106,10 @@ exports[`Component: TestDetails renders correctly 1`] = `
                 "label": "Region",
                 "value": "region",
               },
+              Object {
+                "label": "Sending IP",
+                "value": "sending-ip",
+              },
             ]
           }
         />

--- a/src/pages/inboxPlacement/helpers/formatFilterName.js
+++ b/src/pages/inboxPlacement/helpers/formatFilterName.js
@@ -7,13 +7,15 @@ export const formatFilterName = (filterType, filterName) => {
       return formatRegion(filterName);
     case PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER:
       return formatMailboxProvider(filterName);
+    case PLACEMENT_FILTER_TYPES.SENDING_IP:
+      return filterName;
     default:
       return '';
   }
 };
 
-const formatMailboxProvider = (name) => name;
+const formatMailboxProvider = name => name;
 
-const formatRegion = (name) => _.startCase(name);
+export const formatRegion = name => _.startCase(name);
 
 export default formatFilterName;

--- a/src/pages/inboxPlacement/helpers/tests/formatFilterName.test.js
+++ b/src/pages/inboxPlacement/helpers/tests/formatFilterName.test.js
@@ -1,13 +1,18 @@
 import formatFilterName from '../formatFilterName';
 import { PLACEMENT_FILTER_TYPES } from '../../constants/types';
 
-
 describe('Format Display of Inbox Placement Results Breakdown Group By Name', () => {
   it('should format mailbox providers correctly', () => {
     expect(formatFilterName(PLACEMENT_FILTER_TYPES.MAILBOX_PROVIDER, 'gmail')).toEqual('gmail');
   });
 
   it('should format regions correctly', () => {
-    expect(formatFilterName(PLACEMENT_FILTER_TYPES.REGION, 'north america')).toEqual('North America');
+    expect(formatFilterName(PLACEMENT_FILTER_TYPES.REGION, 'north america')).toEqual(
+      'North America',
+    );
+  });
+
+  it('should format sending ip correctly', () => {
+    expect(formatFilterName(PLACEMENT_FILTER_TYPES.SENDING_IP, '101.101')).toEqual('101.101');
   });
 });

--- a/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
+++ b/src/pages/inboxPlacement/tests/TestDetailsPage.test.js
@@ -3,21 +3,21 @@ import React from 'react';
 import { TestDetailsPage } from '../TestDetailsPage';
 import { StopTest } from '../components/StopTest';
 
-
 describe('Page: Single Inbox Placement Test', () => {
   const subject = ({ ...props }) => {
     const defaults = {
       getInboxPlacementTest: jest.fn(),
       getInboxPlacementByProvider: jest.fn(),
       getInboxPlacementByRegion: jest.fn(),
+      getInboxPlacementBySendingIp: jest.fn(),
       getInboxPlacementTestContent: jest.fn(),
       tabIndex: 0,
       id: 0,
       loading: false,
       error: false,
       history: {
-        replace: jest.fn()
-      }
+        replace: jest.fn(),
+      },
     };
 
     return shallow(<TestDetailsPage {...defaults} {...props} />);
@@ -31,22 +31,29 @@ describe('Page: Single Inbox Placement Test', () => {
     const getInboxPlacementTest = jest.fn().mockReturnValue({});
     const getInboxPlacementByProvider = jest.fn().mockReturnValue({});
     const getInboxPlacementByRegion = jest.fn().mockReturnValue({});
+    const getInboxPlacementBySendingIp = jest.fn().mockReturnValue({});
     const getInboxPlacementTestContent = jest.fn().mockReturnValue({});
 
-    mount(<TestDetailsPage
-      details={{}}
-      content={{}}
-      getInboxPlacementTest={getInboxPlacementTest}
-      getInboxPlacementByProvider={getInboxPlacementByProvider}
-      getInboxPlacementByRegion={getInboxPlacementByRegion}
-      getInboxPlacementTestContent={getInboxPlacementTestContent}
-      id={101}
-      tabIndex={1} //not working nicely with tabIndex=0; TestDetails component
-      history={{ replace: jest.fn() }}
-      StopTestComponent={StopTest}/>);
+    mount(
+      <TestDetailsPage
+        details={{}}
+        content={{}}
+        getInboxPlacementTest={getInboxPlacementTest}
+        getInboxPlacementByProvider={getInboxPlacementByProvider}
+        getInboxPlacementByRegion={getInboxPlacementByRegion}
+        getInboxPlacementBySendingIp={getInboxPlacementBySendingIp}
+        getInboxPlacementTestContent={getInboxPlacementTestContent}
+        id={101}
+        tabIndex={1} //not working nicely with tabIndex=0; TestDetails component
+        history={{ replace: jest.fn() }}
+        StopTestComponent={StopTest}
+      />,
+    );
 
     expect(getInboxPlacementTest).toHaveBeenCalled();
     expect(getInboxPlacementByProvider).toHaveBeenCalled();
+    expect(getInboxPlacementByRegion).toHaveBeenCalled();
+    expect(getInboxPlacementBySendingIp).toHaveBeenCalled();
     expect(getInboxPlacementTestContent).toHaveBeenCalled();
   });
 
@@ -60,8 +67,8 @@ describe('Page: Single Inbox Placement Test', () => {
     const wrapper = subject();
     wrapper.setProps({
       error: {
-        message: 'You dun goofed'
-      }
+        message: 'You dun goofed',
+      },
     });
     expect(wrapper.find('RedirectAndAlert')).toMatchSnapshot();
     expect(wrapper.find('Page')).not.toExist();
@@ -82,18 +89,24 @@ describe('Page: Single Inbox Placement Test', () => {
 
   it('updates URL when tabs change', () => {
     const mockHistory = { replace: jest.fn() };
-    const wrapper = mount(<TestDetailsPage tabIndex={1}
-      details={{}}
-      content={{}}
-      history={mockHistory}
-      getInboxPlacementTest={jest.fn()}
-      getInboxPlacementByProvider={jest.fn()}
-      getInboxPlacementByRegion={jest.fn()}
-      getInboxPlacementTestContent={jest.fn()}
-      StopTestComponent={StopTest}
-    />);
-    wrapper.find('Tab').last().simulate('click');
+    const wrapper = mount(
+      <TestDetailsPage
+        tabIndex={1}
+        details={{}}
+        content={{}}
+        history={mockHistory}
+        getInboxPlacementTest={jest.fn()}
+        getInboxPlacementByProvider={jest.fn()}
+        getInboxPlacementByRegion={jest.fn()}
+        getInboxPlacementBySendingIp={jest.fn()}
+        getInboxPlacementTestContent={jest.fn()}
+        StopTestComponent={StopTest}
+      />,
+    );
+    wrapper
+      .find('Tab')
+      .last()
+      .simulate('click');
     expect(mockHistory.replace).toHaveBeenCalled();
   });
 });
-

--- a/src/reducers/inboxPlacement.js
+++ b/src/reducers/inboxPlacement.js
@@ -10,7 +10,7 @@ export const initialState = {
   placementsByRegion: [],
   placementsBySendingIp: [],
   allMessages: [],
-  messagesById: {}
+  messagesById: {},
 };
 
 export default (state = initialState, { type, payload, meta }) => {
@@ -53,28 +53,48 @@ export default (state = initialState, { type, payload, meta }) => {
     case 'GET_INBOX_PLACEMENT_TESTS_BY_MAILBOX_PROVIDER_PENDING':
       return { ...state, getByProviderPending: true, getByProviderError: null };
     case 'GET_INBOX_PLACEMENT_TESTS_BY_MAILBOX_PROVIDER_SUCCESS':
-      return { ...state, getByProviderPending: false, placementsByProvider: payload, getByProviderError: null };
+      return {
+        ...state,
+        getByProviderPending: false,
+        placementsByProvider: payload,
+        getByProviderError: null,
+      };
     case 'GET_INBOX_PLACEMENT_TESTS_BY_MAILBOX_PROVIDER_FAIL':
       return { ...state, getByProviderPending: false, getByProviderError: payload };
 
     case 'GET_INBOX_PLACEMENT_TESTS_BY_REGION_PENDING':
       return { ...state, getByRegionPending: true, getByRegionError: null };
     case 'GET_INBOX_PLACEMENT_TESTS_BY_REGION_SUCCESS':
-      return { ...state, getByRegionPending: false, placementsByRegion: payload, getByRegionError: null };
+      return {
+        ...state,
+        getByRegionPending: false,
+        placementsByRegion: payload,
+        getByRegionError: null,
+      };
     case 'GET_INBOX_PLACEMENT_TESTS_BY_REGION_FAIL':
       return { ...state, getByRegionPending: false, getByRegionError: payload };
 
     case 'GET_INBOX_PLACEMENT_TESTS_BY_SENDING_IP_PENDING':
       return { ...state, getBySendingIpPending: true, getBySendingIpError: null };
     case 'GET_INBOX_PLACEMENT_TESTS_BY_SENDING_IP_SUCCESS':
-      return { ...state, getBySendingIpPending: false, placementsBySendingIp: payload, getBySendingIpError: null };
+      return {
+        ...state,
+        getBySendingIpPending: false,
+        placementsBySendingIp: payload.filter(test => test.sending_ip), //Due to API bug some tests return null sending ip
+        getBySendingIpError: null,
+      };
     case 'GET_INBOX_PLACEMENT_TESTS_BY_SENDING_IP_FAIL':
       return { ...state, getBySendingIpPending: false, getBySendingIpError: payload };
 
     case 'GET_INBOX_PLACEMENT_TEST_CONTENT_PENDING':
       return { ...state, getTestContentPending: true, getTestContentError: null };
     case 'GET_INBOX_PLACEMENT_TEST_CONTENT_SUCCESS':
-      return { ...state, getTestContentPending: false, currentTestContent: payload, getTestContentError: null };
+      return {
+        ...state,
+        getTestContentPending: false,
+        currentTestContent: payload,
+        getTestContentError: null,
+      };
     case 'GET_INBOX_PLACEMENT_TEST_CONTENT_FAIL':
       return { ...state, getTestContentPending: false, getTestContentError: payload };
 
@@ -84,10 +104,15 @@ export default (state = initialState, { type, payload, meta }) => {
         allMessages: [],
         getAllMessagesError: null,
         getAllMessagesPending: true,
-        messagesById: {} // need to reset
+        messagesById: {}, // need to reset
       };
     case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_SUCCESS':
-      return { ...state, getAllMessagesPending: false, allMessages: payload, getAllMessagesError: null };
+      return {
+        ...state,
+        getAllMessagesPending: false,
+        allMessages: payload,
+        getAllMessagesError: null,
+      };
     case 'GET_ALL_INBOX_PLACEMENT_MESSAGES_FAIL':
       return { ...state, getAllMessagesPending: false, getAllMessagesError: payload };
 
@@ -100,9 +125,9 @@ export default (state = initialState, { type, payload, meta }) => {
         messagesById: {
           ...state.messagesById,
           [meta.context.messageId]: {
-            status: 'loading'
-          }
-        }
+            status: 'loading',
+          },
+        },
       };
 
     case 'GET_INBOX_PLACEMENT_MESSAGE_SUCCESS':
@@ -112,9 +137,9 @@ export default (state = initialState, { type, payload, meta }) => {
           ...state.messagesById,
           [meta.context.messageId]: {
             ...payload,
-            status: 'loaded'
-          }
-        }
+            status: 'loaded',
+          },
+        },
       };
 
     case 'GET_INBOX_PLACEMENT_MESSAGE_FAIL':
@@ -123,9 +148,9 @@ export default (state = initialState, { type, payload, meta }) => {
         messagesById: {
           ...state.messagesById,
           [meta.context.messageId]: {
-            status: 'error'
-          }
-        }
+            status: 'error',
+          },
+        },
       };
 
     default:


### PR DESCRIPTION
Note: Give your PR a short title. Something like "_TICKET NUMBER: feature description_" is good.

### What Changed
 - Added Sending- IP as an option in the dropdown + related tests
 - Added formatting to display Sending IP in the table
 - Random prettier changes

### How To Test
 - Go to `/inbox-placement`. Click on a test. On the details page, use the dropdown to change the selector from `mailbox provider` to `sending ip`.
