### PR TITLE
TR-2047 - Lower max file size for RV from 200MB to 20MB

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -56,7 +56,7 @@ const config = identifier => ({
     cookieName: 'heroku-nav-data',
   },
   maxUploadSizeBytes: 20000000,
-  maxRecipVerifUploadSizeBytes: 20971520,
+  maxRecipVerifUploadSizeBytes: 20971520, // NGNIX configures max upload size in megabytes, translating to this value in bytes
   metricsPrecisionMap: [
     { time: 60, value: '1min', format: 'ha' },
     { time: 60 * 2, value: '5min', format: 'ha' },

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,11 +1,11 @@
-const tenantIdFromHostname = (hostname) => hostname.split('.')[0];
+const tenantIdFromHostname = hostname => hostname.split('.')[0];
 
-const config = (identifier) => ({
+const config = identifier => ({
   apiBase: `https://${identifier}.api.e.sparkpost.com/api`,
   apiDateFormat: 'YYYY-MM-DDTHH:mm',
   apiRequestTimeout: 60000,
   apiRequestHeaders: {
-    'X-Sparky': '1d24c3473dd52a2f4a53fb6808cf9a73'
+    'X-Sparky': '1d24c3473dd52a2f4a53fb6808cf9a73',
   },
   apiRequestBodyMaxSizeBytes: 500 * 1000, // ~ 500 KB
   authentication: {
@@ -13,27 +13,27 @@ const config = (identifier) => ({
       cookie: {
         name: 'auth',
         options: {
-          path: '/'
-        }
+          path: '/',
+        },
       },
-      authHeader: 'Basic bXN5c1dlYlVJOmZhODZkNzJlLTYyODctNDUxMy1hZTdmLWVjOGM4ZmEwZDc2Ng=='
+      authHeader: 'Basic bXN5c1dlYlVJOmZhODZkNzJlLTYyODctNDUxMy1hZTdmLWVjOGM4ZmEwZDc2Ng==',
     },
     site: {
       cookie: {
         name: 'website_auth',
         options: {
           domain: '.sparkpost.com',
-          path: '/'
-        }
+          path: '/',
+        },
       },
-      authHeader: 'Basic bXN5c1VJTGltaXRlZDphZjE0OTdkYS02NjI5LTQ3NTEtODljZS01ZDBmODE4N2MyMDQ='
-    }
+      authHeader: 'Basic bXN5c1VJTGltaXRlZDphZjE0OTdkYS02NjI5LTQ3NTEtODljZS01ZDBmODE4N2MyMDQ=',
+    },
   },
   cardTypes: [
     { paymentFormat: 'visa', apiFormat: 'Visa' },
     { paymentFormat: 'mastercard', apiFormat: 'MasterCard' },
     { paymentFormat: 'amex', apiFormat: 'AmericanExpress' },
-    { paymentFormat: 'discover', apiFormat: 'Discover' }
+    { paymentFormat: 'discover', apiFormat: 'Discover' },
   ],
   chartColors: ['#04AEF9', '#fa6423', '#FFD300', '#8CCA3A', '#b94696'],
   cookieConsent: {
@@ -42,18 +42,18 @@ const config = (identifier) => ({
       ageDays: 365,
       options: {
         domain: 'sparkpost.com',
-        path: '/'
-      }
-    }
+        path: '/',
+      },
+    },
   },
   featureFlags: {
     allow_default_signing_domains_for_ip_pools: true,
     allow_mailbox_verification: true,
     allow_anyone_at_verification: false,
-    has_signup: false
+    has_signup: false,
   },
   heroku: {
-    cookieName: 'heroku-nav-data'
+    cookieName: 'heroku-nav-data',
   },
   maxUploadSizeBytes: 20000000,
   maxRecipVerifUploadSizeBytes: 200000000,
@@ -65,84 +65,91 @@ const config = (identifier) => ({
     { time: 60 * 24 * 7, value: 'day', format: 'MMM Do' },
     { time: 60 * 24 * 33, value: 'day', format: 'MMM Do' },
     { time: 60 * 24 * 190, value: 'week', format: 'MMM Do' },
-    { time: Infinity, value: 'month', format: 'MMM YY' }
+    { time: Infinity, value: 'month', format: 'MMM YY' },
   ],
   release: process.env.REACT_APP_VERSION,
   sandbox: {
     localpart: 'sandbox',
-    domain: 'sparkpostbox.com'
+    domain: 'sparkpostbox.com',
   },
   sendingIps: {
     maxPerAccount: 4,
-    pricePerIp: 20.00,
-    awsPricePerIp: 0.028
+    pricePerIp: 20.0,
+    awsPricePerIp: 0.028,
   },
   splashPage: '/reports/summary',
   summaryChart: {
-    defaultMetrics: ['count_targeted', 'count_rendered', 'count_accepted', 'count_bounce']
+    defaultMetrics: ['count_targeted', 'count_rendered', 'count_accepted', 'count_bounce'],
   },
   support: {
-    maxAttachmentSizeBytes: 500 * 1000 // ~ 500 KB
+    maxAttachmentSizeBytes: 500 * 1000, // ~ 500 KB
   },
   templates: {
     testData: {
       substitution_data: {},
       metadata: {},
-      options: {}
-    }
+      options: {},
+    },
   },
   tenantId: identifier,
   website: {
-    domain: 'sparkpost.com'
+    domain: 'sparkpost.com',
   },
   zuora: {
     baseUrl: 'https://rest.apisandbox.zuora.com/v1',
-    timeout: 15000
+    timeout: 15000,
   },
   brightback: {
     baseUrl: 'https://app.brightback.com',
     downgradeToFreeConfig: {
       app_id: 'bAJDEmD5EK', //Sandbox app Id
       save_return_url: '/account/billing', // Return URL from Brightback for end-users who do not cancel
-      cancel_confirmation_url: '/account/billing/plan/change?immediatePlanChange=free500-0419' // Return URL from Brightback for end-users who cancel
+      cancel_confirmation_url: '/account/billing/plan/change?immediatePlanChange=free500-0419', // Return URL from Brightback for end-users who cancel
     },
     cancelConfig: {
       app_id: 'bAJDEmD5EK', //Sandbox app Id
       save_return_url: '/account/settings',
-      cancel_confirmation_url: '/account/cancel'
+      cancel_confirmation_url: '/account/cancel',
     },
-    enabled: true
+    enabled: true,
   },
   smtpAuth: {
     host: `${identifier}.smtp.e.sparkpost.com`,
     port: 587,
     username: identifier,
-    enabled: true
+    enabled: true,
   },
   bounceDomains: {
     allowDefault: true,
     allowSubaccountDefault: true,
     cnameValue: `${identifier}.mail.e.sparkpost.com`,
-    mxValue: `${identifier}.mx.e.sparkpost.com`
+    mxValue: `${identifier}.mx.e.sparkpost.com`,
   },
   trackingDomains: {
-    cnameValue: `${identifier}.et.e.sparkpost.com`
+    cnameValue: `${identifier}.et.e.sparkpost.com`,
   },
   dateFormat: 'MMM D YYYY',
   timeFormat: 'h:mma',
   messageEvents: {
-    retentionPeriodDays: 10
+    retentionPeriodDays: 10,
   },
   recaptcha: {
     key: '6LeFZQETAAAAACWJfxw_DKHgEPnop3brlj9IsHrY',
-    invisibleKey: '6LekChoUAAAAAJZouMPHnhRss2t7-ZetbAABfsOZ'
+    invisibleKey: '6LekChoUAAAAAJZouMPHnhRss2t7-ZetbAABfsOZ',
   },
   attribution: {
     cookieName: 'attribution',
     cookieDuration: 60 * 24 * 30,
-    cookieDomain: '.sparkpost.com'
+    cookieDomain: '.sparkpost.com',
   },
-  salesforceDataParams: ['src', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']
+  salesforceDataParams: [
+    'src',
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_content',
+    'utm_term',
+  ],
 });
 
-export default (hostname) => config(tenantIdFromHostname(hostname));
+export default hostname => config(tenantIdFromHostname(hostname));

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -56,7 +56,7 @@ const config = identifier => ({
     cookieName: 'heroku-nav-data',
   },
   maxUploadSizeBytes: 20000000,
-  maxRecipVerifUploadSizeBytes: 20000000,
+  maxRecipVerifUploadSizeBytes: 20971520,
   metricsPrecisionMap: [
     { time: 60, value: '1min', format: 'ha' },
     { time: 60 * 2, value: '5min', format: 'ha' },

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -56,7 +56,7 @@ const config = identifier => ({
     cookieName: 'heroku-nav-data',
   },
   maxUploadSizeBytes: 20000000,
-  maxRecipVerifUploadSizeBytes: 200000000,
+  maxRecipVerifUploadSizeBytes: 20000000,
   metricsPrecisionMap: [
     { time: 60, value: '1min', format: 'ha' },
     { time: 60 * 2, value: '5min', format: 'ha' },

--- a/src/pages/recipientValidation/components/tests/ListForm.test.js
+++ b/src/pages/recipientValidation/components/tests/ListForm.test.js
@@ -48,7 +48,7 @@ describe('ListForm', () => {
   });
 
   it('should not submit csv when over size limit', () => {
-    wrapper.setProps({ ...props, file: { size: 20000001 } });
+    wrapper.setProps({ ...props, file: { size: 20971521 } });
     expect(props.uploadList).not.toHaveBeenCalled();
   });
 

--- a/src/pages/recipientValidation/components/tests/ListForm.test.js
+++ b/src/pages/recipientValidation/components/tests/ListForm.test.js
@@ -48,7 +48,7 @@ describe('ListForm', () => {
   });
 
   it('should not submit csv when over size limit', () => {
-    wrapper.setProps({ ...props, file: { size: 200000001 } });
+    wrapper.setProps({ ...props, file: { size: 20000001 } });
     expect(props.uploadList).not.toHaveBeenCalled();
   });
 

--- a/src/pages/recipientValidation/components/tests/ListForm.test.js
+++ b/src/pages/recipientValidation/components/tests/ListForm.test.js
@@ -9,18 +9,18 @@ describe('ListForm', () => {
 
   beforeEach(() => {
     formValuesWithCsv = {
-      csv: 'email,foo@address.com\nbar@address.com\n'
+      csv: 'email,foo@address.com\nbar@address.com\n',
     };
 
     props = {
-      handleSubmit: jest.fn((a) => () => a(formValuesWithCsv)),
+      handleSubmit: jest.fn(a => () => a(formValuesWithCsv)),
       history: {
-        push: jest.fn()
+        push: jest.fn(),
       },
       uploadList: jest.fn(() => Promise.resolve({ list_id: 'A1C1_D1C1' })),
       reset: jest.fn(),
       showAlert: jest.fn(),
-      resetUploadError: jest.fn()
+      resetUploadError: jest.fn(),
     };
 
     wrapper = shallow(<ListForm {...props} />);
@@ -32,7 +32,7 @@ describe('ListForm', () => {
   });
 
   it('should submit csv', async () => {
-    wrapper.setProps({ ...props, file: { size: 45, name: 'test.csv' }});
+    wrapper.setProps({ ...props, file: { size: 45, name: 'test.csv' } });
 
     const csvUpload = props.uploadList.mock.calls[0][0];
     await expect(props.uploadList).toHaveBeenCalledTimes(1);
@@ -42,18 +42,18 @@ describe('ListForm', () => {
     expect(props.reset).toHaveBeenCalledWith('recipientValidationListForm');
     expect(props.showAlert).toHaveBeenCalledWith({
       type: 'success',
-      message: 'Recipients Uploaded'
+      message: 'Recipients Uploaded',
     });
     expect(props.history.push).toHaveBeenCalledWith('/recipient-validation/list/A1C1_D1C1');
   });
 
   it('should not submit csv when over size limit', () => {
-    wrapper.setProps({ ...props, file: { size: 200000001 }});
+    wrapper.setProps({ ...props, file: { size: 200000001 } });
     expect(props.uploadList).not.toHaveBeenCalled();
   });
 
   it('should not submit if not type csv or txt', () => {
-    wrapper.setProps({ ...props, file: { name: 'thing.doc' }});
+    wrapper.setProps({ ...props, file: { name: 'thing.doc' } });
     expect(props.uploadList).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
[TR-2047](https://jira.int.messagesystems.com/browse/TR-2047)

### What Changed
- Reformatted two files with Prettier
- Lowered max RV file size upload from 200MB to 20MB (NOTE: the config defines the limit in bytes, which was derived from https://www.gbmb.org/bytes-to-mb)

### How To Test
- Updated your local `ngnix.conf` (mine was in `/usr/local/etc/openresty`) file to accept larger file uploads, then restart openresty:
  - Directions here: https://stackoverflow.com/questions/26717013/how-to-edit-nginx-conf-to-increase-file-size-upload
- Go to `/recipient-validation/list` and upload a file that is above 20MB and another that is below 20 MB - **For whoever picks up the review, I have some uploaded CSV files in a Google Drive folder that I will share with you**
- Verify that the file size under 20 MB uploads successfully
- Verify that the file size over 20 MB renders an error

### To Do
- [ ] Incorporate feedback
