### PR TITLE
TR-2130 - Adds handling for "Usage limit exceeded" error state for the Recipient Validation feature

### DIFF
--- a/cypress/fixtures/recipient-validation/list/400.get.usage-limit-exceeded.json
+++ b/cypress/fixtures/recipient-validation/list/400.get.usage-limit-exceeded.json
@@ -1,0 +1,11 @@
+{
+  "list_id": "fake-list",
+  "customer_id": 123,
+  "address_count": 2,
+  "original_filename": "fake-list.csv",
+  "triggered_timestamp": 1578067868,
+  "complete": false,
+  "batch_status": "usage_limit_exceeded",
+  "upload_timestamp": 1578067866,
+  "uploaded_file": "/path/to/uploaded/file"
+}

--- a/cypress/fixtures/recipient-validation/single/400.get.usage-limit-exceeded.json
+++ b/cypress/fixtures/recipient-validation/single/400.get.usage-limit-exceeded.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "message": "Usage limit exceeded"
+  }
+}

--- a/cypress/fixtures/recipient-validation/single/400.get.usage-limit-exceeded.json
+++ b/cypress/fixtures/recipient-validation/single/400.get.usage-limit-exceeded.json
@@ -1,5 +1,1 @@
-{
-  "errors": {
-    "message": "Usage limit exceeded"
-  }
-}
+{ "errors": [{ "message": "Usage limit exceeded" }] }

--- a/cypress/tests/integration/recipient-validation/tr-2130.spec.js
+++ b/cypress/tests/integration/recipient-validation/tr-2130.spec.js
@@ -1,0 +1,32 @@
+/// <reference types="Cypress" />
+
+// TODO: This is a temporary location for this test, while https://github.com/SparkPost/2web2ui/pull/1354 is in review
+describe('TR-2130', () => {
+  beforeEach(() => {
+    cy.stubAuth();
+    cy.login({ isStubbed: true });
+  });
+
+  it('renders an error on the single validation page when the server returns a 400 error with the message "Usage limit exceeded"', () => {
+    cy.server();
+    cy.fixture('recipient-validation/single/400.get.usage-limit-exceeded.json').as('RVFixture');
+    cy.route({
+      method: 'GET',
+      status: 400,
+      url: '/api/v1/recipient-validation/single/fake-email@gmail.com',
+      response: '@RVFixture',
+    }).as('getValidation');
+
+    cy.visit('/recipient-validation/single/fake-email@gmail.com');
+
+    cy.wait('@getValidation');
+
+    cy.queryAllByText('View Details')
+      .last()
+      .click();
+
+    cy.findByText('Contact sales').should('have.attr', 'href', 'https://sparkpost.com/sales');
+  });
+
+  it('redirects the user to the list page and shows the validated list in an error state if the batch status returns "usage_limit_exceeded"', () => {});
+});

--- a/cypress/tests/integration/recipient-validation/tr-2130.spec.js
+++ b/cypress/tests/integration/recipient-validation/tr-2130.spec.js
@@ -28,5 +28,28 @@ describe('TR-2130', () => {
     cy.findByText('Contact sales').should('have.attr', 'href', 'https://sparkpost.com/sales');
   });
 
-  it('redirects the user to the list page and shows the validated list in an error state if the batch status returns "usage_limit_exceeded"', () => {});
+  it('it renders a "Validation Error" and an alert with "Usage Limit Exceeded" if the batch status on the list page is "usage_limit_exceeded"', () => {
+    cy.server();
+    cy.fixture('recipient-validation/list/400.get.usage-limit-exceeded.json').as('RVFixture');
+    cy.route({
+      url: '/api/v1/recipient-validation/job/fake-list',
+      response: '@RVFixture',
+    }).as('getValidation');
+
+    cy.visit('/recipient-validation/list/fake-list');
+
+    cy.wait('@getValidation');
+
+    cy.queryByText('Validation Error').should('be.visible');
+
+    cy.wait(5000); // Wait for the polling interval as defined on the list progress component
+
+    cy.findByText('Usage limit exceeded').should('be.visible');
+
+    cy.findByText('View Details')
+      .last()
+      .click();
+
+    cy.findByText('Contact sales').should('have.attr', 'href', 'https://sparkpost.com/sales');
+  });
 });

