### PR TITLE
SA-1135 - Add Datepicker to Incidents Page.

### DIFF
--- a/src/actions/blacklist.js
+++ b/src/actions/blacklist.js
@@ -40,8 +40,7 @@ export function deleteMonitor(resource) {
   });
 }
 
-export function listIncidents(from = '2019-01-01') {
-  //TODO replace with datepicker date
+export function listIncidents(from, to) {
   return sparkpostApiRequest({
     type: 'LIST_INCIDENTS',
     meta: {
@@ -50,6 +49,7 @@ export function listIncidents(from = '2019-01-01') {
       showErrorAlert: false,
       params: {
         from,
+        to,
       },
     },
   });

--- a/src/actions/tests/blacklist.test.js
+++ b/src/actions/tests/blacklist.test.js
@@ -5,7 +5,7 @@ jest.mock('src/actions/helpers/sparkpostApiRequest', () => jest.fn(a => a));
 
 describe('Action Creator: Blacklist', () => {
   it('it makes request to list incidents', async () => {
-    await blacklist.listIncidents('2019-12-01T10:10');
+    await blacklist.listIncidents('2019-12-01T10:10', '2019-12-11T10:10');
     expect(sparkpostApiRequest).toHaveBeenCalledWith({
       type: 'LIST_INCIDENTS',
       meta: {
@@ -14,6 +14,7 @@ describe('Action Creator: Blacklist', () => {
         showErrorAlert: false,
         params: {
           from: '2019-12-01T10:10',
+          to: '2019-12-11T10:10',
         },
       },
     });

--- a/src/components/collection/Collection.js
+++ b/src/components/collection/Collection.js
@@ -8,9 +8,10 @@ import Pagination from './Pagination';
 import FilterBox from './FilterBox';
 import { objectSortMatch } from 'src/helpers/sortMatch';
 
-const PassThroughWrapper = (props) => props.children;
+const PassThroughWrapper = props => props.children;
 const NullComponent = () => null;
-const objectValuesToString = (keys) => (item) => (keys || Object.keys(item)).map((key) => item[key]).join(' ');
+const objectValuesToString = keys => item =>
+  (keys || Object.keys(item)).map(key => item[key]).join(' ');
 
 export class Collection extends Component {
   state = {};
@@ -18,15 +19,15 @@ export class Collection extends Component {
   static defaultProps = {
     defaultPerPage: 25,
     filterBox: {
-      show: false
-    }
-  }
+      show: false,
+    },
+  };
 
   componentDidMount() {
     const { defaultPerPage, location } = this.props;
     this.setState({
       perPage: defaultPerPage,
-      currentPage: Number(qs.parse(location.search).page) || 1
+      currentPage: Number(qs.parse(location.search).page) || 1,
     });
   }
 
@@ -38,22 +39,22 @@ export class Collection extends Component {
     }
   }
 
-  handlePageChange = (index) => {
+  handlePageChange = index => {
     const currentPage = index + 1;
     this.setState({ currentPage }, this.maybeUpdateQueryString);
-  }
+  };
 
-  handlePerPageChange = (perPage) => {
+  handlePerPageChange = perPage => {
     this.setState({ perPage, currentPage: 1 }, this.maybeUpdateQueryString);
-  }
+  };
 
-  handleFilterChange = (pattern) => {
+  handleFilterChange = pattern => {
     const { rows, filterBox, sortColumn, sortDirection } = this.props;
     const { keyMap, itemToStringKeys, matchThreshold } = filterBox;
     const update = {
       currentPage: 1,
       filteredRows: null,
-      pattern
+      pattern,
     };
 
     if (pattern) {
@@ -62,7 +63,7 @@ export class Collection extends Component {
         pattern,
         getter: objectValuesToString(itemToStringKeys),
         keyMap,
-        matchThreshold
+        matchThreshold,
       });
 
       // Ultimately respect the sort column, if present
@@ -114,7 +115,9 @@ export class Collection extends Component {
     const { rows, perPageButtons, pagination, saveCsv = true } = this.props;
     const { currentPage, perPage, filteredRows } = this.state;
 
-    if (!pagination || !currentPage) { return null; }
+    if (!pagination || !currentPage) {
+      return null;
+    }
 
     return (
       <Pagination
@@ -129,7 +132,6 @@ export class Collection extends Component {
     );
   }
 
-
   render() {
     const {
       rows,
@@ -139,11 +141,12 @@ export class Collection extends Component {
       outerWrapper: OuterWrapper = PassThroughWrapper,
       bodyWrapper: BodyWrapper = PassThroughWrapper,
       children,
-      title
+      title,
+      emptyComponent: EmptyComponent,
     } = this.props;
 
     if (!rows.length) {
-      return null;
+      return EmptyComponent ? <EmptyComponent /> : null;
     }
 
     const filterBox = this.renderFilterBox();
@@ -151,24 +154,24 @@ export class Collection extends Component {
       <OuterWrapper>
         <HeaderComponent />
         <BodyWrapper>
-          {this.getVisibleRows().map((row, i) => <RowComponent key={`${row[rowKeyName] || 'row'}-${i}`} {...row} />)}
+          {this.getVisibleRows().map((row, i) => (
+            <RowComponent key={`${row[rowKeyName] || 'row'}-${i}`} {...row} />
+          ))}
         </BodyWrapper>
       </OuterWrapper>
     );
     const pagination = this.renderPagination();
     const heading = <h3>{title}</h3>;
 
-    return (
-      typeof(children) === 'function'
-        ? children({ filterBox, collection, heading, pagination })
-        : (
-          <div>
-            {title && heading}
-            {filterBox}
-            {collection}
-            {pagination}
-          </div>
-        )
+    return typeof children === 'function' ? (
+      children({ filterBox, collection, heading, pagination })
+    ) : (
+      <div>
+        {title && heading}
+        {filterBox}
+        {collection}
+        {pagination}
+      </div>
     );
   }
 }

--- a/src/components/collection/tests/Collection.test.js
+++ b/src/components/collection/tests/Collection.test.js
@@ -7,7 +7,6 @@ import * as sorters from 'src/helpers/sortMatch';
 import delay from 'src/__testHelpers__/delay';
 
 describe('Component: Collection', () => {
-
   let props;
   let pushStub;
 
@@ -27,17 +26,22 @@ describe('Component: Collection', () => {
       perPageButtons: [10, 50],
       location: {
         pathname: '/some/path',
-        search: '?some=search&other=string'
+        search: '?some=search&other=string',
       },
       history: {
-        push: pushStub
-      }
+        push: pushStub,
+      },
     };
   });
 
-  it('should render null if there are no rows', () => {
+  it('should render null if there are no rows and no EmptyComponent', () => {
     const wrapper = shallow(<Collection {...props} />);
     expect(wrapper.equals(null)).toEqual(true);
+  });
+
+  it('should render EmptyComponent if there are no rows and EmptyComponent exists', () => {
+    const wrapper = shallow(<Collection {...props} emptyComponent={() => ''} />);
+    expect(wrapper.find('emptyComponent')).toExist();
   });
 
   it('should render correctly with basic props', () => {
@@ -50,16 +54,22 @@ describe('Component: Collection', () => {
 
   it('should render with custom wrappers', () => {
     addRows(3);
-    props.outerWrapper = function CustomOuterWrapper(props) { return props.children; };
-    props.bodyWrapper = function CustomBodyWrapper(props) { return props.children; };
+    props.outerWrapper = function CustomOuterWrapper(props) {
+      return props.children;
+    };
+    props.bodyWrapper = function CustomBodyWrapper(props) {
+      return props.children;
+    };
     expect(shallow(<Collection {...props} />)).toMatchSnapshot();
   });
 
   it('should use custom render function when child is a render function', () => {
     addRows(3);
-    const renderFn = (renderProps) => (
+    const renderFn = renderProps => (
       <>
-        {Object.keys(renderProps).map((key) => <div key={key}>{renderProps[key]}</div>)}
+        {Object.keys(renderProps).map(key => (
+          <div key={key}>{renderProps[key]}</div>
+        ))}
       </>
     );
     const wrapper = shallow(<Collection {...props} children={renderFn} />);
@@ -99,7 +109,6 @@ describe('Component: Collection', () => {
   });
 
   describe('state changes', () => {
-
     let wrapper;
     let instance;
     let updateQueryStringSpy;
@@ -222,7 +231,5 @@ describe('Component: Collection', () => {
       instance.maybeUpdateQueryString();
       expect(pushStub).toHaveBeenCalledWith('some-pathname?other=cool&page=1&perPage=10');
     });
-
   });
-
 });

--- a/src/pages/blacklist/components/IncidentsCollection.js
+++ b/src/pages/blacklist/components/IncidentsCollection.js
@@ -19,7 +19,7 @@ const filterBoxConfig = {
 const columns = [
   { label: 'Details' },
   { label: 'Listed', sortKey: 'occurred_at' },
-  { label: 'Resolved' },
+  { label: 'Resolved', sortKey: 'resolved_at' },
 ];
 
 const getRowData = ({

--- a/src/pages/blacklist/components/IncidentsCollection.js
+++ b/src/pages/blacklist/components/IncidentsCollection.js
@@ -1,8 +1,13 @@
 import React from 'react';
-import { Table, Panel, Tag } from '@sparkpost/matchbox';
+import { Table, Panel, Tag, Grid, TextField } from '@sparkpost/matchbox';
+import { Search } from '@sparkpost/matchbox-icons';
 
+import { FORMATS } from 'src/constants';
 import { TableCollection, PageLink, DisplayDate } from 'src/components';
 import styles from './IncidentsCollection.module.scss';
+import DatePicker from 'src/components/datePicker/DatePicker';
+
+const RELATIVE_DATE_OPTIONS = ['day', '7days', '30days', '90days', 'custom'];
 
 const filterBoxConfig = {
   show: true,
@@ -53,7 +58,40 @@ const TableWrapper = props => (
 );
 
 export const IncidentsCollection = props => {
-  const { incidents } = props;
+  const { incidents, dateOptions, updateDateRange } = props;
+
+  const renderHeader = ({ textFieldComponent }) => (
+    <Grid>
+      <Grid.Column sm={12} lg={5}>
+        <div className={styles.DatePicker}>
+          <DatePicker
+            {...dateOptions}
+            relativeDateOptions={RELATIVE_DATE_OPTIONS}
+            onChange={updateDateRange}
+            dateFieldFormat={FORMATS.DATE}
+            hideManualEntry
+          />
+        </div>
+      </Grid.Column>
+      <Grid.Column sm={12} lg={7}>
+        {textFieldComponent}
+      </Grid.Column>
+    </Grid>
+  );
+
+  const EmptyComponent = () => {
+    const textFieldComponent = (
+      <div className={styles.FilterBox}>
+        <TextField disabled suffix={<Search />} />
+      </div>
+    );
+    return (
+      <Panel>
+        {renderHeader({ textFieldComponent: textFieldComponent })}
+        <h6 className={styles.Center}>There are no incidents for your date range selection</h6>
+      </Panel>
+    );
+  };
 
   return (
     <TableCollection
@@ -66,11 +104,12 @@ export const IncidentsCollection = props => {
       defaultSortColumn="occurred_at"
       defaultSortDirection="desc"
       saveCsv={false}
+      emptyComponent={EmptyComponent}
     >
       {({ filterBox, collection, pagination }) => (
         <>
           <Panel>
-            {filterBox}
+            {renderHeader({ textFieldComponent: filterBox })}
             {collection}
           </Panel>
           {pagination}

--- a/src/pages/blacklist/components/IncidentsCollection.module.scss
+++ b/src/pages/blacklist/components/IncidentsCollection.module.scss
@@ -1,7 +1,17 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 .FilterBox {
-  padding: spacing() spacing() spacing(smaller);
+  padding: spacing() spacing() spacing(smaller) 0;
+  @media screen and (max-width: breakpoint(medium)) {
+    padding-left: spacing();
+  }
+}
+
+.DatePicker {
+  padding: spacing() 0 spacing(smaller) spacing();
+  @media screen and (max-width: breakpoint(medium)) {
+    padding-right: spacing();
+  }
 }
 
 .Details {
@@ -13,4 +23,11 @@
 .Listing {
   margin-bottom: spacing(larger);
   margin-top: 0;
+}
+
+.Center {
+  @include text-style-heading;
+  text-align: center;
+  padding: rem(100) 0;
+  color: color(gray, 6);
 }

--- a/src/pages/blacklist/components/tests/IncidentsCollection.test.js
+++ b/src/pages/blacklist/components/tests/IncidentsCollection.test.js
@@ -4,6 +4,14 @@ import { render } from '@testing-library/react';
 import IncidentsCollection from '../IncidentsCollection';
 
 describe('Blacklist Component: IncidentsCollection', () => {
+  const now = new Date('2019-12-18T04:20:00-04:00');
+  Date.now = jest.fn(() => now);
+  const updateDateRange = jest.fn();
+  const dateOptions = {
+    from: new Date('2019-12-01T12:00:00.000Z'),
+    to: new Date('2019-12-08T12:00:00.000Z'),
+    dateRange: '7 days',
+  };
   const incidents = [
     {
       id: 1,
@@ -14,7 +22,7 @@ describe('Blacklist Component: IncidentsCollection', () => {
     },
   ];
   const subject = ({ ...props }) => {
-    const defaults = { incidents };
+    const defaults = { incidents, dateOptions, updateDateRange };
 
     return render(
       <Router>
@@ -23,10 +31,17 @@ describe('Blacklist Component: IncidentsCollection', () => {
     );
   };
 
-  it('renders the rows correctly', () => {
+  it('renders the rows correctly when incidents exist', () => {
     const { queryByText } = subject();
     expect(queryByText('101.101')).toBeInTheDocument();
     expect(queryByText('spammy mcspamface')).toBeInTheDocument();
     expect(queryByText('Dec 3 2019 at 10:00am')).toBeInTheDocument();
+    expect(queryByText('Last 7 Days')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no incidents', () => {
+    const { queryByText } = subject({ incidents: [] });
+    expect(queryByText('There are no incidents for your date range selection')).toBeInTheDocument();
+    expect(queryByText('Last 7 Days')).toBeInTheDocument();
   });
 });

--- a/src/pages/blacklist/tests/IncidentsPage.test.js
+++ b/src/pages/blacklist/tests/IncidentsPage.test.js
@@ -4,9 +4,14 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { IncidentsPage } from '../IncidentsPage';
 import IncidentsCollection from '../components/IncidentsCollection';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('../components/IncidentsCollection');
-IncidentsCollection.mockImplementation(() => <div></div>);
+IncidentsCollection.mockImplementation(({ updateDateRange }) => (
+  <button onClick={() => updateDateRange({ to: '123', from: '234', range: '567' })}>
+    Update DatePicker
+  </button>
+));
 
 describe('IncidentsPage', () => {
   const incidents = [
@@ -30,6 +35,9 @@ describe('IncidentsPage', () => {
   const mockListIncidents = jest.fn();
 
   const subject = ({ ...props }) => {
+    const now = new Date('2019-12-18T04:20:00-04:00');
+    Date.now = jest.fn(() => now);
+
     const defaults = {
       incidents: incidents,
       monitors: monitors,
@@ -65,6 +73,12 @@ describe('IncidentsPage', () => {
   it('loads monitors and incidents when page starts rendering', () => {
     subject();
     expect(mockListMonitors).toHaveBeenCalled();
+    expect(mockListIncidents).toHaveBeenCalled();
+  });
+
+  it('reloads incidents when datepicker updates', () => {
+    const { queryByText } = subject();
+    userEvent.click(queryByText('Update DatePicker'));
     expect(mockListIncidents).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

### What Changed
 - Added datepicker to incidents page
 - Updated Collection to allow for am empty page component when there are no rows.
 - Updated Incidents page to hold the date options as state.
 - Updated the dispatched action to use the from and to dates from the datepicker.

### How To Test
 - Go to /blacklist/incidents. Verify that the date picker is working. 

### To Do
- [x] UX approval for some design changes