### PR TITLE
FE-799 Provide account creation timestamp to Pendo

### DIFF
--- a/src/components/pendo/Pendo.js
+++ b/src/components/pendo/Pendo.js
@@ -5,11 +5,19 @@ import { usernameSelector } from 'src/selectors/currentUser';
 import config from 'src/config';
 
 export class Pendo extends React.Component {
-  state = {}
+  state = {};
 
   componentDidUpdate() {
     const { initialised } = this.state;
-    const { accessControlReady, accountId, accountSvcLevel, accountPlanCode, username, userAccessLevel } = this.props;
+    const {
+      accessControlReady,
+      accountCreatedAt,
+      accountId,
+      accountSvcLevel,
+      accountPlanCode,
+      username,
+      userAccessLevel,
+    } = this.props;
     const pendo = window.pendo;
     const { tenantId, release } = config;
 
@@ -33,13 +41,14 @@ export class Pendo extends React.Component {
         id: `${tenantId}_${accountId}`,
         tenant: tenantId,
         plan: accountPlanCode,
-        serviceLevel: accountSvcLevel
+        serviceLevel: accountSvcLevel,
+        accountCreatedAt,
       },
       visitor: {
         id: `${tenantId}_${accountId}_${username}`,
         accessLevel: userAccessLevel,
-        release
-      }
+        release,
+      },
     });
 
     this.setState({ initialised: true });
@@ -50,13 +59,14 @@ export class Pendo extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   accessControlReady: state.accessControlReady,
+  accountCreatedAt: state.account.created,
   accountId: state.account.customer_id,
   accountPlanCode: currentPlanCodeSelector(state),
   accountSvcLevel: state.account.service_level,
   username: usernameSelector(state),
-  userAccessLevel: state.currentUser.access_level
+  userAccessLevel: state.currentUser.access_level,
 });
 
 export default connect(mapStateToProps)(Pendo);

--- a/src/components/pendo/tests/Pendo.test.js
+++ b/src/components/pendo/tests/Pendo.test.js
@@ -5,19 +5,23 @@ import { Pendo } from '../Pendo';
 describe('Component: Pendo', () => {
   beforeEach(() => {
     window.pendo = {
-      initialize: jest.fn()
+      initialize: jest.fn(),
     };
   });
 
-  const subject = (props) => shallow(<Pendo
-    accessControlReady={false}
-    accountId={999999}
-    accountPlanCode='1meellion'
-    accountSvcLevel='enterprise'
-    username='fredo-mcgurk'
-    userAccessLevel='admin'
-    {...props}
-  />);
+  const subject = props =>
+    shallow(
+      <Pendo
+        accessControlReady={false}
+        accountCreatedAt="2014-12-30T17:43:18.954Z"
+        accountId={999999}
+        accountPlanCode="1meellion"
+        accountSvcLevel="enterprise"
+        username="fredo-mcgurk"
+        userAccessLevel="admin"
+        {...props}
+      />,
+    );
 
   it('should initialise Pendo', () => {
     const wrapper = subject();
@@ -33,7 +37,7 @@ describe('Component: Pendo', () => {
     expect(window.pendo.initialize).toHaveBeenCalledTimes(1);
   });
 
-  it('...iff pendo is available', () => {
+  it('...iff pendo is available', async () => {
     delete window.pendo;
     const wrapper = subject();
     const update = new Promise((resolve, reject) => {
@@ -44,7 +48,7 @@ describe('Component: Pendo', () => {
         reject(e);
       }
     });
-    expect(update).resolves.toBe(true);
+    await expect(update).resolves.toBe(true);
   });
 
   it('...after access control is ready', () => {

--- a/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
+++ b/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
@@ -4,6 +4,7 @@ exports[`Component: Pendo should initialise Pendo 1`] = `
 Array [
   Object {
     "account": Object {
+      "accountCreatedAt": "2014-12-30T17:43:18.954Z",
       "id": "test_999999",
       "plan": "1meellion",
       "serviceLevel": "enterprise",


### PR DESCRIPTION
Refer to [FE-799](https://jira.int.messagesystems.com/browse/FE-799)

### What Changed
 - Sending account created timestamp to Pendo

### How To Test
- Execute `pendo.validateInstall()` in devtools console and confirm "accountCreatedAt" is set
- Confirm Pendo is correctly translating our timestamp — https://app.pendo.io/account/app_107
