### PR TITLE
TR-2139 - Address rendering problem with empty values in the RV single validation raw API response

### DIFF
--- a/src/pages/recipientValidation/SingleResult.js
+++ b/src/pages/recipientValidation/SingleResult.js
@@ -113,8 +113,12 @@ function TabCharacter() {
   return <span className={styles.TabCharacter} />;
 }
 
-function WhiteText({ children }) {
-  return <span className={styles.WhiteText}>{children}</span>;
+function WhiteText(props) {
+  return (
+    <span className={styles.WhiteText} data-id={props['data-id']}>
+      {props.children}
+    </span>
+  );
 }
 
 function ResultList({ data }) {
@@ -206,35 +210,42 @@ function ResultCodeBlock({ data }) {
         <>
           <TabCharacter />
           <TabCharacter />
-          "result": "<WhiteText>{result}</WhiteText>",
+          "result": "<WhiteText data-id="result-value">{result}</WhiteText>",
           <br />
         </>
       )}
       <TabCharacter />
       <TabCharacter />
-      "valid": <WhiteText>{valid && valid.toString()}</WhiteText>,<br />
+      "valid": <WhiteText data-id="valid-value">{valid && valid.toString()}</WhiteText>,<br />
       {reason && (
         <>
           <TabCharacter />
           <TabCharacter />
-          "reason": "<WhiteText>{reason}</WhiteText>",
+          "reason": "<WhiteText data-id="reason-value">{reason}</WhiteText>",
           <br />
         </>
       )}
       <TabCharacter />
       <TabCharacter />
-      "is_role": <WhiteText>{is_role && is_role.toString()}</WhiteText>,<br />
+      "is_role": <WhiteText data-id="is_role-value">{is_role && is_role.toString()}</WhiteText>,
+      <br />
       <TabCharacter />
       <TabCharacter />
-      "is_disposable": <WhiteText>{is_disposable && is_disposable.toString()}</WhiteText>,<br />
+      "is_disposable":{' '}
+      <WhiteText data-id="is_disposable-value">
+        {is_disposable && is_disposable.toString()}
+      </WhiteText>
+      ,<br />
       <TabCharacter />
       <TabCharacter />
-      "is_free": <WhiteText>{is_free && is_free.toString()}</WhiteText>,<br />
+      "is_free": <WhiteText data-id="is_free-value">{is_free && is_free.toString()}</WhiteText>,
+      <br />
       {did_you_mean && (
         <>
           <TabCharacter />
           <TabCharacter />
-          "did_you_mean": "<WhiteText>{did_you_mean.toString()}</WhiteText>"<br />
+          "did_you_mean": "
+          <WhiteText data-id="did_you_mean-value">{did_you_mean.toString()}</WhiteText>"<br />
         </>
       )}
       <TabCharacter />

--- a/src/pages/recipientValidation/SingleResult.js
+++ b/src/pages/recipientValidation/SingleResult.js
@@ -216,7 +216,7 @@ function ResultCodeBlock({ data }) {
       )}
       <TabCharacter />
       <TabCharacter />
-      "valid": <WhiteText data-id="valid-value">{valid && valid.toString()}</WhiteText>,<br />
+      "valid": <WhiteText data-id="valid-value">{valid.toString()}</WhiteText>,<br />
       {reason && (
         <>
           <TabCharacter />
@@ -227,18 +227,16 @@ function ResultCodeBlock({ data }) {
       )}
       <TabCharacter />
       <TabCharacter />
-      "is_role": <WhiteText data-id="is_role-value">{is_role && is_role.toString()}</WhiteText>,
+      "is_role": <WhiteText data-id="is_role-value">{is_role.toString()}</WhiteText>,
       <br />
       <TabCharacter />
       <TabCharacter />
       "is_disposable":{' '}
-      <WhiteText data-id="is_disposable-value">
-        {is_disposable && is_disposable.toString()}
-      </WhiteText>
+      <WhiteText data-id="is_disposable-value">{is_disposable.toString()}</WhiteText>
       ,<br />
       <TabCharacter />
       <TabCharacter />
-      "is_free": <WhiteText data-id="is_free-value">{is_free && is_free.toString()}</WhiteText>,
+      "is_free": <WhiteText data-id="is_free-value">{is_free.toString()}</WhiteText>,
       <br />
       {did_you_mean && (
         <>

--- a/src/pages/recipientValidation/tests/SingleResult.test.js
+++ b/src/pages/recipientValidation/tests/SingleResult.test.js
@@ -214,4 +214,24 @@ describe('SingleResult', () => {
 
     expect(queryByText('Recipient Validation')).toBeInTheDocument();
   });
+
+  it('renders the relevant API response value in the "Raw API Response" portion of the view', () => {
+    const { queryByTestId } = subject({
+      singleResults: {
+        valid: false,
+        is_role: true,
+        is_disposable: true,
+        is_free: false,
+      },
+    });
+
+    expect(queryByTestId('valid-value')).toHaveTextContent('false', { normalizeWhitespace: true });
+    expect(queryByTestId('is_role-value')).toHaveTextContent('true', { normalizeWhitespace: true });
+    expect(queryByTestId('is_disposable-value')).toHaveTextContent('true', {
+      normalizeWhitespace: true,
+    });
+    expect(queryByTestId('is_free-value')).toHaveTextContent('false', {
+      normalizeWhitespace: true,
+    });
+  });
 });

--- a/src/pages/recipientValidation/tests/SingleResult.test.js
+++ b/src/pages/recipientValidation/tests/SingleResult.test.js
@@ -222,6 +222,8 @@ describe('SingleResult', () => {
         is_role: true,
         is_disposable: true,
         is_free: false,
+        reason: 'fake reason',
+        did_you_mean: 'fake-email@gmail.com',
       },
     });
 
