### PR TITLE
SE-485 Remove Year from Events Page Date

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -129,6 +129,7 @@ const config = identifier => ({
     cnameValue: `${identifier}.et.e.sparkpost.com`,
   },
   dateFormat: 'MMM D YYYY',
+  dateFormatWithoutYear: 'MMM D',
   timeFormat: 'h:mma',
   messageEvents: {
     retentionPeriodDays: 10,

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -151,7 +151,7 @@ export function formatDateTime(datetime, FORMAT) {
 }
 
 export function formatDateTimeWithoutYear(datetime) {
-  return moment(datetime).format(`${config.dateFormatWithoutYear}, ${config.timeFormat}`);
+  return formatDateTime(datetime, `${config.dateFormatWithoutYear}, ${config.timeFormat}`);
 }
 
 // format as ISO 8601 timestamp to match SP API

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -150,6 +150,10 @@ export function formatDateTime(datetime, FORMAT) {
     : `${formatDate(datetime)}, ${formatTime(datetime)}`;
 }
 
+export function formatDateTimeWithoutYear(datetime) {
+  return moment(datetime).format(`${config.dateFormatWithoutYear}, ${config.timeFormat}`);
+}
+
 // format as ISO 8601 timestamp to match SP API
 export const formatApiTimestamp = time => moment.utc(time).format();
 export const formatApiDate = date => moment.utc(date).format(FORMATS.SHORT_DATE);

--- a/src/helpers/tests/date.test.js
+++ b/src/helpers/tests/date.test.js
@@ -19,6 +19,7 @@ import {
   parseTime,
   parseDatetime,
   toMilliseconds,
+  formatDateTimeWithoutYear,
 } from '../date';
 import { roundBoundaries } from '../metrics';
 import cases from 'jest-in-case';
@@ -207,6 +208,10 @@ describe('Date helpers', () => {
 
     it('should format a date-time consistently', () => {
       expect(formatDateTime(testDate)).toEqual('Oct 15 2017, 8:55am');
+    });
+
+    it('should format a date-time without year consistently', () => {
+      expect(formatDateTimeWithoutYear(testDate)).toEqual('Oct 15, 8:55am');
     });
   });
 

--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -3,11 +3,23 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { snakeToFriendly } from 'src/helpers/string';
 import { Button, Page } from '@sparkpost/matchbox';
-import { PanelLoading, TableCollection, CursorPaging, PerPageButtons, ApiErrorBanner, Empty } from 'src/components';
+import {
+  PanelLoading,
+  TableCollection,
+  CursorPaging,
+  PerPageButtons,
+  ApiErrorBanner,
+  Empty,
+} from 'src/components';
 import DisplayDate from 'src/components/displayDate/DisplayDate';
 import MessageEventsSearch from './components/MessageEventsSearch';
 import ViewDetailsButton from './components/ViewDetailsButton';
-import { getMessageEvents, changePage, getMessageEventsCSV, clearCSV } from 'src/actions/messageEvents';
+import {
+  getMessageEvents,
+  changePage,
+  getMessageEventsCSV,
+  clearCSV,
+} from 'src/actions/messageEvents';
 import { selectMessageEvents, selectMessageEventsCSV } from 'src/selectors/messageEvents';
 import { formatToCsv, download } from 'src/helpers/downloading';
 import { DEFAULT_PER_PAGE_BUTTONS } from 'src/constants';
@@ -23,15 +35,14 @@ const columns = [
   { label: 'Recipient' },
   { label: 'From Address' },
   { label: 'Time' },
-  null
+  null,
 ];
 
 export class MessageEventsPage extends Component {
-
   state = {
     currentPage: 1,
-    perPage: 25
-  }
+    perPage: 25,
+  };
 
   componentDidUpdate(prevProps) {
     const { search, getMessageEvents, eventsCSV } = this.props;
@@ -54,17 +65,17 @@ export class MessageEventsPage extends Component {
     clearCSV();
   };
 
-  handlePageChange = (currentPage) => {
+  handlePageChange = currentPage => {
     this.setState({ currentPage });
     const { changePage } = this.props;
     return changePage(currentPage);
-  }
+  };
 
-  handlePerPageChange = (perPage) => {
+  handlePerPageChange = perPage => {
     const { search, getMessageEvents } = this.props;
     this.setState({ perPage, currentPage: 1 });
     getMessageEvents({ perPage, ...search });
-  }
+  };
 
   //Reload the first page w/ api call, NOT from cache
   handleFirstPage = () => {
@@ -72,34 +83,39 @@ export class MessageEventsPage extends Component {
     const { perPage } = this.state;
     this.setState({ currentPage: 1 });
     getMessageEvents({ perPage, ...search });
-  }
+  };
 
   isPreviousDisabled = () => {
     const { currentPage } = this.state;
     return currentPage <= 1;
-  }
+  };
 
   isNextDisabled = () => {
     const { hasMorePagesAvailable } = this.props;
     return !hasMorePagesAvailable;
-  }
+  };
 
   getCSV = () => {
     const { search, getMessageEventsCSV } = this.props;
     getMessageEventsCSV(search);
-  }
+  };
 
