### PR TITLE
AC-1158 - Test new billing page (Fixes)

### DIFF
--- a/src/__func__/billing/__snapshots__/changePlanFirstTime.test.js.snap
+++ b/src/__func__/billing/__snapshots__/changePlanFirstTime.test.js.snap
@@ -148,6 +148,18 @@ Array [
       "headers": Object {
         "Authorization": "mock-access-token",
       },
+      "method": "post",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/billing/subscription/check",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
       "method": "get",
       "params": Object {
         "include": "usage",

--- a/src/__func__/billing/__snapshots__/updateBillingDetails.test.js.snap
+++ b/src/__func__/billing/__snapshots__/updateBillingDetails.test.js.snap
@@ -165,6 +165,18 @@ Array [
       "method": "post",
       "params": undefined,
       "responseType": "json",
+      "url": "/v1/billing/subscription/check",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
+      "method": "post",
+      "params": undefined,
+      "responseType": "json",
       "url": "/v1/account/billing/collect",
     },
   ],

--- a/src/__func__/signup/__snapshots__/choosePaidPlan.test.js.snap
+++ b/src/__func__/signup/__snapshots__/choosePaidPlan.test.js.snap
@@ -229,6 +229,18 @@ Array [
       "headers": Object {
         "Authorization": "mock-access-token",
       },
+      "method": "post",
+      "params": undefined,
+      "responseType": "json",
+      "url": "/v1/billing/subscription/check",
+    },
+  ],
+  Array [
+    Object {
+      "data": undefined,
+      "headers": Object {
+        "Authorization": "mock-access-token",
+      },
       "method": "get",
       "params": Object {
         "include": "usage",

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -63,6 +63,17 @@ export function syncSubscription({ meta = {} } = {}) {
   });
 }
 
+export function syncBillingSubscription({ meta = {} } = {}) {
+  return sparkpostApiRequest({
+    type: 'SYNC_BILLING_SUBSCRIPTION',
+    meta: {
+      method: 'POST',
+      url: '/v1/billing/subscription/check',
+      ...meta,
+    },
+  });
+}
+
 /**
  * attempts to collect payments (like when payment method is updated) to make sure pending payments are charged
  */

--- a/src/actions/billingCreate.js
+++ b/src/actions/billingCreate.js
@@ -2,7 +2,14 @@ import { isAws, isCustomBilling } from 'src/helpers/conditions/account';
 import { formatCreateData, formatDataForCors } from 'src/helpers/billing';
 import { fetch as fetchAccount, getBillingInfo } from './account';
 import chainActions from 'src/actions/helpers/chainActions';
-import { cors, createZuoraAccount, syncSubscription, updateSubscription, consumePromoCode } from './billing';
+import {
+  cors,
+  createZuoraAccount,
+  syncBillingSubscription,
+  syncSubscription,
+  updateSubscription,
+  consumePromoCode,
+} from './billing';
 
 export default function billingCreate(values) {
   return (dispatch, getState) => {
@@ -15,7 +22,8 @@ export default function billingCreate(values) {
     const { corsData, billingData } = formatDataForCors(values);
 
     // action creator wrappers for chaining as callbacks
-    const corsCreateBilling = ({ meta }) => cors({ meta, context: 'create-account', data: corsData });
+    const corsCreateBilling = ({ meta }) =>
+      cors({ meta, context: 'create-account', data: corsData });
     const fetchUsage = ({ meta }) => fetchAccount({ include: 'usage', meta });
     const fetchBillingInfo = ({ meta }) => getBillingInfo({ meta });
     const constructZuoraAccount = ({ results: { signature, token, ...results }, meta }) => {
@@ -28,9 +36,17 @@ export default function billingCreate(values) {
       return createZuoraAccount({ data, token, signature, meta });
     };
 
-    const actions = [corsCreateBilling, constructZuoraAccount, syncSubscription, fetchUsage, fetchBillingInfo];
+    const actions = [
+      corsCreateBilling,
+      constructZuoraAccount,
+      syncSubscription,
+      syncBillingSubscription,
+      fetchUsage,
+      fetchBillingInfo,
+    ];
     if (values.promoCode) {
-      const consumePromo = ({ meta }) => consumePromoCode({ meta, promoCode: values.promoCode, billingId: billingData.billingId });
+      const consumePromo = ({ meta }) =>
+        consumePromoCode({ meta, promoCode: values.promoCode, billingId: billingData.billingId });
       actions.push(consumePromo);
     }
     return dispatch(chainActions(...actions)());

--- a/src/actions/billingUpdate.js
+++ b/src/actions/billingUpdate.js
@@ -1,7 +1,14 @@
 import { fetch as fetchAccount, getBillingInfo } from './account';
 import { formatUpdateData } from 'src/helpers/billing';
 import chainActions from 'src/actions/helpers/chainActions';
-import { collectPayments, cors, syncSubscription, updateCreditCard, updateSubscription } from './billing';
+import {
+  collectPayments,
+  cors,
+  syncSubscription,
+  syncBillingSubscription,
+  updateCreditCard,
+  updateSubscription,
+} from './billing';
 
 // note: this action creator should detect
 // 1. if payment info is present, contact zuora first
@@ -9,21 +16,37 @@ import { collectPayments, cors, syncSubscription, updateCreditCard, updateSubscr
 //
 // call this action creator from the "free -> paid" form if account.billing is present
 export default function billingUpdate(values) {
-
-  return (dispatch) => {
+  return dispatch => {
     // action creator wrappers for chaining as callbacks
-    const corsUpdateBilling = ({ meta }) => (
-      cors({ context: 'update-billing', meta })
-    );
-    const maybeUpdateSubscription = ({ meta }) => values.planpicker || values.bundle
-      ? updateSubscription({ bundle: values.bundle, code: values.planpicker.code, promoCode: values.promoCode, meta })
-      : meta.onSuccess({ meta }); // bypass
-    const updateZuoraCC = ({ meta, results: { accountKey, token, signature }}) => (
-      updateCreditCard({ data: formatUpdateData({ ...values, accountKey }), signature, token, meta })
-    );
+    const corsUpdateBilling = ({ meta }) => cors({ context: 'update-billing', meta });
+    const maybeUpdateSubscription = ({ meta }) =>
+      values.planpicker || values.bundle
+        ? updateSubscription({
+            bundle: values.bundle,
+            code: values.planpicker.code,
+            promoCode: values.promoCode,
+            meta,
+          })
+        : meta.onSuccess({ meta }); // bypass
+    const updateZuoraCC = ({ meta, results: { accountKey, token, signature } }) =>
+      updateCreditCard({
+        data: formatUpdateData({ ...values, accountKey }),
+        signature,
+        token,
+        meta,
+      });
     const fetchAccountDetails = ({ meta }) => fetchAccount({ include: 'usage', meta });
     const fetchBillingInfo = () => getBillingInfo();
-    const actions = [corsUpdateBilling, updateZuoraCC, maybeUpdateSubscription, syncSubscription, collectPayments, fetchAccountDetails, fetchBillingInfo];
+    const actions = [
+      corsUpdateBilling,
+      updateZuoraCC,
+      maybeUpdateSubscription,
+      syncSubscription,
+      syncBillingSubscription,
+      collectPayments,
+      fetchAccountDetails,
+      fetchBillingInfo,
+    ];
 
     return dispatch(chainActions(...actions)());
   };

--- a/src/actions/tests/billingCreate.test.js
+++ b/src/actions/tests/billingCreate.test.js
@@ -18,59 +18,67 @@ describe('Action Creator: Billing Create', () => {
   let getState;
 
   const checkBillingCreationSteps = () => {
-    expect(billingActions.cors).toHaveBeenCalledWith(expect.objectContaining({
-      context: 'create-account',
-      data: corsData
-    }));
+    expect(billingActions.cors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: 'create-account',
+        data: corsData,
+      }),
+    );
 
-    expect(billingActions.createZuoraAccount).toHaveBeenCalledWith(expect.objectContaining({
-      data: billingData,
-      signature: 'TEST_SIGNATURE',
-      token: 'TEST_TOKEN'
-    }));
+    expect(billingActions.createZuoraAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: billingData,
+        signature: 'TEST_SIGNATURE',
+        token: 'TEST_TOKEN',
+      }),
+    );
 
     expect(billingActions.syncSubscription).toHaveBeenCalled();
-    expect(accountActions.fetch).toHaveBeenCalledWith(expect.objectContaining({ include: 'usage' }));
+    expect(accountActions.fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ include: 'usage' }),
+    );
     expect(accountActions.getBillingInfo).toHaveBeenCalled();
   };
 
   beforeEach(() => {
     values = {};
     currentUser = {
-      email: 'test@example.com'
+      email: 'test@example.com',
     };
     corsData = {
-      email: 'test@example.com'
+      email: 'test@example.com',
     };
     billingData = {
       billingId: 'test-billing-id',
       billToContact: {},
       creditCard: {
-        cardNumber: '1111222233334444'
+        cardNumber: '1111222233334444',
       },
-      invoiceCollect: true
+      invoiceCollect: true,
     };
     getState = () => ({ currentUser });
-    dispatch = jest.fn((a) => a);
+    dispatch = jest.fn(a => a);
     accountConditions.isAws = jest.fn(() => false);
     accountConditions.isCustomBilling = jest.fn(() => false);
     billingActions.createZuoraAccount = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.syncSubscription = jest.fn(({ meta }) => meta.onSuccess({}));
+    billingActions.syncBillingSubscription = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.consumePromoCode = jest.fn(({ meta }) => meta.onSuccess({}));
-    billingActions.cors = jest.fn(({ meta }) => meta.onSuccess({
-      results: {
-        signature: 'TEST_SIGNATURE',
-        token: 'TEST_TOKEN'
-      }
-    }));
+    billingActions.cors = jest.fn(({ meta }) =>
+      meta.onSuccess({
+        results: {
+          signature: 'TEST_SIGNATURE',
+          token: 'TEST_TOKEN',
+        },
+      }),
+    );
     accountActions.fetch = jest.fn(({ meta }) => meta.onSuccess({}));
     accountActions.getBillingInfo = jest.fn(({ meta }) => meta.onSuccess({}));
-    billingHelpers.formatCreateData = jest.fn((a) => a);
-    billingHelpers.formatDataForCors = jest.fn((a) => ({ billingData, corsData }));
+    billingHelpers.formatCreateData = jest.fn(a => a);
+    billingHelpers.formatDataForCors = jest.fn(() => ({ billingData, corsData }));
   });
 
   it('update without a planpicker code', () => {
-
     const thunk = billingCreate(values);
     accountActions.getBillingInfo = jest.fn();
 
@@ -82,7 +90,7 @@ describe('Action Creator: Billing Create', () => {
 
   it('update subscription for AWS users', () => {
     const state = jest.fn();
-    const values = { planpicker: { code: 'plan-code' }};
+    const values = { planpicker: { code: 'plan-code' } };
     const thunk = billingCreate(values);
 
     accountConditions.isAws = jest.fn(() => true);
@@ -101,9 +109,11 @@ describe('Action Creator: Billing Create', () => {
 
     thunk(dispatch, getState);
     checkBillingCreationSteps();
-    expect(billingActions.consumePromoCode).toHaveBeenCalledWith(expect.objectContaining({
-      promoCode: 'test-promo-code',
-      billingId: 'test-billing-id'
-    }));
+    expect(billingActions.consumePromoCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promoCode: 'test-promo-code',
+        billingId: 'test-billing-id',
+      }),
+    );
   });
 });

--- a/src/actions/tests/billingUpdate.test.js
+++ b/src/actions/tests/billingUpdate.test.js
@@ -11,21 +11,24 @@ describe('Action Creator: Billing Update', () => {
   let dispatch;
 
   beforeEach(() => {
-    dispatch = jest.fn((a) => a);
-    billingActions.cors = jest.fn(({ meta }) => meta.onSuccess({
-      results: {
-        accountKey: 'account-key',
-        signature: 'TEST_SIGNATURE',
-        token: 'TEST_TOKEN'
-      }
-    }));
+    dispatch = jest.fn(a => a);
+    billingActions.cors = jest.fn(({ meta }) =>
+      meta.onSuccess({
+        results: {
+          accountKey: 'account-key',
+          signature: 'TEST_SIGNATURE',
+          token: 'TEST_TOKEN',
+        },
+      }),
+    );
     billingActions.updateCreditCard = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.updateSubscription = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.syncSubscription = jest.fn(({ meta }) => meta.onSuccess({}));
+    billingActions.syncBillingSubscription = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.collectPayments = jest.fn(({ meta }) => meta.onSuccess({}));
     accountActions.fetch = jest.fn(({ meta }) => meta.onSuccess({}));
     accountActions.getBillingInfo = jest.fn();
-    billingHelpers.formatUpdateData = jest.fn((a) => a);
+    billingHelpers.formatUpdateData = jest.fn(a => a);
   });
 
   it('update without a planpicker code', () => {
@@ -34,50 +37,65 @@ describe('Action Creator: Billing Update', () => {
 
     thunk(dispatch);
 
-    expect(billingActions.cors).toHaveBeenCalledWith(expect.objectContaining({
-      context: 'update-billing'
-    }));
-    expect(billingActions.updateCreditCard).toHaveBeenCalledWith(expect.objectContaining({
-      data: {
-        accountKey: 'account-key'
-      },
-      signature: 'TEST_SIGNATURE',
-      token: 'TEST_TOKEN'
-    }));
+    expect(billingActions.cors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: 'update-billing',
+      }),
+    );
+    expect(billingActions.updateCreditCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          accountKey: 'account-key',
+        },
+        signature: 'TEST_SIGNATURE',
+        token: 'TEST_TOKEN',
+      }),
+    );
     expect(billingActions.updateSubscription).not.toHaveBeenCalled();
     expect(billingActions.syncSubscription).toHaveBeenCalled();
+    expect(billingActions.syncBillingSubscription).toHaveBeenCalled();
     expect(billingActions.collectPayments).toHaveBeenCalled();
-    expect(accountActions.fetch).toHaveBeenCalledWith(expect.objectContaining({ include: 'usage' }));
+    expect(accountActions.fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ include: 'usage' }),
+    );
     expect(accountActions.getBillingInfo).toHaveBeenCalled();
   });
 
   it('update with a planpicker code', () => {
     const values = {
       planpicker: {
-        code: 'plan-code'
-      }
+        code: 'plan-code',
+      },
     };
     const thunk = billingUpdate(values);
 
     thunk(dispatch);
 
-    expect(billingActions.cors).toHaveBeenCalledWith(expect.objectContaining({
-      context: 'update-billing'
-    }));
-    expect(billingActions.updateCreditCard).toHaveBeenCalledWith(expect.objectContaining({
-      data: {
-        accountKey: 'account-key',
-        ...values
-      },
-      signature: 'TEST_SIGNATURE',
-      token: 'TEST_TOKEN'
-    }));
-    expect(billingActions.updateSubscription).toHaveBeenCalledWith(expect.objectContaining({
-      code: 'plan-code'
-    }));
+    expect(billingActions.cors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: 'update-billing',
+      }),
+    );
+    expect(billingActions.updateCreditCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          accountKey: 'account-key',
+          ...values,
+        },
+        signature: 'TEST_SIGNATURE',
+        token: 'TEST_TOKEN',
+      }),
+    );
+    expect(billingActions.updateSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'plan-code',
+      }),
+    );
     expect(billingActions.syncSubscription).toHaveBeenCalled();
     expect(billingActions.collectPayments).toHaveBeenCalled();
