### PR TITLE
AC-1087 - "Let's Code" list for onboarding

### DIFF
--- a/src/pages/dashboard/components/FeaturesStepList.js
+++ b/src/pages/dashboard/components/FeaturesStepList.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Card, CardTitle, CardContent, CardActions } from 'src/components';
+import { Send } from '@sparkpost/matchbox-icons';
+import styles from './GettingStartedGuide.module.scss';
+import ButtonWrapper from 'src/components/buttonWrapper';
+import { Button, Grid } from '@sparkpost/matchbox';
+
+const FeaturesStepList = ({ setAndStoreStepName }) => (
+  <Grid>
+    <Grid.Column xs={12} key={`Start Sending`}>
+      <Card>
+        <CardTitle>
+          <Send size="20" className={styles.SendIcon} /> &nbsp;{`Sending with Sparkpost`}
+        </CardTitle>
+        <CardContent>
+          <p className={styles.FeaturesCardContent}>
+            Learn how to send emails, integrate our API into your code, and make the most of our
+            powerful analytics.
+          </p>
+        </CardContent>
+        <CardActions>
+          <ButtonWrapper>
+            <Button color="orange" onClick={() => setAndStoreStepName('Sending')}>
+              Start Sending
+            </Button>
+          </ButtonWrapper>
+        </CardActions>
+      </Card>
+    </Grid.Column>
+  </Grid>
+);
+
+export default FeaturesStepList;

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -1,13 +1,13 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Panel, Button, Grid } from '@sparkpost/matchbox';
-import { ArrowDownward, Send } from '@sparkpost/matchbox-icons';
-import { Card, CardTitle, CardContent, CardActions } from 'src/components';
-import ButtonWrapper from 'src/components/buttonWrapper';
+import { Panel } from '@sparkpost/matchbox';
+import { ArrowDownward } from '@sparkpost/matchbox-icons';
 import styles from './GettingStartedGuide.module.scss';
 import { BreadCrumbs, BreadCrumbsItem } from 'src/components';
 import { GuideListItem, GuideListItemTitle, GuideListItemDescription } from './GuideListItem';
-import { GUIDE_IDS, BREADCRUMB_ITEMS } from '../constants';
+import { GUIDE_IDS, LETS_CODE_LIST, SHOW_ME_SPARKPOST_LIST, BREADCRUMB_ITEMS } from '../constants';
 import { UnstyledLink } from '@sparkpost/matchbox';
