### PR TITLE
SA-1145: Invalid metrics parameter on bounce, delayed, and engagement report

### DIFF
--- a/src/actions/bounceReport.js
+++ b/src/actions/bounceReport.js
@@ -1,31 +1,49 @@
-import { fetchDeliverability, fetchBounceClassifications, fetchBounceReasonsByDomain } from 'src/actions/metrics';
-import { getQueryFromOptions } from 'src/helpers/metrics';
+import {
+  fetchDeliverability,
+  fetchBounceClassifications,
+  fetchBounceReasonsByDomain,
+} from 'src/actions/metrics';
+import { getMetricsFromKeys, getQueryFromOptions } from 'src/helpers/metrics';
+
+const ADMIN_REASON_METRICS = getMetricsFromKeys(['count_admin_bounce']);
+const CLASSIFICATION_METRICS = getMetricsFromKeys(['count_bounce', 'count_admin_bounce']);
+const DELIVERABILITY_METRICS = getMetricsFromKeys([
+  'count_sent',
+  'count_bounce',
+  'count_inband_bounce',
+  'count_outofband_bounce',
+  'count_admin_bounce',
+  'count_targeted',
+]);
+const REASON_METRICS = getMetricsFromKeys(['count_bounce']);
 
 export function refreshBounceReport(updates = {}) {
-  return (dispatch) => {
-    const params = getQueryFromOptions(updates);
-
+  return dispatch => {
     // get new data
     return Promise.all([
-      dispatch(fetchDeliverability({
-        type: 'GET_BOUNCE_REPORT_AGGREGATES',
-        params: {
-          ...params,
-          metrics: 'count_sent,count_bounce,count_inband_bounce,count_outofband_bounce,count_admin_bounce,count_targeted'
-        }
-      })),
-      dispatch(fetchBounceClassifications({
-        ...params,
-        metrics: 'count_bounce,count_admin_bounce'
-      })),
-      dispatch(fetchBounceReasonsByDomain({
-        ...params,
-        metrics: 'count_bounce'
-      }, 'FETCH_METRICS_BOUNCE_REASONS_BY_DOMAIN')),
-      dispatch(fetchBounceReasonsByDomain({
-        ...params,
-        metrics: 'count_admin_bounce'
-      }, 'FETCH_METRICS_ADMIN_BOUNCE_REASONS_BY_DOMAIN'))
+      dispatch(
+        fetchDeliverability({
+          type: 'GET_BOUNCE_REPORT_AGGREGATES',
+          params: getQueryFromOptions({ ...updates, metrics: DELIVERABILITY_METRICS }),
+        }),
+      ),
+      dispatch(
+        fetchBounceClassifications(
+          getQueryFromOptions({ ...updates, metrics: CLASSIFICATION_METRICS }),
+        ),
+      ),
+      dispatch(
+        fetchBounceReasonsByDomain(
+          getQueryFromOptions({ ...updates, metrics: REASON_METRICS }),
+          'FETCH_METRICS_BOUNCE_REASONS_BY_DOMAIN',
+        ),
+      ),
+      dispatch(
+        fetchBounceReasonsByDomain(
+          getQueryFromOptions({ ...updates, metrics: ADMIN_REASON_METRICS }),
+          'FETCH_METRICS_ADMIN_BOUNCE_REASONS_BY_DOMAIN',
+        ),
+      ),
     ]);
   };
 }

--- a/src/actions/delayReport.js
+++ b/src/actions/delayReport.js
@@ -1,20 +1,22 @@
 import { fetchDeliverability, fetchDelayReasonsByDomain } from 'src/actions/metrics';
-import { getQueryFromOptions } from 'src/helpers/metrics';
+import { getMetricsFromKeys, getQueryFromOptions } from 'src/helpers/metrics';
+
+const DELIVERABILITY_METRICS = getMetricsFromKeys([
+  'count_accepted',
+  'count_delayed',
+  'count_delayed_first',
+]);
 
 export function refreshDelayReport(updates = {}) {
-  return (dispatch) => {
-    const params = getQueryFromOptions(updates);
-
+  return dispatch => {
     return Promise.all([
-      dispatch(fetchDeliverability({
-        type: 'GET_DELAY_REPORT_AGGREGATES',
-        params: {
-          ...params,
-          metrics: 'count_accepted,count_delayed,count_delayed_first'
-        }
-      })),
-      dispatch(fetchDelayReasonsByDomain(params))
+      dispatch(
+        fetchDeliverability({
+          type: 'GET_DELAY_REPORT_AGGREGATES',
+          params: getQueryFromOptions({ ...updates, metrics: DELIVERABILITY_METRICS }),
+        }),
+      ),
+      dispatch(fetchDelayReasonsByDomain(getQueryFromOptions(updates))),
     ]);
   };
-
 }

--- a/src/actions/engagementReport.js
+++ b/src/actions/engagementReport.js
@@ -1,27 +1,32 @@
 import { fetch as getMetrics } from 'src/actions/metrics';
-import { getQueryFromOptions } from 'src/helpers/metrics';
+import { getMetricsFromKeys, getQueryFromOptions } from 'src/helpers/metrics';
 
-export function refreshEngagementReport (updates = {}) {
-  return (dispatch) => {
-    const params = getQueryFromOptions(updates);
+const DELIVERABILITY_METRICS = getMetricsFromKeys([
+  'count_accepted',
+  'count_sent',
+  'count_unique_clicked_approx',
+  'count_unique_confirmed_opened_approx',
+]);
 
+const LINK_METRICS = getMetricsFromKeys(['count_clicked', 'count_raw_clicked_approx']);
+
+export function refreshEngagementReport(updates = {}) {
+  return dispatch => {
     return Promise.all([
-      dispatch(getMetrics({
-        params: {
-          ...params,
-          metrics: 'count_accepted,count_sent,count_unique_clicked_approx,count_unique_confirmed_opened_approx'
-        },
-        path: 'deliverability',
-        type: 'GET_ENGAGEMENT_AGGREGATE_METRICS'
-      })),
-      dispatch(getMetrics({
-        params: {
-          ...params,
-          metrics: 'count_clicked,count_raw_clicked_approx'
-        },
-        path: 'deliverability/link-name',
-        type: 'GET_ENGAGEMENT_LINK_METRICS'
-      }))
+      dispatch(
+        getMetrics({
+          params: getQueryFromOptions({ ...updates, metrics: DELIVERABILITY_METRICS }),
+          path: 'deliverability',
+          type: 'GET_ENGAGEMENT_AGGREGATE_METRICS',
+        }),
+      ),
+      dispatch(
+        getMetrics({
+          params: getQueryFromOptions({ ...updates, metrics: LINK_METRICS }),
+          path: 'deliverability/link-name',
+          type: 'GET_ENGAGEMENT_LINK_METRICS',
+        }),
+      ),
     ]);
   };
 }

--- a/src/actions/tests/bounceReport.test.js
+++ b/src/actions/tests/bounceReport.test.js
@@ -4,15 +4,13 @@ import * as metricsActions from 'src/actions/metrics';
 jest.mock('src/actions/metrics');
 
 describe('Action Creator: Refresh Bounce Report', () => {
-  let dispatchMock;
-
-  beforeEach(() => {
-    dispatchMock = jest.fn(a => Promise.resolve(a));
-    refreshBounceReport({ filters: [{ type: 'Campaign', value: 'test-camp' }] })(dispatchMock);
-  });
+  const subject = args => {
+    refreshBounceReport(args)(a => Promise.resolve(a));
+  };
 
   it('should dispatch actions', () => {
-    expect(dispatchMock).toHaveBeenCalledTimes(4);
+    subject({ filters: [{ type: 'Campaign', value: 'test-camp' }] });
+
     expect(metricsActions.fetchDeliverability).toHaveBeenCalledWith({
       type: 'GET_BOUNCE_REPORT_AGGREGATES',
       params: expect.objectContaining({
@@ -37,6 +35,39 @@ describe('Action Creator: Refresh Bounce Report', () => {
     expect(metricsActions.fetchBounceReasonsByDomain).toHaveBeenCalledWith(
       expect.objectContaining({
         campaigns: 'test-camp',
+        metrics: 'count_admin_bounce',
+      }),
+      'FETCH_METRICS_ADMIN_BOUNCE_REASONS_BY_DOMAIN',
+    );
+  });
+
+  it('should use unique delimiter when comma in filter value', () => {
+    subject({ filters: [{ type: 'Campaign', value: 'test,camp' }] });
+
+    expect(metricsActions.fetchDeliverability).toHaveBeenCalledWith({
+      type: 'GET_BOUNCE_REPORT_AGGREGATES',
+      params: expect.objectContaining({
+        campaigns: 'test,camp',
+        metrics:
+          'count_sent;count_bounce;count_inband_bounce;count_outofband_bounce;count_admin_bounce;count_targeted',
+      }),
+    });
+    expect(metricsActions.fetchBounceClassifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaigns: 'test,camp',
+        metrics: 'count_bounce;count_admin_bounce',
+      }),
+    );
+    expect(metricsActions.fetchBounceReasonsByDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaigns: 'test,camp',
+        metrics: 'count_bounce',
+      }),
+      'FETCH_METRICS_BOUNCE_REASONS_BY_DOMAIN',
+    );
+    expect(metricsActions.fetchBounceReasonsByDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaigns: 'test,camp',
         metrics: 'count_admin_bounce',
       }),
       'FETCH_METRICS_ADMIN_BOUNCE_REASONS_BY_DOMAIN',

--- a/src/actions/tests/bounceReport.test.js
+++ b/src/actions/tests/bounceReport.test.js
@@ -1,54 +1,45 @@
 import { refreshBounceReport } from '../bounceReport';
 import * as metricsActions from 'src/actions/metrics';
-import * as metricsHelpers from 'src/helpers/metrics';
 
-jest.mock('src/helpers/metrics');
 jest.mock('src/actions/metrics');
 
 describe('Action Creator: Refresh Bounce Report', () => {
-
   let dispatchMock;
-  let queryMock;
-  let updates;
-  let result;
 
   beforeEach(() => {
-    queryMock = {};
-    updates = { abc: 'cool' };
-    metricsHelpers.getQueryFromOptions = jest.fn(() => queryMock);
-    dispatchMock = jest.fn((a) => Promise.resolve(a));
-    result = refreshBounceReport(updates)(dispatchMock);
-  });
-
-  it('should return a promise', () => {
-    expect(result).toBeInstanceOf(Promise);
-  });
-
-  it('should get query options, passing in updates', () => {
-    expect(metricsHelpers.getQueryFromOptions).toHaveBeenCalledWith(updates);
+    dispatchMock = jest.fn(a => Promise.resolve(a));
+    refreshBounceReport({ filters: [{ type: 'Campaign', value: 'test-camp' }] })(dispatchMock);
   });
 
   it('should dispatch actions', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(4);
     expect(metricsActions.fetchDeliverability).toHaveBeenCalledWith({
       type: 'GET_BOUNCE_REPORT_AGGREGATES',
-      params: {
-        ...queryMock,
-        metrics: 'count_sent,count_bounce,count_inband_bounce,count_outofband_bounce,count_admin_bounce,count_targeted'
-      }
+      params: expect.objectContaining({
+        campaigns: 'test-camp',
+        metrics:
+          'count_sent,count_bounce,count_inband_bounce,count_outofband_bounce,count_admin_bounce,count_targeted',
+      }),
     });
-    expect(metricsActions.fetchBounceClassifications).toHaveBeenCalledWith({
-      ...queryMock,
-      metrics: 'count_bounce,count_admin_bounce'
-    });
-    expect(metricsActions.fetchBounceReasonsByDomain).toHaveBeenCalledWith({
-      ...queryMock,
-      metrics: 'count_bounce'
-    }, 'FETCH_METRICS_BOUNCE_REASONS_BY_DOMAIN');
-    expect(metricsActions.fetchBounceReasonsByDomain).toHaveBeenCalledWith({
-      ...queryMock,
-      metrics: 'count_admin_bounce'
-    }, 'FETCH_METRICS_ADMIN_BOUNCE_REASONS_BY_DOMAIN');
+    expect(metricsActions.fetchBounceClassifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaigns: 'test-camp',
+        metrics: 'count_bounce,count_admin_bounce',
+      }),
+    );
+    expect(metricsActions.fetchBounceReasonsByDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaigns: 'test-camp',
+        metrics: 'count_bounce',
+      }),
+      'FETCH_METRICS_BOUNCE_REASONS_BY_DOMAIN',
+    );
+    expect(metricsActions.fetchBounceReasonsByDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaigns: 'test-camp',
+        metrics: 'count_admin_bounce',
+      }),
+      'FETCH_METRICS_ADMIN_BOUNCE_REASONS_BY_DOMAIN',
+    );
   });
-
 });

--- a/src/actions/tests/delayReport.test.js
+++ b/src/actions/tests/delayReport.test.js
@@ -1,43 +1,27 @@
 import { refreshDelayReport } from '../delayReport';
 import * as metricsActions from 'src/actions/metrics';
-import * as metricsHelpers from 'src/helpers/metrics';
 
-jest.mock('src/helpers/metrics');
 jest.mock('src/actions/metrics');
 
 describe('Action Creator: Refresh Delay Report', () => {
-
   let dispatchMock;
-  let queryMock;
-  let updates;
-  let result;
 
   beforeEach(() => {
-    queryMock = {};
-    updates = { abc: 'cool' };
-    metricsHelpers.getQueryFromOptions = jest.fn(() => queryMock);
-    dispatchMock = jest.fn((a) => Promise.resolve(a));
-    result = refreshDelayReport(updates)(dispatchMock);
-  });
-
-  it('should return a promise', () => {
-    expect(result).toBeInstanceOf(Promise);
-  });
-
-  it('should get query options, passing in updates', () => {
-    expect(metricsHelpers.getQueryFromOptions).toHaveBeenCalledWith(updates);
+    dispatchMock = jest.fn(a => Promise.resolve(a));
+    refreshDelayReport({ filters: [{ type: 'Campaign', value: 'test-camp' }] })(dispatchMock);
   });
 
   it('should dispatch actions', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(2);
     expect(metricsActions.fetchDeliverability).toHaveBeenCalledWith({
       type: 'GET_DELAY_REPORT_AGGREGATES',
-      params: {
-        ...queryMock,
-        metrics: 'count_accepted,count_delayed,count_delayed_first'
-      }
+      params: expect.objectContaining({
+        campaigns: 'test-camp',
+        metrics: 'count_accepted,count_delayed,count_delayed_first',
+      }),
     });
-    expect(metricsActions.fetchDelayReasonsByDomain).toHaveBeenCalledWith(queryMock);
+    expect(metricsActions.fetchDelayReasonsByDomain).toHaveBeenCalledWith(
+      expect.objectContaining({ campaigns: 'test-camp' }),
+    );
   });
-
 });

--- a/src/actions/tests/delayReport.test.js
+++ b/src/actions/tests/delayReport.test.js
@@ -4,15 +4,13 @@ import * as metricsActions from 'src/actions/metrics';
 jest.mock('src/actions/metrics');
 
 describe('Action Creator: Refresh Delay Report', () => {
-  let dispatchMock;
-
-  beforeEach(() => {
-    dispatchMock = jest.fn(a => Promise.resolve(a));
-    refreshDelayReport({ filters: [{ type: 'Campaign', value: 'test-camp' }] })(dispatchMock);
-  });
+  const subject = args => {
+    refreshDelayReport(args)(a => Promise.resolve(a));
+  };
 
   it('should dispatch actions', () => {
-    expect(dispatchMock).toHaveBeenCalledTimes(2);
+    subject({ filters: [{ type: 'Campaign', value: 'test-camp' }] });
+
     expect(metricsActions.fetchDeliverability).toHaveBeenCalledWith({
       type: 'GET_DELAY_REPORT_AGGREGATES',
       params: expect.objectContaining({
@@ -22,6 +20,21 @@ describe('Action Creator: Refresh Delay Report', () => {
     });
     expect(metricsActions.fetchDelayReasonsByDomain).toHaveBeenCalledWith(
       expect.objectContaining({ campaigns: 'test-camp' }),
+    );
+  });
+
+  it('should use unique delimiter when comma in filter value', () => {
+    subject({ filters: [{ type: 'Campaign', value: 'test,camp' }] });
+
+    expect(metricsActions.fetchDeliverability).toHaveBeenCalledWith({
+      type: 'GET_DELAY_REPORT_AGGREGATES',
+      params: expect.objectContaining({
+        campaigns: 'test,camp',
+        metrics: 'count_accepted;count_delayed;count_delayed_first',
+      }),
+    });
+    expect(metricsActions.fetchDelayReasonsByDomain).toHaveBeenCalledWith(
+      expect.objectContaining({ campaigns: 'test,camp' }),
     );
   });
 });

--- a/src/actions/tests/engagementReport.test.js
+++ b/src/actions/tests/engagementReport.test.js
@@ -1,51 +1,34 @@
 import { refreshEngagementReport } from '../engagementReport';
 import * as metricsActions from 'src/actions/metrics';
-import * as metricsHelpers from 'src/helpers/metrics';
 
-jest.mock('src/helpers/metrics');
 jest.mock('src/actions/metrics');
 
 describe('Action Creator: Refresh Engagement Report', () => {
-
   let dispatchMock;
-  let queryMock;
-  let updates;
-  let result;
 
   beforeEach(() => {
-    queryMock = {};
-    updates = { abc: 'cool' };
-    metricsHelpers.getQueryFromOptions = jest.fn(() => queryMock);
-    dispatchMock = jest.fn((a) => Promise.resolve(a));
-    result = refreshEngagementReport(updates)(dispatchMock);
-  });
-
-  it('should return a promise', () => {
-    expect(result).toBeInstanceOf(Promise);
-  });
-
-  it('should get query options, passing in updates', () => {
-    expect(metricsHelpers.getQueryFromOptions).toHaveBeenCalledWith(updates);
+    dispatchMock = jest.fn(a => Promise.resolve(a));
+    refreshEngagementReport({ filters: [{ type: 'Campaign', value: 'test-camp' }] })(dispatchMock);
   });
 
   it('should dispatch actions', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(2);
     expect(metricsActions.fetch).toHaveBeenCalledWith({
-      params: {
-        ...queryMock,
-        metrics: 'count_accepted,count_sent,count_unique_clicked_approx,count_unique_confirmed_opened_approx'
-      },
+      params: expect.objectContaining({
+        campaigns: 'test-camp',
+        metrics:
+          'count_accepted,count_sent,count_unique_clicked_approx,count_unique_confirmed_opened_approx',
+      }),
       path: 'deliverability',
-      type: 'GET_ENGAGEMENT_AGGREGATE_METRICS'
+      type: 'GET_ENGAGEMENT_AGGREGATE_METRICS',
     });
     expect(metricsActions.fetch).toHaveBeenCalledWith({
-      params: {
-        ...queryMock,
-        metrics: 'count_clicked,count_raw_clicked_approx'
-      },
+      params: expect.objectContaining({
+        campaigns: 'test-camp',
+        metrics: 'count_clicked,count_raw_clicked_approx',
+      }),
       path: 'deliverability/link-name',
-      type: 'GET_ENGAGEMENT_LINK_METRICS'
+      type: 'GET_ENGAGEMENT_LINK_METRICS',
     });
   });
-
 });

--- a/src/actions/tests/engagementReport.test.js
+++ b/src/actions/tests/engagementReport.test.js
@@ -4,15 +4,13 @@ import * as metricsActions from 'src/actions/metrics';
 jest.mock('src/actions/metrics');
 
 describe('Action Creator: Refresh Engagement Report', () => {
-  let dispatchMock;
-
-  beforeEach(() => {
-    dispatchMock = jest.fn(a => Promise.resolve(a));
-    refreshEngagementReport({ filters: [{ type: 'Campaign', value: 'test-camp' }] })(dispatchMock);
-  });
+  const subject = args => {
+    refreshEngagementReport(args)(a => Promise.resolve(a));
+  };
 
   it('should dispatch actions', () => {
-    expect(dispatchMock).toHaveBeenCalledTimes(2);
+    subject({ filters: [{ type: 'Campaign', value: 'test-camp' }] });
+
     expect(metricsActions.fetch).toHaveBeenCalledWith({
       params: expect.objectContaining({
         campaigns: 'test-camp',
@@ -26,6 +24,28 @@ describe('Action Creator: Refresh Engagement Report', () => {
       params: expect.objectContaining({
         campaigns: 'test-camp',
         metrics: 'count_clicked,count_raw_clicked_approx',
+      }),
+      path: 'deliverability/link-name',
+      type: 'GET_ENGAGEMENT_LINK_METRICS',
+    });
+  });
+
+  it('should use unique delimiter when comma in filter value', () => {
+    subject({ filters: [{ type: 'Campaign', value: 'test,camp' }] });
+
+    expect(metricsActions.fetch).toHaveBeenCalledWith({
+      params: expect.objectContaining({
+        campaigns: 'test,camp',
+        metrics:
+          'count_accepted;count_sent;count_unique_clicked_approx;count_unique_confirmed_opened_approx',
+      }),
+      path: 'deliverability',
+      type: 'GET_ENGAGEMENT_AGGREGATE_METRICS',
+    });
+    expect(metricsActions.fetch).toHaveBeenCalledWith({
+      params: expect.objectContaining({
+        campaigns: 'test,camp',
+        metrics: 'count_clicked;count_raw_clicked_approx',
       }),
       path: 'deliverability/link-name',
       type: 'GET_ENGAGEMENT_LINK_METRICS',


### PR DESCRIPTION
See [SA-1145](https://jira.int.messagesystems.com/browse/SA-1145)

### What Changed
 - Modified how metrics parameter values are joined on bounce, delayed, and engagement reports

### How To Test
- Create a subaccount with a comma in the name
- Open each bounce, delayed, and engagement reports
- Add filter for your new subaccount

Expected, to not break.