### PR TITLE
[AC-1217] Unable to change plan when Use Another Credit Card is clicked and another credit card is used

### DIFF
--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -26,7 +26,7 @@ export function updateSubscription({ code, bundle = code, promoCode, meta = {} }
                 : '/v1/billing/subscription/bundle',
               data: {
                 promo_code: promoCode,
-                [isAws(getState()) ? 'code' : 'bundle']: code || bundle,
+                [isAws(getState()) ? 'code' : 'bundle']: bundle,
               },
               ...meta,
               onSuccess: meta.onSuccess ? meta.onSuccess : fetchAccountAction,


### PR DESCRIPTION
[AC-1217] Unable to change plan when Use Another Credit Card is clicked and another credit card is used

### What Changed
 - Fix when upgrading your paid account with a new credit card

### How To Test
 - Create a paid account
 - Navigate to /account/billing/plan page
 - Upgrade your account and use a new credit card
 - Click "Change Plan"

Expect, billing summary to update with new plan