+import SendingStepList from './SendingStepList';
+import FeatureStepList from './FeaturesStepList';
 
 export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption }) => {
   const {
@@ -91,28 +91,7 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
         return (
           <Panel.Section>
             {renderBreadCrumbs()}
-            <Grid>
-              <Grid.Column xs={12}>
-                <Card>
-                  <CardTitle>
-                    <Send size="20" className={styles.SendIcon} /> &nbsp;{`Sending with Sparkpost`}
-                  </CardTitle>
-                  <CardContent>
-                    <p className={styles.FeaturesCardContent}>
-                      Learn how to send emails, integrate our API into your code, and make the most
-                      of our powerful analytics.
-                    </p>
-                  </CardContent>
-                  <CardActions>
-                    <ButtonWrapper>
-                      <Button color="orange" onClick={() => setAndStoreStepName('Sending')}>
-                        Start Sending
-                      </Button>
-                    </ButtonWrapper>
-                  </CardActions>
-                </Card>
-              </Grid.Column>
-            </Grid>
+            <FeatureStepList setAndStoreStepName={setAndStoreStepName} />
           </Panel.Section>
         );
 
@@ -129,84 +108,25 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
             >
               Where Would You Like to Begin?
             </p>
-            <Grid>
-              <Grid.Column xs={12} md={6}>
-                <Card textAlign="center">
-                  <CardContent>
-                    <p className={styles.FeaturesCardContent}>
-                      {`Send your first email in one click and dive right into what SparkPost can do
-                      for your email strategy`}
-                    </p>
-                  </CardContent>
-                  <CardActions>
-                    <ButtonWrapper>
-                      <Button
-                        color="orange"
-                        onClick={() => setAndStoreStepName('Show Me SparkPost')}
-                        className={styles.SendingStepButtons}
-                      >
-                        Show Me SparkPost
-                      </Button>
-                    </ButtonWrapper>
-                  </CardActions>
-                </Card>
-              </Grid.Column>
-              <Grid.Column xs={12} md={6}>
-                <Card textAlign="center">
-                  <CardContent>
-                    <p className={styles.FeaturesCardContent}>
-                      Ready to integrate via SMTP or API? We'll get you set up ASAP so you can start
-                      building with SparkPost
-                    </p>
-                  </CardContent>
-                  <CardActions>
-                    <ButtonWrapper>
-                      <Button
-                        color="orange"
-                        onClick={() => setAndStoreStepName("Let's Code")}
-                        className={styles.SendingStepButtons}
-                      >
-                        Let's Code
-                      </Button>
-                    </ButtonWrapper>
-                  </CardActions>
-                </Card>
-              </Grid.Column>
-            </Grid>
+            <SendingStepList setAndStoreStepName={setAndStoreStepName} />
           </Panel.Section>
         );
+
       case 'Show Me SparkPost':
         return (
           <>
             <Panel.Section>
               {renderBreadCrumbs()}
-              <GuideListItem
-                action={{
-                  name: 'Send Test Email',
-                  onClick: () => handleAction('Send Test Email'),
-                }}
+              <CheckListItem
+                {...SHOW_ME_SPARKPOST_LIST['Send Test Email']}
                 itemCompleted={send_test_email_completed}
-              >
-                <GuideListItemTitle>Send a Test Email</GuideListItemTitle>
-                <GuideListItemDescription>
-                  Send a test email using our starter template.
-                </GuideListItemDescription>
-              </GuideListItem>
+              />
             </Panel.Section>
             <Panel.Section>
-              <GuideListItem
-                action={{
-                  name: 'Explore Analytics',
-                  onClick: () => handleAction('Explore Analytics'),
-                }}
+              <CheckListItem
+                {...SHOW_ME_SPARKPOST_LIST['Explore Analytics']}
                 itemCompleted={explore_analytics_completed}
-              >
-                <GuideListItemTitle>Explore Analytics</GuideListItemTitle>
-                <GuideListItemDescription>
-                  Get acquainted with our powerful analytics to make the most of your sending
-                  strategy.
-                </GuideListItemDescription>
-              </GuideListItem>
+              />
             </Panel.Section>
             <Panel.Section>
               <GuideListItem
@@ -241,26 +161,13 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
           <>
             <Panel.Section>
               {renderBreadCrumbs()}
-              <GuideListItem
-                action={{
-                  name: 'Add Sending Domain',
-                  onClick: () => handleAction('Add Sending Domain'),
-                }}
+              <CheckListItem
+                {...LETS_CODE_LIST['Add Sending Domain']}
                 itemCompleted={add_sending_domain_completed}
-              >
-                <GuideListItemTitle>Add a Sending Domain</GuideListItemTitle>
-                <GuideListItemDescription>
-                  You'll need to add a sending domain in order to start sending emails.
-                </GuideListItemDescription>
-              </GuideListItem>
+              />
             </Panel.Section>
             <Panel.Section>
-              <GuideListItem action={{ name: 'Generate API Key', onClick: () => {} }}>
-                <GuideListItemTitle>Generate an API Key</GuideListItemTitle>
-                <GuideListItemDescription>
-                  An API key is required to use our APIs within your app.
-                </GuideListItemDescription>
-              </GuideListItem>
+              <CheckListItem {...LETS_CODE_LIST['Generate API Key']} />
             </Panel.Section>
           </>
         );
@@ -268,6 +175,18 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
         return null;
     }
   };