@@ -231,6 +233,12 @@ describe('SingleResult', () => {
       normalizeWhitespace: true,
     });
     expect(queryByTestId('is_free-value')).toHaveTextContent('false', {
+      normalizeWhitespace: true,
+    });
+    expect(queryByTestId('reason-value')).toHaveTextContent('fake reason', {
+      normalizeWhitespace: true,
+    });
+    expect(queryByTestId('did_you_mean-value')).toHaveTextContent('fake-email@gmail.com', {
       normalizeWhitespace: true,
     });
   });

--- a/src/pages/recipientValidation/tests/SingleResult.test.js
+++ b/src/pages/recipientValidation/tests/SingleResult.test.js
@@ -220,7 +220,7 @@ describe('SingleResult', () => {
       singleResults: {
         valid: false,
         is_role: false,
-        is_disposabl: false,
+        is_disposable: false,
         is_free: false,
         reason: 'fake reason',
         did_you_mean: 'fake-email@gmail.com',

--- a/src/pages/recipientValidation/tests/SingleResult.test.js
+++ b/src/pages/recipientValidation/tests/SingleResult.test.js
@@ -219,8 +219,8 @@ describe('SingleResult', () => {
     const { queryByTestId } = subject({
       singleResults: {
         valid: false,
-        is_role: true,
-        is_disposable: true,
+        is_role: false,
+        is_disposabl: false,
         is_free: false,
         reason: 'fake reason',
         did_you_mean: 'fake-email@gmail.com',
@@ -228,8 +228,10 @@ describe('SingleResult', () => {
     });
 
     expect(queryByTestId('valid-value')).toHaveTextContent('false', { normalizeWhitespace: true });
-    expect(queryByTestId('is_role-value')).toHaveTextContent('true', { normalizeWhitespace: true });
-    expect(queryByTestId('is_disposable-value')).toHaveTextContent('true', {
+    expect(queryByTestId('is_role-value')).toHaveTextContent('false', {
+      normalizeWhitespace: true,
+    });
+    expect(queryByTestId('is_disposable-value')).toHaveTextContent('false', {
       normalizeWhitespace: true,
     });
     expect(queryByTestId('is_free-value')).toHaveTextContent('false', {


### PR DESCRIPTION
[TR-2139](https://jira.int.messagesystems.com/browse/TR-2139)

### What Changed
- Adds `data-id` prop to the `<WhiteText/>` component
- Adds test that checks for expected rendering
- Removes truthiness conditional that was inappropriately rendering portions of the UI as empty

#### Before

<img width="350" alt="Screen Shot 2020-01-16 at 10 47 12 AM" src="https://user-images.githubusercontent.com/3613392/72551242-7939c100-3862-11ea-85ab-ae09042620e4.png">

#### After

![Screen Shot 2020-01-16 at 1 16 49 PM](https://user-images.githubusercontent.com/3613392/72551254-7ccd4800-3862-11ea-9230-1e75972ee348.png)

### How To Test
- Go to `/recipient-validation/single/hello@me.com` and verify that `"is_disposable"` has a value of `false` instead of nothing
- Go to `/recipient-validation/single/nick.lemmon@gmail.com` and verify that `"is_disposable"` and `"is_role"` render as `false` instead of blank
- Go to `/recipient-validation/single/me@nicklemmon.com` and verify that `"is_role"` and `"is_disposable"` and `"is_free"` all have a value of `false`
- Go to `/recipient-validation/single/hello@gm` and verify that `"valid"` has a value of `false`

### To Do
- [ ] Incorporate feedback
