### PR TITLE
TR-2017: Unable to save and publish changes to template options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,13 @@
     "jest": true
   },
   "rules": {
+    // doesn't work with jest-in-case
+    "jest/no-standalone-expect": "off",
+
     "lodash/chaining": ["error", "never"],
+
+    // allow `import debounce from 'lodash/debounce';` for easy mocking
+    "lodash/import-scope": "off",
 
     // All of the following "lodash/*" rules are lodash's "Preference over Native"
     // We prefer native functions over lodash in most cases to reduce proneness to

--- a/src/pages/templates/components/SendTestEmailButton.js
+++ b/src/pages/templates/components/SendTestEmailButton.js
@@ -1,11 +1,6 @@
 /* eslint-disable max-lines */
 import React, { useState } from 'react';
-import {
-  Button,
-  Panel,
-  Modal,
-  TextField
-} from '@sparkpost/matchbox';
+import { Button, Panel, Modal, TextField } from '@sparkpost/matchbox';
 import PanelLoading from 'src/components/panelLoading';
 import ButtonWrapper from 'src/components/buttonWrapper';
 import MultiEmailField, { useMultiEmailField } from 'src/components/multiEmailField';
@@ -15,14 +10,13 @@ const SendTestEmailButton = () => {
   const {
     content,
     isPublishedMode,
-    match,
     sendPreview,
     template,
     showAlert,
     setTestDataAction,
     parsedTestData,
     updateDraft,
-    setHasSaved
+    setHasSaved,
   } = useEditorContext();
   const {
     handleMultiEmailChange,
@@ -33,10 +27,8 @@ const SendTestEmailButton = () => {
     setMultiEmailList,
     multiEmailValue,
     multiEmailList,
-    multiEmailError
+    multiEmailError,
   } = useMultiEmailField();
-  const templateId = match.params.id;
-  const subaccountId = template.subaccount_id;
   const [isModalOpen, setModalOpen] = useState(false);
   const [isModalLoading, setModalLoading] = useState(false);
   const [fromEmail, setFromEmail] = useState('');
@@ -57,15 +49,21 @@ const SendTestEmailButton = () => {
 
       // Save the template, then allow the user to send a preview
       // The preview can be send whether the current draft was successfully saved or not.
-      updateDraft({
-        id: templateId,
-        content,
-        parsedTestData
-      }, subaccountId)
-        .then(() => {
-          setModalLoading(false);
-          setHasSaved(true);
-        });
+      updateDraft(
+        {
+          id: template.id,
+          name: template.name,
+          description: template.description,
+          content,
+          options: template.options,
+          shared_with_subaccounts: template.shared_with_subaccounts,
+          parsedTestData,
+        },
+        template.subaccount_id,
+      ).then(() => {
+        setModalLoading(false);
+        setHasSaved(true);
+      });
     }
 
     if (isPublishedMode) {
@@ -83,7 +81,7 @@ const SendTestEmailButton = () => {
     setMultiEmailError('');
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = e => {
     e.preventDefault();
 
     if (multiEmailList.length === 0) {
@@ -95,11 +93,11 @@ const SendTestEmailButton = () => {
     setModalLoading(true);
 
     sendPreview({
-      id: templateId,
-      subaccountId: subaccountId,
+      id: template.id,
+      subaccountId: template.subaccount_id,
       mode: isPublishedMode ? 'published' : 'draft',
-      emails: multiEmailList.map((item) => item.email),
-      from: fromEmail
+      emails: multiEmailList.map(item => item.email),
+      from: fromEmail,
     })
       .then(() => {
         setModalLoading(false); // Seems repetitive, but prevents janky loading state from continuing even after success
@@ -108,7 +106,7 @@ const SendTestEmailButton = () => {
 
         showAlert({
           type: 'success',
-          message: 'Successfully sent a test email'
+          message: 'Successfully sent a test email',
         });
       })
       .finally(() => setModalLoading(false));
@@ -133,14 +131,10 @@ const SendTestEmailButton = () => {
         onClose={handleModalClose}
         data-id="send-test-email-modal"
       >
-        {isModalLoading && <PanelLoading/>}
+        {isModalLoading && <PanelLoading />}
 
-        {!isModalLoading &&
-          <Panel
-            accent
-            title="Send a Test"
-            sectioned
-          >
+        {!isModalLoading && (
+          <Panel accent title="Send a Test" sectioned>
             <p>Verify your email renders as expected in the inbox by sending a quick test.</p>
 
             <form onSubmit={handleSubmit}>
@@ -148,8 +142,8 @@ const SendTestEmailButton = () => {
                 id="multi-email-email-to"
                 label="To"
                 name="emailTo"
-                onChange={(e) => handleMultiEmailChange(e)}
-                onKeyDownAndBlur={(e) => handleMultiEmailKeyDownAndBlur(e)}
+                onChange={e => handleMultiEmailChange(e)}
+                onKeyDownAndBlur={e => handleMultiEmailKeyDownAndBlur(e)}
                 onRemoveEmail={handleMultiEmailRemove}
                 error={multiEmailError}
                 value={multiEmailValue}
@@ -177,17 +171,13 @@ const SendTestEmailButton = () => {
               />
 
               <ButtonWrapper>
-                <Button
-                  color="orange"
-                  type="submit"
-                  data-id="button-send-email"
-                >
+                <Button color="orange" type="submit" data-id="button-send-email">
                   Send Email
                 </Button>
               </ButtonWrapper>
             </form>
           </Panel>
-        }
+        )}
       </Modal>
     </>
   );

--- a/src/pages/templates/components/SendTestEmailButton.js
+++ b/src/pages/templates/components/SendTestEmailButton.js
@@ -68,9 +68,9 @@ const SendTestEmailButton = () => {
 
     if (isPublishedMode) {
       setTestDataAction({
-        id: templateId,
+        id: template.id,
         mode: 'published',
-        data: parsedTestData
+        data: parsedTestData,
       });
     }
   };

--- a/src/pages/templates/components/editorActions/SaveAndPublishConfirmationModal.js
+++ b/src/pages/templates/components/editorActions/SaveAndPublishConfirmationModal.js
@@ -5,7 +5,7 @@ import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { RedirectAndAlert } from 'src/components/globalAlert';
 import useEditorContext from '../../hooks/useEditorContext';
 
-const SaveAndPublishConfirmationModal = (props) => {
+const SaveAndPublishConfirmationModal = props => {
   const { open, onCancel } = props;
   const {
     draft,
@@ -13,41 +13,54 @@ const SaveAndPublishConfirmationModal = (props) => {
     parsedTestData,
     isDraftPublishing,
     setHasSaved,
-    publishDraft
+    publishDraft,
   } = useEditorContext();
   const [hasSuccessRedirect, setSuccessRedirect] = useState(false);
 
   const handleConfirm = () => {
-    publishDraft({
-      id: draft.id,
-      content,
-      parsedTestData
-    }, draft.subaccount_id)
-      .then(() => {
-        setHasSaved(true);
-        setSuccessRedirect(true);
-      });
+    publishDraft(
+      {
+        id: draft.id,
+        name: draft.name,
+        description: draft.description,
+        content,
+        options: draft.options,
+        shared_with_subaccounts: draft.shared_with_subaccounts,
+        parsedTestData,
+      },
+      draft.subaccount_id,
+    ).then(() => {
+      setHasSaved(true);
+      setSuccessRedirect(true);
+    });
   };
 
   return (
     <>
-      {hasSuccessRedirect &&
+      {hasSuccessRedirect && (
         <RedirectAndAlert
-          to={`/${routeNamespace}/edit/${draft.id}/published/content${setSubaccountQuery(draft.subaccount_id)}`}
+          to={`/${routeNamespace}/edit/${draft.id}/published/content${setSubaccountQuery(
+            draft.subaccount_id,
+          )}`}
           alert={{
             type: 'success',
-            message: 'Template published'
+            message: 'Template published',
           }}
         />
-      }
+      )}
 
       <ConfirmationModal
-        title='Are you sure you want to publish your template?'
-        content={<p>Once published, your template will be available for use in email campaigns and A/B tests.</p>}
+        title="Are you sure you want to publish your template?"
+        content={
+          <p>
+            Once published, your template will be available for use in email campaigns and A/B
+            tests.
+          </p>
+        }
         confirming={isDraftPublishing}
         isPending={isDraftPublishing}
         open={open}
-        confirmVerb='Save and Publish'
+        confirmVerb="Save and Publish"
         onCancel={onCancel}
         onConfirm={handleConfirm}
       />
@@ -56,4 +69,3 @@ const SaveAndPublishConfirmationModal = (props) => {
 };
 
 export default SaveAndPublishConfirmationModal;
-

--- a/src/pages/templates/components/editorActions/SaveDraft.js
+++ b/src/pages/templates/components/editorActions/SaveDraft.js
@@ -3,7 +3,7 @@ import { FileEdit } from '@sparkpost/matchbox-icons';
 import useEditorContext from '../../hooks/useEditorContext';
 import { UnstyledLink } from '@sparkpost/matchbox';
 
-const SaveDraft = (props) => {
+const SaveDraft = props => {
   const { className, onClick } = props;
   const {
     draft,
@@ -11,7 +11,7 @@ const SaveDraft = (props) => {
     updateDraft,
     showAlert,
     setHasSaved,
-    parsedTestData
+    parsedTestData,
   } = useEditorContext();
 
   const handleClick = useCallback(() => {
@@ -19,19 +19,21 @@ const SaveDraft = (props) => {
       onClick();
     }
 
-    updateDraft({
-      id: draft.id,
-      content,
-      parsedTestData
-    }, draft.subaccount_id)
-      .then(() => {
-        showAlert({
-          type: 'success',
-          message: 'Draft saved'
-        });
-
-        setHasSaved(true);
-      });
+    updateDraft(
+      {
+        id: draft.id,
+        name: draft.name,
+        description: draft.description,
+        content,
+        options: draft.options,
+        shared_with_subaccounts: draft.shared_with_subaccounts,
+        parsedTestData,
+      },
+      draft.subaccount_id,
+    ).then(() => {
+      showAlert({ type: 'success', message: 'Draft saved' });
+      setHasSaved(true);
+    });
   });
 
   return (
@@ -42,7 +44,7 @@ const SaveDraft = (props) => {
         role="button"
         data-id="action-save-draft"
       >
-        <FileEdit/>
+        <FileEdit />
 
         <span>Save Draft</span>
       </UnstyledLink>

--- a/src/pages/templates/components/settings/SettingsForm.js
+++ b/src/pages/templates/components/settings/SettingsForm.js
@@ -31,7 +31,7 @@ export default class SettingsForm extends React.Component {
         content: { ...values.content, amp_html, html, text },
         options: values.options,
         // this value is only editable and present when template is not assigned to a subaccount
-        shared_with_subaccounts: draft.subaccount_id ? false : values.shared_with_subaccounts,
+        shared_with_subaccounts: draft.subaccount_id ? undefined : values.shared_with_subaccounts,
         parsedTestData,
       },
       draft.subaccount_id, // not in form and not allowed to change

--- a/src/pages/templates/components/settings/SettingsForm.js
+++ b/src/pages/templates/components/settings/SettingsForm.js
@@ -12,39 +12,49 @@ import styles from './SettingsForm.module.scss';
 import { emailOrSubstitution } from '../validation';
 
 export default class SettingsForm extends React.Component {
-  updateSettings = (values = {}) => {
+  updateSettings = values => {
     const {
       draft,
       updateDraft,
       parsedTestData,
       showAlert,
-      content,
-      setHasSaved
+      content: { amp_html, html, text },
+      setHasSaved,
     } = this.props;
 
-    const { subject: _subject, from: _from, reply_to: _reply_to, ...rest } = content; //content object has updated values for html, text etc, provided by useEditorContext
-    const subaccountId = draft.subaccount_id;
-    values.content = { ...values.content , ...rest };
-
-    return updateDraft({
-      id: draft.id,
-      parsedTestData,
-      ...values
-    }, subaccountId)
-      .then(() => {
-        setHasSaved(true);
-        showAlert({ type: 'success', message: 'Template settings updated.' });
-      });
+    return updateDraft(
+      {
+        id: draft.id,
+        name: values.name,
+        description: values.description,
+        // must include other content parts to avoid work in progress
+        content: { ...values.content, amp_html, html, text },
+        options: values.options,
+        // this value is only editable and present when template is not assigned to a subaccount
+        shared_with_subaccounts: draft.subaccount_id ? false : values.shared_with_subaccounts,
+        parsedTestData,
+      },
+      draft.subaccount_id, // not in form and not allowed to change
+    ).then(() => {
+      setHasSaved(true);
+      showAlert({ type: 'success', message: 'Template settings updated.' });
+    });
   };
 
-  parseToggle = (value) => !!value;
+  parseToggle = value => !!value;
 
   renderPublishedIntro = () => {
     const { hasDraft } = this.props;
-    return (<Panel.Section>
-      <p className={styles.SettingsIntro}>{`Template settings can only be changed in drafts. Simply select '${hasDraft ? 'Edit Draft' : 'Save as Draft'}' in the top right to access the draft version, and adjust settings as needed.`}</p>
-    </Panel.Section>);
-  }
+    return (
+      <Panel.Section>
+        <p
+          className={styles.SettingsIntro}
+        >{`Template settings can only be changed in drafts. Simply select '${
+          hasDraft ? 'Edit Draft' : 'Save as Draft'
+        }' in the top right to access the draft version, and adjust settings as needed.`}</p>
+      </Panel.Section>
+    );
+  };
   render() {
     const {
       handleSubmit,
@@ -57,119 +67,131 @@ export default class SettingsForm extends React.Component {
       hasSubaccounts,
       canViewSubaccount,
       isPublishedMode,
-      draft
+      draft,
     } = this.props;
 
     const canViewSubaccountSection = hasSubaccounts && canViewSubaccount;
-    const fromEmailHelpText = !domainsLoading && !domains.length ? (subaccountId ? 'The selected subaccount does not have any verified sending domains.' : 'You do not have any verified sending domains to use.') : null;
+    const fromEmailHelpText =
+      !domainsLoading && !domains.length
+        ? subaccountId
+          ? 'The selected subaccount does not have any verified sending domains.'
+          : 'You do not have any verified sending domains to use.'
+        : null;
 
-    return (<>
-      {isPublishedMode && this.renderPublishedIntro()}
-      <form onSubmit={handleSubmit(this.updateSettings)}>
-        <Panel.Section>
-          <Field
-            name='name'
-            component={TextFieldWrapper}
-            label='Template Name'
-            disabled={submitting || isPublishedMode}
-            validate={required}
-          />
+    return (
+      <>
+        {isPublishedMode && this.renderPublishedIntro()}
+        <form onSubmit={handleSubmit(this.updateSettings)}>
+          <Panel.Section>
+            <Field
+              name="name"
+              component={TextFieldWrapper}
+              label="Template Name"
+              disabled={submitting || isPublishedMode}
+              validate={required}
+            />
 
-          <CopyField
-            name='id'
-            id='template-id-field'
-            label='Template ID'
-            value={draft.id}
-            helpText={'A Unique ID for your template, we\'ll fill this in for you.'}
-            disabled={true}
-          />
-        </Panel.Section>
-        {canViewSubaccountSection && <SubaccountSection newTemplate={false} disabled={submitting || isPublishedMode}/>}
-        <Panel.Section>
-          <Field
-            name='content.subject'
-            component={TextFieldWrapper}
-            label='Subject'
-            validate={required}
-            disabled={submitting || isPublishedMode}
-          />
+            <CopyField
+              name="id"
+              id="template-id-field"
+              label="Template ID"
+              value={draft.id}
+              helpText={"A Unique ID for your template, we'll fill this in for you."}
+              disabled={true}
+            />
+          </Panel.Section>
+          {canViewSubaccountSection && (
+            <SubaccountSection newTemplate={false} disabled={submitting || isPublishedMode} />
+          )}
+          <Panel.Section>
+            <Field
+              name="content.subject"
+              component={TextFieldWrapper}
+              label="Subject"
+              validate={required}
+              disabled={submitting || isPublishedMode}
+            />
 
-          <Field
-            name='content.from.email'
-            component={FromEmailWrapper}
-            placeholder='example@email.com'
-            label='From Email'
-            validate={[required, emailOrSubstitution]}
-            domains={domains}
-            helpText={fromEmailHelpText}
-            disabled={submitting || isPublishedMode}
-          />
+            <Field
+              name="content.from.email"
+              component={FromEmailWrapper}
+              placeholder="example@email.com"
+              label="From Email"
+              validate={[required, emailOrSubstitution]}
+              domains={domains}
+              helpText={fromEmailHelpText}
+              disabled={submitting || isPublishedMode}
+            />
 
-          <Field
-            name='content.from.name'
-            component={TextFieldWrapper}
-            label='From Name'
-            helpText='A friendly from for your recipients.'
-            disabled={submitting || isPublishedMode}
-          />
+            <Field
+              name="content.from.name"
+              component={TextFieldWrapper}
+              label="From Name"
+              helpText="A friendly from for your recipients."
+              disabled={submitting || isPublishedMode}
+            />
 
-          <Field
-            name='content.reply_to'
-            component={TextFieldWrapper}
-            label='Reply To'
-            helpText='An email address recipients can reply to.'
-            validate={emailOrSubstitution}
-            disabled={submitting || isPublishedMode}
-          />
+            <Field
+              name="content.reply_to"
+              component={TextFieldWrapper}
+              label="Reply To"
+              helpText="An email address recipients can reply to."
+              validate={emailOrSubstitution}
+              disabled={submitting || isPublishedMode}
+            />
 
-          <Field
-            name='description'
-            component={TextFieldWrapper}
-            label='Description'
-            helpText='Not visible to recipients.'
-            disabled={submitting || isPublishedMode}
-          />
-        </Panel.Section>
-        <Panel.Section>
-          <Field
-            name='options.open_tracking'
-            component={ToggleBlock}
-            label='Track Opens'
-            type='checkbox'
-            parse={this.parseToggle}
-            disabled={submitting || isPublishedMode}
-          />
+            <Field
+              name="description"
+              component={TextFieldWrapper}
+              label="Description"
+              helpText="Not visible to recipients."
+              disabled={submitting || isPublishedMode}
+            />
+          </Panel.Section>
+          <Panel.Section>
+            <Field
+              name="options.open_tracking"
+              component={ToggleBlock}
+              label="Track Opens"
+              type="checkbox"
+              parse={this.parseToggle}
+              disabled={submitting || isPublishedMode}
+            />
 
-          <Field
-            name='options.click_tracking'
-            component={ToggleBlock}
-            label='Track Clicks'
-            type='checkbox'
-            parse={this.parseToggle}
-            disabled={submitting || isPublishedMode}
-          />
-          <Field
-            name='options.transactional'
-            component={ToggleBlock}
-            label='Transactional'
-            type='checkbox'
-            parse={this.parseToggle}
-            helpText={<p className={styles.HelpText}>Transactional messages are triggered by a user’s actions on the
-              website, like requesting a password reset, signing up, or making a purchase.</p>}
-            disabled={submitting || isPublishedMode}
-
-          />
-        </Panel.Section>
-        <Panel.Section>
-          <Button
-            type='submit'
-            primary
-            disabled={submitting || !valid || pristine || isPublishedMode}
-          >
-            Update Settings
-          </Button>
-        </Panel.Section>
-      </form>
-    </>);
+            <Field
+              name="options.click_tracking"
+              component={ToggleBlock}
+              label="Track Clicks"
+              type="checkbox"
+              parse={this.parseToggle}
+              disabled={submitting || isPublishedMode}
+            />
+            <Field
+              name="options.transactional"
+              component={ToggleBlock}
+              label="Transactional"
+              type="checkbox"
+              parse={this.parseToggle}
+              helpText={
+                <p className={styles.HelpText}>
+                  Transactional messages are triggered by a user’s actions on the website, like
+                  requesting a password reset, signing up, or making a purchase.
+                </p>
+              }
+              disabled={submitting || isPublishedMode}
+            />
+          </Panel.Section>
+          <Panel.Section>
+            <Button
+              type="submit"
+              primary
+              disabled={submitting || !valid || pristine || isPublishedMode}
+            >
+              Update Settings
+            </Button>
+          </Panel.Section>
+        </form>
+      </>
+    );
   }
 }

--- a/src/pages/templates/components/settings/tests/SettingsForm.test.js
+++ b/src/pages/templates/components/settings/tests/SettingsForm.test.js
@@ -1,32 +1,31 @@
 import { shallow } from 'enzyme';
 import React from 'react';
+import cases from 'jest-in-case';
 import every from 'lodash/every';
 import SettingsForm from '../SettingsForm';
 
 describe('SettingsForm', () => {
-  const subject = (props) => {
+  const subject = props => {
     const defaultProps = {
-      domains: [
-        { domain: 'test.com' },
-        { domain: 'verified.com' }
-      ],
+      domains: [{ domain: 'test.com' }, { domain: 'verified.com' }],
       draft: {
-        id: 'fake-id'
+        id: 'fake-id',
       },
       domainsLoading: false,
       hasSubaccounts: false,
       canViewSubaccount: false,
       content: {
         html: '<p>Hello</p>',
-        text: ''
+        text: '',
       },
       values: {
-        content: {}
+        content: {},
+        name: 'Test Template',
       },
       isPublishedMode: false,
-      handleSubmit: jest.fn((func) => func),
+      handleSubmit: jest.fn(func => func),
       showAlert: jest.fn(),
-      setHasSaved: jest.fn()
+      setHasSaved: jest.fn(),
     };
 
     return shallow(<SettingsForm {...defaultProps} {...props} />);
@@ -39,19 +38,23 @@ describe('SettingsForm', () => {
   });
 
   it('renders with subaccounts', () => {
-    expect(subject({ hasSubaccounts: true, canViewSubaccount: true }).exists('SubaccountSection')).toBe(true);
+    expect(
+      subject({ hasSubaccounts: true, canViewSubaccount: true }).exists('SubaccountSection'),
+    ).toBe(true);
   });
 
   it('renders From Email help text with no verified domains', () => {
-    const wrapper = subject({ domains: []});
-    expect(wrapper.find('[name="content.from.email"]').prop('helpText'))
-      .toEqual('You do not have any verified sending domains to use.');
+    const wrapper = subject({ domains: [] });
+    expect(wrapper.find('[name="content.from.email"]').prop('helpText')).toEqual(
+      'You do not have any verified sending domains to use.',
+    );
   });
 
   it('renders From Email help text with no verified domains for subaccount', () => {
-    const wrapper = subject({ subaccountId: 101, domains: []});
-    expect(wrapper.find('[name="content.from.email"]').prop('helpText'))
-      .toEqual('The selected subaccount does not have any verified sending domains.');
+    const wrapper = subject({ subaccountId: 101, domains: [] });
+    expect(wrapper.find('[name="content.from.email"]').prop('helpText')).toEqual(
+      'The selected subaccount does not have any verified sending domains.',
+    );
   });
 
   it('renders id field disabled and leverages the CopyField component', () => {
@@ -63,8 +66,12 @@ describe('SettingsForm', () => {
 
   describe('Published version', () => {
     it('renders with fields disabled', () => {
-      const wrapper = subject({ hasSubaccounts: true, canViewSubaccount: true, isPublishedMode: true });
-      const fieldProps = wrapper.find('Field').map((field) => field.prop('disabled'));
+      const wrapper = subject({
+        hasSubaccounts: true,
+        canViewSubaccount: true,
+        isPublishedMode: true,
+      });
+      const fieldProps = wrapper.find('Field').map(field => field.prop('disabled'));
       expect(fieldProps.length).toEqual(9);
       expect(every(fieldProps)).toBe(true);
       expect(wrapper.find('SubaccountSection').prop('disabled')).toBe(true);
@@ -72,11 +79,15 @@ describe('SettingsForm', () => {
     });
 
     it('renders settings intro when draft does not exist', () => {
-      expect(subject({ hasDraft: false, isPublishedMode: true }).find('[className="SettingsIntro"]')).toMatchSnapshot();
+      expect(
+        subject({ hasDraft: false, isPublishedMode: true }).find('[className="SettingsIntro"]'),
+      ).toMatchSnapshot();
     });
 
     it('renders settings intro when draft exists', () => {
-      expect(subject({ hasDraft: true, isPublishedMode: true }).find('[className="SettingsIntro"]')).toMatchSnapshot();
+      expect(
+        subject({ hasDraft: true, isPublishedMode: true }).find('[className="SettingsIntro"]'),
+      ).toMatchSnapshot();
     });
   });
 
@@ -90,70 +101,111 @@ describe('SettingsForm', () => {
     });
   });
 
-  describe('form submission', () => {
-    it('renders submit button disabled', () => {
-      const buttonSelector = 'Button[type="submit"]';
-
-      expect(subject({
-        submitting: false,
-        valid: false,
-        pristine: true
-      }).find(buttonSelector).prop('disabled')).toBe(true);
-      expect(subject({
-        submitting: false,
-        valid: false,
-        pristine: false
-      }).find(buttonSelector).prop('disabled')).toBe(true);
-      expect(subject({
+  cases(
+    'disables submit button',
+    ({ name, ...props }) => {
+      const wrapper = subject({ valid: true, ...props });
+      expect(wrapper.find('Button[type="submit"]')).toHaveProp('disabled', true);
+    },
+    {
+      'when submitting': {
         submitting: true,
-        valid: true,
-        pristine: false
-      }).find(buttonSelector).prop('disabled')).toBe(true);
-    });
+      },
+      'when pristine': {
+        pristine: true,
+      },
+      'when invalid': {
+        valid: false,
+      },
+      'when in publish mode': {
+        isPublishedMode: true,
+      },
+    },
+  );
 
-    it('updates settings', async () => {
-      const mockUpdateDraft = jest.fn(() => Promise.resolve());
-      const parsedTestData = {
-        some: 'data'
+  describe('when form is submitted', () => {
+    const submitForm = async (props = {}, values = {}) => {
+      const wrapper = subject({
+        parsedTestData: {
+          name: 'Bob Bell',
+        },
+        pristine: false,
+        setHasSaved: () => {},
+        showAlert: () => {},
+        updateDraft: () => Promise.resolve(),
+        valid: true,
+        ...props,
+      });
+
+      await wrapper.find('form').simulate('submit', {
+        description: '',
+        options: { click_tracking: true, open_tracking: true, transactional: true },
+        ...values,
+        content: { text: '', ...values.content },
+      });
+
+      return wrapper;
+    };
+
+    it('requests setting update', async () => {
+      const draft = { id: 'test-template' };
+      const content = { html: 'Hello {{name}}', text: 'Hello {{name}}' };
+      const values = {
+        name: 'Test Template',
+        description: 'This is only a test',
+        shared_with_subaccounts: true,
+        content: {
+          from: { email: 'bob@bell.com' },
+        },
       };
-      const mockAlert = jest.fn();
-      const mockSetHasSaved = jest.fn();
-      const wrapper = subject({
-        valid: true,
-        pristine: false,
-        updateDraft: mockUpdateDraft,
-        parsedTestData,
-        draft: { id: 'foo', subaccount_id: 123 },
-        showAlert: mockAlert,
-        setHasSaved: mockSetHasSaved
-      });
-      await wrapper.find('form').simulate('submit');
-      expect(mockUpdateDraft).toHaveBeenCalledWith({
-        id: 'foo',
-        parsedTestData,
-        content: {
-          'html': '<p>Hello</p>',
-          'text': ''
-        }}, 123);
-      expect(mockAlert).toHaveBeenCalledWith({ type: 'success', message: 'Template settings updated.' });
-      expect(mockSetHasSaved).toHaveBeenCalledWith(true);
+      const updateDraft = jest.fn(() => Promise.resolve());
+      await submitForm({ content, draft, updateDraft }, values);
+
+      expect(updateDraft).toHaveBeenCalledWith(
+        {
+          id: 'test-template',
+          name: 'Test Template',
+          description: 'This is only a test',
+          content: {
+            amp_html: undefined,
+            html: 'Hello {{name}}',
+            text: 'Hello {{name}}',
+            from: { email: 'bob@bell.com' },
+          },
+          options: { click_tracking: true, open_tracking: true, transactional: true },
+          shared_with_subaccounts: true,
+          parsedTestData: {
+            name: 'Bob Bell',
+          },
+        },
+        undefined,
+      );
     });
 
-    it('updates settings with subaccount', () => {
-      const mockUpdateDraft = jest.fn(() => Promise.resolve());
-      const wrapper = subject({
-        valid: true,
-        pristine: false,
-        updateDraft: mockUpdateDraft,
-        draft: { id: 'foo', subaccount_id: 123 }
+    it('requests setting update for template assinged to subaccount', async () => {
+      const draft = {
+        id: 'test-template-for-123',
+        subaccount_id: 123,
+      };
+      const updateDraft = jest.fn(() => Promise.resolve());
+      await submitForm({ draft, updateDraft });
+
+      expect(updateDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test-template-for-123',
+        }),
+        123,
+      );
+    });
+
+    it('alerts on success', async () => {
+      const showAlert = jest.fn();
+      await submitForm({ showAlert });
+
+      expect(showAlert).toHaveBeenCalledWith({
+        type: 'success',
+        message: 'Template settings updated.',
       });
-      wrapper.find('form').simulate('submit');
-      expect(mockUpdateDraft).toHaveBeenCalledWith({
-        id: 'foo',
-        content: {
-          'html': '<p>Hello</p>',
-          'text': ''
-        }}, 123);
     });
   });
 });

--- a/src/pages/templates/components/settings/tests/SettingsForm.test.js
+++ b/src/pages/templates/components/settings/tests/SettingsForm.test.js
@@ -193,6 +193,7 @@ describe('SettingsForm', () => {
       expect(updateDraft).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'test-template-for-123',
+          shared_with_subaccounts: undefined,
         }),
         123,
       );

--- a/src/pages/templates/components/settings/tests/SettingsForm.test.js
+++ b/src/pages/templates/components/settings/tests/SettingsForm.test.js
@@ -198,6 +198,13 @@ describe('SettingsForm', () => {
       );
     });
 
+    it('reports have has completed', async () => {
+      const setHasSaved = jest.fn();
+      await submitForm({ setHasSaved });
+
+      expect(setHasSaved).toHaveBeenCalledWith(true);
+    });
+
     it('alerts on success', async () => {
       const showAlert = jest.fn();
       await submitForm({ showAlert });

--- a/src/pages/templates/components/tests/SendTestEmailButton.test.js
+++ b/src/pages/templates/components/tests/SendTestEmailButton.test.js
@@ -11,33 +11,29 @@ describe('SendTestEmailButton', () => {
     useEditorContext.mockReturnValue({
       content: {
         from: {
-          email: 'nick@bounce.uat.sparkpost.com'
+          email: 'nick@bounce.uat.sparkpost.com',
         },
         subject: 'Mock Subject',
         text: 'Here is some text',
-        html: '<p>Here is some HTML'
-      },
-      match: {
-        params: {
-          id: '123456'
-        }
+        html: '<p>Here is some HTML',
       },
       template: {
-        subaccount_id: 123
+        id: '123456',
+        subaccount_id: 123,
       },
       isPublishedMode: false,
       updateDraft: jest.fn(() => Promise.resolve()),
       setHasSaved: jest.fn(),
-      ...editorState
+      ...editorState,
     });
 
-    return render(<SendTestEmailButton {...props}/>);
+    return render(<SendTestEmailButton {...props} />);
   };
 
   it('opens the modal in the loading state and saves the draft when the "Send a Test" button is clicked', () => {
     const mockUpdateDraft = jest.fn(() => Promise.resolve());
     const { getByText, queryByTestId } = subject({
-      updateDraft: mockUpdateDraft
+      updateDraft: mockUpdateDraft,
     });
 
     userEvent.click(getByText('Send a Test'));
@@ -50,7 +46,7 @@ describe('SendTestEmailButton', () => {
     const promise = Promise.resolve();
     const mockUpdateDraft = jest.fn(() => promise);
     const { queryByText, queryByLabelText, queryByTestId } = subject({
-      updateDraft: mockUpdateDraft
+      updateDraft: mockUpdateDraft,
     });
 
     userEvent.click(queryByText('Send a Test'));
@@ -89,15 +85,10 @@ describe('SendTestEmailButton', () => {
       const mockSendPreview = jest.fn(() => sendPreviewPromise);
       const mockUpdateDraft = jest.fn(() => updateDraftPromise);
       const mockShowAlert = jest.fn();
-      const {
-        getByText,
-        queryByText,
-        getByLabelText,
-        queryByTestId
-      } = subject({
+      const { getByText, queryByText, getByLabelText, queryByTestId } = subject({
         sendPreview: mockSendPreview,
         showAlert: mockShowAlert,
-        updateDraft: mockUpdateDraft
+        updateDraft: mockUpdateDraft,
       });
 
       userEvent.click(getByText('Send a Test'));
@@ -115,13 +106,13 @@ describe('SendTestEmailButton', () => {
           mode: 'draft',
           emails: ['toEmail@sparkpost.com'],
           from: 'nick@bounce.uat.sparkpost.com',
-          subaccountId: 123
+          subaccountId: 123,
         });
 
         return sendPreviewPromise.then(() => {
           expect(mockShowAlert).toHaveBeenCalledWith({
             type: 'success',
-            message: 'Successfully sent a test email'
+            message: 'Successfully sent a test email',
           });
         });
       });
@@ -133,14 +124,10 @@ describe('SendTestEmailButton', () => {
       const mockSendPreview = jest.fn(() => sendPreviewPromise);
       const mockUpdateDraft = jest.fn(() => updateDraftPromise);
       const mockShowAlert = jest.fn();
-      const {
-        getByText,
-        getByLabelText,
-        queryByTestId
-      } = subject({
+      const { getByText, getByLabelText, queryByTestId } = subject({
         sendPreview: mockSendPreview,
         showAlert: mockShowAlert,
-        updateDraft: mockUpdateDraft
+        updateDraft: mockUpdateDraft,
       });
 
       userEvent.click(getByText('Send a Test'));


### PR DESCRIPTION
### What Changed
 - The PUT request to save a template is made with all the template params instead of just content.

### How To Test
 - Open a draft template in the editor
 - Open the "template settings" tab
 - Modify any of the fields (easiest with click & open options)
 - Click "Save Settings" button
 - Click "Save as Draft" button
 - Refresh the page to confirm changes persisted