### PR TITLE
SA-1093: Prevent submitting date picker update with only 1 date selected

### DIFF
--- a/src/components/datePicker/DatePicker.js
+++ b/src/components/datePicker/DatePicker.js
@@ -1,7 +1,13 @@
 /* eslint-disable max-lines */
 import React, { Component } from 'react';
 import { subMonths, format } from 'date-fns';
-import { getStartOfDay, getEndOfDay, getRelativeDateOptions, getNextHour, isSameDate } from 'src/helpers/date';
+import {
+  getStartOfDay,
+  getEndOfDay,
+  getRelativeDateOptions,
+  getNextHour,
+  isSameDate,
+} from 'src/helpers/date';
 import { roundBoundaries } from 'src/helpers/metrics';
 import { Button, TextField, Select, Popover, WindowEvent, Error } from '@sparkpost/matchbox';
 import DateSelector from 'src/components/dateSelector/DateSelector';
@@ -11,14 +17,13 @@ import styles from './DatePicker.module.scss';
 import PropTypes from 'prop-types';
 
 export default class AppDatePicker extends Component {
-
   DATE_FORMAT = FORMATS.LONG_DATETIME;
   state = {
     showDatePicker: false,
     selecting: false,
-    selected: { },
-    validationError: null
-  }
+    selected: {},
+    validationError: null,
+  };
 
   componentDidMount() {
     this.syncTimeToState(this.props);
@@ -32,11 +37,11 @@ export default class AppDatePicker extends Component {
 
   // Sets local state from reportOptions redux state - need to separate to handle pre-apply state
   syncTimeToState = ({ from, to }) => {
-    this.setState({ selected: { from, to }});
-  }
+    this.setState({ selected: { from, to } });
+  };
 
   // Closes popover on escape, submits on enter
-  handleKeyDown = (e) => {
+  handleKeyDown = e => {
     if (!this.state.showDatePicker) {
       return;
     }
@@ -48,29 +53,32 @@ export default class AppDatePicker extends Component {
     if (!this.state.selecting && e.key === 'Enter') {
       this.handleSubmit();
     }
-  }
+  };
 
   handleDayKeyDown = (day, modifiers, e) => {
     this.handleKeyDown(e);
     e.stopPropagation();
-  }
+  };
 
   cancelDatePicker = () => {
     this.syncTimeToState(this.props);
     this.setState({ showDatePicker: false });
-  }
+  };
 
   showDatePicker = () => {
     this.setState({ showDatePicker: true });
-  }
+  };
 
-  handleDayClick = (clicked) => {
+  handleDayClick = clicked => {
     const { selecting, selected } = this.state;
     const { validate } = this.props;
 
     const dates = selecting
       ? selected
-      : { from: this.fromFormatter(clicked), to: getEndOfDay(clicked, { preventFuture: this.props.preventFuture }) };
+      : {
+          from: this.fromFormatter(clicked),
+          to: getEndOfDay(clicked, { preventFuture: this.props.preventFuture }),
+        };
 
     const validationError = validate && validate(dates);
 
@@ -83,17 +91,17 @@ export default class AppDatePicker extends Component {
       selected: dates,
       beforeSelected: dates,
       selecting: !selecting,
-      validationError: null
+      validationError: null,
     });
-  }
+  };
 