-    expect(accountActions.fetch).toHaveBeenCalledWith(expect.objectContaining({ include: 'usage' }));
+    expect(accountActions.fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ include: 'usage' }),
+    );
     expect(accountActions.getBillingInfo).toHaveBeenCalled();
   });
 });

--- a/src/pages/billing/components/PlanSelect.js
+++ b/src/pages/billing/components/PlanSelect.js
@@ -17,10 +17,9 @@ export const useModal = () => {
   }
   return {
     isShowing,
-    toggle
+    toggle,
   };
 };
-
 
 export const SelectedPlan = ({ bundle, onChange, promoCodeObj, handlePromoCode }) => {
   const { messaging: plan, tier } = bundle;
@@ -33,10 +32,14 @@ export const SelectedPlan = ({ bundle, onChange, promoCodeObj, handlePromoCode }
       title="Your New Plan"
       actions={[
         {
-          content: (<span>Compare Features <ViewModule /></span>),
+          content: (
+            <span>
+              Compare Features <ViewModule />
+            </span>
+          ),
           onClick: toggle,
-          color: 'orange'
-        }
+          color: 'orange',
+        },
       ]}
     >
       <FeatureComparisonModal open={isShowing} handleClose={toggle} />
@@ -45,83 +48,96 @@ export const SelectedPlan = ({ bundle, onChange, promoCodeObj, handlePromoCode }
           <div className={styles.tierLabel}>{PLAN_TIERS[tier]}</div>
           <div className={styles.PlanRow}>
             <div>
-              <PlanPrice showOverage showIp showCsm plan={plan} selectedPromo={selectedPromo}/>
+              <PlanPrice showOverage showIp showCsm plan={plan} selectedPromo={selectedPromo} />
             </div>
             <div>
-              <Button
-                onClick={() => onChange()}
-                size="small"
-                flat
-                color="orange"
-              >
+              <Button onClick={() => onChange()} size="small" flat color="orange">
                 Change
               </Button>
             </div>
           </div>
         </div>
       </Panel.Section>
-      {price > 0 &&
+      {price > 0 && (
         <Panel.Section>
           <div className={styles.PlanRow}>
             <PromoCodeNew
               key={selectedPromo.promoCode || 'promocode'}
-              promoCodeObj ={promoCodeObj}
-              handlePromoCode ={handlePromoCode}
+              promoCodeObj={promoCodeObj}
+              handlePromoCode={handlePromoCode}
             />
           </div>
         </Panel.Section>
-      }
-
+      )}
     </Panel>
   );
 };
 