--- a/cypress/tests/integration/recipient-validation/tr-2130.spec.js
+++ b/cypress/tests/integration/recipient-validation/tr-2130.spec.js
@@ -21,7 +21,9 @@ describe('TR-2130', () => {
 
     cy.wait('@getValidation');
 
-    cy.queryAllByText('View Details')
+    cy.findByText('Usage limit exceeded');
+
+    cy.findAllByText('View Details')
       .last()
       .click();
 

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -17,13 +17,13 @@ import styles from './RecipientValidationPage.module.scss';
 const tabs = [
   { content: <span className={styles.TabPadding}>List</span>, key: 'list' },
   { content: 'Single Address', key: 'single' },
-  { content: 'API Integration', key: 'api' }
+  { content: 'API Integration', key: 'api' },
 ];
 
 export class RecipientValidationPage extends Component {
   state = {
     selectedTab: this.props.tab || 0,
-    showPriceModal: false
+    showPriceModal: false,
   };
 
   handleTabs(tabIdx) {
@@ -33,7 +33,7 @@ export class RecipientValidationPage extends Component {
     this.setState({ selectedTab: tabIdx });
   }
 
-  renderTabContent = (tabId) => {
+  renderTabContent = tabId => {
     switch (tabId) {
       case 0:
         return <ListForm />;
@@ -42,15 +42,12 @@ export class RecipientValidationPage extends Component {
       case 2:
         return <ApiDetails />;
     }
-  }
+  };
 
   handleModal = (showPriceModal = false) => this.setState({ showPriceModal });
 
   renderRVPriceModal = () => (
-    <Panel
-      className={styles.modalContainer}
-      accent
-    >
+    <Panel className={styles.modalContainer} accent>
       <div style={{ float: 'right' }}>
         <Button onClick={() => this.handleModal(false)} flat>
           <Close />
@@ -61,8 +58,8 @@ export class RecipientValidationPage extends Component {
         <RecipientValidationPriceTable
           cellProps={{
             style: {
-              padding: '8px 0'
-            }
+              padding: '8px 0',
+            },
           }}
         />
       </div>
@@ -74,23 +71,30 @@ export class RecipientValidationPage extends Component {
 
     return (
       <Page
-        title='Recipient Validation'
-        primaryArea={<Button size='large' onClick={() => this.handleModal(true)}>See Pricing</Button>}>
+        title="Recipient Validation"
+        primaryArea={
+          <Button size="large" onClick={() => this.handleModal(true)}>
+            See Pricing
+          </Button>
+        }
+      >
         <p className={styles.LeadText}>
           Recipient Validation is an easy, efficient way to verify that email addresses are valid
-          before you send. We run each address through a series of checks to catch many common problems,
-          including syntax errors and non-existent mailboxes, to drive better deliverability, cut down on
-          fraud, and capture every opportunity.
+          before you send. We run each address through a series of checks to catch many common
+          problems, including syntax errors and non-existent mailboxes, to drive better
+          deliverability, cut down on fraud, and capture every opportunity.
         </p>
+
         <Tabs
           selected={selectedTab}
           connectBelow={true}
           tabs={tabs.map(({ content }, idx) => ({ content, onClick: () => this.handleTabs(idx) }))}
         />
-        <Panel>
-          {this.renderTabContent(selectedTab)}
-        </Panel>
+
+        <Panel>{this.renderTabContent(selectedTab)}</Panel>
+
         {selectedTab === 0 && <JobsTableCollection />}
+
         <Modal open={showPriceModal} onClose={() => this.handleModal(false)}>
           {this.renderRVPriceModal()}
         </Modal>
@@ -105,7 +109,7 @@ export class RecipientValidationPage extends Component {
           {this.renderRecipientValidation()}
         </Case>
         <Case condition={defaultCase}>
-          <RVDisabledPage/>
+          <RVDisabledPage />
         </Case>
       </ConditionSwitch>
     );
@@ -113,7 +117,7 @@ export class RecipientValidationPage extends Component {
 }
 
 const mapStateToProps = (state, props) => ({
-  tab: tabs.findIndex(({ key }) => key === props.match.params.category) || 0
+  tab: tabs.findIndex(({ key }) => key === props.match.params.category) || 0,
 });
 
 export default withRouter(connect(mapStateToProps)(RecipientValidationPage));

--- a/src/pages/recipientValidation/SingleResult.js
+++ b/src/pages/recipientValidation/SingleResult.js
@@ -23,7 +23,7 @@ export function SingleResult(props) {
   const { singleResults = {}, loading, address, history, showAlert, singleAddress } = props;
 
   useEffect(() => {
-    singleAddress(address).catch(({ response, message }) => {
+    singleAddress(address).catch(({ response = {}, message }) => {
       const { status } = response;
       // When receiving the 'Usage limit exceeded' error, render a link in the alert details with a way to contact sales
       showAlert({

--- a/src/pages/recipientValidation/SingleResult.js
+++ b/src/pages/recipientValidation/SingleResult.js
@@ -23,13 +23,14 @@ export function SingleResult(props) {
   const { singleResults = {}, loading, address, history, showAlert, singleAddress } = props;
 
   useEffect(() => {
-    singleAddress(address).catch(({ message }) => {
+    singleAddress(address).catch(({ response, message }) => {
+      const { status } = response;
       // When receiving the 'Usage limit exceeded' error, render a link in the alert details with a way to contact sales
       showAlert({
         type: 'error',
         message,
         details:
-          message === 'Usage limit exceeded' ? (
+          status === 400 ? (
             <UnstyledLink external to="https://sparkpost.com/sales">
               Contact sales
             </UnstyledLink>
@@ -207,7 +208,7 @@ function ResultCodeBlock({ data }) {
       )}
       <TabCharacter />
       <TabCharacter />
-      "valid": <WhiteText>{valid.toString()}</WhiteText>,<br />
+      "valid": <WhiteText>{valid && valid.toString()}</WhiteText>,<br />
       {reason && (
         <>
           <TabCharacter />
@@ -218,13 +219,13 @@ function ResultCodeBlock({ data }) {
       )}
       <TabCharacter />
       <TabCharacter />
-      "is_role": <WhiteText>{is_role.toString()}</WhiteText>,<br />
+      "is_role": <WhiteText>{is_role && is_role.toString()}</WhiteText>,<br />
       <TabCharacter />
       <TabCharacter />
-      "is_disposable": <WhiteText>{is_disposable.toString()}</WhiteText>,<br />
+      "is_disposable": <WhiteText>{is_disposable && is_disposable.toString()}</WhiteText>,<br />
       <TabCharacter />
       <TabCharacter />
-      "is_free": <WhiteText>{is_free.toString()}</WhiteText>,<br />
+      "is_free": <WhiteText>{is_free && is_free.toString()}</WhiteText>,<br />
       {did_you_mean && (
         <>
           <TabCharacter />

--- a/src/pages/recipientValidation/SingleResult.js
+++ b/src/pages/recipientValidation/SingleResult.js
@@ -24,7 +24,20 @@ export function SingleResult(props) {
 
   useEffect(() => {
     singleAddress(address).catch(({ message }) => {
-      showAlert({ message, type: 'error' });
+      // When receiving the 'Usage limit exceeded' error, render a link in the alert details with a way to contact sales
+      showAlert({
+        type: 'error',
+        message,
+        details:
+          message === 'Usage limit exceeded' ? (
+            <UnstyledLink external to="https://sparkpost.com/sales">
+              Contact sales
+            </UnstyledLink>
+          ) : (
+            undefined
+          ),
+      });
+
       history.push(SINGLE_RV_LINK);
     });
   }, [address, history, showAlert, singleAddress]);

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -21,7 +21,7 @@ export class UploadedListPage extends Component {
   handleSubmit = () => {
     const { listId, triggerJob } = this.props;
     triggerJob(listId);
-  }
+  };
 
   render() {
     const { job, jobLoadingStatus, listId } = this.props;
@@ -31,7 +31,7 @@ export class UploadedListPage extends Component {
         <RedirectAndAlert
           alert={{
             message: `Unable to find list ${listId}`,
-            type: 'error'
+            type: 'error',
           }}
           to="/recipient-validation"
         />
@@ -44,7 +44,7 @@ export class UploadedListPage extends Component {
 
     return (
       <Page
-        title='Recipient Validation'
+        title="Recipient Validation"
         breadcrumbAction={{ content: 'Back', component: PageLink, to: '/recipient-validation' }}
       >
         <Panel>
@@ -55,12 +55,17 @@ export class UploadedListPage extends Component {
               <strong>{formatTime(job.updatedAt)}</strong>
             </div>
           </Panel.Section>
+
           <Panel.Section>
-            {job.status === 'queued_for_batch' && <UploadedListForm job={job} onSubmit={this.handleSubmit} />}
+            {job.status === 'queued_for_batch' && (
+              <UploadedListForm job={job} onSubmit={this.handleSubmit} />
+            )}
 
-            {job.status === 'error' && <ListError/>}
+            {job.status === 'error' && <ListError />}
 
-            {(job.status !== 'queued_for_batch' && job.status !== 'error') && <ListProgress job={job} />}
+            {job.status !== 'queued_for_batch' && job.status !== 'error' && (
+              <ListProgress job={job} />
+            )}
           </Panel.Section>
         </Panel>
       </Page>
@@ -74,7 +79,7 @@ const mapStateToProps = (state, props) => {
   return {
     listId,
     job: selectRecipientValidationJobById(state, listId),
-    jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId]
+    jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId],
   };
 };
 

--- a/src/pages/recipientValidation/components/JobStatusTag.js
+++ b/src/pages/recipientValidation/components/JobStatusTag.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { Tag } from '@sparkpost/matchbox';
 import { Error, CheckCircle, Cached, CloudUpload } from '@sparkpost/matchbox-icons';
 import styles from './JobStatusTag.module.scss';
@@ -9,7 +10,7 @@ const statusProps = {
     icon: Error,
     message: 'Validation Error',
   },
-  usage_limit_reached: {
+  usage_limit_exceeded: {
     className: styles.Failed,
     icon: Error,
     message: 'Validation Error',
@@ -36,7 +37,7 @@ const JobStatusTag = ({ status }) => {
 
   return (
     <Tag>
-      <span className={className}>
+      <span className={classNames(styles.JobStatusTagContent, className)}>
         <Icon />
         &nbsp;
       </span>

--- a/src/pages/recipientValidation/components/JobStatusTag.js
+++ b/src/pages/recipientValidation/components/JobStatusTag.js
@@ -3,28 +3,27 @@ import { Tag } from '@sparkpost/matchbox';
 import { Error, CheckCircle, Cached, CloudUpload } from '@sparkpost/matchbox-icons';
 import styles from './JobStatusTag.module.scss';
 
-
 const statusProps = {
   error: {
     className: styles.Failed,
     icon: Error,
-    message: 'Validation Error'
+    message: 'Validation Error',
   },
   success: {
     className: styles.Complete,
     icon: CheckCircle,
-    message: 'Complete'
+    message: 'Complete',
   },
   queued_for_batch: {
     className: styles.Ready,
     icon: CloudUpload,
-    message: 'Ready to validate'
+    message: 'Ready to validate',
   },
   loading: {
     className: styles.Loading,
     icon: Cached,
-    message: 'Processing'
-  }
+    message: 'Processing',
+  },
 };
 
 const JobStatusTag = ({ status }) => {
@@ -33,7 +32,8 @@ const JobStatusTag = ({ status }) => {
   return (
     <Tag>
       <span className={className}>
-        <Icon />&nbsp;
+        <Icon />
+        &nbsp;
       </span>
       <span>{message}</span>
     </Tag>

--- a/src/pages/recipientValidation/components/JobStatusTag.js
+++ b/src/pages/recipientValidation/components/JobStatusTag.js
@@ -9,6 +9,11 @@ const statusProps = {
     icon: Error,
     message: 'Validation Error',
   },
+  usage_limit_reached: {
+    className: styles.Failed,
+    icon: Error,
+    message: 'Validation Error',
+  },
   success: {
     className: styles.Complete,
     icon: CheckCircle,

--- a/src/pages/recipientValidation/components/JobStatusTag.module.scss
+++ b/src/pages/recipientValidation/components/JobStatusTag.module.scss
@@ -1,5 +1,11 @@
 @import 'src/styles/status-color';
 
+.JobStatusTagContent {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
 .Complete {
   color: status-color('success');
 }

--- a/src/pages/recipientValidation/components/JobsTableCollection.js
+++ b/src/pages/recipientValidation/components/JobsTableCollection.js
@@ -11,27 +11,25 @@ import JobStatusTag from './JobStatusTag';
 export const JobsTableCollection = ({ jobs }) => {
   const columns = [
     {
-      dataCellComponent: ({ filename }) => (
-        <JobFileName filename={filename} />
-      ),
+      dataCellComponent: ({ filename }) => <JobFileName filename={filename} />,
       header: {
         label: 'File Name',
-        sortKey: 'filename'
-      }
+        sortKey: 'filename',
+      },
     },
     {
       dataCellComponent: ({ uploadedAt }) => formatDateTime(uploadedAt),
       header: {
         label: 'Date Uploaded',
-        sortKey: 'uploadedAt'
-      }
+        sortKey: 'uploadedAt',
+      },
     },
     {
       dataCellComponent: ({ status }) => <JobStatusTag status={status} />,
       header: {
         label: 'Status',
-        sortKey: 'status'
-      }
+        sortKey: 'status',
+      },
     },
     {
       dataCellComponent: ({ addressCount, status }) => (
@@ -39,26 +37,21 @@ export const JobsTableCollection = ({ jobs }) => {
       ),
       header: {
         label: 'Total',
-        sortKey: 'addressCount'
-      }
+        sortKey: 'addressCount',
+      },
     },
     {
       dataCellComponent: ({ rejectedUrl, status, jobId }) => (
-        <JobActionLink
-          fileHref={rejectedUrl}
-          status={status}
-          jobId={jobId}
-        />
+        <JobActionLink fileHref={rejectedUrl} status={status} jobId={jobId} />
       ),
       header: {
-        label: 'Actions'
-      }
-    }
+        label: 'Actions',
+      },
+    },
   ];
 
-  const renderRow = (columns) => (props) => (
-    columns.map(({ dataCellComponent: DataCellComponent }) => <DataCellComponent {...props} />)
-  );
+  const renderRow = columns => props =>
+    columns.map(({ dataCellComponent: DataCellComponent }) => <DataCellComponent {...props} />);
 
   return (
     <TableCollection
@@ -73,9 +66,7 @@ export const JobsTableCollection = ({ jobs }) => {
       {({ collection, filterBox, heading, pagination }) => (
         <>
           <Panel>
-            <Panel.Section>
-              {heading}
-            </Panel.Section>
+            <Panel.Section>{heading}</Panel.Section>
             {filterBox}
             {collection}
           </Panel>

--- a/src/pages/recipientValidation/components/ListProgress.js
+++ b/src/pages/recipientValidation/components/ListProgress.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Button } from '@sparkpost/matchbox';
+import { Button, UnstyledLink } from '@sparkpost/matchbox';
 import { getJobStatus } from 'src/actions/recipientValidation';
 import FocusContainer from 'src/components/focusContainer';
 import PageLink from 'src/components/pageLink';
@@ -23,6 +23,7 @@ const BATCH_STATUS = [
   'performing_did_you_mean',
   'uploading_results_to_s3',
   'success',
+  'usage_limit_exceeded',
 ];
 
 export const ListProgress = ({
@@ -48,12 +49,24 @@ export const ListProgress = ({
               batch_status === 'error' ||
               batch_status === 'success'
             ) {
-              stopPolling(jobId);
               showAlert({
                 type: batch_status === 'success' ? 'success' : 'error',
-                message: `Validation of ${filename} recipient list has completed`,
+                message:
+                  batch_status === 'usage_limit_exceeded'
+                    ? 'Usage limit exceeded'
+                    : `Validation of ${filename} recipient list has completed`,
                 dedupeId: jobId,
+                details:
+                  batch_status === 'usage_limit_exceeded' ? (
+                    <UnstyledLink external to="https://sparkpost.com/sales">
+                      Contact sales
+                    </UnstyledLink>
+                  ) : (
+                    undefined
+                  ),
               });
+
+              stopPolling(jobId);
             }
           })
           .catch(() => {

--- a/src/pages/recipientValidation/components/ListProgress.js
+++ b/src/pages/recipientValidation/components/ListProgress.js
@@ -23,7 +23,6 @@ const BATCH_STATUS = [
   'performing_did_you_mean',
   'uploading_results_to_s3',
   'success',
-  'usage_limit_exceeded',
 ];
 
 export const ListProgress = ({

--- a/src/pages/recipientValidation/components/tests/ListProgress.test.js
+++ b/src/pages/recipientValidation/components/tests/ListProgress.test.js
@@ -2,23 +2,25 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { ListProgress } from '../ListProgress';
 
+/* eslint-disable jest/no-test-callback */
 describe('ListProgress', () => {
-  const subject = (props = {}) => shallow(
-    <ListProgress
-      getJobStatus={() => {}}
-      job={{
-        filename: 'big-test.csv',
-        jobId: 'A1C1_D1C1',
-        status: 'checking_regex'
-      }}
-      startPolling={() => {}}
-      stopPolling={() => {}}
-      {...props}
-    />
-  );
+  const subject = (props = {}) =>
+    shallow(
+      <ListProgress
+        getJobStatus={() => {}}
+        job={{
+          filename: 'big-test.csv',
+          jobId: 'A1C1_D1C1',
+          status: 'checking_regex',
+        }}
+        startPolling={() => {}}
+        stopPolling={() => {}}
+        {...props}
+      />,
+    );
 
   beforeEach(() => {
-    React.useEffect = jest.fn((effect) => effect());
+    React.useEffect = jest.fn(effect => effect());
   });
 
   it('renders status and progress bar', () => {
@@ -29,7 +31,7 @@ describe('ListProgress', () => {
     const errorJob = {
       filename: 'big-test.csv',
       jobId: 'A1C1_D1C1',
-      status: 'error'
+      status: 'error',
     };
     const wrapper = subject({ job: errorJob });
 
@@ -44,7 +46,9 @@ describe('ListProgress', () => {
 
   it('keeps polling if in progress', () => {
     const getJobStatus = jest.fn(() => Promise.resolve({ batch_status: 'performing_mx_lookup' }));
-    const startPolling = jest.fn(({ action }) => { action(); });
+    const startPolling = jest.fn(({ action }) => {
+      action();
+    });
     const stopPolling = jest.fn();
 
     subject({ getJobStatus, startPolling, stopPolling });
@@ -53,9 +57,11 @@ describe('ListProgress', () => {
     expect(stopPolling).not.toHaveBeenCalled();
   });
 
-  it('stops polling and alerts when validation is complete', (done) => {
+  it('stops polling and alerts when validation is complete', done => {
     const getJobStatus = jest.fn(() => Promise.resolve({ batch_status: 'success' }));
     const showAlert = jest.fn();
+    const stopPolling = jest.fn();
+
     const startPolling = jest.fn(async ({ action }) => {
       await action();
       expect(getJobStatus).toHaveBeenCalledWith('A1C1_D1C1');
@@ -63,16 +69,35 @@ describe('ListProgress', () => {
       expect(showAlert).toHaveBeenCalledWith({
         type: 'success',
         message: 'Validation of big-test.csv recipient list has completed',
-        dedupeId: 'A1C1_D1C1'
+        dedupeId: 'A1C1_D1C1',
       });
       done();
     });
-    const stopPolling = jest.fn();
 
     subject({ getJobStatus, showAlert, startPolling, stopPolling });
   });
 
-  it('stops polling when validation explodes', (done) => {
+  it('stops polling and shows an error alert when validation return as "usage_limit_exceeded"', done => {
+    const getJobStatus = jest.fn(() => Promise.resolve({ batch_status: 'usage_limit_exceeded' }));
+    const showAlert = jest.fn();
+    const stopPolling = jest.fn();
+
+    const startPolling = jest.fn(async ({ action }) => {
+      await action();
+      expect(getJobStatus).toHaveBeenCalledWith('A1C1_D1C1');
+      expect(stopPolling).toHaveBeenCalledWith('A1C1_D1C1');
+      expect(showAlert).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'Validation of big-test.csv recipient list has completed',
+        dedupeId: 'A1C1_D1C1',
+      });
+      done();
+    });
+
+    subject({ getJobStatus, showAlert, startPolling, stopPolling });
+  });
+
+  it('stops polling when validation explodes', done => {
     const getJobStatus = jest.fn(() => Promise.reject());
     const showAlert = jest.fn(() => done());
     const startPolling = jest.fn(async ({ action }) => {

--- a/src/pages/recipientValidation/components/tests/ListProgress.test.js
+++ b/src/pages/recipientValidation/components/tests/ListProgress.test.js
@@ -77,26 +77,6 @@ describe('ListProgress', () => {
     subject({ getJobStatus, showAlert, startPolling, stopPolling });
   });
 
-  it('stops polling and shows an error alert when validation return as "usage_limit_exceeded"', done => {
-    const getJobStatus = jest.fn(() => Promise.resolve({ batch_status: 'usage_limit_exceeded' }));
-    const showAlert = jest.fn();
-    const stopPolling = jest.fn();
-
-    const startPolling = jest.fn(async ({ action }) => {
-      await action();
-      expect(getJobStatus).toHaveBeenCalledWith('A1C1_D1C1');
-      expect(stopPolling).toHaveBeenCalledWith('A1C1_D1C1');
-      expect(showAlert).toHaveBeenCalledWith({
-        type: 'error',
-        message: 'Validation of big-test.csv recipient list has completed',
-        dedupeId: 'A1C1_D1C1',
-      });
-      done();
-    });
-
-    subject({ getJobStatus, showAlert, startPolling, stopPolling });
-  });
-
   it('stops polling when validation explodes', done => {
     const getJobStatus = jest.fn(() => Promise.reject());
     const showAlert = jest.fn(() => done());

--- a/src/pages/recipientValidation/components/tests/__snapshots__/JobStatusTag.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/JobStatusTag.test.js.snap
@@ -3,7 +3,7 @@
 exports[`JobStatusTag renders a loading tag 1`] = `
 <Tag>
   <span
-    className="Loading"
+    className="JobStatusTagContent Loading"
   >
     <Cached />
      
@@ -17,7 +17,7 @@ exports[`JobStatusTag renders a loading tag 1`] = `
 exports[`JobStatusTag renders a ready tag 1`] = `
 <Tag>
   <span
-    className="Ready"
+    className="JobStatusTagContent Ready"
   >
     <CloudUpload />
      
@@ -31,7 +31,7 @@ exports[`JobStatusTag renders a ready tag 1`] = `
 exports[`JobStatusTag renders a success tag 1`] = `
 <Tag>
   <span
-    className="Complete"
+    className="JobStatusTagContent Complete"
   >
     <CheckCircle />
      
@@ -45,7 +45,7 @@ exports[`JobStatusTag renders a success tag 1`] = `
 exports[`JobStatusTag renders an error tag 1`] = `
 <Tag>
   <span
-    className="Failed"
+    className="JobStatusTagContent Failed"
   >
     <Error />
      

--- a/src/pages/recipientValidation/components/tests/__snapshots__/ListProgress.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/ListProgress.test.js.snap
@@ -43,7 +43,7 @@ exports[`ListProgress renders status and progress bar 1`] = `
         className="Progress"
         style={
           Object {
-            "width": "18.181818181818183%",
+            "width": "20%",
           }
         }
       />

--- a/src/pages/recipientValidation/components/tests/__snapshots__/ListProgress.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/ListProgress.test.js.snap
@@ -43,7 +43,7 @@ exports[`ListProgress renders status and progress bar 1`] = `
         className="Progress"
         style={
           Object {
-            "width": "20%",
+            "width": "18.181818181818183%",
           }
         }
       />

--- a/src/pages/recipientValidation/components/tests/__snapshots__/ListProgress.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/ListProgress.test.js.snap
@@ -9,7 +9,8 @@ exports[`ListProgress renders status and progress bar 1`] = `
   </h2>
   <p>
     <span>
-      Your list is validating. You can track its progress on the recipient validation 
+      Your list is validating. You can track its progress on the recipient validation
+       
     </span>
     <PageLink
       to="/recipient-validation"

--- a/src/pages/recipientValidation/tests/SingleResult.test.js
+++ b/src/pages/recipientValidation/tests/SingleResult.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { SingleResult } from '../SingleResult';
-import { UnstyledLink } from '@sparkpost/matchbox';
 
 describe('SingleResult', () => {
   const subject = props => {
@@ -55,31 +54,6 @@ describe('SingleResult', () => {
       expect(mockShowAlert).toHaveBeenCalledWith({
         message: 'Mock error message',
         type: 'error',
-      });
-      expect(mockPush).toHaveBeenCalledWith('/recipient-validation/single');
-    });
-  });
-
-  it('should redirect and show specific error content when the "Usage limit exceeded" error is received', () => {
-    const promise = Promise.reject({ message: 'Usage limit exceeded' });
-    const mockShowAlert = jest.fn();
-    const mockPush = jest.fn();
-    const mockHistory = { push: mockPush };
-    subject({
-      showAlert: mockShowAlert,
-      history: mockHistory,
-      singleAddress: jest.fn(() => promise),
-    });
-
-    return promise.catch(() => {
-      expect(mockShowAlert).toHaveBeenCalledWith({
-        type: 'error',
-        message: 'Usage limit exceeded',
-        details: (
-          <UnstyledLink external to="https://sparkpost.com/sales">
-            Contact sales
-          </UnstyledLink>
-        ),
       });
       expect(mockPush).toHaveBeenCalledWith('/recipient-validation/single');
     });

--- a/src/pages/recipientValidation/tests/SingleResult.test.js
+++ b/src/pages/recipientValidation/tests/SingleResult.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { SingleResult } from '../SingleResult';
+import { UnstyledLink } from '@sparkpost/matchbox';
 
 describe('SingleResult', () => {
   const subject = props => {
@@ -54,6 +55,31 @@ describe('SingleResult', () => {
       expect(mockShowAlert).toHaveBeenCalledWith({
         message: 'Mock error message',
         type: 'error',
+      });
+      expect(mockPush).toHaveBeenCalledWith('/recipient-validation/single');
+    });
+  });
+
+  it('should redirect and show specific error content when the "Usage limit exceeded" error is received', () => {
+    const promise = Promise.reject({ message: 'Usage limit exceeded' });
+    const mockShowAlert = jest.fn();
+    const mockPush = jest.fn();
+    const mockHistory = { push: mockPush };
+    subject({
+      showAlert: mockShowAlert,
+      history: mockHistory,
+      singleAddress: jest.fn(() => promise),
+    });
+
+    return promise.catch(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'Usage limit exceeded',
+        details: (
+          <UnstyledLink external to="https://sparkpost.com/sales">
+            Contact sales
+          </UnstyledLink>
+        ),
       });
       expect(mockPush).toHaveBeenCalledWith('/recipient-validation/single');
     });


### PR DESCRIPTION
[TR-2130](https://jira.int.messagesystems.com/browse/TR-2130)

### What Changed
- Fixes icon alignment issue on RV pages within status tags - *not really related to this ticket, but it was bothering me and won't impact other features*
- Reformats a few files with Prettier
- Adds error handling for "Usage limit exceeded" error that will return a `400` status code
- Adds Cypress integration tests to handle "Usage limit exceeded" states for both the single validation and list progress pages

#### Notes:
- These changes are in support of upcoming API changes here: https://github.com/SparkPost/recipient-verification/pull/422
- The backend team initially deployed these changes to staging, but they caused some issue with the list progress page, so were rolled back. Though the above PR is marked as merged, we are going to deploy these UI updates first

### How To Test
- Run Cypress integration tests locally and verify the UI renders as expected in the test cases
- Verify that new fixtures accurately mimic the API changes outlined in: https://github.com/SparkPost/recipient-verification/pull/422

### To Do
- [x] Incorporate feedback
- [ ] Move Cypress tests to existing RV tests that are a part of a PR that is under review - I'll do this after the other PR wraps up
