### PR TITLE
AC-1126: Add Payment Functionality Recipient Validation - Single Address Tab

### DIFF
--- a/cypress/fixtures/authenticate/grants/200.get.admin.json
+++ b/cypress/fixtures/authenticate/grants/200.get.admin.json
@@ -100,7 +100,7 @@
       "key": "engagement-recency/manage"
     },
     {
-      "key": "recipient-validation/manage"
+      "key": "recipient-validation/preview"
     },
     {
       "key": "signals/manage"

--- a/src/__testHelpers__/http-responses/default/v1/authenticate/grants/get.js
+++ b/src/__testHelpers__/http-responses/default/v1/authenticate/grants/get.js
@@ -3,87 +3,87 @@ export default () => ({
     {
       label: 'Metrics: Read-only',
       description: 'Provides the GET grant for the Metrics API.',
-      key: 'metrics/view'
+      key: 'metrics/view',
     },
     {
       label: 'Events Search: Read-only',
       description: 'Provides the GET grants for the Message Events and Events Search API.',
-      key: 'message_events/view'
+      key: 'message_events/view',
     },
     {
       label: 'Event Webhooks: Read-only',
       description: 'Provides the GET grant for the Event Webhooks API.',
-      key: 'webhooks/view'
+      key: 'webhooks/view',
     },
     {
       label: 'Event Webhooks: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Event Webhooks API.',
-      key: 'webhooks/modify'
+      key: 'webhooks/modify',
     },
     {
       label: 'Templates: Read-only',
       description: 'Provides the GET grant for the Snippets and Templates API.',
-      key: 'templates/view'
+      key: 'templates/view',
     },
     {
       label: 'Templates: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Snippets and Templates API.',
-      key: 'templates/modify'
+      key: 'templates/modify',
     },
     {
       label: 'Templates: Preview',
       description: 'Provides the POST grant for the Template Previews API.',
-      key: 'templates/preview'
+      key: 'templates/preview',
     },
     {
       label: 'Transmissions: Read-only',
       description: 'Provides the GET grant for the Transmissions API.',
-      key: 'transmissions/view'
+      key: 'transmissions/view',
     },
     {
       label: 'Transmissions: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Transmissions API.',
-      key: 'transmissions/modify'
+      key: 'transmissions/modify',
     },
     {
       label: 'Recipient Lists: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Recipient Lists API.',
-      key: 'recipient_lists/manage'
+      key: 'recipient_lists/manage',
     },
     {
       label: 'Tracking Domains: Read-only',
       description: 'Provides the GET grant for the Tracking Domains API.',
-      key: 'tracking_domains/view'
+      key: 'tracking_domains/view',
     },
     {
       label: 'Tracking Domains: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Tracking Domains API.',
-      key: 'tracking_domains/manage'
+      key: 'tracking_domains/manage',
     },
     {
       label: 'Sending Domains: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Sending Domains API.',
-      key: 'sending_domains/manage'
+      key: 'sending_domains/manage',
     },
     {
       label: 'Inbound Domains: Read/Write',
       description: 'Provides GET, POST, and DELETE grants for the Inbound Domains API.',
-      key: 'inbound_domains/manage'
+      key: 'inbound_domains/manage',
     },
     {
       label: 'Suppression Lists: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Suppression Lists API.',
-      key: 'suppression_lists/manage'
+      key: 'suppression_lists/manage',
     },
     {
       label: 'Relay Webhooks: Read-only',
       description: 'Provides the GET grant for the Relay Webhooks API.',
-      key: 'relay_webhooks/view'
+      key: 'relay_webhooks/view',
     },
     {
       label: 'Relay Webhooks: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Relay Webhooks API.',
-      key: 'relay_webhooks/modify'
+      key: 'relay_webhooks/modify',
     },
     { key: 'users/self-manage' },
     { key: 'users/manage' },
@@ -94,50 +94,55 @@ export default () => ({
     {
       label: 'Subaccounts: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the Subaccounts API.',
-      key: 'subaccount/manage'
+      key: 'subaccount/manage',
     },
     {
       label: 'Subaccounts: Read',
       description: 'Provides GET grants for the Subaccounts API.',
-      key: 'subaccount/view'
+      key: 'subaccount/view',
     },
     {
       label: 'IP Pools: Read/Write',
       description: 'Provides GET, POST, PUT, and DELETE grants for the IP Pools API.',
-      key: 'ip_pools/manage'
+      key: 'ip_pools/manage',
     },
     {
       label: 'IP Pools: Read',
       description: 'Provides GET grants for the IP Pools API.',
-      key: 'ip_pools/view'
+      key: 'ip_pools/view',
     },
     { key: 'messaging-tools/manage' },
     {
       label: 'A/B Testing: Read/Write',
       description: 'Provides the GET, POST, PUT and DELETE grants for the AB-Testing API.',
-      key: 'ab-testing/manage'
+      key: 'ab-testing/manage',
     },
     {
       label: 'Alerts: Read/Write',
       description: 'Provides the GET, POST, PUT and DELETE grants for the Alerts API.',
-      key: 'alerts/manage'
+      key: 'alerts/manage',
+    },
+    {
+      label: 'Recipient Validation: Read',
+      description: 'Provides the GET Recipient Validation API.',
+      key: 'recipient-validation/preview',
     },
     {
       label: 'Recipient Validation: Read/Write',
       description:
         'Provides the GET, POST, PUT and DELETE grants for the Recipient Validation API.',
-      key: 'recipient-validation/manage'
+      key: 'recipient-validation/manage',
     },
     {
       label: 'Signals: Read/Write',
       description: 'Provides the GET, POST, PUT and DELETE grants for the Signals API.',
-      key: 'signals/manage'
+      key: 'signals/manage',
     },
     { key: 'support/manage' },
     {
       label: 'Incoming Events: Write',
       description: 'Provides the POST grants for the Incoming Events API.',
-      key: 'events/ingest'
-    }
-  ]
+      key: 'events/ingest',
+    },
+  ],
 });

