### PR TITLE
FE-727 Add useABTest hook

### DIFF
--- a/src/hooks/useABTest/hash.js
+++ b/src/hooks/useABTest/hash.js
@@ -1,3 +1,5 @@
+// Based on Java's hashcode function
+// https://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
 export const hash = str => {
   let hash = 0;
   if (str.length === 0) {

--- a/src/hooks/useABTest/hash.js
+++ b/src/hooks/useABTest/hash.js
@@ -1,0 +1,13 @@
+export const hash = str => {
+  let hash = 0;
+  if (str.length === 0) {
+    return hash;
+  }
+
+  for (let i = 0, l = str.length; i < l; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0;
+  }
+  return Math.abs(hash);
+};

--- a/src/hooks/useABTest/hash.test.js
+++ b/src/hooks/useABTest/hash.test.js
@@ -1,0 +1,22 @@
+import { hash } from './hash';
+
+describe('hash', () => {
+  it('gets the same value on multiple calls to hash', () => {
+    expect(hash('abc123')).toEqual(hash('abc123'));
+  });
+
+  it('gets the different values for different string values', () => {
+    const cids = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
+    for (let i = 0; i < cids.length; i++) {
+      for (let j = 0; j < cids.length; j++) {
+        if (i !== j) {
+          expect(hash(cids[i])).not.toEqual(hash(cids[j]));
+        }
+      }
+    }
+  });
+
+  it('gets 0 hash for empty string', () => {
+    expect(hash('')).toEqual(0);
+  });
+});

--- a/src/hooks/useABTest/index.js
+++ b/src/hooks/useABTest/index.js
@@ -1,0 +1,1 @@
+export { default } from './useABTest';

--- a/src/hooks/useABTest/useABTest.js
+++ b/src/hooks/useABTest/useABTest.js
@@ -1,0 +1,27 @@
+import { useMemo, useEffect } from 'react';
+import { hash } from './hash';
+
+const logToPendo = ({ testName, variantName }) => {
+  if (window.pendo) {
+    window.pendo.track(`${testName} | ${variantName}`);
+  }
+};
+
+function useABTest(options = {}) {
+  const { testName, variants = [], onVariantLoad = logToPendo, uid } = options;
+
+  const index = useMemo(() => hash(uid) % variants.length, [variants.length, uid]);
+
+  const VariantComponent = variants[index];
+  const variantName = VariantComponent.displayName || VariantComponent.name || 'ABTestVariant';
+
+  useEffect(() => {
+    if (onVariantLoad && uid && variantName && testName) {
+      onVariantLoad({ testName, variantName, uid });
+    }
+  }, [onVariantLoad, testName, uid, variantName]);
+
+  return VariantComponent;
+}
+
+export default useABTest;

--- a/src/hooks/useABTest/useABTest.js
+++ b/src/hooks/useABTest/useABTest.js
@@ -10,6 +10,20 @@ const logToPendo = ({ testName, variantName }) => {
 function useABTest(options = {}) {
   const { testName, variants = [], onVariantLoad = logToPendo, uid } = options;
 
+  if (!testName) {
+    throw new Error('useABTest requires a string testName');
+  }
+
+  if (!uid) {
+    throw new Error(
+      'useABTest requires a uid to be set. Without it, the first variant will always be chosen',
+    );
+  }
+
+  if (!onVariantLoad || typeof onVariantLoad !== 'function') {
+    throw new Error('useABTest requires that if onVariantLoad is passed, it must be a function');
+  }
+
   const index = useMemo(() => hash(uid) % variants.length, [variants.length, uid]);
 
   const VariantComponent = variants[index];

--- a/src/hooks/useABTest/useABTest.test.js
+++ b/src/hooks/useABTest/useABTest.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { shallow } from 'enzyme';
 import { render, queryByText } from '@testing-library/react';
 import { hash } from './hash';
 import useABTest from './useABTest';
@@ -67,5 +68,25 @@ describe('useABTest', () => {
       testName: 'Test 1',
       variantName: 'VariantA',
     });
+  });
+
+  it("throws an error if the test doesn't have a test name", () => {
+    expect(() => {
+      shallow(<MockComponent />);
+    }).toThrowError('useABTest requires a string testName');
+  });
+
+  it("throws an error if the test doesn't have a uid", () => {
+    expect(() => {
+      shallow(<MockComponent testName="Test" />);
+    }).toThrowError(
+      'useABTest requires a uid to be set. Without it, the first variant will always be chosen',
+    );
+  });
+
+  it("throws an error if the test doesn't have a function for onVariantLoad", () => {
+    expect(() => {
+      shallow(<MockComponent testName="Test" uid="123" onVariantLoad="abc" />);
+    }).toThrowError('useABTest requires that if onVariantLoad is passed, it must be a function');
   });
 });