-
 const PlanSelectSection = ({ bundles, currentPlan, onSelect }) => {
-
-  const bundlesByTier = useMemo(() =>
-    _.groupBy(bundles, 'tier')
-  , [bundles]);
-
+  const publicBundlesByTier = useMemo(
+    () =>
+      _.groupBy(
+        bundles.filter(x => x.status !== 'secret'),
+        'tier',
+      ),
+    [bundles],
+  );
   const { isShowing, toggle } = useModal(false);
-  const planList = _.map(PLAN_TIERS, (label, key) => (bundlesByTier[key] &&
-    <Panel.Section key={`tier_section_${key}`}>
-      <div className={styles.tierLabel}>{label}</div>
-      <div className={styles.tierPlans}>
-        {
-          bundlesByTier[key].map((bundle) => {
-            const { messaging, bundle: bundleCode } = bundle;
-            const isCurrentPlan = currentPlan.code === bundleCode;
-            return (
-              <div className={cx(styles.PlanRow, isCurrentPlan && styles.SelectedPlan)} key={`plan_row_${bundleCode}`}>
-                <div>
-                  {isCurrentPlan && <Check className={styles.CheckIcon}/>}
-                  <PlanPrice showOverage showIp showCsm plan={messaging} />
-                </div>
-                <div>
-                  <Button
-                    className={styles.selectButton}
-                    disabled={isCurrentPlan}
-                    onClick={() => onSelect(bundleCode)}
-                    size='small'>
+  const planList = _.map(
+    PLAN_TIERS,
+    (label, key) =>
+      publicBundlesByTier[key] && (
+        <Panel.Section key={`tier_section_${key}`}>
+          <div className={styles.tierLabel}>{label}</div>
+          <div className={styles.tierPlans}>
+            {publicBundlesByTier[key].map(bundle => {
+              const { messaging, bundle: bundleCode } = bundle;
+              const isCurrentPlan = currentPlan.code === bundleCode;
+              return (
+                <div
+                  className={cx(styles.PlanRow, isCurrentPlan && styles.SelectedPlan)}
+                  key={`plan_row_${bundleCode}`}
+                >
+                  <div>
+                    {isCurrentPlan && <Check className={styles.CheckIcon} />}
+                    <PlanPrice showOverage showIp showCsm plan={messaging} />
+                  </div>
+                  <div>
+                    <Button
+                      className={styles.selectButton}
+                      disabled={isCurrentPlan}
+                      onClick={() => onSelect(bundleCode)}
+                      size="small"
+                    >
                       Select
-                  </Button>
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            );
-          })
-        }
-      </div>
-    </Panel.Section>
-  ));
+              );
+            })}
+          </div>
+        </Panel.Section>
+      ),
+  );
 
-  return <Panel title="Select a Plan"
-    actions={[{
-      content: <span>Compare Features <ViewModule /></span>, onClick: toggle, color: 'orange' }]}>
-    <FeatureComparisonModal open={isShowing} handleClose={toggle} />
-    {planList}
-  </Panel>;
-}
-;
-
+  return (
+    <Panel
+      title="Select a Plan"
+      actions={[
+        {
+          content: (
+            <span>
+              Compare Features <ViewModule />
+            </span>
+          ),
+          onClick: toggle,
+          color: 'orange',
+        },
+      ]}
+    >
+      <FeatureComparisonModal open={isShowing} handleClose={toggle} />
+      {planList}
+    </Panel>
+  );
+};
 export default PlanSelectSection;

