### PR TITLE
FE-797 - Resolve React Testing Library matcher conflicts

### DIFF
--- a/config/jest/matchers/index.js
+++ b/config/jest/matchers/index.js
@@ -1,2 +1,23 @@
+// Some Testing Library matchers need to have an alias to prevent conflicts with Enzyme matchers
+export {
+  toBeDisabled,
+  toBeEnabled,
+  toBeEmpty,
+  toBeInTheDocument,
+  toBeInvalid,
+  toBeRequired,
+  toBeValid as RTLtoBeValid,
+  toBeVisible,
+  toContainElement,
+  toContainHTML,
+  toHaveAttribute,
+  toHaveClass,
+  toHaveFocus,
+  toHaveFormValues,
+  toHaveStyle,
+  toHaveTextContent as RTLtoHaveTextContent,
+  toHaveValue as RTLtoHaveValue,
+  toBeChecked,
+} from '@testing-library/jest-dom';
 export { default as toBeValid } from './toBeValid';
 export { default as toHaveTextContent } from './toHaveTextContent';

--- a/config/jest/matchers/index.js
+++ b/config/jest/matchers/index.js
@@ -1,3 +1,3 @@
-export { default as toBeValid } from './toBeValid';
+export { default as toBeValidMomentDate } from './toBeValidMomentDate';
 export { default as toHaveTextContent } from './toHaveTextContent';
 export { default as toHaveValue } from './toHaveValue';

--- a/config/jest/matchers/index.js
+++ b/config/jest/matchers/index.js
@@ -1,23 +1,3 @@
-// Some Testing Library matchers need to have an alias to prevent conflicts with Enzyme matchers
-export {
-  toBeDisabled,
-  toBeEnabled,
-  toBeEmpty,
-  toBeInTheDocument,
-  toBeInvalid,
-  toBeRequired,
-  toBeValid as RTLtoBeValid,
-  toBeVisible,
-  toContainElement,
-  toContainHTML,
-  toHaveAttribute,
-  toHaveClass,
-  toHaveFocus,
-  toHaveFormValues,
-  toHaveStyle,
-  toHaveTextContent as RTLtoHaveTextContent,
-  toHaveValue as RTLtoHaveValue,
-  toBeChecked,
-} from '@testing-library/jest-dom';
 export { default as toBeValid } from './toBeValid';
 export { default as toHaveTextContent } from './toHaveTextContent';
+export { default as toHaveValue } from './toHaveValue';

--- a/config/jest/matchers/toBeValid.js
+++ b/config/jest/matchers/toBeValid.js
@@ -1,5 +1,5 @@
 // This was created for Moment, but could be used for any object with a isValid method