--- a/src/config/navItems/index.js
+++ b/src/config/navItems/index.js
@@ -97,7 +97,7 @@ export default [
       {
         label: 'Recipient Validation',
         to: '/recipient-validation/list',
-        condition: hasGrants('recipient-validation/manage'),
+        condition: hasGrants('recipient-validation/preview'),
       },
       {
         label: 'Recipient Lists',

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -723,7 +723,7 @@ const routes = [
   {
     path: '/recipient-validation/single/:email',
     component: SingleResultPage,
-    condition: hasGrants('recipient-validation/manage'),
+    condition: hasGrants('recipient-validation/preview'),
     layout: App,
     title: 'Results | Recipient Validation',
     supportDocsSearch: 'Recipient Validation',
@@ -731,7 +731,7 @@ const routes = [
   {
     path: '/recipient-validation/list/:listId',
     component: UploadedListPage,
-    condition: hasGrants('recipient-validation/manage'),
+    condition: hasGrants('recipient-validation/preview'),
     layout: App,
     title: 'Validation Status | List | Recipient Validation',
     supportDocsSearch: 'Recipient Validation',
@@ -739,7 +739,7 @@ const routes = [
   {
     path: '/recipient-validation/:category',
     component: RecipientValidationPage,
-    condition: hasGrants('recipient-validation/manage'), // must manual keep in sync with nav item
+    condition: hasGrants('recipient-validation/preview'), // must manual keep in sync with nav item
     layout: App,
     title: 'Recipient Validation',
     supportDocsSearch: 'Recipient Validation',

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -74,7 +74,7 @@ export class RecipientValidationPage extends Component {
 
   renderRecipientValidation = () => {
     const { selectedTab, showPriceModal } = this.state;
-    const { isStandAloneRVSet, billing } = this.props;
+    const { isStandAloneRVSet, billing, billingLoading } = this.props;
 
     return (
       <Page
@@ -102,7 +102,7 @@ export class RecipientValidationPage extends Component {
 
         {selectedTab === 0 && <JobsTableCollection />}
 
-        {selectedTab === 1 && isStandAloneRVSet && (
+        {selectedTab === 1 && isStandAloneRVSet && !billingLoading && (
           <ValidateSection credit_card={billing.credit_card} handleValidate={() => {}} />
         )}
 
@@ -133,6 +133,7 @@ const mapStateToProps = (state, props) => ({
   tab: tabs.findIndex(({ key }) => key === props.match.params.category) || 0,
   isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
   billing: state.account.billing || {},
+  billingLoading: state.account.billingLoading,
 });
 
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -13,6 +13,8 @@ import ConditionSwitch, { Case, defaultCase } from 'src/components/auth/Conditio
 import RecipientValidationPriceTable from './components/RecipientValidationPriceTable';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import styles from './RecipientValidationPage.module.scss';
+import ValidateSection from './components/ValidateSection';
+import { getBillingInfo } from 'src/actions/account';
 
 const tabs = [
   { content: <span className={styles.TabPadding}>List</span>, key: 'list' },
@@ -25,6 +27,10 @@ export class RecipientValidationPage extends Component {
     selectedTab: this.props.tab || 0,
     showPriceModal: false,
   };
+
+  componentDidMount() {
+    this.props.getBillingInfo();
+  }
 
   handleTabs(tabIdx) {
     const { history } = this.props;
@@ -68,6 +74,7 @@ export class RecipientValidationPage extends Component {
 
   renderRecipientValidation = () => {
     const { selectedTab, showPriceModal } = this.state;
+    const { isStandAloneRVSet, billing } = this.props;
 
     return (
       <Page
@@ -95,6 +102,10 @@ export class RecipientValidationPage extends Component {
 
         {selectedTab === 0 && <JobsTableCollection />}
 
+        {selectedTab === 1 && isStandAloneRVSet && (
+          <ValidateSection credit_card={billing.credit_card} handleValidate={() => {}} />
+        )}
+
         <Modal open={showPriceModal} onClose={() => this.handleModal(false)}>
           {this.renderRVPriceModal()}
         </Modal>
@@ -121,6 +132,7 @@ export class RecipientValidationPage extends Component {
 const mapStateToProps = (state, props) => ({
   tab: tabs.findIndex(({ key }) => key === props.match.params.category) || 0,
   isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
+  billing: state.account.billing || {},
 });
 
-export default withRouter(connect(mapStateToProps)(RecipientValidationPage));
+export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -7,6 +7,7 @@ import { TextFieldWrapper } from 'src/components';
 import { required, email, maxLength } from 'src/helpers/validation';
 import { singleAddress } from 'src/actions/recipientValidation';
 import styles from './SingleAddressForm.module.scss';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 
 const formName = 'singleAddressForm';
 export class SingleAddressForm extends Component {
@@ -25,7 +26,7 @@ export class SingleAddressForm extends Component {
           <p className={styles.Subheader}>
             Enter the email address below you would like to validate.
           </p>
-          <div className={styles.Field}>
+          <div className={!this.props.isStandAloneRVSet ? styles.Field : styles.FieldSRV}>
             <Label className={styles.FieldLabel} id="email-address-field">
               Email Address
             </Label>
@@ -40,17 +41,25 @@ export class SingleAddressForm extends Component {
               normalize={(value = '') => value.trim()}
             />
           </div>
-          <div className={styles.Submit}>
-            <Button size="large" fullWidth primary submit disabled={submitDisabled}>
-              {buttonContent}
-            </Button>
-          </div>
+          {!this.props.isStandAloneRVSet && (
+            <div className={styles.Submit}>
+              <Button size="large" fullWidth primary submit disabled={submitDisabled}>
+                {buttonContent}
+              </Button>
+            </div>
+          )}
         </form>
       </Panel.Section>
     );
   }
 }
 
+const mapStateToProps = state => {
+  return {
+    isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
+  };
+};
+
 const WrappedForm = reduxForm({ form: formName })(SingleAddressForm);
 
-export default withRouter(connect(null, { singleAddress })(WrappedForm));
+export default withRouter(connect(mapStateToProps, { singleAddress })(WrappedForm));

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -36,9 +36,9 @@ export class SingleAddressForm extends Component {
               id="email-address-field"
               style={
                 !this.props.isStandAloneRVSet && {
-                  height: '3.22rem',
+                  height: '3.2rem',
                   paddingLeft: '1.5em',
-                  fontSize: '0.9em',
+                  fontSize: '.9em',
                 }
               }
               name="address"

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -8,26 +8,28 @@ import { required, email, maxLength } from 'src/helpers/validation';
 import { singleAddress } from 'src/actions/recipientValidation';
 import styles from './SingleAddressForm.module.scss';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import classNames from 'classnames';
 
 const formName = 'singleAddressForm';
 export class SingleAddressForm extends Component {
   singleAddressForm = values =>
     this.props.history.push(`/recipient-validation/single/${values.address}`);
 
-  getClassName = className => (!this.props.isStandAloneRVSet ? className : className + 'SRV');
   render() {
-    const { valid, pristine, submitting, handleSubmit } = this.props;
+    const { valid, pristine, submitting, handleSubmit, isStandAloneRVSet } = this.props;
     const submitDisabled = pristine || !valid || submitting;
     const buttonContent = submitting ? 'Validating...' : 'Validate';
 
     return (
       <Panel.Section>
         <form onSubmit={handleSubmit(this.singleAddressForm)}>
-          <div className={styles[this.getClassName('Header')]}>Validate a Single Address</div>
-          <p className={styles[this.getClassName('Subheader')]}>
+          <div className={classNames(styles.Header, isStandAloneRVSet && styles.HeaderSRV)}>
+            Validate a Single Address
+          </div>
+          <p className={classNames(styles.Subheader, isStandAloneRVSet && styles.SubheaderSRV)}>
             Enter the email address below you would like to validate.
           </p>
-          <div className={styles[this.getClassName('Field')]}>
+          <div className={classNames(styles.Field, isStandAloneRVSet && styles.FieldSRV)}>
             <Label className={styles.FieldLabel} id="email-address-field">
               Email Address
             </Label>
@@ -35,7 +37,7 @@ export class SingleAddressForm extends Component {
             <Field
               id="email-address-field"
               style={
-                !this.props.isStandAloneRVSet && {
+                !isStandAloneRVSet && {
                   height: '3.2rem',
                   paddingLeft: '1.5em',
                   fontSize: '.9em',
@@ -48,7 +50,7 @@ export class SingleAddressForm extends Component {
               normalize={(value = '') => value.trim()}
             />
           </div>
-          {!this.props.isStandAloneRVSet && (
+          {!isStandAloneRVSet && (
             <div className={styles.Submit}>
               <Button size="large" fullWidth primary submit disabled={submitDisabled}>
                 {buttonContent}

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -34,7 +34,13 @@ export class SingleAddressForm extends Component {
 
             <Field
               id="email-address-field"
-              style={styles[this.getClassName('EmailAddressFieldSRV')]}
+              style={
+                !this.props.isStandAloneRVSet && {
+                  height: '3.22rem',
+                  paddingLeft: '1.5em',
+                  fontSize: '0.9em',
+                }
+              }
               name="address"
               component={TextFieldWrapper}
               placeholder={'harry.potter@hogwarts.edu'}

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -14,6 +14,7 @@ export class SingleAddressForm extends Component {
   singleAddressForm = values =>
     this.props.history.push(`/recipient-validation/single/${values.address}`);
 
+  getClassName = className => (!this.props.isStandAloneRVSet ? className : className + 'SRV');
   render() {
     const { valid, pristine, submitting, handleSubmit } = this.props;
     const submitDisabled = pristine || !valid || submitting;
@@ -22,18 +23,18 @@ export class SingleAddressForm extends Component {
     return (
       <Panel.Section>
         <form onSubmit={handleSubmit(this.singleAddressForm)}>
-          <div className={styles.Header}>Validate a Single Address</div>
-          <p className={styles.Subheader}>
+          <div className={styles[this.getClassName('Header')]}>Validate a Single Address</div>
+          <p className={styles[this.getClassName('Subheader')]}>
             Enter the email address below you would like to validate.
           </p>
-          <div className={!this.props.isStandAloneRVSet ? styles.Field : styles.FieldSRV}>
+          <div className={styles[this.getClassName('Field')]}>
             <Label className={styles.FieldLabel} id="email-address-field">
               Email Address
             </Label>
 
             <Field
               id="email-address-field"
-              style={{ height: '3.2rem', paddingLeft: '1.5em', fontSize: '.9em' }}
+              style={styles[this.getClassName('EmailAddressFieldSRV')]}
               name="address"
               component={TextFieldWrapper}
               placeholder={'harry.potter@hogwarts.edu'}

--- a/src/pages/recipientValidation/components/SingleAddressForm.module.scss
+++ b/src/pages/recipientValidation/components/SingleAddressForm.module.scss
@@ -38,6 +38,7 @@
   margin: spacing() 0;
   font-size: rem(20);
   font-weight: 600;
+  text-align: left;
 }
 
 .Subheader {

--- a/src/pages/recipientValidation/components/SingleAddressForm.module.scss
+++ b/src/pages/recipientValidation/components/SingleAddressForm.module.scss
@@ -34,8 +34,17 @@
   text-align: center;
 }
 
+.HeaderSRV {
+  margin: spacing() 0;
+  font-size: rem(20);
+  font-weight: 600;
+}
+
 .Subheader {
   text-align: center;
+}
+.SubheaderSRV {
+  text-align: left;
 }
 
 .Field {
@@ -45,7 +54,7 @@
 
 .FieldSRV {
   max-width: 500px;
-  margin: 1rem auto 0;
+  margin: 1rem 0;
 }
 
 .Submit {
@@ -55,4 +64,14 @@
 
 .FieldLabel {
   @include visually-hidden();
+}
+
+.EmailAddressField {
+  height: '3.22rem';
+  padding-left: '1.5em';
+  font-size: '0.9em';
+}
+
+.EmailAddressFieldSRV {
+  padding-left: '1.5em';
 }

--- a/src/pages/recipientValidation/components/SingleAddressForm.module.scss
+++ b/src/pages/recipientValidation/components/SingleAddressForm.module.scss
@@ -66,13 +66,3 @@
 .FieldLabel {
   @include visually-hidden();
 }
-
-.EmailAddressField {
-  height: '3.22rem';
-  padding-left: '1.5em';
-  font-size: '0.9em';
-}
-
-.EmailAddressFieldSRV {
-  padding-left: '1.5em';
-}

--- a/src/pages/recipientValidation/components/SingleAddressForm.module.scss
+++ b/src/pages/recipientValidation/components/SingleAddressForm.module.scss
@@ -43,6 +43,11 @@
   margin: 4rem auto 0;
 }
 
+.FieldSRV {
+  max-width: 500px;
+  margin: 1rem auto 0;
+}
+
 .Submit {
   max-width: 160px;
   margin: 3em auto;

--- a/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
+++ b/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
@@ -14,11 +14,13 @@ describe('Page: Recipient Email Verification', () => {
   beforeEach(() => {
     props = {
       history: {
-        replace: jest.fn()
-      }
+        replace: jest.fn(),
+      },
+      getBillingInfo: jest.fn(),
+      billing: {},
     };
 
-    wrapper = shallow(<RecipientValidationPage {...props}/>);
+    wrapper = shallow(<RecipientValidationPage {...props} />);
     instance = wrapper.instance();
   });
 

--- a/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
+++ b/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
@@ -39,11 +39,37 @@ describe('Page: Recipient Email Verification', () => {
     expect(wrapper.find(ApiDetails)).toExist();
   });
 
+  it('getBillingInfo is called when Recipient Validation Page mounts', () => {
+    wrapper.setState({ selectedTab: 1 });
+    expect(props.getBillingInfo).toHaveBeenCalled();
+  });
+
   describe('handleTabs', () => {
     it('changes selected tab correctly', () => {
       expect(wrapper.state().selectedTab).toEqual(0);
       instance.handleTabs(1);
       expect(wrapper.state().selectedTab).toEqual(1);
+    });
+  });
+
+  describe('when isStandAloneRVSet is true', () => {
+    let subject, defaultProps;
+    beforeEach(() => {
+      defaultProps = {
+        history: {
+          replace: jest.fn(),
+        },
+        getBillingInfo: jest.fn(),
+        billing: {},
+        isStandAloneRVSet: true,
+      };
+      subject = props => shallow(<RecipientValidationPage {...defaultProps} {...props} />);
+    });
+
+    it('when billingLoading is true ValidateSection is not rendered', () => {
+      const instance = subject({ billingLoading: true });
+      instance.setState({ selectedTab: 1 });
+      expect(instance.find('ValidateSection')).not.toExist();
     });
   });
 });


### PR DESCRIPTION
AC-1126: Add Payment Functionality Recipient Validation - Single Address Tab

### What Changed
- Feature Flag to hide this new flow/page.(_standalone_rv_)
- (UX-Change - Show the Add Credit Card Form with the validate button instead of Add Payment method button and the modal.)
- Once CC is added the details of the entered CC shows up along with validate button.
- If the user already has a CC on file then CC details show up along with validate button.

### How To Test
- Create an account and enable 'standalone_rv' flag.
- Navigate to /recipient-validation/single.
- Check if it works as described above.
### To Do
- [ ] Address Feedback