--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -86,38 +86,10 @@ export const FeatureChangeProvider = ({
             resObject.auth = {
               label: 'Authentication and Security',
               description:
-                'Your new plan no longer allows for single sign-on and multifactor authentication.',
+                'Your new plan no longer allows for single sign-on and account-wide requirement of two-factor authentication.',
             };
           }
           return resObject;
-        // case 'subaccounts': {
-        //   const limit = _.get(comparedPlan, 'limit', 0);
-        //   const condition = Boolean(quantity <= limit);
-        //   if (actions.subaccounts || !condition) {
-        //     resObject.subaccounts = {
-        //       label: 'Subaccounts',
-        //       description: (
-        //         <div>
-        //           {
-        //             limit === 0
-        //               ? 'Your new plan doesn\'t include subaccounts.'
-        //               : `Your new plan only allows for ${pluralString(limit, 'active subaccount', 'active subaccounts')}.`
-        //           }
-        //           {!condition &&
-        //             <>
-        //               <span> Please </span>
-        //               <strong>change the status to terminated for {pluralString(quantity - limit, 'subaccount', 'subaccounts')}</strong>
-        //               <span> to continue.</span>
-        //             </>
-        //           }
-        //         </div>
-        //       ),
-        //       condition,
-        //       action: <Button destructive external to='/account/subaccounts'>Update Status</Button>
-        //     };
-        //   }
-        //   return resObject;
-        // }
         case 'messaging':
         default:
           return resObject;

--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -5,7 +5,6 @@ import { Button } from '@sparkpost/matchbox';
 
 import { getSubscription } from 'src/actions/billing';
 import { selectPlansByKey } from 'src/selectors/accountBillingInfo';
-import SupportTicketLink from 'src/components/supportTicketLink/SupportTicketLink';
 // import { pluralString } from 'src/helpers/string';
 
 const FeatureChangeContext = createContext({});
@@ -16,19 +15,23 @@ export const FeatureChangeProvider = ({
   subscription,
   selectedBundle,
   loading,
-  getSubscription
+  getSubscription,
 }) => {
-
-  const [ actions, updateActions ] = useState({});
+  const [actions, updateActions] = useState({});
   //State to keep track of features that can't directly be addressed, and are acknowledged by user
-  const [ confirmations, setConfirm ] = useState({});
-  const onConfirm = (key) => { setConfirm({ ...confirmations, [key]: true }); };
+  const [confirmations, setConfirm] = useState({});
+  const onConfirm = key => {
+    setConfirm({ ...confirmations, [key]: true });
+  };
 
-  useEffect(() => { getSubscription(); }, [getSubscription]);
-
+  useEffect(() => {
+    getSubscription();
+  }, [getSubscription]);
 
   //Rechecks conditions on re-entering tab. Only initializes once
-  const checkConditions = useCallback(() => { getSubscription(); }, [getSubscription]);
+  const checkConditions = useCallback(() => {
+    getSubscription();
+  }, [getSubscription]);
   useEffect(() => {
     window.addEventListener('focus', checkConditions);
     return () => {
@@ -38,14 +41,14 @@ export const FeatureChangeProvider = ({
 
   //Keys the selected plan by product to make for easier comparison
   const selectedPlansByProduct = useMemo(() => {
-
     const { products } = selectedBundle;
-    return products.reduce((res, { product, plan: planId }) => (
-      {
+    return products.reduce(
+      (res, { product, plan: planId }) => ({
         ...res,
-        [product]: plans[planId]
-      }
-    ), {});
+        [product]: plans[planId],
+      }),
+      {},
+    );
   }, [plans, selectedBundle]);
 
   // Used for finding the features that need to have a proper function
@@ -69,17 +72,11 @@ export const FeatureChangeProvider = ({
               description: (
                 <div>
                   <span>
-                    Your new plan doesn't include dedicated IPs.
-                    Your current IPs will now be billed at $20/month each, or you can
-                  </span>
-                  <SupportTicketLink issueId="general_issue">
-                     &nbsp;submit a ticket&nbsp;
-                  </SupportTicketLink>
-                  <span>
-                     to delete them.
+                    {`Your new plan doesn't include dedicated IPs. 
+                    Your current IP(s) will be removed at the end of your current billing cycle.`}
                   </span>
                 </div>
-              )
+              ),
             };
           }
           return resObject;
@@ -88,7 +85,8 @@ export const FeatureChangeProvider = ({
           if (actions.auth || !comparedPlan) {
             resObject.auth = {
               label: 'Authentication and Security',
-              description: 'Your new plan no longer allows for single sign-on and multifactor authentication.'
+              description:
+                'Your new plan no longer allows for single sign-on and multifactor authentication.',
             };
           }
           return resObject;
@@ -131,34 +129,37 @@ export const FeatureChangeProvider = ({
   useMemo(calculateDifferences, [subscription]);
 
   //Evaluates condition and generates action if condition exists
-  const featuresWithActions = useMemo(() => (_.map(actions, ({ action, condition, ...rest }, key) => ({
-    ...rest,
-    key,
-    value: condition !== undefined ? condition : confirmations[key],
-    action: condition !== undefined ? action : <Button onClick={() => onConfirm(key)}>Got it</Button>
-  }))), [actions, confirmations, onConfirm]);
+  const featuresWithActions = useMemo(
+    () =>
+      _.map(actions, ({ action, condition, ...rest }, key) => ({
+        ...rest,
+        key,
+        value: condition !== undefined ? condition : confirmations[key],
+        action:
+          condition !== undefined ? action : <Button onClick={() => onConfirm(key)}>Got it</Button>,
+      })),
+    [actions, confirmations, onConfirm],
+  );
 
   //Checks if all provided conditions are good
   const value = {
     isReady: _.every(featuresWithActions, 'value'),
     features: featuresWithActions,
-    loading
+    loading,
   };
 
-  return (
-    <FeatureChangeContext.Provider value={value}>
-      {children}
-    </FeatureChangeContext.Provider>
-  );
+  return <FeatureChangeContext.Provider value={value}>{children}</FeatureChangeContext.Provider>;
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   plans: selectPlansByKey(state),
   subscription: state.billing.subscription,
-  loading: state.billing.loading
+  loading: state.billing.loading,
 });
 
-export const FeatureChangeContextProvider = connect(mapStateToProps, { getSubscription })(FeatureChangeProvider);
+export const FeatureChangeContextProvider = connect(mapStateToProps, { getSubscription })(
+  FeatureChangeProvider,
+);
 
 export const useFeatureChangeContext = () => useContext(FeatureChangeContext);
 

--- a/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
+++ b/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
@@ -10,7 +10,7 @@ Object {
       >
         Got it
       </Button>,
-      "description": "Your new plan no longer allows for single sign-on and multifactor authentication.",
+      "description": "Your new plan no longer allows for single sign-on and account-wide requirement of two-factor authentication.",
       "key": "auth",
       "label": "Authentication and Security",
       "value": undefined,

--- a/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
+++ b/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
@@ -33,15 +33,8 @@ Object {
       </Button>,
       "description": <div>
         <span>
-          Your new plan doesn't include dedicated IPs. Your current IPs will now be billed at $20/month each, or you can
-        </span>
-        <Connect(SupportTicketLink)
-          issueId="general_issue"
-        >
-           submit a ticket 
-        </Connect(SupportTicketLink)>
-        <span>
-          to delete them.
+          Your new plan doesn't include dedicated IPs. 
+                    Your current IP(s) will be removed at the end of your current billing cycle.
         </span>
       </div>,
       "key": "dedicated_ip",


### PR DESCRIPTION
AC-1158 - Test new billing page (Fixes)

### What Changed
1. Changing the wordings - “Your new plan doesn’t include dedicated IPs. Your current IP(s) will be removed at the end of your current billing cycle.”
2. Adding the filtering for secret bundles in PlanSelect
3. users were still able to "enable tfa required " after selecting a starter plan. Solved by - [an additional call to {{/billing/subscription/check}} after the form has been submitted when a user upgrade from free to paid (along with the call to {{/account/subscription/check}})]

### How To Test
 - enable ui flag - "account_feature_limits"
 - to test the first change downgrade from premier plan to starter/free and check the wording in Changes to Features Section
- to test the second change make sure 2.5M plan gets selected when you click on this url http://localhost:3001/account/billing/plan?code=2.5M-0817 and also select plan section you do not see the 2.5M plan(or any secret plan returned by the bundle endpoint).
- to test the third change upgrade to a starter plan and ensure that you are not able to turn on tfa_required toggle and ui throws an error if you try to enable it.


### To Do
- [ ] Address Feedback
