### PR TITLE
SA-953 - Add Week and Month precision labels for Metrics Summary Chart

### DIFF
--- a/src/helpers/chart.js
+++ b/src/helpers/chart.js
@@ -71,7 +71,7 @@ const getTooltipLabelFormatter = _.memoize(precisionType => {
 function getLineChartFormatters(precision) {
   const formatters = {};
   const precisionType = getPrecisionType(precision);
-  console.log(precisionType);
+
   formatters.xTickFormatter = getTimeTickFormatter(precisionType);
   formatters.tooltipLabelFormatter = getTooltipLabelFormatter(precisionType);
 

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -85,7 +85,7 @@ export function getMomentPrecision(from, to = moment()) {
 }
 
 export function getPrecisionType(precision) {
-  return (indexedPrecisions[precision].time <= (60 * 24 * 2)) ? 'hours' : 'days';
+  return (indexedPrecisions[precision].time <= (60 * 24 * 2)) ? 'hour' : precision;
 }
 
 /**

--- a/src/helpers/tests/chart.test.js
+++ b/src/helpers/tests/chart.test.js
@@ -3,7 +3,7 @@ import {
   getTimeTickFormatter,
   getTooltipLabelFormatter,
   getLineChartFormatters,
-  formatYAxisPercent
+  formatYAxisPercent,
 } from '../chart';
 import * as metrics from '../metrics';
 import moment from 'moment';
@@ -22,7 +22,6 @@ function getTimestampWithFixedHour(date, hour) {
 }
 
 describe('Helper: chart', () => {
-
   let data;
 
   beforeEach(() => {
@@ -32,7 +31,7 @@ describe('Helper: chart', () => {
       { ts: getTimestampWithFixedHour('2017-01-02T12:00', 12) },
       { ts: getTimestampWithFixedHour('2017-01-03T00:00', 0) },
       { ts: getTimestampWithFixedHour('2017-01-03T00:15', 0) },
-      { ts: getTimestampWithFixedHour('2017-01-03T12:00', 12) }
+      { ts: getTimestampWithFixedHour('2017-01-03T12:00', 12) },
     ];
   });
 
@@ -44,13 +43,13 @@ describe('Helper: chart', () => {
     });
 
     it('should return an item for every 0-hour date', () => {
-      metrics.getPrecisionType = jest.fn(() => 'hours');
+      metrics.getPrecisionType = jest.fn(() => 'hour');
       const lines = getDayLines(data);
       expect(lines).toHaveLength(3);
     });
 
     it('should ignore 0-hour dates in the first and last position', () => {
-      metrics.getPrecisionType = jest.fn(() => 'hours');
+      metrics.getPrecisionType = jest.fn(() => 'hour');
       data[0] = getTimestampWithFixedHour('2017-01-01', 0);
       data[data.length - 1] = getTimestampWithFixedHour('2017-01-01', 0);
       const lines = getDayLines(data);
@@ -59,17 +58,28 @@ describe('Helper: chart', () => {
   });
 
   describe('getTimeTickFormatter', () => {
-
     it('should format an "hourly" tick', () => {
-      const format = getTimeTickFormatter('hours');
+      const format = getTimeTickFormatter('hour');
       const formatted = format(getDate(12));
       expect(formatted).toEqual('12:00pm');
     });
 
-    it('should format a "non-hourly" tick', () => {
-      const format = getTimeTickFormatter('days');
+    it('should format a "daily" tick for day precision', () => {
+      const format = getTimeTickFormatter('day');
       const formatted = format(getDate(12));
       expect(formatted).toEqual('Jun 15th');
+    });
+
+    it('should format a "daily" tick for week precision', () => {
+      const format = getTimeTickFormatter('week');
+      const formatted = format(getDate(12));
+      expect(formatted).toEqual('Jun 15th');
+    });
+
+    it('should format a "monthly" tick for month precision', () => {
+      const format = getTimeTickFormatter('month');
+      const formatted = format(getDate(12));
+      expect(formatted).toEqual('Jun');
     });
 
     it('should return the same function for the same precision (memoized)', () => {
@@ -90,9 +100,21 @@ describe('Helper: chart', () => {
     });
 
     it('should format a "non-hourly" label', () => {
-      const format = getTooltipLabelFormatter('days');
+      const format = getTooltipLabelFormatter('day');
       const formatted = format(getDate(16));
       expect(formatted).toEqual('June 15th');
+    });
+
+    it('should format a "weekly" label', () => {
+      const format = getTooltipLabelFormatter('week');
+      const formatted = format(getDate(16));
+      expect(formatted).toEqual('Jun 15th - Jun 21st');
+    });
+
+    it('should format a "monthly" label', () => {
+      const format = getTooltipLabelFormatter('month');
+      const formatted = format(getDate(16));
+      expect(formatted).toEqual('June 2017');
     });
 
     it('should memoize', () => {
@@ -109,7 +131,7 @@ describe('Helper: chart', () => {
     metrics.getPrecisionType = jest.fn(() => 'hours');
     expect(getLineChartFormatters()).toEqual({
       xTickFormatter: expect.any(Function),
-      tooltipLabelFormatter: expect.any(Function)
+      tooltipLabelFormatter: expect.any(Function),
     });
   });
 
@@ -122,5 +144,4 @@ describe('Helper: chart', () => {
       expect(formatYAxisPercent(0.00051)).toEqual('0.001%');
     });
   });
-
 });

--- a/src/helpers/tests/chart.test.js
+++ b/src/helpers/tests/chart.test.js
@@ -2,6 +2,7 @@ import {
   getDayLines,
   getTimeTickFormatter,
   getTooltipLabelFormatter,
+  getWeekPrecisionFormatter,
   getLineChartFormatters,
   formatYAxisPercent,
 } from '../chart';
@@ -92,9 +93,27 @@ describe('Helper: chart', () => {
     });
   });
 
+  describe('getWeekPrecisionFormatter', () => {
+    const sunday = '2017-06-11T12:00';
+
+    it('should format a "weekly" label', () => {
+      const to = '2017-06-20T12:00';
+      const format = getWeekPrecisionFormatter(to);
+      const formatted = format(getDate(16, sunday));
+      expect(formatted).toEqual('Jun 11th - Jun 17th');
+    });
+
+    it('should format a "weekly" label for an ending date', () => {
+      const to = '2017-06-15T12:00';
+      const format = getWeekPrecisionFormatter(to);
+      const formatted = format(getDate(0, sunday));
+      expect(formatted).toEqual('Jun 11th - Jun 15th');
+    });
+  });
+
   describe('getTooltipLabelFormatter', () => {
     it('should format an "hourly" label', () => {
-      const format = getTooltipLabelFormatter('hours');
+      const format = getTooltipLabelFormatter('hour');
       const formatted = format(getDate(16));
       expect(formatted).toEqual('Jun 15th at 4:00 PM');
     });
@@ -105,12 +124,6 @@ describe('Helper: chart', () => {
       expect(formatted).toEqual('June 15th');
     });
 
-    it('should format a "weekly" label', () => {
-      const format = getTooltipLabelFormatter('week');
-      const formatted = format(getDate(16));
-      expect(formatted).toEqual('Jun 15th - Jun 21st');
-    });
-
     it('should format a "monthly" label', () => {
       const format = getTooltipLabelFormatter('month');
       const formatted = format(getDate(16));
@@ -118,9 +131,9 @@ describe('Helper: chart', () => {
     });
 
     it('should memoize', () => {
-      const a = getTooltipLabelFormatter('hours');
-      const b = getTooltipLabelFormatter('hours');
-      const c = getTooltipLabelFormatter('days');
+      const a = getTooltipLabelFormatter('hour');
+      const b = getTooltipLabelFormatter('hour');
+      const c = getTooltipLabelFormatter('day');
 
       expect(a).toBe(b);
       expect(a).not.toBe(c);
@@ -128,7 +141,7 @@ describe('Helper: chart', () => {
   });
 
   describe('getLineChartFormatters', () => {
-    metrics.getPrecisionType = jest.fn(() => 'hours');
+    metrics.getPrecisionType = jest.fn(() => 'hour');
     expect(getLineChartFormatters()).toEqual({
       xTickFormatter: expect.any(Function),
       tooltipLabelFormatter: expect.any(Function),

--- a/src/helpers/tests/metrics.test.js
+++ b/src/helpers/tests/metrics.test.js
@@ -119,12 +119,12 @@ describe('metrics helpers', () => {
     expect(metricsHelpers.getMomentPrecision(from, to)).toEqual('days');
   });
 
-  it('should return hours as precision type', () => {
-    expect(metricsHelpers.getPrecisionType('1min')).toEqual('hours');
+  it('should return hours as precision type for time <= 2 days', () => {
+    expect(metricsHelpers.getPrecisionType('1min')).toEqual('hour');
   });
 
-  it('should return days as precision type', () => {
-    expect(metricsHelpers.getPrecisionType('day')).toEqual('days');
+  it('should return the same precision if precision type > 2 days', () => {
+    expect(metricsHelpers.getPrecisionType('day')).toEqual('day');
   });
 
   describe('roundBoundaries', () => {

--- a/src/pages/reports/summary/SummaryPage.js
+++ b/src/pages/reports/summary/SummaryPage.js
@@ -15,8 +15,8 @@ export class SummaryReportPage extends Component {
   state = {
     metricsModal: false,
     eventTime: 'real',
-    scale: 'linear'
-  }
+    scale: 'linear',
+  };
 
   componentDidUpdate(prevProps) {
     if (prevProps.reportOptions !== this.props.reportOptions) {
@@ -27,33 +27,38 @@ export class SummaryReportPage extends Component {
   renderLoading() {
     const { chart } = this.props;
     if (chart.chartLoading) {
-      return <div className={styles.Loading}><Loading /></div>;
+      return (
+        <div className={styles.Loading}>
+          <Loading />
+        </div>
+      );
     }
   }
 
-  handleMetricsApply = (selectedMetrics) => {
+  handleMetricsApply = selectedMetrics => {
     this.setState({ metricsModal: false });
     this.props.refreshReportOptions({ metrics: selectedMetrics });
-  }
+  };
 
   handleMetricsModal = () => {
     this.setState({ metricsModal: !this.state.metricsModal });
-  }
+  };
 
-  handleTimeClick = (time) => {
+  handleTimeClick = time => {
     this.setState({ eventTime: time });
-  }
+  };
 
-  handleScaleClick = (scale) => {
+  handleScaleClick = scale => {
     this.setState({ scale });
-  }
+  };
 
   render() {
-    const { chart, summarySearchOptions, enhancementsEnabled } = this.props;
+    const { chart, summarySearchOptions = {}, enhancementsEnabled } = this.props;
+    const { to } = summarySearchOptions;
     const { scale, eventTime, metricsModal } = this.state;
 
     return (
-      <Page title='Summary Report'>
+      <Page title="Summary Report">
         <ReportOptions
           reportLoading={chart.chartLoading}
           searchOptions={summarySearchOptions}
@@ -61,7 +66,9 @@ export class SummaryReportPage extends Component {
         />
 
         <Panel>
-          <Panel.Section className={classnames(styles.ChartSection, chart.chartLoading && styles.pending)}>
+          <Panel.Section
+            className={classnames(styles.ChartSection, chart.chartLoading && styles.pending)}
+          >
             <ChartHeader
               selectedMetrics={chart.metrics}
               selectedTime={eventTime}
@@ -70,7 +77,7 @@ export class SummaryReportPage extends Component {
               onTimeClick={this.handleTimeClick}
               onMetricsToggle={this.handleMetricsModal}
             />
-            <ChartGroup {...chart} yScale={scale} />
+            <ChartGroup {...chart} to={to} yScale={scale} />
           </Panel.Section>
 
           {this.renderLoading()}
@@ -82,22 +89,23 @@ export class SummaryReportPage extends Component {
           selectedMetrics={chart.metrics}
           open={metricsModal}
           onCancel={this.handleMetricsModal}
-          onSubmit={this.handleMetricsApply} />
+          onSubmit={this.handleMetricsApply}
+        />
       </Page>
     );
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   chart: state.summaryChart,
   reportOptions: state.reportOptions,
   summarySearchOptions: selectSummaryChartSearchOptions(state),
-  enhancementsEnabled: selectReportsEnhancementsEnabled(state)
+  enhancementsEnabled: selectReportsEnhancementsEnabled(state),
 });
 
 const mapDispatchToProps = {
   refreshReportOptions,
-  refreshSummaryReport
+  refreshSummaryReport,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(SummaryReportPage);

--- a/src/pages/reports/summary/components/ChartGroup.js
+++ b/src/pages/reports/summary/components/ChartGroup.js
@@ -10,7 +10,6 @@ function getUniqueUnits(metrics) {
 }
 
 export default class ChartGroup extends Component {
-
   createDayReferenceLines() {
     const { chartData, precision } = this.props;
 
@@ -18,45 +17,47 @@ export default class ChartGroup extends Component {
       key: ts,
       x: ts,
       stroke: '#bbb',
-      strokeWidth: 2
+      strokeWidth: 2,
     }));
   }
 
   render() {
-    const { chartData = [], metrics, chartLoading, precision, yScale } = this.props;
+    const { chartData = [], metrics, chartLoading, precision, yScale, to } = this.props;
 
     if (!chartData.length || !metrics) {
       return null;
     }
 
-    const formatters = getLineChartFormatters(precision);
+    const formatters = getLineChartFormatters(precision, to);
     const referenceLines = this.createDayReferenceLines();
-    const charts = getUniqueUnits(metrics).map((unit) => ({
-      metrics: metrics.filter((metric) => metric.unit === unit),
-      ...METRICS_UNIT_CONFIG[unit]
+    const charts = getUniqueUnits(metrics).map(unit => ({
+      metrics: metrics.filter(metric => metric.unit === unit),
+      ...METRICS_UNIT_CONFIG[unit],
     }));
 
     return (
       <div>
-        {charts.map((chart, i) => <LineChart
-          key={`chart=${i}`}
-          syncId='summaryChart'
-          data={chartData}
-          precision={precision}
-          lines={chart.metrics.map(({ name, label, stroke }) => ({
-            key: name,
-            dataKey: name,
-            name: label,
-            stroke: chartLoading ? '#f8f8f8' : stroke
-          }))}
-          {...formatters}
-          yTickFormatter={chart.yAxisFormatter}
-          yScale={yScale}
-          yLabel={chart.label}
-          tooltipValueFormatter={chart.yAxisFormatter}
-          referenceLines={referenceLines}
-          showXAxis={i === charts.length - 1}
-        />)}
+        {charts.map((chart, i) => (
+          <LineChart
+            key={`chart=${i}`}
+            syncId="summaryChart"
+            data={chartData}
+            precision={precision}
+            lines={chart.metrics.map(({ name, label, stroke }) => ({
+              key: name,
+              dataKey: name,
+              name: label,
+              stroke: chartLoading ? '#f8f8f8' : stroke,
+            }))}
+            {...formatters}
+            yTickFormatter={chart.yAxisFormatter}
+            yScale={yScale}
+            yLabel={chart.label}
+            tooltipValueFormatter={chart.yAxisFormatter}
+            referenceLines={referenceLines}
+            showXAxis={i === charts.length - 1}
+          />
+        ))}
       </div>
     );
   }

--- a/src/pages/reports/summary/tests/__snapshots__/SummaryPage.test.js.snap
+++ b/src/pages/reports/summary/tests/__snapshots__/SummaryPage.test.js.snap
@@ -5,7 +5,9 @@ exports[`Page: SummaryPage should render correctly 1`] = `
   empty={Object {}}
   title="Summary Report"
 >
-  <withRouter(Connect(ReportOptions)) />
+  <withRouter(Connect(ReportOptions))
+    searchOptions={Object {}}
+  />
   <Panel>
     <Panel.Section
       className="ChartSection"
@@ -59,6 +61,7 @@ exports[`Page: SummaryPage should render when loading 1`] = `
 >
   <withRouter(Connect(ReportOptions))
     reportLoading={true}
+    searchOptions={Object {}}
   />
   <Panel>
     <Panel.Section


### PR DESCRIPTION
### What Changed
 - Added Options for month and week labels for the tooltip.
 - Added Monthly display for the x-axis ticks.

### How To Test
 - Go to /reports/summary. Change the date ranges to see hourly, <hourly, daily, weekly, and monthly precision.

### To Do
- [ ] UX/TPM approval