-  getRowData = (rowData) => {
+  getRowData = rowData => {
     const { timestamp, formattedDate, type, friendly_from, rcpt_to, subject } = rowData;
     return [
       snakeToFriendly(type),
       <div className={styles.MessageSubject}>{subject}</div>,
       rcpt_to,
       friendly_from,
-      <DisplayDate timestamp={timestamp} formattedDate={formattedDate} diffTime={59} diffScale='seconds'/>,
-      <ViewDetailsButton {...rowData} />
+      <DisplayDate
+        timestamp={timestamp}
+        formattedDate={formattedDate}
+        diffTime={59}
+        diffScale="seconds"
+      />,
+      <ViewDetailsButton {...rowData} />,
     ];
-  }
+  };
 
   renderError() {
     const { error, getMessageEvents, search } = this.props;
@@ -120,41 +136,41 @@ export class MessageEventsPage extends Component {
       return <PanelLoading />;
     }
 
-    const content = empty
-      ? <Empty message={emptyMessage} />
-      : (
-        <div>
-          <TableCollection
-            columns={columns}
-            rows={events}
-            getRowData={this.getRowData}
-            defaultSortColumn='timestamp'
-            defaultSortDirection='desc'
-          />
-          <CursorPaging
-            currentPage={currentPage}
-            handlePageChange = {this.handlePageChange}
-            previousDisabled={this.isPreviousDisabled()}
-            nextDisabled={this.isNextDisabled()}
-            handleFirstPage={this.handleFirstPage}
-            perPage={perPage}
+    const content = empty ? (
+      <Empty message={emptyMessage} />
+    ) : (
+      <div>
+        <TableCollection
+          columns={columns}
+          rows={events}
+          getRowData={this.getRowData}
+          defaultSortColumn="timestamp"
+          defaultSortDirection="desc"
+        />
+        <CursorPaging
+          currentPage={currentPage}
+          handlePageChange={this.handlePageChange}
+          previousDisabled={this.isPreviousDisabled()}
+          nextDisabled={this.isNextDisabled()}
+          handleFirstPage={this.handleFirstPage}
+          perPage={perPage}
+          totalCount={totalCount}
+        />
+        <div className={styles.RightAlignedButtons}>
+          <PerPageButtons
             totalCount={totalCount}
+            data={events}
+            onPerPageChange={this.handlePerPageChange}
+            perPageButtons={DEFAULT_PER_PAGE_BUTTONS}
+            perPage={perPage}
+            saveCsv={true}
           />
-          <div className={styles.RightAlignedButtons}>
-            <PerPageButtons
-              totalCount={totalCount}
-              data={events}
-              onPerPageChange={this.handlePerPageChange}
-              perPageButtons={DEFAULT_PER_PAGE_BUTTONS}
-              perPage={perPage}
-              saveCsv={true}
-            />
-            <Button onClick={this.getCSV} disabled={eventsCSVLoading}>
-              {(eventsCSVLoading) ? 'Saving CSV...' : 'Save as CSV'}
-            </Button>
-          </div>
+          <Button onClick={this.getCSV} disabled={eventsCSVLoading}>
+            {eventsCSVLoading ? 'Saving CSV...' : 'Save as CSV'}
+          </Button>
         </div>
-      );
+      </div>
+    );
 
     return content;
   }
@@ -163,20 +179,26 @@ export class MessageEventsPage extends Component {
     const { error } = this.props;
 
     return (
-      <Page title='Events Search'>
+      <Page title="Events Search">
         <MessageEventsSearch />
         {error ? this.renderError() : this.renderCollection()}
       </Page>
     );
   }
-
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   const events = selectMessageEvents(state);
   const eventsCSV = selectMessageEventsCSV(state);
   const { messageEvents } = state;