-  handleDayHover = (hovered) => {
+  handleDayHover = hovered => {
     const { selecting } = this.state;
 
     if (selecting) {
-      this.setState({ selected: { ...this.getOrderedRange(hovered) }});
+      this.setState({ selected: { ...this.getOrderedRange(hovered) } });
     }
-  }
+  };
 
   getOrderedRange(newDate) {
     let { from, to } = this.state.beforeSelected;
@@ -112,7 +120,7 @@ export default class AppDatePicker extends Component {
     return { from, to };
   }
 
-  handleSelectRange = (e) => {
+  handleSelectRange = e => {
     const value = e.currentTarget.value;
 
     if (value === 'custom') {
@@ -121,11 +129,11 @@ export default class AppDatePicker extends Component {
       this.setState({ showDatePicker: false });
       this.props.onChange({ relativeRange: value });
     }
-  }
+  };
 
   handleFormDates = ({ from, to }, callback) => {
-    this.setState({ selected: { from, to }}, () => callback());
-  }
+    this.setState({ selected: { from, to } }, () => callback());
+  };
 
   handleSubmit = () => {
     if (this.state.validationError) {
@@ -134,22 +142,26 @@ export default class AppDatePicker extends Component {
 
     this.setState({ showDatePicker: false, selecting: false, validationError: null });
     this.props.onChange({ ...this.state.selected, relativeRange: 'custom' });
-  }
+  };
 
   handleTextUpdate = () => {
     if (this.props.onBlur) {
       this.props.onBlur();
     }
-  }
+  };
 
-  fromFormatter = (fromDate) => {
+  fromFormatter = fromDate => {
     const isDateToday = isSameDate(getStartOfDay(fromDate), getStartOfDay(new Date()));
-    const formatter = (this.props.fromSelectsNextHour && isDateToday) ? getNextHour : getStartOfDay;
+    const formatter = this.props.fromSelectsNextHour && isDateToday ? getNextHour : getStartOfDay;
     return formatter(fromDate);
-  }
+  };
 
   render() {
-    const { selected: { from, to }, showDatePicker, validationError } = this.state;
+    const {
+      selected: { from, to },
+      showDatePicker,
+      validationError,
+    } = this.state;
     const selectedRange = showDatePicker ? 'custom' : this.props.relativeRange;
 
     // allow for prop-level override of "now" (DI, etc.)
@@ -165,37 +177,41 @@ export default class AppDatePicker extends Component {
       showPresets = true,
       error,
       left,
-      hideManualEntry
+      hideManualEntry,
     } = this.props;
     const dateFormat = dateFieldFormat || this.DATE_FORMAT;
 
-    const rangeSelect = showPresets
-      ? <Select
+    const rangeSelect = showPresets ? (
+      <Select
         options={getRelativeDateOptions(relativeDateOptions)}
         onChange={this.handleSelectRange}
         value={selectedRange}
-        disabled={disabled} />
-      : null;
+        disabled={disabled}
+      />
+    ) : null;
 
-    const dateField = <TextField
-      onClick={this.showDatePicker}
-      connectLeft={rangeSelect}
-      value={`${format(from, dateFormat)} – ${format(to, dateFormat)}`}
-      readOnly
-      onBlur={this.handleTextUpdate}
-      error={error}
-      disabled={disabled}
-      {...textFieldProps} />;
+    const dateField = (
+      <TextField
+        onClick={this.showDatePicker}
+        connectLeft={rangeSelect}
+        value={`${format(from, dateFormat)} – ${format(to, dateFormat)}`}
+        readOnly
+        onBlur={this.handleTextUpdate}
+        error={error}
+        disabled={disabled}
+        {...textFieldProps}
+      />
+    );
 
     return (
       <Popover
-        wrapper='div'
+        wrapper="div"
         className={styles.Popover}
         trigger={dateField}
         onClose={this.cancelDatePicker}
         open={this.state.showDatePicker}
-        left={left} >
-
+        left={left}
+      >
         <DateSelector
           numberOfMonths={2}
           fixedWeeks
@@ -223,14 +239,21 @@ export default class AppDatePicker extends Component {
           />
         )}
 
-        <Button primary onClick={this.handleSubmit} className={styles.Apply}>Apply</Button>
+        <Button
+          primary
+          onClick={this.handleSubmit}
+          disabled={this.state.selecting}
+          className={styles.Apply}
+        >
+          Apply
+        </Button>
         <Button onClick={this.cancelDatePicker}>Cancel</Button>
         {validationError && (
           <span className={styles.Error}>
-            <Error wrapper='span' error={validationError}></Error>
+            <Error wrapper="span" error={validationError}></Error>
           </span>
         )}
-        <WindowEvent event='keydown' handler={this.handleKeyDown} />
+        <WindowEvent event="keydown" handler={this.handleKeyDown} />
       </Popover>
     );
   }