+  const CheckListItem = ({ name, title, description, itemCompleted }) => (
+    <GuideListItem
+      action={{
+        name: name,
+        onClick: () => handleAction(name),
+      }}
+      itemCompleted={itemCompleted}
+    >
+      <GuideListItemTitle>{title}</GuideListItemTitle>
+      <GuideListItemDescription>{description}</GuideListItemDescription>
+    </GuideListItem>
+  );
   return (
     <Panel title="Getting Started" actions={actions}>
       {renderStep()}

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -85,6 +85,29 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
     }
   };
 
+  const getDescription = checklist_name => {
+    if (checklist_name === 'Invite a Collaborator')
+      return (
+        <>
+          {
+            'Need help integrating? Pass the ball on to someone else to finish setting up this account.'
+          }
+          <br />
+          {'Or you can '}
+          <UnstyledLink
+            onClick={() => {
+              setAndStoreStepName("Let's Code");
+              setOnboardingAccountOption({ invite_collaborator_completed: true });
+            }}
+          >
+            setup email sending now
+          </UnstyledLink>
+        </>
+      );
+
+    return null;
+  };
+
   const renderStep = () => {
     switch (stepName) {
       case 'Features':
@@ -129,30 +152,10 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
               />
             </Panel.Section>
             <Panel.Section>
-              <GuideListItem
-                action={{
-                  name: 'Invite a Collaborator',
-                  onClick: () => handleAction('Invite a Collaborator'),
-                }}
+              <CheckListItem
+                {...SHOW_ME_SPARKPOST_LIST['Invite a Collaborator']}
                 itemCompleted={invite_collaborator_completed}
-              >
-                <GuideListItemTitle>Invite Your Team</GuideListItemTitle>
-                <GuideListItemDescription>
-                  {
-                    'Need help integrating? Pass the ball on to someone else to finish setting up this account.'
-                  }
-                  <br />
-                  {'Or you can '}
-                  <UnstyledLink
-                    onClick={() => {
-                      setAndStoreStepName("Let's Code");
-                      setOnboardingAccountOption({ invite_collaborator_completed: true });
-                    }}
-                  >
-                    setup email sending now
-                  </UnstyledLink>
-                </GuideListItemDescription>
-              </GuideListItem>
+              />
             </Panel.Section>
           </>
         );
@@ -184,7 +187,7 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
       itemCompleted={itemCompleted}
     >
       <GuideListItemTitle>{title}</GuideListItemTitle>
-      <GuideListItemDescription>{description}</GuideListItemDescription>
+      <GuideListItemDescription>{getDescription(name) || description}</GuideListItemDescription>
     </GuideListItem>
   );
   return (

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -16,6 +16,7 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
     send_test_email_completed,
     explore_analytics_completed,
     invite_collaborator_completed,
+    add_sending_domain_completed,
   } = onboarding;
 
   const setOnboardingAccountOption = (obj = {}) => {
@@ -236,7 +237,33 @@ export const GettingStartedGuide = ({ onboarding = {}, history, setAccountOption
           </>
         );
       case "Let's Code":
-        return <Panel.Section>{renderBreadCrumbs()}</Panel.Section>;
+        return (
+          <>
+            <Panel.Section>
+              {renderBreadCrumbs()}
+              <GuideListItem
+                action={{
+                  name: 'Add Sending Domain',
+                  onClick: () => handleAction('Add Sending Domain'),
+                }}
+                itemCompleted={add_sending_domain_completed}
+              >
+                <GuideListItemTitle>Add a Sending Domain</GuideListItemTitle>
+                <GuideListItemDescription>
+                  You'll need to add a sending domain in order to start sending emails.
+                </GuideListItemDescription>
+              </GuideListItem>
+            </Panel.Section>
+            <Panel.Section>
+              <GuideListItem action={{ name: 'Generate API Key', onClick: () => {} }}>
+                <GuideListItemTitle>Generate an API Key</GuideListItemTitle>
+                <GuideListItemDescription>
+                  An API key is required to use our APIs within your app.
+                </GuideListItemDescription>
+              </GuideListItem>
+            </Panel.Section>
+          </>
+        );
       default:
         return null;
     }

--- a/src/pages/dashboard/components/SendingStepList.js
+++ b/src/pages/dashboard/components/SendingStepList.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Card, CardContent, CardActions } from 'src/components';
+import ButtonWrapper from 'src/components/buttonWrapper';
+import { Button, Grid } from '@sparkpost/matchbox';
+import styles from './GettingStartedGuide.module.scss';
+import { SENDING_STEP_LIST } from '../constants';
+
+const SendingStepListItem = ({ setAndStoreStepName, name, content }) => (
+  <Grid.Column xs={12} md={6} key={name}>
+    <Card textAlign="center">
+      <CardContent>
+        <p className={styles.FeaturesCardContent}>{content}</p>
+      </CardContent>
+      <CardActions>
+        <ButtonWrapper>
+          <Button
+            color="orange"
+            onClick={() => setAndStoreStepName(name)}
+            className={styles.SendingStepButtons}
+          >
+            {name}
+          </Button>
+        </ButtonWrapper>
+      </CardActions>
+    </Card>
+  </Grid.Column>
+);
+
+const SendingStepList = ({ setAndStoreStepName }) => (
+  <Grid>
+    <SendingStepListItem
+      setAndStoreStepName={setAndStoreStepName}
+      {...SENDING_STEP_LIST['Show Me SparkPost']}
+    />
+    <SendingStepListItem
+      setAndStoreStepName={setAndStoreStepName}
+      {...SENDING_STEP_LIST["Let's Code"]}
+    />
+  </Grid>
+);
+
+export default SendingStepList;

