### PR TITLE
SA-1132 - Add delete functionality for blacklist monitors

### DIFF
--- a/src/actions/blacklist.js
+++ b/src/actions/blacklist.js
@@ -29,6 +29,17 @@ export function watchlistAdd(resource) {
   }
 }
 
+export function deleteMonitor(resource) {
+  return sparkpostApiRequest({
+    type: 'DELETE_MONITOR',
+    meta: {
+      method: 'DELETE',
+      url: `/v1/blacklist-monitors/${resource}`,
+      resource,
+    },
+  });
+}
+
 export function listIncidents(from = '2019-01-01') {
   //TODO replace with datepicker date
   return sparkpostApiRequest({

--- a/src/actions/tests/blacklist.test.js
+++ b/src/actions/tests/blacklist.test.js
@@ -45,4 +45,16 @@ describe('Action Creator: Blacklist', () => {
       },
     });
   });
+
+  it('it makes request to delete monitor', async () => {
+    await blacklist.deleteMonitor('test');
+    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+      type: 'DELETE_MONITOR',
+      meta: {
+        method: 'DELETE',
+        url: '/v1/blacklist-monitors/test',
+        resource: 'test',
+      },
+    });
+  });
 });

--- a/src/pages/blacklist/WatchlistPage.js
+++ b/src/pages/blacklist/WatchlistPage.js
@@ -7,6 +7,7 @@ import { ApiErrorBanner, Loading } from 'src/components';
 import { selectBlacklistedCount } from 'src/selectors/blacklist';
 import { listMonitors } from 'src/actions/blacklist';
 import MonitorsCollection from './components/MonitorsCollection';
+import StopMonitoringModal from './components/StopMonitoringModal';
 import CongratsBanner from './components/CongratsBanner';
 import styles from './WatchlistPage.module.scss';
 
@@ -14,6 +15,9 @@ export const WatchlistPage = props => {
   const { loading, listMonitors, monitors, hasBlacklisted, error } = props;
 
   const [showCongrats, setShowCongrats] = useState(true);
+  const [monitorToDelete, setMonitorToDelete] = useState(null);
+
+  const closeModal = () => setMonitorToDelete(null);
 
   useEffect(() => {
     listMonitors();
@@ -44,7 +48,7 @@ export const WatchlistPage = props => {
           <CongratsBanner onDismiss={() => setShowCongrats(false)} />
         )}
         <div data-id="monitors-table">
-          <MonitorsCollection monitors={monitors} />
+          <MonitorsCollection monitors={monitors} handleDelete={setMonitorToDelete} />
         </div>
       </>
     );
@@ -71,6 +75,7 @@ export const WatchlistPage = props => {
         affected.
       </p>
       {renderContent()}
+      <StopMonitoringModal monitorToDelete={monitorToDelete} closeModal={closeModal} />
     </Page>
   );
 };

--- a/src/pages/blacklist/components/MonitorsCollection.js
+++ b/src/pages/blacklist/components/MonitorsCollection.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button } from '@sparkpost/matchbox';
 
 import { PageLink } from 'src/components';
@@ -28,21 +28,27 @@ const columns = [
   { label: '', width: '20%' },
 ];
 