--- a/src/hooks/useABTest/useABTest.test.js
+++ b/src/hooks/useABTest/useABTest.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, queryByText } from '@testing-library/react';
+import { hash } from './hash';
+import useABTest from './useABTest';
+
+jest.mock('./hash');
+
+const VariantA = () => <h1>a</h1>;
+
+const VariantB = () => <h1>b</h1>;
+
+const VariantC = () => <h1>c</h1>;
+
+describe('useABTest', () => {
+  const MockComponent = ({ testName, variants, uid, onVariantLoad }) => {
+    const Variant = useABTest({ testName, variants, uid, onVariantLoad });
+    return <Variant />;
+  };
+
+  const subject = (testName, variants, uid, onVariantLoad) => {
+    return render(
+      <MockComponent
+        variants={variants}
+        uid={uid}
+        onVariantLoad={onVariantLoad}
+        testName={testName}
+      />,
+    );
+  };
+
+  it('gets the same variant based on hash', () => {
+    hash.mockImplementation(() => '1');
+    const { container: container1 } = subject('Test 1', [VariantA, VariantB, VariantC], '123');
+    const { container: container2 } = subject('Test 1', [VariantA, VariantB, VariantC], '123');
+
+    expect(queryByText(container1, 'b')).toBeInTheDocument();
+    expect(queryByText(container2, 'b')).toBeInTheDocument();
+  });
+
+  it('gets a different variant based on hash', () => {
+    hash.mockImplementation(() => '0');
+    const { container: container1 } = subject('Test 1', [VariantA, VariantB, VariantC], '123');
+    hash.mockImplementation(() => '1');
+    const { container: container2 } = subject('Test 1', [VariantA, VariantB, VariantC], '234');
+
+    expect(queryByText(container1, 'a')).toBeInTheDocument();
+    expect(queryByText(container2, 'b')).toBeInTheDocument();
+  });
+
+  it('logs to pendo by default', () => {
+    window.pendo = {};
+    window.pendo.track = jest.fn();
+    hash.mockImplementation(() => '0');
+    subject('Test 1', [VariantA, VariantB, VariantC], '123');
+    expect(window.pendo.track).toBeCalledWith('Test 1 | VariantA');
+  });
+
+  it('calls onVariantLoad instead of pendo track when passed', () => {
+    window.pendo = {};
+    window.pendo.track = jest.fn();
+    hash.mockImplementation(() => '0');
+    const onVariantLoad = jest.fn();
+    subject('Test 1', [VariantA, VariantB, VariantC], '123', onVariantLoad);
+    expect(window.pendo.track).not.toBeCalledWith('Test 1 | VariantA');
+    expect(onVariantLoad).toBeCalledWith({
+      uid: '123',
+      testName: 'Test 1',
+      variantName: 'VariantA',
+    });
+  });
+});


### PR DESCRIPTION
### What Changed
 - Added a hook to get a specific variant of an experiment AB Test based on UID

### How To Test
 - Ensure tests are passing and are good enough coverage

### To Do
- Determine if we should import the redux store in the hook so that we don't need to pass the customer_id from every use of this hook.
