### PR TITLE
FE-838 - Update styles to properly hide global alerts from screen readers and Cypress tests

### DIFF
--- a/cypress/tests/integration/accounts/onboarding/billing-plan-page.spec.js
+++ b/cypress/tests/integration/accounts/onboarding/billing-plan-page.spec.js
@@ -137,10 +137,14 @@ describe('The billing plan page', () => {
           fixture: 'account/subscription/promo-codes/400.get.json',
           url: '/api/v1/account/subscription/promo-codes/*',
           statusCode: 400,
+          alias: 'invalidPromoCode',
         });
 
         cy.findByLabelText('Promo Code').type('abc');
         cy.findByText('Apply').click();
+
+        cy.wait('@invalidPromoCodeRequest');
+
         cy.queryByText('Invalid promo code').should('be.visible');
       });
 
@@ -149,9 +153,13 @@ describe('The billing plan page', () => {
           url: '/api/v1/account/subscription/promo-codes/*',
           fixture: 'account/subscription/promo-codes/404.get.json',
           statusCode: 404,
+          alias: 'resourceNotFound',
         });
 
         cy.findByText('Apply').click();
+
+        cy.wait('@resourceNotFoundRequest');
+
         cy.queryByText('Resource could not be found');
       });
 

--- a/src/components/globalAlert/Animator.module.scss
+++ b/src/components/globalAlert/Animator.module.scss
@@ -2,23 +2,26 @@
 
 .Animator {
   display: block;
-
   transform: translate(20px, 0);
+  visibility: hidden;
   opacity: 0;
-  transition: 0.2s cubic-bezier(0,0,.5,1.5);
+  transition: 0.2s cubic-bezier(0, 0, 0.5, 1.5);
 }
 
 .entered {
   transform: translate(0, 0);
+  visibility: visible;
   opacity: 1;
 }
 
-.exiting, .exited {
+.exiting,
+.exited {
   transform: translate(20px, 0);
   opacity: 0;
 }
 
 .exited {
   height: 0 !important;
+  visibility: hidden;
   pointer-events: none;
 }


### PR DESCRIPTION
[FE-838](https://jira.int.messagesystems.com/browse/FE-838)

**NOTE:** - I did not add any automated testing to check for this change in this PR. Future Cypress tests will end up testing this behavior "naturally" without having to introduce a test with a 15 second `cy.wait()`

### What Changed
- Updated global alert animation styles to use `visibility` CSS property
- Adds some `cy.wait()` to two tests that have proven to be somewhat flaky in the pipeline (no flake locally! I would assume due to a hardware difference between the runner and our Macs)

### How To Test
1. Go to `/templates`
1. Find a random template, click the trash can icon
1. Confirm the modal and verify that the alert animates in as usual
1. Confirm that the modal animates out as usual as well

### To Do
- [x] Incorporate feedback