@@ -248,10 +271,10 @@ AppDatePicker.propTypes = {
   dateFieldFormat: PropTypes.string,
   disabled: PropTypes.bool,
   showPresets: PropTypes.bool,
-  hideManualEntry: PropTypes.bool
+  hideManualEntry: PropTypes.bool,
 };
 
 AppDatePicker.defaultProps = {
   roundToPrecision: false,
-  preventFuture: true
+  preventFuture: true,
 };

--- a/src/components/datePicker/DatePicker.js
+++ b/src/components/datePicker/DatePicker.js
@@ -136,7 +136,11 @@ export default class AppDatePicker extends Component {
   };
 
   handleSubmit = () => {
-    if (this.state.validationError) {
+    const { validate } = this.props;
+
+    const validationError = validate && validate(this.state.selected);
+    if (validationError) {
+      this.setState({ validationError });
       return;
     }
 
@@ -239,12 +243,7 @@ export default class AppDatePicker extends Component {
           />
         )}
 
-        <Button
-          primary
-          onClick={this.handleSubmit}
-          disabled={this.state.selecting}
-          className={styles.Apply}
-        >
+        <Button primary onClick={this.handleSubmit} className={styles.Apply}>
           Apply
         </Button>
         <Button onClick={this.cancelDatePicker}>Cancel</Button>

--- a/src/components/datePicker/tests/DatePicker.test.js
+++ b/src/components/datePicker/tests/DatePicker.test.js
@@ -13,7 +13,6 @@ jest.mock('react-dom');
 jest.mock('date-fns');
 
 describe('Component: DatePicker', () => {
-
   let wrapper;
   let instance;
   let props;
@@ -32,23 +31,26 @@ describe('Component: DatePicker', () => {
       onBlur: jest.fn(),
       now: mockNow,
       disabled: false,
-      roundToPrecision: true
+      roundToPrecision: true,
     };
 
     dateHelpers.getStartOfDay = jest.fn(() => 'start-of-day');
     dateHelpers.getNextHour = jest.fn(() => 'next-hour');
     dateHelpers.getEndOfDay = jest.fn(() => 'end-of-day');
     dateHelpers.isSameDate = jest.fn(() => false);
-    metricsHelpers.roundBoundaries = jest.fn(() => ({ from: moment(mockFrom), to: moment(mockNow) }));
+    metricsHelpers.roundBoundaries = jest.fn(() => ({
+      from: moment(mockFrom),
+      to: moment(mockNow),
+    }));
     dateHelpers.getRelativeDateOptions = jest.fn(() => [1, 2, 3]);
-    datefns.format = jest.fn((a,b) => b);
-    datefns.subMonths = jest.fn((a) => a);
+    datefns.format = jest.fn((a, b) => b);
+    datefns.subMonths = jest.fn(a => a);
 
     wrapper = shallow(<DatePicker {...props} />);
     instance = wrapper.instance();
 
     // spy on all instance methods
-    _.functions(instance).forEach((f) => jest.spyOn(instance, f));
+    _.functions(instance).forEach(f => jest.spyOn(instance, f));
   });
 
   it('should render ok by default', () => {
@@ -72,8 +74,17 @@ describe('Component: DatePicker', () => {
     expect(wrapper.find('ManualEntryForm')).not.toExist();
   });
 
-  describe('syncTimeToState', () => {
+  it('should disable submit button when selecting date', () => {
+    wrapper.setState({ selecting: true });
+    expect(
+      wrapper
+        .find('Button')
+        .first()
+        .prop('disabled'),
+    ).toEqual(true);
+  });
 
+  describe('syncTimeToState', () => {
     const before = { from: 'unchanged', to: 'unchanged' };
     const after = { from: new Date(), to: new Date() };
 
@@ -85,17 +96,15 @@ describe('Component: DatePicker', () => {
       expect(wrapper.state('selected')).toEqual(after);
     });
 
-    it('shouldn\'t sync the state when from and to aren\'t changed', () => {
+    it("shouldn't sync the state when from and to aren't changed", () => {
       wrapper.setState({ selected: before });
       wrapper.setProps({ other: 'stuff' });
       expect(instance.syncTimeToState).not.toHaveBeenCalled();
       expect(wrapper.state('selected')).toEqual(before);
     });
-
   });
 
   describe('handleKeyDown', () => {
-
     const ESCAPE = { key: 'Escape' };
     const ENTER = { key: 'Enter' };
 
@@ -130,11 +139,9 @@ describe('Component: DatePicker', () => {
       expect(instance.handleSubmit).not.toHaveBeenCalled();
       expect(wrapper.state('showDatePicker')).toEqual(true);
     });
-
   });
 
   describe('handleDayKeyDown', () => {
-
     it('should stop propagation on a day key down event', () => {
       const e = { stopPropagation: jest.fn() };
       const x = '';
@@ -142,7 +149,6 @@ describe('Component: DatePicker', () => {
       expect(instance.handleKeyDown).toHaveBeenCalledWith(e);
       expect(e.stopPropagation).toHaveBeenCalledTimes(1);
     });
-
   });
 
   describe('handleTextUpdate', () => {
@@ -159,28 +165,23 @@ describe('Component: DatePicker', () => {
   });
 
   describe('cancelDatePicker', () => {
-
     it('should sync props and close date picker', () => {
       wrapper.setState({ showDatePicker: true });
       instance.cancelDatePicker();
       expect(instance.syncTimeToState).toHaveBeenCalledWith(instance.props);
       expect(wrapper.state('showDatePicker')).toEqual(false);
     });
-
   });
 
   describe('showDatePicker', () => {
-
     it('should set date picker state', () => {
       wrapper.setState({ showDatePicker: false });
       instance.showDatePicker();
       expect(wrapper.state('showDatePicker')).toEqual(true);
     });
-
   });
 
   describe('handleDayClick', () => {
-
     it('should handle a day click while selecting', () => {
       const mockSelected = {};
       wrapper.setState({ selecting: true, selected: mockSelected, beforeSelected: null });
@@ -244,11 +245,9 @@ describe('Component: DatePicker', () => {
       expect(validate).toHaveBeenCalledWith(mockNewSelected);
       expect(wrapper.state('selecting')).toEqual(true);
     });
-
   });
 
   describe('handleDayHover', () => {
-
     it('should handle a day hover while selecting', () => {
       const mockOrderedRange = { from: 'from', to: 'to' };
       const mockHovered = {};
@@ -272,17 +271,15 @@ describe('Component: DatePicker', () => {
       expect(instance.getOrderedRange).not.toHaveBeenCalled();
       expect(wrapper.state('selected')).toEqual(mockSelected);
     });
-
   });
 
   describe('getOrderedRange', () => {
-
     it('should return correct range when new date is between from and to', () => {
       const from = new Date('2018-01-01');
       const newDate = new Date('2018-01-02');
       const to = new Date('2018-01-03');
 
-      wrapper.setState({ beforeSelected: { from, to }});
+      wrapper.setState({ beforeSelected: { from, to } });
       const range = instance.getOrderedRange(newDate);
 
       expect(dateHelpers.getEndOfDay).toHaveBeenCalledWith(newDate, { preventFuture: true });
@@ -296,7 +293,7 @@ describe('Component: DatePicker', () => {
       const from = new Date('2018-01-02');
       const to = new Date('2018-01-03');
 
-      wrapper.setState({ beforeSelected: { from, to }});
+      wrapper.setState({ beforeSelected: { from, to } });
       const range = instance.getOrderedRange(newDate);
 
       expect(dateHelpers.getEndOfDay).not.toHaveBeenCalled();
@@ -314,7 +311,7 @@ describe('Component: DatePicker', () => {
       dateHelpers.isSameDate = jest.fn(() => true);
 
       wrapper.setProps({ fromSelectsNextHour: true });
-      wrapper.setState({ beforeSelected: { from, to }});
+      wrapper.setState({ beforeSelected: { from, to } });
       const range = instance.getOrderedRange(newDate);
 
       expect(dateHelpers.getEndOfDay).not.toHaveBeenCalled();
@@ -329,7 +326,7 @@ describe('Component: DatePicker', () => {
       const to = new Date('2018-01-02');
       const newDate = new Date('2018-01-03');
 
-      wrapper.setState({ beforeSelected: { from, to }});
+      wrapper.setState({ beforeSelected: { from, to } });
       const range = instance.getOrderedRange(newDate);
 
       expect(dateHelpers.getEndOfDay).toHaveBeenCalledWith(newDate, { preventFuture: true });
@@ -343,7 +340,7 @@ describe('Component: DatePicker', () => {
       const newDate = new Date('2018-01-01');
       const to = new Date('2018-01-03');
 
-      wrapper.setState({ beforeSelected: { from, to }});
+      wrapper.setState({ beforeSelected: { from, to } });
       const range = instance.getOrderedRange(newDate);
 
       expect(dateHelpers.getEndOfDay).toHaveBeenCalledWith(newDate, { preventFuture: true });
@@ -351,7 +348,6 @@ describe('Component: DatePicker', () => {
       expect(metricsHelpers.roundBoundaries).toHaveBeenCalledWith(from, 'end-of-day');
       expect(range).toEqual({ from: moment(mockFrom).toDate(), to: moment(mockNow).toDate() });
     });
-
   });
 
   describe('handleSelectRange', () => {
@@ -359,7 +355,7 @@ describe('Component: DatePicker', () => {
 
     beforeEach(() => {
       e = {
-        currentTarget: {}
+        currentTarget: {},
       };
     });
 
@@ -378,11 +374,9 @@ describe('Component: DatePicker', () => {
       expect(wrapper.state('showDatePicker')).toEqual(false);
       expect(props.onChange).toHaveBeenCalledWith({ relativeRange: 'lasagna' });
     });
-
   });
 
   describe('handleFormDates', () => {
-
     it('should use a date field format if provided', () => {
       wrapper.setProps({ dateFieldFormat: 'YYYY-MM h' });
       expect(wrapper.find('Popover').props().trigger).toMatchSnapshot();
@@ -396,11 +390,9 @@ describe('Component: DatePicker', () => {
       expect(wrapper.state('selected')).toEqual(mockSelected);
       expect(mockCallback).toHaveBeenCalledTimes(1);
     });
-
   });
 
   describe('handleSubmit', () => {
-
     it('should reset some state and refresh', () => {
       const mockSelected = { a: 1, b: 2, c: 3 };
       wrapper.setState({ showDatePicker: true, selecting: true, selected: mockSelected });
@@ -412,17 +404,20 @@ describe('Component: DatePicker', () => {
 
     it('should not do anything with a validation error', () => {
       const mockSelected = { a: 1, b: 2, c: 3 };
-      wrapper.setState({ showDatePicker: true, selecting: true, selected: mockSelected, validationError: 'oh no' });
+      wrapper.setState({
+        showDatePicker: true,
+        selecting: true,
+        selected: mockSelected,
+        validationError: 'oh no',
+      });
       instance.handleSubmit();
       expect(wrapper.state('showDatePicker')).toEqual(true);
       expect(wrapper.state('selecting')).toEqual(true);
       expect(props.onChange).not.toHaveBeenCalled();
     });
-
   });
 
   describe('fromFormatter', () => {
-
     it('should format from date with getNextHour', () => {
       dateHelpers.isSameDate = jest.fn(() => true);
       wrapper.setProps({ fromSelectsNextHour: true });
@@ -447,5 +442,4 @@ describe('Component: DatePicker', () => {
       expect(dateHelpers.getStartOfDay).toHaveBeenCalledTimes(3);
     });
   });
-
 });

--- a/src/components/datePicker/tests/DatePicker.test.js
+++ b/src/components/datePicker/tests/DatePicker.test.js
@@ -402,7 +402,7 @@ describe('Component: DatePicker', () => {
         selected: mockSelected,
       });
       instance.handleSubmit();
-      expect(wrapper.state('showDatePicker')).toEqual(true);
+      expect(wrapper.state('selecting')).toEqual(true);
       expect(wrapper.find('Popover')).toHaveProp('open', true);
       expect(validate).toHaveBeenCalled();
       expect(props.onChange).not.toHaveBeenCalled();

--- a/src/components/datePicker/tests/DatePicker.test.js
+++ b/src/components/datePicker/tests/DatePicker.test.js
@@ -74,16 +74,6 @@ describe('Component: DatePicker', () => {
     expect(wrapper.find('ManualEntryForm')).not.toExist();
   });
 
-  it('should disable submit button when selecting date', () => {
-    wrapper.setState({ selecting: true });
-    expect(
-      wrapper
-        .find('Button')
-        .first()
-        .prop('disabled'),
-    ).toEqual(true);
-  });
-
   describe('syncTimeToState', () => {
     const before = { from: 'unchanged', to: 'unchanged' };
     const after = { from: new Date(), to: new Date() };
@@ -230,7 +220,7 @@ describe('Component: DatePicker', () => {
       expect(wrapper.state('selecting')).toEqual(true);
     });
 
-    it('should handle a day click whith a validation error', () => {
+    it('should handle a day click with a validation error', () => {
       const validate = jest.fn(() => 'error oh no');
       const mockSelected = {};
       const mockClicked = {};
@@ -403,16 +393,18 @@ describe('Component: DatePicker', () => {
     });
 
     it('should not do anything with a validation error', () => {
+      const validate = jest.fn(() => 'error oh no');
       const mockSelected = { a: 1, b: 2, c: 3 };
+      wrapper.setProps({ validate });
       wrapper.setState({
         showDatePicker: true,
         selecting: true,
         selected: mockSelected,
-        validationError: 'oh no',
       });
       instance.handleSubmit();
       expect(wrapper.state('showDatePicker')).toEqual(true);
-      expect(wrapper.state('selecting')).toEqual(true);
+      expect(wrapper.find('Popover')).toHaveProp('open', true);
+      expect(validate).toHaveBeenCalled();
       expect(props.onChange).not.toHaveBeenCalled();
     });
   });

--- a/src/components/datePicker/tests/__snapshots__/DatePicker.test.js.snap
+++ b/src/components/datePicker/tests/__snapshots__/DatePicker.test.js.snap
@@ -106,7 +106,6 @@ exports[`Component: DatePicker should render ok by default 1`] = `
   />
   <Button
     className="Apply"
-    disabled={false}
     onClick={[Function]}
     primary={true}
     size="default"

--- a/src/components/datePicker/tests/__snapshots__/DatePicker.test.js.snap
+++ b/src/components/datePicker/tests/__snapshots__/DatePicker.test.js.snap
@@ -106,6 +106,7 @@ exports[`Component: DatePicker should render ok by default 1`] = `
   />
   <Button
     className="Apply"
+    disabled={false}
     onClick={[Function]}
     primary={true}
     size="default"

--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -102,6 +102,7 @@ const FilterSortCollectionRow = ({
   />,
 ];
 
+//TODO See if minDays from /helpers/validation can be used
 const validateDate = ({ from, to }) => {
   const momentFrom = moment(from);
   const momentTo = moment(to);


### PR DESCRIPTION
### What Changed
 - Disabled Date Picker submit button when only selected one date.

### How To Test
 - Go to signals page. Open date picker and select only 1 date. You should not be able to submit the change.
 - Check other date pickers to make sure nothing else breaks. Especially for inbox placement trends since it also uses validation

### Notes
 - This isn't quite the same as the AC but this was the most painless way to fix the bug.

- [ ] Get Product approval for this solution.