-  const { loading, error, search, totalCount, hasMorePagesAvailable, eventsCSVLoading } = messageEvents;
+  const {
+    loading,
+    error,
+    search,
+    totalCount,
+    hasMorePagesAvailable,
+    eventsCSVLoading,
+  } = messageEvents;
   return {
     events: events,
     loading,
@@ -186,8 +208,13 @@ const mapStateToProps = (state) => {
     totalCount,
     hasMorePagesAvailable,
     eventsCSV,
-    eventsCSVLoading
+    eventsCSVLoading,
   };
 };
 
-export default connect(mapStateToProps, { getMessageEvents, getMessageEventsCSV, changePage, clearCSV })(MessageEventsPage);
+export default connect(mapStateToProps, {
+  getMessageEvents,
+  getMessageEventsCSV,
+  changePage,
+  clearCSV,
+})(MessageEventsPage);

--- a/src/selectors/messageEvents.js
+++ b/src/selectors/messageEvents.js
@@ -3,83 +3,88 @@ import { formatDateTime } from 'src/helpers/date';
 import moment from 'moment';
 import { createSelector, createStructuredSelector } from 'reselect';
 
-const getMessageEvents = (state) => state.messageEvents.events;
-const getMessageEventsCSV = (state) => state.messageEvents.eventsCSV;
-const getMessageHistory = (state) => state.messageEvents.history;
-const getSingleSelectedEvent = (state) => state.messageEvents.selectedEvent;
+const getMessageEvents = state => state.messageEvents.events;
+const getMessageEventsCSV = state => state.messageEvents.eventsCSV;
+const getMessageHistory = state => state.messageEvents.history;
+const getSingleSelectedEvent = state => state.messageEvents.selectedEvent;
 export const getMessageIdParam = (state, props) => props.match.params.messageId;
 const getEventIdParam = (state, props) => props.match.params.eventId;
 