-const toBeValid = (received) => {
+const toBeValid = received => {
   if (received && received.isValid && received.isValid()) {
     return {
       message: () => `expected ${received} not to be valid`,

--- a/config/jest/matchers/toBeValidMomentDate.js
+++ b/config/jest/matchers/toBeValidMomentDate.js
@@ -1,5 +1,5 @@
-// This was created for Moment, but could be used for any object with a isValid method
-const toBeValid = received => {
+// This was created for Moment, but could be used for any object with a [isValid](https://momentjs.com/docs/#/parsing/is-valid/) method
+const toBeValidMomentDate = received => {
   if (received && received.isValid && received.isValid()) {
     return {
       message: () => `expected ${received} not to be valid`,
@@ -13,4 +13,4 @@ const toBeValid = received => {
   };
 };
 
-export default toBeValid;
+export default toBeValidMomentDate;

--- a/config/jest/matchers/toHaveTextContent.js
+++ b/config/jest/matchers/toHaveTextContent.js
@@ -1,10 +1,15 @@
-const toHaveTextContent = (received, expectedContent) => {
-  const text = received.debug && received.debug();
+import { toHaveTextContent as testingLibraryToHaveTextContent } from '@testing-library/jest-dom';
 
-  return {
-    message: () => `expected component to have content "${expectedContent}"`,
-    pass: RegExp(expectedContent).test(text),
-  };
-};
+export default function toHaveTextContent(received, expectedContent) {
+  try {
+    // Using `.apply` necessary so that the Testing Library .toHaveValue had access to a valid value for `this`
+    testingLibraryToHaveTextContent.apply(this, [HTMLElement, expectedContent]);
+  } catch {
+    const text = received.debug && received.debug();
 
-export default toHaveTextContent;
+    return {
+      message: () => `expected component to have content "${expectedContent}"`,
+      pass: RegExp(expectedContent).test(text),
+    };
+  }
+}

--- a/config/jest/matchers/toHaveTextContent.js
+++ b/config/jest/matchers/toHaveTextContent.js
@@ -3,7 +3,7 @@ import { toHaveTextContent as testingLibraryToHaveTextContent } from '@testing-l
 export default function toHaveTextContent(received, expectedContent) {
   try {
     // Using `.apply` necessary so that the Testing Library .toHaveValue had access to a valid value for `this`
-    testingLibraryToHaveTextContent.apply(this, [HTMLElement, expectedContent]);
+    return testingLibraryToHaveTextContent.apply(this, [HTMLElement, expectedContent]);
   } catch {
     const text = received.debug && received.debug();
 

--- a/config/jest/matchers/toHaveTextContent.js
+++ b/config/jest/matchers/toHaveTextContent.js
@@ -3,7 +3,7 @@ const toHaveTextContent = (received, expectedContent) => {
 
   return {
     message: () => `expected component to have content "${expectedContent}"`,
-    pass: RegExp(expectedContent).test(text)
+    pass: RegExp(expectedContent).test(text),
   };
 };
 

--- a/config/jest/matchers/toHaveValue.js
+++ b/config/jest/matchers/toHaveValue.js
@@ -1,9 +1,14 @@
 import { toHaveValue as testingLibraryToHaveValue } from '@testing-library/jest-dom';
-import { toHaveValue as enzymeToHaveValue } from 'enzyme-matchers/lib/assertions/toHaveValue';
+import { toHaveValue as enzymeToHaveValue } from 'enzyme-matchers';
 
 export default function toHaveValue(element, expectedValue) {
   try {
-    return enzymeToHaveValue(element, expectedValue);
+    const { pass, message } = enzymeToHaveValue(element, expectedValue);
+
+    return {
+      pass,
+      message: () => message,
+    };
   } catch {
     // Using `.apply` necessary so that the Testing Library .toHaveValue had access to a valid value for `this`
     return testingLibraryToHaveValue.apply(this, [element, expectedValue]);

--- a/config/jest/matchers/toHaveValue.js
+++ b/config/jest/matchers/toHaveValue.js
@@ -2,15 +2,28 @@ import { toHaveValue as testingLibraryToHaveValue } from '@testing-library/jest-
 import { toHaveValue as enzymeToHaveValue } from 'enzyme-matchers';
 
 export default function toHaveValue(element, expectedValue) {
-  try {
+  const isEnzymeObject =
+    element &&
+    (element.constructor.name === 'ShallowWrapper' || element.constructor.name === 'ReactWrapper');
+  const isHTMLElement = element && element instanceof window.HTMLElement; // Based on testing library's implementation => https://github.com/testing-library/jest-dom/blob/master/src/utils.js#L53
+
+  if (isEnzymeObject) {
     const { pass, message } = enzymeToHaveValue(element, expectedValue);
 
     return {
       pass,
       message: () => message,
     };
-  } catch {
+  }
+
+  if (isHTMLElement) {
     // Using `.apply` necessary so that the Testing Library .toHaveValue had access to a valid value for `this`
     return testingLibraryToHaveValue.apply(this, [element, expectedValue]);
   }
+
+  return {
+    pass: false,
+    message: () =>
+      `A valid Enzyme object or HTML element is required when using the "toHaveValue" matcher.`,
+  };
 }

--- a/config/jest/matchers/toHaveValue.js
+++ b/config/jest/matchers/toHaveValue.js
@@ -2,10 +2,10 @@ import { toHaveValue as testingLibraryToHaveValue } from '@testing-library/jest-
 import { toHaveValue as enzymeToHaveValue } from 'enzyme-matchers/lib/assertions/toHaveValue';
 
 export default function toHaveValue(element, expectedValue) {
-  // Using `.apply` necessary so that the Testing Library .toHaveValue had access to a valid value for `this`
   try {
     return enzymeToHaveValue(element, expectedValue);
   } catch {
+    // Using `.apply` necessary so that the Testing Library .toHaveValue had access to a valid value for `this`
     return testingLibraryToHaveValue.apply(this, [element, expectedValue]);
   }
 }

--- a/config/jest/matchers/toHaveValue.js
+++ b/config/jest/matchers/toHaveValue.js
@@ -1,0 +1,11 @@
+import { toHaveValue as testingLibraryToHaveValue } from '@testing-library/jest-dom';
+import { toHaveValue as enzymeToHaveValue } from 'enzyme-matchers/lib/assertions/toHaveValue';
+
+export default function toHaveValue(element, expectedValue) {
+  // Using `.apply` necessary so that the Testing Library .toHaveValue had access to a valid value for `this`
+  try {
+    return enzymeToHaveValue(element, expectedValue);
+  } catch {
+    return testingLibraryToHaveValue.apply(this, [element, expectedValue]);
+  }
+}

--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -2,6 +2,7 @@
 import raf from './tempPolyfills';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import '@testing-library/jest-dom/extend-expect'; // Provides Testing Library matchers
 import { configure } from '@testing-library/react';
 import * as matchers from './matchers';
 import setupPortals from 'src/__testHelpers__/setupPortals';

--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-unused-vars, no-console */
-
 import raf from './tempPolyfills';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import '@testing-library/jest-dom/extend-expect';
 import { configure } from '@testing-library/react';
 import * as matchers from './matchers';
 import setupPortals from 'src/__testHelpers__/setupPortals';
@@ -18,17 +16,17 @@ Enzyme.configure({ adapter: new Adapter() });
 
 // React testing library configuration
 configure({
-  testIdAttribute: 'data-id' // Overriding the default test ID used by `getByTestId` matcher - `data-testid` isn't used so we can also use these attributes for analytics tagging
+  testIdAttribute: 'data-id', // Overriding the default test ID used by `getByTestId` matcher - `data-testid` isn't used so we can also use these attributes for analytics tagging
 });
 
 // this is just a little hack to silence a warning that we'll get with React Testing Library get
 //  until we upgrade to React 16.9. See:
 // 1. https://github.com/facebook/react/pull/14853
 // 2. and from the official React Testing Library docs https://github.com/testing-library/react-testing-library#suppressing-unnecessary-warnings-on-react-dom-168
-const originalError = console.error = (message) => {
+const originalError = (console.error = message => {
   // Fail tests on any warning
   throw new Error(message);
-};
+});
 
 beforeAll(() => {
   console.error = (...args) => {
@@ -44,9 +42,7 @@ afterAll(() => {
   console.error = originalError;
 });
 
-
 setupPortals();
-
 
 beforeEach(() => {
   // Verifies that at least one assertion is called during a test
@@ -69,7 +65,7 @@ Object.defineProperty(global.window.location, 'assign', { value: jest.fn(), conf
 
 // Show a stack track for unhandled rejections to help
 // track them down.
-process.on('unhandledRejection', (reason) => {
+process.on('unhandledRejection', reason => {
   console.log(reason);
 });
 
@@ -77,7 +73,7 @@ const mockLocalStorage = {
   clear: jest.fn(),
   getItem: jest.fn(),
   removeItem: jest.fn(),
-  setItem: jest.fn()
+  setItem: jest.fn(),
 };
 
 Object.defineProperty(global.window, 'localStorage', { value: mockLocalStorage });

--- a/src/components/multiEmailField/tests/MultiEmailField.test.js
+++ b/src/components/multiEmailField/tests/MultiEmailField.test.js
@@ -4,16 +4,8 @@ import MultiEmailField from '../MultiEmailField';
 import useMultiEmailField from '../useMultiEmailField';
 
 describe('MultiEmailField', () => {
-  const subject = (props) => (
-    shallow(
-      <MultiEmailField
-        id="multi-email-email-to"
-        label="To:"
-        name="emailTo"
-        {...props}
-      />
-    )
-  );
+  const subject = props =>
+    shallow(<MultiEmailField id="multi-email-email-to" label="To:" name="emailTo" {...props} />);
 
   it('renders', () => {
     const wrapper = subject();
@@ -44,20 +36,20 @@ describe('MultiEmailField', () => {
     const wrapper = subject();
 
     expect(wrapper).toHaveProp('selectedItems', []);
-    expect(wrapper).toHaveProp('value', '');
+    expect(wrapper).toHaveValue('');
     expect(wrapper).toHaveProp('error', '');
   });
 });
 
 describe('MultiEmailField with useMultiEmailField', () => {
-  const MultiEmailFieldWithHook = (props) => {
+  const MultiEmailFieldWithHook = props => {
     const {
       handleMultiEmailChange,
       handleMultiEmailKeyDownAndBlur,
       handleMultiEmailRemove,
       multiEmailValue,
       multiEmailList,
-      multiEmailError
+      multiEmailError,
     } = useMultiEmailField();
 
     return (
@@ -65,8 +57,8 @@ describe('MultiEmailField with useMultiEmailField', () => {
         id="multi-email-email-to"
         label="To:"
         name="emailTo"
-        onChange={(e) => handleMultiEmailChange(e)}
-        onKeyDownAndBlur={(e) => handleMultiEmailKeyDownAndBlur(e)}
+        onChange={e => handleMultiEmailChange(e)}
+        onKeyDownAndBlur={e => handleMultiEmailKeyDownAndBlur(e)}
         onRemoveEmail={handleMultiEmailRemove}
         error={multiEmailError}
         value={multiEmailValue}
@@ -75,12 +67,16 @@ describe('MultiEmailField with useMultiEmailField', () => {
       />
     );
   };
-  const subject = (props) => shallow(<MultiEmailFieldWithHook {...props}/>);
+  const subject = props => shallow(<MultiEmailFieldWithHook {...props} />);
 
   it('does not submit a form when the user hits the "enter" key', () => {
     const mockPreventDefault = jest.fn();
 
-    subject().simulate('keyDownAndBlur', { keyCode: 13, type: 'keydown', preventDefault: mockPreventDefault });
+    subject().simulate('keyDownAndBlur', {
+      keyCode: 13,
+      type: 'keydown',
+      preventDefault: mockPreventDefault,
+    });
 
     expect(mockPreventDefault).toHaveBeenCalled();
   });
@@ -89,38 +85,42 @@ describe('MultiEmailField with useMultiEmailField', () => {
     const mockPreventDefault = jest.fn();
     const wrapper = subject();
 
-    wrapper.simulate('keyDownAndBlur', { keyCode: 32, type: 'keydown', preventDefault: mockPreventDefault });
+    wrapper.simulate('keyDownAndBlur', {
+      keyCode: 32,
+      type: 'keydown',
+      preventDefault: mockPreventDefault,
+    });
     expect(mockPreventDefault).toHaveBeenCalled();
-    expect(wrapper).not.toHaveProp('value', ' ');
+    expect(wrapper).not.toHaveValue(' ');
   });
 
   it('updates the `emailList` prop, clears the `value` prop a valid email address and hits the space bar or tab key', () => {
     const wrapper = subject();
 
     // Adding a selected item via the spacebar
-    wrapper.simulate('change', { target: { value: 'hello@me.com' }});
+    wrapper.simulate('change', { target: { value: 'hello@me.com' } });
 
-    expect(wrapper).toHaveProp('value', 'hello@me.com');
+    expect(wrapper).toHaveValue('hello@me.com');
 
     wrapper.simulate('keyDownAndBlur', { keyCode: 32, preventDefault: jest.fn() });
 
-    expect(wrapper).not.toHaveProp('value', 'hello@me.com');
-    expect(wrapper).toHaveProp('emailList', [ { email: 'hello@me.com' } ]);
+    expect(wrapper).not.toHaveValue('hello@me.com');
+    expect(wrapper).toHaveProp('emailList', [{ email: 'hello@me.com' }]);
   });
 
   it('updates the `error` prop when the user enters an invalid email and hits the spacebar or blurs the field', () => {
     const wrapper = subject();
 
-    wrapper.simulate('change', { target: { value: 'invalidEmail' }});
+    wrapper.simulate('change', { target: { value: 'invalidEmail' } });
     wrapper.simulate('keyDownAndBlur', { keyCode: 32, preventDefault: jest.fn() });
 
     expect(wrapper).toHaveProp('error', 'Please enter a valid email address');
 
-    wrapper.simulate('change', { target: { value: '' }}); // Clear the error
+    wrapper.simulate('change', { target: { value: '' } }); // Clear the error
 
     expect(wrapper).toHaveProp('error', '');
 
-    wrapper.simulate('change', { target: { value: 'invalidEmailAgain' }});
+    wrapper.simulate('change', { target: { value: 'invalidEmailAgain' } });
     wrapper.simulate('keyDownAndBlur', { type: 'blur' });
 
     expect(wrapper).toHaveProp('error', 'Please enter a valid email address');
@@ -128,17 +128,17 @@ describe('MultiEmailField with useMultiEmailField', () => {
   it('removes the last item in the `emailList` array when the user uses the backspace key', () => {
     const wrapper = subject();
 
-    wrapper.simulate('change', { target: { value: 'hello@me.com' }});
+    wrapper.simulate('change', { target: { value: 'hello@me.com' } });
     wrapper.simulate('keyDownAndBlur', { keyCode: 32, preventDefault: jest.fn() });
 
-    expect(wrapper).toHaveProp('emailList', [ { email: 'hello@me.com' } ]);
+    expect(wrapper).toHaveProp('emailList', [{ email: 'hello@me.com' }]);
 
-    wrapper.simulate('change', { target: { value: 'hello@you.com' }});
+    wrapper.simulate('change', { target: { value: 'hello@you.com' } });
     wrapper.simulate('keyDownAndBlur', { keyCode: 32, preventDefault: jest.fn() });
 
     wrapper.simulate('keyDownAndBlur', { keyCode: 8, preventDefault: jest.fn() });
 
-    expect(wrapper).toHaveProp('emailList', [ { email: 'hello@me.com' } ]);
+    expect(wrapper).toHaveProp('emailList', [{ email: 'hello@me.com' }]);
 
     wrapper.simulate('keyDownAndBlur', { keyCode: 8, preventDefault: jest.fn() });
 
@@ -148,7 +148,7 @@ describe('MultiEmailField with useMultiEmailField', () => {
   it('removes an item from the `emailList` prop when `removeItem` is invoked', () => {
     const wrapper = subject();
 
-    wrapper.simulate('change', { target: { value: 'hello@me.com' }});
+    wrapper.simulate('change', { target: { value: 'hello@me.com' } });
     wrapper.simulate('keyDownAndBlur', { type: 'keyDown', keyCode: 32, preventDefault: jest.fn() });
 
     // Invoking `wrapper.props().onRemove()` wasn't triggering the deletion - works when tested manually
@@ -158,5 +158,3 @@ describe('MultiEmailField with useMultiEmailField', () => {
     expect(wrapper).toHaveProp('emailList', []);
   });
 });
-
-

--- a/src/helpers/tests/date.test.js
+++ b/src/helpers/tests/date.test.js
@@ -18,7 +18,7 @@ import {
   parseDate,
   parseTime,
   parseDatetime,
-  toMilliseconds
+  toMilliseconds,
 } from '../date';
 import { roundBoundaries } from '../metrics';
 import cases from 'jest-in-case';
@@ -73,41 +73,79 @@ describe('Date helpers', () => {
   });
 
   describe('getRelativeDates', () => {
-
-    cases('calculations', ({ range, roundToPrecision, subtractArgs }) => {
-      const date = moment(new Date('2017-12-17T12:00:00'));
-      Date.now = jest.fn(() => date);
-      const { from, to, relativeRange } = getRelativeDates(range, { roundToPrecision });
-      let expectedFrom = moment(date.toDate()).subtract(...subtractArgs);
-      let expectedTo = date;
-      if (roundToPrecision) {
-        const rounded = roundBoundaries(expectedFrom, expectedTo);
-        expectedFrom = rounded.from;
-        expectedTo = rounded.to;
-      }
-      expect(to).toEqual(expectedTo.toDate());
-      expect(from).toEqual(expectedFrom.toDate());
-      expect(relativeRange).toEqual(range);
-    }, {
-      'for an hour ago': { range: 'hour', subtractArgs: [1, 'hours'], roundToPrecision: false },
-      'for a day ago': { range: 'day', subtractArgs: [1, 'days'], roundToPrecision: false },
-      'for a week ago': { range: '7days', subtractArgs: [7, 'days'], roundToPrecision: false },
-      'for 10 days ago': { range: '10days', subtractArgs: [10, 'days'], roundToPrecision: false },
-      'for two weeks ago': { range: '14days', subtractArgs: [14, 'days'], roundToPrecision: false },
-      'for a month': { range: '30days', subtractArgs: [30, 'days'], roundToPrecision: false },
-      'for a quarter ago': { range: '90days', subtractArgs: [90, 'days'], roundToPrecision: false },
-      'for an hour ago rounded': { range: 'hour', subtractArgs: [1, 'hours'], roundToPrecision: true },
-      'for a day ago rounded': { range: 'day', subtractArgs: [1, 'days'], roundToPrecision: true },
-      'for a week ago rounded': { range: '7days', subtractArgs: [7, 'days'], roundToPrecision: true },
-      'for 10 days ago rounded': { range: '10days', subtractArgs: [10, 'days'], roundToPrecision: true },
-      'for a month rounded': { range: '30days', subtractArgs: [30, 'days'], roundToPrecision: true },
-      'for a quarter ago rounded': { range: '90days', subtractArgs: [90, 'days'], roundToPrecision: true }
-    });
+    cases(
+      'calculations',
+      ({ range, roundToPrecision, subtractArgs }) => {
+        const date = moment(new Date('2017-12-17T12:00:00'));
+        Date.now = jest.fn(() => date);
+        const { from, to, relativeRange } = getRelativeDates(range, { roundToPrecision });
+        let expectedFrom = moment(date.toDate()).subtract(...subtractArgs);
+        let expectedTo = date;
+        if (roundToPrecision) {
+          const rounded = roundBoundaries(expectedFrom, expectedTo);
+          expectedFrom = rounded.from;
+          expectedTo = rounded.to;
+        }
+        expect(to).toEqual(expectedTo.toDate());
+        expect(from).toEqual(expectedFrom.toDate());
+        expect(relativeRange).toEqual(range);
+      },
+      {
+        'for an hour ago': { range: 'hour', subtractArgs: [1, 'hours'], roundToPrecision: false },
+        'for a day ago': { range: 'day', subtractArgs: [1, 'days'], roundToPrecision: false },
+        'for a week ago': { range: '7days', subtractArgs: [7, 'days'], roundToPrecision: false },
+        'for 10 days ago': { range: '10days', subtractArgs: [10, 'days'], roundToPrecision: false },
+        'for two weeks ago': {
+          range: '14days',
+          subtractArgs: [14, 'days'],
+          roundToPrecision: false,
+        },
+        'for a month': { range: '30days', subtractArgs: [30, 'days'], roundToPrecision: false },
+        'for a quarter ago': {
+          range: '90days',
+          subtractArgs: [90, 'days'],
+          roundToPrecision: false,
+        },
+        'for an hour ago rounded': {
+          range: 'hour',
+          subtractArgs: [1, 'hours'],
+          roundToPrecision: true,
+        },
+        'for a day ago rounded': {
+          range: 'day',
+          subtractArgs: [1, 'days'],
+          roundToPrecision: true,
+        },
+        'for a week ago rounded': {
+          range: '7days',
+          subtractArgs: [7, 'days'],
+          roundToPrecision: true,
+        },
+        'for 10 days ago rounded': {
+          range: '10days',
+          subtractArgs: [10, 'days'],
+          roundToPrecision: true,
+        },
+        'for a month rounded': {
+          range: '30days',
+          subtractArgs: [30, 'days'],
+          roundToPrecision: true,
+        },
+        'for a quarter ago rounded': {
+          range: '90days',
+          subtractArgs: [90, 'days'],
+          roundToPrecision: true,
+        },
+      },
+    );
 
     it('should default to rounding the range', () => {
       const date = moment(new Date('2017-12-17T12:00:00'));
       Date.now = jest.fn(() => date);
-      const { from: expectedFrom, to: expectedTo } = roundBoundaries(moment(date.toDate()).subtract(7, 'days'), date);
+      const { from: expectedFrom, to: expectedTo } = roundBoundaries(
+        moment(date.toDate()).subtract(7, 'days'),
+        date,
+      );
       const { from, to, relativeRange } = getRelativeDates('7days');
 
       expect(to).toEqual(expectedTo.toDate());
@@ -125,22 +163,21 @@ describe('Date helpers', () => {
     });
 
     it('should throw an error if range is unknown', () => {
-      expect(() => getRelativeDates('invalid-like-whoa')).toThrow('Tried to calculate a relative date range with an invalid range value: invalid-like-whoa');
+      expect(() => getRelativeDates('invalid-like-whoa')).toThrow(
+        'Tried to calculate a relative date range with an invalid range value: invalid-like-whoa',
+      );
     });
-
   });
 
   describe('getRelativeDateOptions', () => {
-
     it('should get a set of date range options', () => {
       const options = getRelativeDateOptions(['hour', 'day', 'custom']);
       expect(options).toEqual([
         { value: 'hour', label: expect.any(String) },
         { value: 'day', label: expect.any(String) },
-        { value: 'custom', label: expect.any(String) }
+        { value: 'custom', label: expect.any(String) },
       ]);
     });
-
   });
 
   describe('date formatting', () => {
@@ -174,7 +211,6 @@ describe('Date helpers', () => {
   });
 
   describe('getLocalTimezone', () => {
-
     it('should return UTC if Intl is not defined', () => {
       delete global.Intl;
       expect(getLocalTimezone()).toEqual('UTC');
@@ -188,7 +224,7 @@ describe('Date helpers', () => {
     it('should return UTC if resolvedOptions is not a function', () => {
       const dtfMock = jest.fn(() => ({}));
       global.Intl = {
-        DateTimeFormat: dtfMock
+        DateTimeFormat: dtfMock,
       };
 
       expect(getLocalTimezone()).toEqual('UTC');
@@ -198,10 +234,10 @@ describe('Date helpers', () => {
     it('should return the timezone', () => {
       const optionsMock = jest.fn(() => ({ timeZone: 'Cool/Story' }));
       const dtfMock = jest.fn(() => ({
-        resolvedOptions: optionsMock
+        resolvedOptions: optionsMock,
       }));
       global.Intl = {
-        DateTimeFormat: dtfMock
+        DateTimeFormat: dtfMock,
       };
       expect(getLocalTimezone()).toEqual('Cool/Story');
       expect(dtfMock).toHaveBeenCalledTimes(1);
@@ -233,67 +269,67 @@ describe('Date helpers', () => {
 
   describe('parseDate', () => {
     it('returns invalid date for undefined', () => {
-      expect(parseDate()).not.toBeValid();
+      expect(parseDate()).not.toBeValidMomentDate();
     });
 
     it('returns invalid date for empty string', () => {
-      expect(parseDate('')).not.toBeValid();
+      expect(parseDate('')).not.toBeValidMomentDate();
     });
 
     it('returns invalid date', () => {
-      expect(parseDate('04-17-2018')).not.toBeValid();
+      expect(parseDate('04-17-2018')).not.toBeValidMomentDate();
     });
 
     it('returns valid date for ISO-8601 date strings', () => {
-      expect(parseDate('2018-04-17')).toBeValid();
+      expect(parseDate('2018-04-17')).toBeValidMomentDate();
     });
   });
 
   describe('parseTime', () => {
     it('returns invalid time for undefined', () => {
-      expect(parseTime()).not.toBeValid();
+      expect(parseTime()).not.toBeValidMomentDate();
     });
 
     it('returns invalid time for empty string', () => {
-      expect(parseTime('')).not.toBeValid();
+      expect(parseTime('')).not.toBeValidMomentDate();
     });
 
     it('returns valid time for zero-hour', () => {
-      expect(parseTime('00:00')).toBeValid();
+      expect(parseTime('00:00')).toBeValidMomentDate();
     });
 
     it('returns valid time for 12-hour time', () => {
-      expect(parseTime('12:00am')).toBeValid();
+      expect(parseTime('12:00am')).toBeValidMomentDate();
     });
 
     it('returns valid time for 24-hour time', () => {
-      expect(parseTime('14:00')).toBeValid();
+      expect(parseTime('14:00')).toBeValidMomentDate();
     });
 
     it('returns valid time for 24-hour with am/pm', () => {
-      expect(parseTime('14:00am')).toBeValid();
+      expect(parseTime('14:00am')).toBeValidMomentDate();
     });
   });
 
   describe('parseDatetime', () => {
     it('returns invalid date time for undefined', () => {
-      expect(parseDatetime()).not.toBeValid();
+      expect(parseDatetime()).not.toBeValidMomentDate();
     });
 
     it('returns invalid date time for empty string', () => {
-      expect(parseDatetime('')).not.toBeValid();
+      expect(parseDatetime('')).not.toBeValidMomentDate();
     });
 
     it('returns valid date time for 12-hour time', () => {
-      expect(parseDatetime('2018-01-01 12:00am')).toBeValid();
+      expect(parseDatetime('2018-01-01 12:00am')).toBeValidMomentDate();
     });
 
     it('returns valid time for 24-hour time', () => {
-      expect(parseDatetime('2018-01-01 14:00')).toBeValid();
+      expect(parseDatetime('2018-01-01 14:00')).toBeValidMomentDate();
     });
 
     it('returns valid time for 24-hour with am/pm', () => {
-      expect(parseDatetime('2018-01-01 14:00am')).toBeValid();
+      expect(parseDatetime('2018-01-01 14:00am')).toBeValidMomentDate();
     });
   });
 
@@ -303,7 +339,9 @@ describe('Date helpers', () => {
     });
 
     it('returns the duration between two dates in days', () => {
-      expect(getDuration({ from: '2017-12-18T00:00:00', to: '2017-12-19T00:00:00' }, 'days')).toEqual(1);
+      expect(
+        getDuration({ from: '2017-12-18T00:00:00', to: '2017-12-19T00:00:00' }, 'days'),
+      ).toEqual(1);
     });
   });
 
@@ -312,7 +350,7 @@ describe('Date helpers', () => {
       const dates = { to: '2018-02-03T04:20:00-04:00', from: '2018-01-26T04:20:00-04:00' };
       const dataSet = [
         { date: '2018-02-02', value: 234 },
-        { date: '2018-01-30', value: 123 }
+        { date: '2018-01-30', value: 123 },
       ];
       const fill = { value: null };
 
@@ -322,11 +360,9 @@ describe('Date helpers', () => {
 
   describe('getDateTicks', () => {
     it('returns an array of start, end and middle days', () => {
-      expect(getDateTicks({ to: '2018-05-25T04:20:00-04:00', from: '2018-05-01T04:20:00-04:00' })).toEqual([
-        '2018-05-01',
-        '2018-05-13',
-        '2018-05-25'
-      ]);
+      expect(
+        getDateTicks({ to: '2018-05-25T04:20:00-04:00', from: '2018-05-01T04:20:00-04:00' }),
+      ).toEqual(['2018-05-01', '2018-05-13', '2018-05-25']);
     });
   });
 

--- a/src/pages/templates/components/tests/SendTestEmailButton.test.js
+++ b/src/pages/templates/components/tests/SendTestEmailButton.test.js
@@ -85,7 +85,7 @@ describe('SendTestEmailButton', () => {
       const mockSendPreview = jest.fn(() => sendPreviewPromise);
       const mockUpdateDraft = jest.fn(() => updateDraftPromise);
       const mockShowAlert = jest.fn();
-      const { getByText, queryByText, getByLabelText, queryByTestId } = subject({
+      const { getByText, queryByText, queryByLabelText, queryByTestId } = subject({
         sendPreview: mockSendPreview,
         showAlert: mockShowAlert,
         updateDraft: mockUpdateDraft,
@@ -94,10 +94,11 @@ describe('SendTestEmailButton', () => {
       userEvent.click(getByText('Send a Test'));
 
       return updateDraftPromise.then(() => {
-        userEvent.type(getByLabelText('To'), 'toEmail@sparkpost.com');
+        userEvent.type(queryByLabelText('To'), 'toEmail@sparkpost.com');
         // Hit the enter key to add the email address to the list of values
-        fireEvent.keyDown(getByLabelText('To'), { preventDefault: jest.fn(), keyCode: 13 });
+        fireEvent.keyDown(queryByLabelText('To'), { preventDefault: jest.fn(), keyCode: 13 });
         expect(queryByText('toEmail@sparkpost.com')).toBeInTheDocument(); // The email address is stored in the DOM instead of the `value` attribute
+        expect(queryByLabelText('From')).RTLtoHaveValue('nick@bounce.uat.sparkpost.com');
         userEvent.click(getByText('Send Email'));
 
         expect(queryByTestId('panel-loading')).toBeInTheDocument();
@@ -152,16 +153,16 @@ describe('SendTestEmailButton', () => {
       const mockParsedTestData = {
         options: {},
         substitution_data: {
-          foo: 'bar'
+          foo: 'bar',
         },
-        metadata: {}
+        metadata: {},
       };
 
       const { getByText } = subject({
         isPublishedMode: true,
         updateDraft: mockUpdateDraft,
         parsedTestData: mockParsedTestData,
-        setTestDataAction: mockSetTestData
+        setTestDataAction: mockSetTestData,
       });
 
       userEvent.click(getByText('Send a Test'));
@@ -170,7 +171,7 @@ describe('SendTestEmailButton', () => {
       expect(mockSetTestData).toHaveBeenCalledWith({
         id: '123456',
         mode: 'published',
-        data: mockParsedTestData
+        data: mockParsedTestData,
       });
     });
   });

--- a/src/pages/templates/components/tests/SendTestEmailButton.test.js
+++ b/src/pages/templates/components/tests/SendTestEmailButton.test.js
@@ -98,7 +98,7 @@ describe('SendTestEmailButton', () => {
         // Hit the enter key to add the email address to the list of values
         fireEvent.keyDown(queryByLabelText('To'), { preventDefault: jest.fn(), keyCode: 13 });
         expect(queryByText('toEmail@sparkpost.com')).toBeInTheDocument(); // The email address is stored in the DOM instead of the `value` attribute
-        expect(queryByLabelText('From')).RTLtoHaveValue('nick@bounce.uat.sparkpost.com');
+        expect(queryByLabelText('From')).toHaveValue('nick@bounce.uat.sparkpost.com');
         userEvent.click(getByText('Send Email'));
 
         expect(queryByTestId('panel-loading')).toBeInTheDocument();


### PR DESCRIPTION
[FE-797](https://jira.int.messagesystems.com/browse/FE-797)

### What Changed
- Added custom `toHaveValue` matcher that conditionally runs the Enzyme and Testing Library `.toHaveValue` matchers
- Updated `toHaveTextContent` custom matcher to conditionally run the Testing Library variant
- Renamed `toBeValid` => `toBeValidMomentDate`

### How To Test
- `npm run test SendTestEmailButton.test.js`, then:
  + on line 101, change the asserted value to `'nick'` and verify the test feedback works as expected
  + on line 101, change the selected element from a valid one to a random variable (i.e., `2`)
  + on line 101, change the assertion to a negative one (by chaining `.not`) and verify the test feedback works as expected
- `npm run test MultiEmailField.test.js`, then:
  + on line 103, change the asserted value to 'you@me.com' and verify the test feedback works as expected
  + on line 103, change the selected element from a valid one to a random variable (i.e., 'hello')
  + on line 103, change the assertion to a negative one (by chaining `.not`) and verify the test feedback works as expected

### To Do
- [ ] Incorporate feedback
