### PR TITLE
SE-518: Fixed word wrapping on events table

### DIFF
--- a/src/pages/reports/messageEvents/MessageEventsPage.js
+++ b/src/pages/reports/messageEvents/MessageEventsPage.js
@@ -103,16 +103,18 @@ export class MessageEventsPage extends Component {
   getRowData = rowData => {
     const { timestamp, formattedDate, type, friendly_from, rcpt_to, subject } = rowData;
     return [
-      snakeToFriendly(type),
+      <div className={styles.WordWrap}>{snakeToFriendly(type)}</div>,
       <div className={styles.MessageSubject}>{subject}</div>,
       rcpt_to,
       friendly_from,
-      <DisplayDate
-        timestamp={timestamp}
-        formattedDate={formattedDate}
-        diffTime={59}
-        diffScale="seconds"
-      />,
+      <div className={styles.WordWrap}>
+        <DisplayDate
+          timestamp={timestamp}
+          formattedDate={formattedDate}
+          diffTime={59}
+          diffScale="seconds"
+        />
+      </div>,
       <ViewDetailsButton {...rowData} />,
     ];
   };

--- a/src/pages/reports/messageEvents/MessageEventsPage.module.scss
+++ b/src/pages/reports/messageEvents/MessageEventsPage.module.scss
@@ -1,6 +1,5 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
-
 .RightAlignedButtons {
   @media screen and (min-width: breakpoint(small)) {
     width: 50%;
@@ -19,4 +18,8 @@
   overflow: hidden;
   white-space: nowrap;
   max-width: 15vw;
+}
+
+.WordWrap {
+  word-break: normal;
 }

--- a/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
+++ b/src/pages/reports/messageEvents/tests/__snapshots__/MessageEventsPage.test.js.snap
@@ -2,17 +2,25 @@
 
 exports[`Page: Message Events tests getRowData renders correctly 1`] = `
 Array [
-  "Injection",
+  <div
+    className="WordWrap"
+  >
+    Injection
+  </div>,
   <div
     className="MessageSubject"
   />,
   "tom.haverford@pawnee.state.in.us",
   "mean@friendly",
-  <DisplayDate
-    diffScale="seconds"
-    diffTime={59}
-    formattedDate="formatted"
-  />,
+  <div
+    className="WordWrap"
+  >
+    <DisplayDate
+      diffScale="seconds"
+      diffTime={59}
+      formattedDate="formatted"
+    />
+  </div>,
   <ViewDetailsButton
     event_id="456xyz"
     formattedDate="formatted"


### PR DESCRIPTION

### What Changed
 - Fixed word wrapping on columns Event and Time column

### How To Test
 - Navigate to events table and decrease viewport to where words wrap
   -Event and time columns shouldn't cut split characters in middle of word