-const appendFormattedDate = (event) => ({
+const appendFormattedDate = event => ({
   ...event,
-  formattedDate: formatDateTime(event.timestamp)
+  formattedDate: formatDateTime(event.timestamp),
 });
 
-export const selectMessageEvents = createSelector(
-  [ getMessageEvents ],
-  (events) => _.map(events, appendFormattedDate)
+export const selectMessageEvents = createSelector([getMessageEvents], events =>
+  _.map(events, appendFormattedDate),
 );
 
-export const selectMessageEventsCSV = createSelector(
-  [ getMessageEventsCSV ],
-  (events) => _.map(events, appendFormattedDate)
+export const selectMessageEventsCSV = createSelector([getMessageEventsCSV], events =>
+  _.map(events, appendFormattedDate),
 );
 
 export const selectMessageHistory = createSelector(
   [getMessageHistory, getMessageIdParam],
-  (history, id) => _.map(history[id], appendFormattedDate)
+  (history, id) => _.map(history[id], appendFormattedDate),
 );
 
 export const selectInitialEventId = createSelector(
   [selectMessageHistory, getEventIdParam],
-  (messageHistory, selectedEventId) => selectedEventId || _.get(messageHistory[0], 'event_id')
+  (messageHistory, selectedEventId) => selectedEventId || _.get(messageHistory[0], 'event_id'),
 );
 
-const selectMessageEventsDateOptions = (state) => ({
-  from: moment(_.get(state, 'messageEvents.search.dateOptions.from')).utc().format(),
-  to: moment(_.get(state, 'messageEvents.search.dateOptions.to')).utc().format(),
-  range: _.get(state, 'messageEvents.search.dateOptions.relativeRange')
+const selectMessageEventsDateOptions = state => ({
+  from: moment(_.get(state, 'messageEvents.search.dateOptions.from'))
+    .utc()
+    .format(),
+  to: moment(_.get(state, 'messageEvents.search.dateOptions.to'))
+    .utc()
+    .format(),
+  range: _.get(state, 'messageEvents.search.dateOptions.relativeRange'),
 });
 
-const selectSearch = (state) => _.omit(state.messageEvents.search, ['dateOptions']);
+const selectSearch = state => _.omit(state.messageEvents.search, ['dateOptions']);
 
 /**
  * Converts reportOptions for url sharing for message events
  */
 export const selectMessageEventsSearchOptions = createSelector(
   [selectMessageEventsDateOptions, selectSearch],
-  (dates, search) => ({ ...dates, ...search })
+  (dates, search) => ({ ...dates, ...search }),
 );
 
 export const isMessageHistoryEmpty = createSelector(
   [getMessageHistory, getMessageIdParam],
-  (history, id) => _.get(history, id, []).length === 0
+  (history, id) => _.get(history, id, []).length === 0,
 );
 
 export const getSelectedEventFromMessageHistory = createSelector(
   [selectMessageHistory, getEventIdParam],
-  (messageHistory, eventId) => _.find(messageHistory, (event) => event.event_id === eventId)
+  (messageHistory, eventId) => _.find(messageHistory, ['event_id', eventId]),
 );
 
 //whether the event is without a message_id (defaulted to _noid_)
-const isOrphanEvent = createSelector(
-  [getMessageIdParam], (messageId) => messageId === '_noid_'
-);
+const isOrphanEvent = createSelector([getMessageIdParam], messageId => messageId === '_noid_');
 
 const getSelectedEvent = createSelector(
-  [isOrphanEvent, getSingleSelectedEvent, getSelectedEventFromMessageHistory], (isOrphanEvent, selectedEvent, eventFromMessageHistory) => isOrphanEvent ? selectedEvent : eventFromMessageHistory
+  [isOrphanEvent, getSingleSelectedEvent, getSelectedEventFromMessageHistory],
+  (isOrphanEvent, selectedEvent, eventFromMessageHistory) =>
+    isOrphanEvent ? selectedEvent : eventFromMessageHistory,
 );
 
-export const eventPageMSTP = (state, props) => createStructuredSelector({
-  isMessageHistoryEmpty: isMessageHistoryEmpty,
-  isOrphanEvent: isOrphanEvent,
-  loading: (state) => !!(state.messageEvents.historyLoading ||
-    state.messageEvents.documentationLoading ||
-    state.messageEvents.selectedEventLoading),
-  messageHistory: selectMessageHistory,
-  messageId: getMessageIdParam,
-  documentation: (state) => state.messageEvents.documentation,
-  selectedEventId: selectInitialEventId,
-  selectedEvent: getSelectedEvent
-});
-
+export const eventPageMSTP = () =>
+  createStructuredSelector({
+    isMessageHistoryEmpty: isMessageHistoryEmpty,
+    isOrphanEvent: isOrphanEvent,
+    loading: state =>
+      !!(
+        state.messageEvents.historyLoading ||
+        state.messageEvents.documentationLoading ||
+        state.messageEvents.selectedEventLoading
+      ),
+    messageHistory: selectMessageHistory,
+    messageId: getMessageIdParam,
+    documentation: state => state.messageEvents.documentation,
+    selectedEventId: selectInitialEventId,
+    selectedEvent: getSelectedEvent,
+  });

--- a/src/selectors/messageEvents.js
+++ b/src/selectors/messageEvents.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { formatDateTime } from 'src/helpers/date';
+import { formatDateTime, formatDateTimeWithoutYear } from 'src/helpers/date';
 import moment from 'moment';
 import { createSelector, createStructuredSelector } from 'reselect';
 
@@ -15,8 +15,13 @@ const appendFormattedDate = event => ({
   formattedDate: formatDateTime(event.timestamp),
 });
 
+const appendFormattedDateWithoutYear = event => ({
+  ...event,
+  formattedDate: formatDateTimeWithoutYear(event.timestamp),
+});
+
 export const selectMessageEvents = createSelector([getMessageEvents], events =>
-  _.map(events, appendFormattedDate),
+  _.map(events, appendFormattedDateWithoutYear),
 );
 
 export const selectMessageEventsCSV = createSelector([getMessageEventsCSV], events =>

--- a/src/selectors/tests/__snapshots__/messageEvents.test.js.snap
+++ b/src/selectors/tests/__snapshots__/messageEvents.test.js.snap
@@ -22,13 +22,13 @@ Array [
   Object {
     "event_id": "default_id",
     "foo": "bar",
-    "formattedDate": "Nov 9 2017, 12:00am",
+    "formattedDate": "Nov 9, 12:00am",
     "timestamp": "2017-11-09T00:00",
   },
   Object {
     "bat": "baz",
     "foo": "bar",
-    "formattedDate": "Nov 8 2017, 11:00am",
+    "formattedDate": "Nov 8, 11:00am",
     "timestamp": "2017-11-08T11:00",
   },
 ]


### PR DESCRIPTION
### What Changed
 - Added a new config for `dateFormatWithoutYear`
 - Added new date formatter function `formatDateTimeWithoutYear`
 - Use this new formatter on the messageEvents selector (but only for the events list, not the CSV)

### How To Test
 - Open /reports/message-events
 - Move to the next page so dates show up
 - Ensure there is no year on the dates