-const getRowData = ({ resource, active_listing_count, total_listing_count }) => {
-  return [
-    <div className={styles.NameDetails}>
-      <PageLink to={`/`} /*TODO link to ?*/>{resource}</PageLink>
-    </div>,
-    <div className={styles.ListingDetails}>{active_listing_count}</div>,
-    <div className={styles.ListingDetails}>{total_listing_count}</div>,
-    <div className={styles.Delete}>
-      <Button outline>Stop Monitoring</Button>
-    </div>,
-  ];
-};
-
 export const MonitorsCollection = props => {
-  const { monitors } = props;
+  const { monitors, handleDelete } = props;
+
+  const getRowData = useCallback(
+    ({ resource, active_listing_count, total_listing_count }) => {
+      return [
+        <div className={styles.NameDetails}>
+          <PageLink to={`/`} /*TODO link to ?*/>{resource}</PageLink>
+        </div>,
+        <div className={styles.ListingDetails}>{active_listing_count}</div>,
+        <div className={styles.ListingDetails}>{total_listing_count}</div>,
+        <div className={styles.Delete}>
+          <Button outline onClick={() => handleDelete(resource)}>
+            Stop Monitoring
+          </Button>
+        </div>,
+      ];
+    },
+    [handleDelete],
+  );
+
   return (
     <FilterSortCollection
       columns={columns}

--- a/src/pages/blacklist/components/StopMonitoringModal.js
+++ b/src/pages/blacklist/components/StopMonitoringModal.js
@@ -25,12 +25,9 @@ export const StopMonitoringModal = ({
   };
   const renderContent = () => {
     return (
-      <>
-        <h4>Explanation Text</h4>
-        <Button className={styles.Confirm} disabled={isPending} onClick={confirmAction} primary>
-          Stop Monitoring
-        </Button>
-      </>
+      <Button className={styles.Confirm} disabled={isPending} onClick={confirmAction} primary>
+        Stop Monitoring
+      </Button>
     );
   };
 

--- a/src/pages/blacklist/components/StopMonitoringModal.js
+++ b/src/pages/blacklist/components/StopMonitoringModal.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Button, Modal, Panel } from '@sparkpost/matchbox';
+import { connect } from 'react-redux';
+
+import { Loading } from 'src/components';
+import styles from './StopMonitoringModal.module.scss';
+import { deleteMonitor } from 'src/actions/blacklist';
+import { showAlert } from 'src/actions/globalAlert';
+
+export const StopMonitoringModal = ({
+  closeModal,
+  deleteMonitor,
+  isPending,
+  monitorToDelete,
+  showAlert,
+}) => {
+  const confirmAction = () => {
+    deleteMonitor(monitorToDelete).then(() => {
+      showAlert({
+        type: 'success',
+        message: `Stopped Monitoring ${monitorToDelete}.`,
+      });
+      closeModal();
+    });
+  };
+  const renderContent = () => {
+    return (
+      <>
+        <h4>Explanation Text</h4>
+        <Button className={styles.Confirm} disabled={isPending} onClick={confirmAction} primary>
+          Stop Monitoring
+        </Button>
+      </>
+    );
+  };
+
+  const title = monitorToDelete ? `Stop Monitoring ${monitorToDelete}` : '';
+
+  return (
+    <Modal open={Boolean(monitorToDelete)} onClose={closeModal} showCloseButton={true}>
+      <Panel title={title} accent sectioned>
+        {isPending ? (
+          <div className={styles.Loading}>
+            <Loading />
+          </div>
+        ) : (
+          renderContent()
+        )}
+      </Panel>
+    </Modal>
+  );
+};
+
+const mapStateToProps = state => ({
+  isPending: state.blacklist.deleteMonitorPending || state.blacklist.monitorsPending,
+});
+export default connect(mapStateToProps, { deleteMonitor, showAlert })(StopMonitoringModal);

--- a/src/pages/blacklist/components/StopMonitoringModal.module.scss
+++ b/src/pages/blacklist/components/StopMonitoringModal.module.scss
@@ -1,0 +1,8 @@
+.Confirm {
+  float: left;
+}
+
+.Loading {
+  min-height: 100px;
+  position: relative;
+}

--- a/src/pages/blacklist/components/tests/StopMonitoringModal.test.js
+++ b/src/pages/blacklist/components/tests/StopMonitoringModal.test.js
@@ -19,7 +19,6 @@ describe('Stop Monitoring Modal', () => {
 
     expect(queryByText('Stop Monitoring sparkpost.io')).toBeInTheDocument();
     expect(queryByText('Stop Monitoring')).toBeInTheDocument();
-    expect(queryByText('Explanation Text')).toBeInTheDocument();
   });
 
   it('upon clicking the confirm button, deletes the resource, shows alert, and closes the modal', async () => {

--- a/src/pages/blacklist/components/tests/StopMonitoringModal.test.js
+++ b/src/pages/blacklist/components/tests/StopMonitoringModal.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import { StopMonitoringModal } from '../StopMonitoringModal';
+
+describe('Stop Monitoring Modal', () => {
+  const closeModal = jest.fn();
+  const deleteMonitor = jest.fn().mockResolvedValue();
+  const showAlert = jest.fn();
+  const monitorToDelete = 'sparkpost.io';
+  const subject = ({ ...props }) => {
+    const defaults = { closeModal, monitorToDelete, deleteMonitor, showAlert };
+
+    return render(<StopMonitoringModal {...defaults} {...props} />);
+  };
+
+  it('renders the modal correctly', () => {
+    const { queryByText } = subject();
+
+    expect(queryByText('Stop Monitoring sparkpost.io')).toBeInTheDocument();
+    expect(queryByText('Stop Monitoring')).toBeInTheDocument();
+    expect(queryByText('Explanation Text')).toBeInTheDocument();
+  });
+
+  it('upon clicking the confirm button, deletes the resource, shows alert, and closes the modal', async () => {
+    const { queryByText } = subject();
+
+    await fireEvent.click(queryByText('Stop Monitoring'));
+    expect(deleteMonitor).toHaveBeenCalled();
+    expect(showAlert).toHaveBeenCalled();
+    expect(closeModal).toHaveBeenCalled();
+  });
+});

--- a/src/pages/blacklist/tests/WatchlistPage.test.js
+++ b/src/pages/blacklist/tests/WatchlistPage.test.js
@@ -1,9 +1,11 @@
 import { shallow } from 'enzyme';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { WatchlistPage } from '../WatchlistPage';
+
+jest.mock('../components/StopMonitoringModal', () => () => 'My Delete Modal');
 
 describe('WatchlistPage', () => {
   const monitors = [
@@ -72,6 +74,12 @@ describe('WatchlistPage', () => {
   it('renders Monitors Collection when correct data exists', () => {
     const wrapper = shallowSubject();
     expect(wrapper.find({ 'data-id': 'monitors-table' })).toExist();
+  });
+
+  it('renders delete modal when trying to delete a resource', () => {
+    const { queryByText } = renderSubject();
+    fireEvent.click(queryByText('Stop Monitoring'));
+    expect(queryByText('My Delete Modal')).toBeInTheDocument();
   });
 
   it('loads monitors when page starts rendering', () => {

--- a/src/reducers/blacklist.js
+++ b/src/reducers/blacklist.js
@@ -1,11 +1,15 @@
 export const initialState = {
   monitorsPending: false,
   monitors: [],
+  monitorsError: null,
   incidentsPending: false,
   incidents: [],
+  incidentsError: null,
+  deleteMonitorPending: false,
+  deleteMonitorError: null,
 };
 
-export default (state = initialState, { type, payload }) => {
+export default (state = initialState, { type, payload, meta }) => {
   switch (type) {
     case 'LIST_MONITORS_PENDING':
       return { ...state, monitorsPending: true, monitorsError: null };
@@ -27,6 +31,18 @@ export default (state = initialState, { type, payload }) => {
       return { ...state, watchlistAddPending: false, watchlistAddError: payload };
     case 'ADD_WATCHLIST_SUCCESS':
       return { ...state, watchlistAddPending: false, watchlistAddError: null };
+
+    case 'DELETE_MONITOR_PENDING':
+      return { ...state, deleteMonitorPending: true, deleteMonitorError: null };
+    case 'DELETE_MONITOR_FAIL':
+      return { ...state, deleteMonitorPending: false, deleteMonitorError: payload };
+    case 'DELETE_MONITOR_SUCCESS':
+      return {
+        ...state,
+        deleteMonitorPending: false,
+        deleteMonitorError: null,
+        monitors: state.monitors.filter(a => a.resource !== meta.resource),
+      };
     default:
       return state;
   }

--- a/src/reducers/tests/__snapshots__/blacklist.test.js.snap
+++ b/src/reducers/tests/__snapshots__/blacklist.test.js.snap
@@ -2,9 +2,13 @@
 
 exports[`BlackList Reducer add watchlist fail 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
+  "incidentsError": null,
   "incidentsPending": false,
   "monitors": Array [],
+  "monitorsError": null,
   "monitorsPending": false,
   "watchlistAddError": Object {
     "errors": Array [
@@ -19,9 +23,13 @@ Object {
 
 exports[`BlackList Reducer add watchlist pending 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
+  "incidentsError": null,
   "incidentsPending": false,
   "monitors": Array [],
+  "monitorsError": null,
   "monitorsPending": false,
   "watchlistAddError": null,
   "watchlistAddPending": true,
@@ -30,17 +38,55 @@ Object {
 
 exports[`BlackList Reducer add watchlist success 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
+  "incidentsError": null,
   "incidentsPending": false,
   "monitors": Array [],
+  "monitorsError": null,
   "monitorsPending": false,
   "watchlistAddError": null,
   "watchlistAddPending": false,
 }
 `;
 
+exports[`BlackList Reducer delete monitor fail 1`] = `
+Object {
+  "deleteMonitorError": Object {
+    "errors": Array [
+      Object {
+        "message": "Some error occurred",
+      },
+    ],
+  },
+  "deleteMonitorPending": false,
+  "incidents": Array [],
+  "incidentsError": null,
+  "incidentsPending": false,
+  "monitors": Array [],
+  "monitorsError": null,
+  "monitorsPending": false,
+}
+`;
+
+exports[`BlackList Reducer delete monitor pending 1`] = `
+Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": true,
+  "incidents": Array [],
+  "incidentsError": null,
+  "incidentsPending": false,
+  "monitors": Array [],
+  "monitorsError": null,
+  "monitorsPending": false,
+}
+`;
+
 exports[`BlackList Reducer list incidents fail 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
   "incidentsError": Object {
     "errors": Array [
@@ -51,35 +97,45 @@ Object {
   },
   "incidentsPending": false,
   "monitors": Array [],
+  "monitorsError": null,
   "monitorsPending": false,
 }
 `;
 
 exports[`BlackList Reducer list incidents pending 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
   "incidentsError": null,
   "incidentsPending": true,
   "monitors": Array [],
+  "monitorsError": null,
   "monitorsPending": false,
 }
 `;
 
 exports[`BlackList Reducer list incidents success 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Object {
     "fakeData": true,
   },
   "incidentsError": null,
   "incidentsPending": false,
   "monitors": Array [],
+  "monitorsError": null,
   "monitorsPending": false,
 }
 `;
 
 exports[`BlackList Reducer list monitors fail 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
+  "incidentsError": null,
   "incidentsPending": false,
   "monitors": Array [],
   "monitorsError": Object {
@@ -95,7 +151,10 @@ Object {
 
 exports[`BlackList Reducer list monitors pending 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
+  "incidentsError": null,
   "incidentsPending": false,
   "monitors": Array [],
   "monitorsError": null,
@@ -105,7 +164,10 @@ Object {
 
 exports[`BlackList Reducer list monitors success 1`] = `
 Object {
+  "deleteMonitorError": null,
+  "deleteMonitorPending": false,
   "incidents": Array [],
+  "incidentsError": null,
   "incidentsPending": false,
   "monitors": Object {
     "fakeData": true,

--- a/src/reducers/tests/blacklist.test.js
+++ b/src/reducers/tests/blacklist.test.js
@@ -35,6 +35,13 @@ const TEST_CASES = {
     payload: { errors: [{ message: 'Some error occurred' }] },
     type: 'ADD_WATCHLIST_FAIL',
   },
+  'delete monitor pending': {
+    type: 'DELETE_MONITOR_PENDING',
+  },
+  'delete monitor fail': {
+    payload: { errors: [{ message: 'Some error occurred' }] },
+    type: 'DELETE_MONITOR_FAIL',
+  },
 };
 
 cases(
@@ -44,3 +51,14 @@ cases(
   },
   TEST_CASES,
 );
+
+it('BlackList Reducer delete monitor success deletes the resource from redux store list', () => {
+  const state = { ...initialState, monitors: [{ resource: '101.101' }, { resource: '101.102' }] };
+  const action = {
+    type: 'DELETE_MONITOR_SUCCESS',
+    meta: {
+      resource: '101.101',
+    },
+  };
+  expect(blacklistReducer(state, action).monitors).toEqual([{ resource: '101.102' }]);
+});


### PR DESCRIPTION

### What Changed
 - Added delete modal

### How To Test
 - go to `/blacklist/watchlist` and click on the `Stop Monitoring` Button.

### TODO
- [ ] Add correct text for the delete modal.

### Notes
 - The delete success reducer deletes the resource from redux store upon success to have a cleaner transition. 

