### PR TITLE
TR-2038 - Simpler implementation - sync validation of recipient list file size handling by updating config, add global 413 error handling

### DIFF
--- a/src/actions/helpers/sparkpostApiRequest.js
+++ b/src/actions/helpers/sparkpostApiRequest.js
@@ -111,10 +111,7 @@ const sparkpostRequest = requestHelperFactory({
         showAlert({
           type: 'error',
           message: 'Something went wrong.',
-          details:
-            response.status === 413
-              ? 'File size larger than the server allows. Try again.'
-              : message,
+          details: response.status === 413 ? 'File size larger than the server allows.' : message,
         }),
       );
     }

--- a/src/actions/helpers/tests/sparkpostApiRequest.test.js
+++ b/src/actions/helpers/tests/sparkpostApiRequest.test.js
@@ -241,6 +241,7 @@ describe('Helper: SparkPost API Request', () => {
         });
 
         /* eslint-disable jest/no-try-expect */
+        // NOTE: This probably can be re-worked - will think on it
         try {
           await mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_MAX_RETRIES', meta: {} }));
         } catch (err) {

--- a/src/actions/helpers/tests/sparkpostApiRequest.test.js
+++ b/src/actions/helpers/tests/sparkpostApiRequest.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines */
+// /* eslint-disable jest/no-try-expect */
 import sparkpostApiRequest, { refreshing, refreshTokensUsed } from '../sparkpostApiRequest';
 import SparkpostApiError from '../sparkpostApiError';
 import { createMockStore } from 'src/__testHelpers__/mockStore';
@@ -15,7 +15,6 @@ jest.mock('src/actions/account');
 jest.mock('src/helpers/http');
 
 describe('Helper: SparkPost API Request', () => {
-
   let meta;
   let results;
   let state;
@@ -25,7 +24,7 @@ describe('Helper: SparkPost API Request', () => {
   let mockStore;
 
   beforeEach(() => {
-    state = { auth: { loggedIn: true, token: 'TEST-TOKEN' }, account: { status: 'active' }};
+    state = { auth: { loggedIn: true, token: 'TEST-TOKEN' }, account: { status: 'active' } };
     mockStore = createMockStore(state);
 
     meta = { url: '/some/path', method: 'GET' };
@@ -33,7 +32,7 @@ describe('Helper: SparkPost API Request', () => {
     results = [];
     authMock.logout = jest.fn(() => ({ type: 'LOGOUT' }));
 
-    axiosMocks.sparkpost.mockImplementation(() => Promise.resolve({ data: { results }}));
+    axiosMocks.sparkpost.mockImplementation(() => Promise.resolve({ data: { results } }));
     globalAlertMock.showAlert = jest.fn(() => ({ type: 'SHOW_ALERT' }));
     accountActions.fetch = jest.fn(() => ({ type: 'FETCH_ACCOUNT' }));
   });
@@ -43,11 +42,13 @@ describe('Helper: SparkPost API Request', () => {
 
     expect(actualResults).toBe(results);
     expect(mockStore.getActions()).toMatchSnapshot();
-    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(expect.objectContaining({
-      method: 'get',
-      url: '/some/path',
-      headers: { Authorization: 'TEST-TOKEN' }
-    }));
+    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        url: '/some/path',
+        headers: { Authorization: 'TEST-TOKEN' },
+      }),
+    );
   });
 
   it('should successfully call the API with a non-json response type', async () => {
@@ -59,54 +60,59 @@ describe('Helper: SparkPost API Request', () => {
     await mockStore.dispatch(sparkpostApiRequest(action));
 
     expect(mockStore.getActions()).toMatchSnapshot();
-    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(expect.objectContaining({
-      method: 'get',
-      url: '/some/path',
-      responseType: 'blob',
-      headers: { Authorization: 'TEST-TOKEN' }
-    }));
+    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        url: '/some/path',
+        responseType: 'blob',
+        headers: { Authorization: 'TEST-TOKEN' },
+      }),
+    );
   });
 
   it('should successfully call the API when the data response is null', async () => {
-
     axiosMocks.sparkpost.mockImplementation(() => Promise.resolve({ data: null }));
 
     await mockStore.dispatch(sparkpostApiRequest(action));
 
     expect(mockStore.getActions()).toMatchSnapshot();
-    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(expect.objectContaining({
-      method: 'get',
-      url: '/some/path',
-      headers: { Authorization: 'TEST-TOKEN' }
-    }));
+    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        url: '/some/path',
+        headers: { Authorization: 'TEST-TOKEN' },
+      }),
+    );
   });
 
   it('should get the correct response when response object has links and total_count', async () => {
-
-    axiosMocks.sparkpost.mockImplementation(() => Promise.resolve({ data: { results: [], links: { next: '' }, total_count: 0 }}));
+    axiosMocks.sparkpost.mockImplementation(() =>
+      Promise.resolve({ data: { results: [], links: { next: '' }, total_count: 0 } }),
+    );
 
     await mockStore.dispatch(sparkpostApiRequest(action));
 
     expect(mockStore.getActions()).toMatchSnapshot();
-    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(expect.objectContaining({
-      method: 'get',
-      url: '/some/path',
-      headers: { Authorization: 'TEST-TOKEN' }
-    }));
+    expect(axiosMocks.sparkpost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        url: '/some/path',
+        headers: { Authorization: 'TEST-TOKEN' },
+      }),
+    );
   });
 
   describe('failure cases', () => {
-
     let apiErr;
 
     beforeEach(() => {
       const error = new Error('API call failed');
-      error.response = { status: 400, data: { results }};
+      error.response = { status: 400, data: { results } };
       apiErr = new SparkpostApiError(error);
 
       axiosMocks.sparkpost.mockImplementation(() => Promise.reject(apiErr));
       refreshTokensUsed.clear();
-      globalAlertMock.showAlert = jest.fn((a) => a);
+      globalAlertMock.showAlert = jest.fn(a => a);
     });
 
     it('should handle a failed API call', async () => {
@@ -114,9 +120,23 @@ describe('Helper: SparkPost API Request', () => {
       expect(globalAlertMock.showAlert).toHaveBeenCalledWith({
         type: 'error',
         message: 'Something went wrong.',
-        details: apiErr.message
+        details: apiErr.message,
       });
       expect(mockStore.getActions()).toMatchSnapshot();
+    });
+
+    it('should render a with file size related error message when the HTTP code is a 413', async () => {
+      const error = new Error('API call failed');
+      error.response = { status: 413 };
+      apiErr = new SparkpostApiError(error);
+
+      await expect(mockStore.dispatch(sparkpostApiRequest(action))).rejects.toThrow(apiErr);
+
+      expect(globalAlertMock.showAlert).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'Something went wrong.',
+        details: 'File size larger than the server allows. Try again.',
+      });
     });
 
     it('should not show error alert when request failed', async () => {
@@ -140,21 +160,18 @@ describe('Helper: SparkPost API Request', () => {
       expect(globalAlertMock.showAlert).toHaveBeenCalledWith({
         type: 'error',
         message: 'Something went wrong.',
-        details: apiErr.message
+        details: apiErr.message,
       });
       expect(mockStore.getActions()).toMatchSnapshot();
     });
 
     it('should fetch account on a 403', async () => {
       apiErr.response.status = 403;
-      try {
-        await mockStore.dispatch(sparkpostApiRequest(action));
-      } catch (err) {
-        expect(err).toEqual(apiErr);
-        expect(authMock.logout).not.toHaveBeenCalled();
-        expect(accountActions.fetch).toHaveBeenCalledTimes(1);
-        expect(mockStore.getActions()).toMatchSnapshot();
-      }
+
+      await expect(mockStore.dispatch(sparkpostApiRequest(action))).rejects.toThrow(apiErr);
+      expect(authMock.logout).not.toHaveBeenCalled();
+      expect(accountActions.fetch).toHaveBeenCalledTimes(1);
+      expect(mockStore.getActions()).toMatchSnapshot();
     });
 
     it('should dispatch a logout action on a 401 with no refresh token', async () => {
@@ -166,7 +183,6 @@ describe('Helper: SparkPost API Request', () => {
     });
 
     describe('with refresh tokens', () => {
-
       beforeEach(() => {
         state.auth.refreshToken = 'REFRESH_1';
         mockStore = createMockStore(state);
@@ -179,7 +195,7 @@ describe('Helper: SparkPost API Request', () => {
       it('should get a refresh token and re-dispatch', async () => {
         axiosMocks.sparkpost
           .mockImplementationOnce(() => Promise.reject(apiErr))
-          .mockImplementation(() => Promise.resolve({ data: { results }}));
+          .mockImplementation(() => Promise.resolve({ data: { results } }));
 
         await mockStore.dispatch(sparkpostApiRequest(action));
         expect(httpHelpersMock.useRefreshToken).toHaveBeenCalledTimes(1);
@@ -195,12 +211,12 @@ describe('Helper: SparkPost API Request', () => {
           .mockImplementationOnce(() => Promise.reject(apiErr))
           .mockImplementationOnce(() => Promise.reject(apiErr))
           .mockImplementationOnce(() => Promise.reject(apiErr))
-          .mockImplementation(() => Promise.resolve({ data: { results }}));
+          .mockImplementation(() => Promise.resolve({ data: { results } }));
 
         await Promise.all([
-          mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_WITH_REFRESH', meta: {}})),
-          mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_NO_REFRESH', meta: {}})),
-          mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_NO_REFRESH', meta: {}}))
+          mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_WITH_REFRESH', meta: {} })),
+          mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_NO_REFRESH', meta: {} })),
+          mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_NO_REFRESH', meta: {} })),
         ]);
 
         expect(httpHelpersMock.useRefreshToken).toHaveBeenCalledTimes(1);
@@ -210,7 +226,7 @@ describe('Helper: SparkPost API Request', () => {
         // checking action counts instead of snapshotting them in order because these
         // are "kind of async" so they can sometimes get out of order and fail the snapshot
         const actions = mockStore.getActions();
-        const byType = (keep) => ({ type }) => type === keep;
+        const byType = keep => ({ type }) => type === keep;
         expect(actions.filter(byType('TEST_WITH_REFRESH_PENDING'))).toHaveLength(2);
         expect(actions.filter(byType('TEST_WITH_REFRESH_SUCCESS'))).toHaveLength(1);
         expect(actions.filter(byType('REFRESH'))).toHaveLength(1);
@@ -224,22 +240,28 @@ describe('Helper: SparkPost API Request', () => {
           return { type: 'REFRESH' };
         });
 
+        /* eslint-disable jest/no-try-expect */
         try {
-          await mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_MAX_RETRIES', meta: {}}));
+          await mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_MAX_RETRIES', meta: {} }));
         } catch (err) {
           expect(httpHelpersMock.useRefreshToken).toHaveBeenCalledTimes(3);
           expect(httpHelpersMock.useRefreshToken).toHaveBeenCalledWith('REFRESH_1');
           expect(authMock.refresh).toHaveBeenCalledWith('NEW_TOKEN', 'REFRESH_1');
           expect(mockStore.getActions()).toMatchSnapshot();
         }
+        /* eslint-enable jest/no-try-expect */
       });
 
       it('should only retry once with the same token', async () => {
         try {
-          await mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_ONE_RETRY_PER_TOKEN', meta: {}}));
+          await mockStore.dispatch(
+            sparkpostApiRequest({ type: 'TEST_ONE_RETRY_PER_TOKEN', meta: {} }),
+          );
         } catch (err) {
+          /* eslint-disable jest/no-try-expect */
           expect(httpHelpersMock.useRefreshToken).toHaveBeenCalledTimes(1);
           expect(mockStore.getActions()).toMatchSnapshot();
+          /* eslint-enable jest/no-try-expect */
         }
       });
 
@@ -248,15 +270,15 @@ describe('Helper: SparkPost API Request', () => {
         httpHelpersMock.useRefreshToken = jest.fn(() => Promise.reject(refreshErr));
 
         try {
-          await mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_REFRESH_FAILED', meta: {}}));
+          await mockStore.dispatch(sparkpostApiRequest({ type: 'TEST_REFRESH_FAILED', meta: {} }));
         } catch (err) {
+          /* eslint-disable jest/no-try-expect */
           expect(refreshing).toEqual(false);
           expect(err).toBe(refreshErr);
           expect(authMock.logout).toHaveBeenCalledTimes(1);
+          /* eslint-enable jest/no-try-expect */
         }
       });
-
     });
-
   });
 });

--- a/src/actions/helpers/tests/sparkpostApiRequest.test.js
+++ b/src/actions/helpers/tests/sparkpostApiRequest.test.js
@@ -134,7 +134,7 @@ describe('Helper: SparkPost API Request', () => {
       expect(globalAlertMock.showAlert).toHaveBeenCalledWith({
         type: 'error',
         message: 'Something went wrong.',
-        details: 'File size larger than the server allows. Try again.',
+        details: 'File size larger than the server allows.',
       });
     });
 

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -57,6 +57,7 @@ const config = identifier => ({
   },
   maxUploadSizeBytes: 20000000,
   maxRecipVerifUploadSizeBytes: 20971520, // NGNIX configures max upload size in megabytes, translating to this value in bytes
+  maxRecipListUploadSizeBytes: 12582912, // NGNIX configures max upload size in megabytes, translating to this value in bytes
   metricsPrecisionMap: [
     { time: 60, value: '1min', format: 'ha' },
     { time: 60 * 2, value: '5min', format: 'ha' },

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -57,7 +57,6 @@ const config = identifier => ({
   },
   maxUploadSizeBytes: 20000000,
   maxRecipVerifUploadSizeBytes: 20971520, // NGNIX configures max upload size in megabytes, translating to this value in bytes
-  maxRecipListUploadSizeBytes: 12582912, // NGNIX configures max upload size in megabytes, translating to this value in bytes
   metricsPrecisionMap: [
     { time: 60, value: '1min', format: 'ha' },
     { time: 60 * 2, value: '5min', format: 'ha' },

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -19,27 +19,29 @@ import exampleRecipientListPath from './example-recipient-list.csv';
 const formName = 'recipientListForm';
 
 export class RecipientListForm extends Component {
-  parseCsv = (csv) => parseRecipientListCsv(csv)
-    .catch((csvErrors) => {
+  parseCsv = csv =>
+    parseRecipientListCsv(csv).catch(csvErrors => {
       throw new SubmissionError({ _error: csvErrors });
     });
 
   // `csv` is an internal field. The outer conponent can access the parsed records in `recipients`.
-  formatValues = (values) => _.omit(values, ['csv']);
+  formatValues = values => _.omit(values, ['csv']);
 
-  submitWithRecipients = (values, recipients) => this.props.onSubmit({
-    recipients,
-    ...this.formatValues(values)
-  });
+  submitWithRecipients = (values, recipients) =>
+    this.props.onSubmit({
+      recipients,
+      ...this.formatValues(values),
+    });
 
-  submitWithoutRecipients = (values) => this.props.onSubmit(this.formatValues(values));
+  submitWithoutRecipients = values => this.props.onSubmit(this.formatValues(values));
 
   // Parse CSV, store JSON result, collect and show parsing errors
-  preSubmit = (values) => {
+  preSubmit = values => {
     if (values.csv) {
       // CSV upload is optional in edit mode
-      return this.parseCsv(values.csv)
-        .then((recipients) => this.submitWithRecipients(values, recipients));
+      return this.parseCsv(values.csv).then(recipients =>
+        this.submitWithRecipients(values, recipients),
+      );
     } else {
       return this.submitWithoutRecipients(this.formatValues(values));
     }
@@ -47,9 +49,13 @@ export class RecipientListForm extends Component {
 
   renderCsvErrors() {
     const { error } = this.props;
-    return <Banner status='danger' title='CSV Format Errors'>
-      {error.map((err, idx) => <Error key={idx} error={err}/>)}
-    </Banner>;
+    return (
+      <Banner status="danger" title="CSV Format Errors">
+        {error.map((err, idx) => (
+          <Error key={idx} error={err} />
+        ))}
+      </Banner>
+    );
   }
 
   render() {
@@ -59,72 +65,79 @@ export class RecipientListForm extends Component {
 
     let actionText = 'Create';
     let uploadHint = 'Upload a CSV file of recipients';
-    let uploadValidators = [required, maxFileSize(config.maxUploadSizeBytes)];
+    let uploadValidators = [required, maxFileSize(config.maxRecipListUploadSizeBytes)];
 
     if (editMode) {
       actionText = 'Update';
-      uploadHint = 'Optional: Upload a CSV file of recipients to replace the existing recipients in this list';
+      uploadHint =
+        'Optional: Upload a CSV file of recipients to replace the existing recipients in this list';
       uploadValidators = uploadValidators.slice(1);
     }
 
-    return <div>
-      {error && this.renderCsvErrors()}
-      <form onSubmit={handleSubmit(this.preSubmit)}>
-        <Panel>
-          <Panel.Section>
-            <Field
-              name='name'
-              label='Name'
-              placeholder='My favorite recipients'
-              validate={[required, maxLength(64)]}
-              disabled={submitting}
-              component={TextFieldWrapper}
-            />
-            {!editMode && <Field
-              name='id'
-              label='ID'
-              placeholder='my-favorite-recipients'
-              validate={[required, maxLength(64)]}
-              disabled={submitting}
-              component={TextFieldWrapper}
-            />}
-            <Field
-              name='description'
-              label='Description'
-              placeholder='All my favorite recipients'
-              validate={[maxLength(1024)]}
-              disabled={submitting}
-              component={TextFieldWrapper}
-            />
-            <Field
-              component={FileFieldWrapper}
-              disabled={submitting}
-              fileType="csv"
-              helpText={
-                <span>
-                  You can download
-                  a <DownloadLink href={exampleRecipientListPath}>CSV template here</DownloadLink> to
-                  use when formatting your recipient list for upload.
-                </span>
-              }
-              label={uploadHint}
-              name="csv"
-              validate={uploadValidators}
-            />
-          </Panel.Section>
-          <Panel.Section>
-            <Button primary submit disabled={submitDisabled}>{actionText} Recipient List</Button>
-          </Panel.Section>
-        </Panel>
-      </form>
-    </div>;
+    return (
+      <div>
+        {error && this.renderCsvErrors()}
+        <form onSubmit={handleSubmit(this.preSubmit)}>
+          <Panel>
+            <Panel.Section>
+              <Field
+                name="name"
+                label="Name"
+                placeholder="My favorite recipients"
+                validate={[required, maxLength(64)]}
+                disabled={submitting}
+                component={TextFieldWrapper}
+              />
+              {!editMode && (
+                <Field
+                  name="id"
+                  label="ID"
+                  placeholder="my-favorite-recipients"
+                  validate={[required, maxLength(64)]}
+                  disabled={submitting}
+                  component={TextFieldWrapper}
+                />
+              )}
+              <Field
+                name="description"
+                label="Description"
+                placeholder="All my favorite recipients"
+                validate={[maxLength(1024)]}
+                disabled={submitting}
+                component={TextFieldWrapper}
+              />
+              <Field
+                component={FileFieldWrapper}
+                disabled={submitting}
+                fileType="csv"
+                helpText={
+                  <span>
+                    You can download a{' '}
+                    <DownloadLink href={exampleRecipientListPath}>CSV template here</DownloadLink>{' '}
+                    to use when formatting your recipient list for upload.
+                  </span>
+                }
+                label={uploadHint}
+                name="csv"
+                validate={uploadValidators}
+              />
+            </Panel.Section>
+            <Panel.Section>
+              <Button primary submit disabled={submitDisabled}>
+                {actionText} Recipient List
+              </Button>
+            </Panel.Section>
+          </Panel>
+        </form>
+      </div>
+    );
   }
 }
 
 const WrappedForm = reduxForm({ form: formName })(RecipientListForm);
 
 const mapStateToProps = (state, props) => ({
-  initialValues: props.editMode ? state.recipientLists.current : {}
+  initialValues: props.editMode ? state.recipientLists.current : {},
 });
 
 export default connect(mapStateToProps)(WrappedForm);

--- a/src/pages/recipientLists/components/RecipientListForm.js
+++ b/src/pages/recipientLists/components/RecipientListForm.js
@@ -6,13 +6,11 @@ import _ from 'lodash';
 
 import { Panel, Banner, Button, Error } from '@sparkpost/matchbox';
 import { DownloadLink, TextFieldWrapper } from 'src/components';
-import { required, maxLength, maxFileSize } from 'src/helpers/validation';
+import { required, maxLength } from 'src/helpers/validation';
 
 import FileFieldWrapper from 'src/components/reduxFormWrappers/FileFieldWrapper';
 
 import parseRecipientListCsv from '../helpers/csv';
-
-import config from 'src/config';
 
 import exampleRecipientListPath from './example-recipient-list.csv';
 
@@ -65,7 +63,7 @@ export class RecipientListForm extends Component {
 
     let actionText = 'Create';
     let uploadHint = 'Upload a CSV file of recipients';
-    let uploadValidators = [required, maxFileSize(config.maxRecipListUploadSizeBytes)];
+    let uploadValidators = [required];
 
     if (editMode) {
       actionText = 'Update';

--- a/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
+++ b/src/pages/recipientLists/components/tests/__snapshots__/RecipientListForm.test.js.snap
@@ -45,20 +45,21 @@ exports[`RecipientListForm defaults to create mode 1`] = `
           fileType="csv"
           helpText={
             <span>
-              You can download a 
+              You can download a
+               
               <DownloadLink
                 href="example-recipient-list.csv"
               >
                 CSV template here
               </DownloadLink>
-               to use when formatting your recipient list for upload.
+               
+              to use when formatting your recipient list for upload.
             </span>
           }
           label="Upload a CSV file of recipients"
           name="csv"
           validate={
             Array [
-              [Function],
               [Function],
             ]
           }
@@ -138,20 +139,21 @@ exports[`RecipientListForm renders CSV errors 1`] = `
           fileType="csv"
           helpText={
             <span>
-              You can download a 
+              You can download a
+               
               <DownloadLink
                 href="example-recipient-list.csv"
               >
                 CSV template here
               </DownloadLink>
-               to use when formatting your recipient list for upload.
+               
+              to use when formatting your recipient list for upload.
             </span>
           }
           label="Upload a CSV file of recipients"
           name="csv"
           validate={
             Array [
-              [Function],
               [Function],
             ]
           }
@@ -218,20 +220,21 @@ exports[`RecipientListForm renders correctly in create mode 1`] = `
           fileType="csv"
           helpText={
             <span>
-              You can download a 
+              You can download a
+               
               <DownloadLink
                 href="example-recipient-list.csv"
               >
                 CSV template here
               </DownloadLink>
-               to use when formatting your recipient list for upload.
+               
+              to use when formatting your recipient list for upload.
             </span>
           }
           label="Upload a CSV file of recipients"
           name="csv"
           validate={
             Array [
-              [Function],
               [Function],
             ]
           }
@@ -286,22 +289,20 @@ exports[`RecipientListForm renders correctly in edit mode 1`] = `
           fileType="csv"
           helpText={
             <span>
-              You can download a 
+              You can download a
+               
               <DownloadLink
                 href="example-recipient-list.csv"
               >
                 CSV template here
               </DownloadLink>
-               to use when formatting your recipient list for upload.
+               
+              to use when formatting your recipient list for upload.
             </span>
           }
           label="Optional: Upload a CSV file of recipients to replace the existing recipients in this list"
           name="csv"
-          validate={
-            Array [
-              [Function],
-            ]
-          }
+          validate={Array []}
         />
       </Panel.Section>
       <Panel.Section>
@@ -369,20 +370,21 @@ exports[`RecipientListForm should disable form elements on submit 1`] = `
           fileType="csv"
           helpText={
             <span>
-              You can download a 
+              You can download a
+               
               <DownloadLink
                 href="example-recipient-list.csv"
               >
                 CSV template here
               </DownloadLink>
-               to use when formatting your recipient list for upload.
+               
+              to use when formatting your recipient list for upload.
             </span>
           }
           label="Upload a CSV file of recipients"
           name="csv"
           validate={
             Array [
-              [Function],
               [Function],
             ]
           }


### PR DESCRIPTION
[TR-2038](https://jira.int.messagesystems.com/browse/TR-2038)

### What Changed
- Prettier formatting for multiple files
- Incorporate default message details content
- Updates sparkPostApi request tests so they no longer violate the ESLint `jest/no-try-expect` rule (https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-try-expect.md)

### How To Test
1. Reach out to me and I'll give access to example CSV files that can be used to verify the frontend validation behavior
1. Upload said files and encounter the new error

### To Do
- [x] Incorporate feedback
- [x] Incorporate error message content
