### PR TITLE
SE-463: Alert incidents polish

### DIFF
--- a/src/pages/alerts/components/AlertForm.js
+++ b/src/pages/alerts/components/AlertForm.js
@@ -132,6 +132,7 @@ export class AlertForm extends Component {
                     options={visibleMetricOptions}
                     onChange={this.resetFormValues}
                     validate={required}
+                    disabled={submitting || !isNewAlert}
                   />
                 </div>
                 {metric !== '' && (
@@ -140,6 +141,7 @@ export class AlertForm extends Component {
                       key={metric}
                       disabled={submitting}
                       shouldUpdateRecommendation={isNewAlert && !isDuplicate}
+                      isNewAlert={isNewAlert}
                     />
                   </div>
                 )}

--- a/src/pages/alerts/components/fields/EvaluatorFields.js
+++ b/src/pages/alerts/components/fields/EvaluatorFields.js
@@ -14,6 +14,7 @@ export const EvaluatorFields = ({
   operator,
   disabled,
   change,
+  isNewAlert,
   shouldUpdateRecommendation,
 }) => {
   const handleSourceChange = event => {
@@ -54,7 +55,7 @@ export const EvaluatorFields = ({
               id="alertEvaluatorSource"
               name="source"
               component={SelectWrapper}
-              disabled={disabled}
+              disabled={disabled || !isNewAlert}
               options={sourceOptions}
               onChange={handleSourceChange}
             />

--- a/src/pages/alerts/components/fields/tests/__snapshots__/EvaluatorFields.test.js.snap
+++ b/src/pages/alerts/components/fields/tests/__snapshots__/EvaluatorFields.test.js.snap
@@ -16,7 +16,7 @@ exports[`Evaluator Fields Component renders correctly 1`] = `
       </Label>
       <Field
         component={[Function]}
-        disabled={false}
+        disabled={true}
         id="alertEvaluatorSource"
         name="source"
         onChange={[Function]}

--- a/src/pages/alerts/components/tests/__snapshots__/AlertForm.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertForm.test.js.snap
@@ -36,6 +36,7 @@ exports[`Alert Form Component should render the alert form component correctly 1
             </label>
             <Field
               component={[Function]}
+              disabled={false}
               name="metric"
               onChange={[Function]}
               options={
@@ -75,6 +76,7 @@ exports[`Alert Form Component should render the alert form component correctly 1
           >
             <Connect(EvaluatorFields)
               disabled={false}
+              isNewAlert={true}
               key="health_score"
               shouldUpdateRecommendation={true}
             />

--- a/src/pages/alerts/components/tests/__snapshots__/AlertIncidents.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertIncidents.test.js.snap
@@ -15,7 +15,7 @@ Array [
     className="rightAlign"
   >
     30
-    %
+    
   </div>,
 ]
 `;


### PR DESCRIPTION
### What Changed
 - Alert edit form disabled changing metric/evaluator
 - Health score (raw) now removes percent correctly in alert incidents
 - Health score label will now show appropriate evaluator as column header in incidents table
 - Added keys to table
 - Changed precision of values

### How To Test
 - Go to `/alerts` page and click on a health score alert (or create one)
    - Create form should be able to change the metric/evaluator
    - Edit form should disable metric field and evaluator (if health score metric alert)
 - Verify alert incident table changes are made