--- a/src/pages/dashboard/components/SendingStepList.js
+++ b/src/pages/dashboard/components/SendingStepList.js
@@ -5,7 +5,7 @@ import { Button, Grid } from '@sparkpost/matchbox';
 import styles from './GettingStartedGuide.module.scss';
 import { SENDING_STEP_LIST } from '../constants';
 
-const SendingStepListItem = ({ setAndStoreStepName, name, content }) => (
+export const SendingStepListItem = ({ setAndStoreStepName, name, content }) => (
   <Grid.Column xs={12} md={6} key={name}>
     <Card textAlign="center">
       <CardContent>

--- a/src/pages/dashboard/components/tests/FeatureStepList.test.js
+++ b/src/pages/dashboard/components/tests/FeatureStepList.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import FeaturesStepList from '../FeaturesStepList';
+
+describe('FeatureStepList', () => {
+  const defaultProps = {
+    setAndStoreStepName: jest.fn(),
+  };
+  const subject = (props, func = shallow) =>
+    func(<FeaturesStepList {...defaultProps} {...props} />);
+  it('should contain one Card', () => {
+    const instance = subject();
+    expect(instance.find('Card')).toHaveLength(1);
+  });
+  it('should call setAndStoreStepName when action button is clicked', () => {
+    const instance = subject();
+    instance.find('Button').simulate('click');
+    expect(defaultProps.setAndStoreStepName).toHaveBeenCalledWith('Sending');
+  });
+});

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -122,5 +122,10 @@ describe('GettingStartedGuide', () => {
     expect(defaultProps.setAccountOption).toHaveBeenCalledWith('onboarding', {
       invite_collaborator_completed: true,
     });
+  it("should render two list items when on step Let's Code ", () => {
+    const instance = subject();
+    instance.find('Button').simulate('click');
+    instance.find({ children: "Let's Code" }).simulate('click');
+    expect(instance.find('GuideListItem')).toHaveLength(2);
   });
 });

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -122,6 +122,7 @@ describe('GettingStartedGuide', () => {
     expect(defaultProps.setAccountOption).toHaveBeenCalledWith('onboarding', {
       invite_collaborator_completed: true,
     });
+  });
   it("should render two list items when on step Let's Code ", () => {
     const instance = subject();
     instance.find('Button').simulate('click');

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { GettingStartedGuide } from '../GettingStartedGuide';
 import { GUIDE_IDS } from '../../constants';
 
@@ -17,14 +17,8 @@ describe('GettingStartedGuide', () => {
     setAccountOption: jest.fn(),
   };
 
-  const subject = props => shallow(<GettingStartedGuide {...defaultProps} {...props} />);
-
-  const guideOnSecondStep = buttonName => {
-    const instance = subject();
-    instance.find('Button').simulate('click');
-    instance.find({ children: buttonName }).simulate('click');
-    return instance;
-  };
+  const subject = (props, func = shallow) =>
+    func(<GettingStartedGuide {...defaultProps} {...props} />);
 
   it('should render correctly when guide is at bottom or when guide is at top', () => {
     expect(
@@ -39,46 +33,27 @@ describe('GettingStartedGuide', () => {
     ).not.toBe(null);
   });
 
-  it('should render Sending Step when Start Sending Button is clicked', () => {
-    const instance = subject();
-    instance.find('Button').simulate('click');
-    expect(instance.find('Card')).toHaveLength(2);
-    expect(instance).toHaveTextContent('Show Me SparkPost');
-    expect(instance).toHaveTextContent('Let&#39;s Code');
-  });
-
-  it('should store the stepName when any CardAction Button is clicked', () => {
-    const instance = subject();
-    instance
-      .find('CardActions')
-      .find('Button')
-      .at(0)
-      .simulate('click');
-    expect(defaultProps.setAccountOption).toHaveBeenCalled();
-  });
-
   it('should render the corresponding step when breadcrumb is clicked', () => {
-    const instance = guideOnSecondStep('Show Me SparkPost');
+    const instance = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
     instance
       .find('BreadCrumbsItem')
       .at(1)
       .simulate('click');
-    expect(instance).toHaveTextContent('Show Me SparkPost');
-    expect(instance).toHaveTextContent('Let&#39;s Code');
+    expect(instance.find('SendingStepList')).toHaveLength(1);
   });
 
   it('should render the BreadCrumbItem as active corresponding to the Step', () => {
-    const instance = guideOnSecondStep('Show Me SparkPost');
+    const instance = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
     expect(instance.find({ active: true })).toHaveTextContent('Show Me SparkPost');
   });
 
   it('should render three list items when on step "Show Me SparkPost" ', () => {
-    const instance = guideOnSecondStep('Show Me SparkPost');
-    expect(instance.find('GuideListItem')).toHaveLength(3);
+    const instance = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
+    expect(instance.find('CheckListItem')).toHaveLength(3);
   });
 
   it('should navigate to templates page when Send a Test Email button is clicked', () => {
-    const instance = guideOnSecondStep('Show Me SparkPost');
+    const instance = subject({ onboarding: { active_step: 'Show Me SparkPost' } }, mount);
     instance
       .find('GuideListItem')
       .at(0)
@@ -103,7 +78,7 @@ describe('GettingStartedGuide', () => {
   });
 
   it('should navigate to users page when Invite a Collaborator is clicked', () => {
-    const instance = guideOnSecondStep('Show Me SparkPost');
+    const instance = subject({ onboarding: { active_step: 'Show Me SparkPost' } }, mount);
     instance
       .find('GuideListItem')
       .at(2)
@@ -113,7 +88,7 @@ describe('GettingStartedGuide', () => {
   });
 
   it('should mark Invite a Collaborator list item as completed when the the corresponding button is clicked', () => {
-    const instance = guideOnSecondStep('Show Me SparkPost');
+    const instance = subject({ onboarding: { active_step: 'Show Me SparkPost' } }, mount);
     instance
       .find('GuideListItem')
       .at(2)
@@ -123,10 +98,9 @@ describe('GettingStartedGuide', () => {
       invite_collaborator_completed: true,
     });
   });
+
   it("should render two list items when on step Let's Code ", () => {
-    const instance = subject();
-    instance.find('Button').simulate('click');
-    instance.find({ children: "Let's Code" }).simulate('click');
-    expect(instance.find('GuideListItem')).toHaveLength(2);
+    const instance = subject({ onboarding: { active_step: "Let's Code" } });
+    expect(instance.find('CheckListItem')).toHaveLength(2);
   });
 });

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -65,7 +65,7 @@ describe('GettingStartedGuide', () => {
   });
 
   it('should navigate to summary report when Exlplore Analytics button is clicked', () => {
-    const instance = guideOnSecondStep('Show Me SparkPost');
+    const instance = subject({ onboarding: { active_step: 'Show Me SparkPost' } }, mount);
 
     instance
       .find('GuideListItem')

--- a/src/pages/dashboard/components/tests/SendingStepList.test.js
+++ b/src/pages/dashboard/components/tests/SendingStepList.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SendingStepList, { SendingStepListItem } from '../SendingStepList';
+import { SENDING_STEP_LIST } from 'src/pages/dashboard/constants';
+
+describe('SendingStepList', () => {
+  const defaultProps = {
+    setAndStoreStepName: jest.fn(),
+  };
+
+  const subject = (props, func = shallow) => func(<SendingStepList {...defaultProps} {...props} />);
+
+  it('Sending Step contains two items', () => {
+    const instance = subject();
+    expect(instance.find('SendingStepListItem')).toHaveLength(2);
+  });
+});
+
+describe('SendingListItem', () => {
+  const defaultProps = {
+    setAndStoreStepName: jest.fn(),
+    ...SENDING_STEP_LIST['Show Me SparkPost'],
+  };
+
+  const subject = (props, func = shallow) =>
+    func(<SendingStepListItem {...defaultProps} {...props} />);
+
+  it('should call setAndStoreStepName when action button is clicked', () => {
+    const instance = subject();
+    instance.find('Button').simulate('click');
+    expect(defaultProps.setAndStoreStepName).toHaveBeenCalledWith(defaultProps.name);
+  });
+});

--- a/src/pages/dashboard/constants.js
+++ b/src/pages/dashboard/constants.js
@@ -47,4 +47,9 @@ export const SHOW_ME_SPARKPOST_LIST = {
     description:
       'Get acquainted with our powerful analytics to make the most of your sending strategy.',
   },
+  'Invite a Collaborator': {
+    name: 'Invite a Collaborator',
+    title: 'Invite Your Team',
+    description: '',
+  },
 };

--- a/src/pages/dashboard/constants.js
+++ b/src/pages/dashboard/constants.js
@@ -9,3 +9,42 @@ export const BREADCRUMB_ITEMS = {
   'Show Me SparkPost': ['Features', 'Sending', 'Show Me SparkPost'],
   "Let's Code": ['Features', 'Sending', "Let's Code"],
 };
+export const SENDING_STEP_LIST = {
+  'Show Me SparkPost': {
+    name: 'Show Me SparkPost',
+    content:
+      'Send your first email in one click and dive right into what SparkPost can do for your email strategy',
+  },
+  "Let's Code": {
+    name: "Let's Code",
+    content:
+      "Ready to integrate via SMTP or API? We'll get you set up ASAP so you can start building with SparkPost",
+  },
+};
+
+export const LETS_CODE_LIST = {
+  'Add Sending Domain': {
+    name: 'Add Sending Domain',
+    title: 'Add a Sending Domain',
+    description: "You'll need to add a sending domain in order to start sending emails.",
+  },
+  'Generate API Key': {
+    name: 'Generate API Key',
+    title: 'Generate an API Key',
+    description: 'An API key is required to use our APIs within your app.',
+  },
+};
+
+export const SHOW_ME_SPARKPOST_LIST = {
+  'Send Test Email': {
+    name: 'Send Test Email',
+    title: 'Send a Test Email',
+    description: 'Send a test email using our starter template.',
+  },
+  'Explore Analytics': {
+    name: 'Explore Analytics',
+    title: 'Explore Analytics',
+    description:
+      'Get acquainted with our powerful analytics to make the most of your sending strategy.',
+  },
+};


### PR DESCRIPTION
AC-1087 - "Let's Code" list for onboarding

### What Changed
 - Bread crumb includes "Let's Code"
 - List persists as the active list through session until switching off guide explicitly
 - mock - https://sparkpost.invisionapp.com/share/DHULLYL45GB#/screens/390961106

### How To Test
 - Enable messaging_onboarding ui flag.
 - Check if it matches the mock.

### To Do
- [ ] Address Feedback.
