### PR TITLE
AC-1221 - Fix for TypeError: Cannot read property 'securityCode' of undefined

### DIFF
--- a/src/components/billing/CreditCardSection.js
+++ b/src/components/billing/CreditCardSection.js
@@ -10,6 +10,7 @@ function CreditCardSection({
   formname: FORMNAME,
   submitting = false,
   countries = [],
+  defaultToggleState,
 }) {
   const handleUseAnotherCC = () => {
     setUseAnotherCC(!useAnotherCC);
@@ -19,7 +20,7 @@ function CreditCardSection({
     ? [{ content: 'Use Saved Payment Method', onClick: handleUseAnotherCC, color: 'orange' }]
     : null;
 
-  const [useAnotherCC, setUseAnotherCC] = useState(false);
+  const [useAnotherCC, setUseAnotherCC] = useState(defaultToggleState || false);
 
   if (!credit_card || useAnotherCC)
     return (

--- a/src/components/billing/CreditCardSection.js
+++ b/src/components/billing/CreditCardSection.js
@@ -20,7 +20,7 @@ function CreditCardSection({
     ? [{ content: 'Use Saved Payment Method', onClick: handleUseAnotherCC, color: 'orange' }]
     : null;
 
-  const [useAnotherCC, setUseAnotherCC] = useState(defaultToggleState || false);
+  const [useAnotherCC, setUseAnotherCC] = useState(Boolean(defaultToggleState));
 
   if (!credit_card || useAnotherCC)
     return (

--- a/src/components/billing/CreditCardSection.js
+++ b/src/components/billing/CreditCardSection.js
@@ -10,7 +10,7 @@ function CreditCardSection({
   formname: FORMNAME,
   submitting = false,
   countries = [],
-  defaultToggleState,
+  defaultToggleState = false,
 }) {
   const handleUseAnotherCC = () => {
     setUseAnotherCC(!useAnotherCC);

--- a/src/pages/billing/components/CardSection.js
+++ b/src/pages/billing/components/CardSection.js
@@ -10,6 +10,7 @@ const CardSection = ({
   account,
   submitting,
   handleCardToggle,
+  defaultToggleState,
   isNewChangePlanForm, //TODO: remove this when removing the OldChangePlanForm
 }) => {
   const { isReady, loading } = useFeatureChangeContext();
@@ -29,6 +30,7 @@ const CardSection = ({
       formname={FORMNAME}
       submitting={submitting}
       countries={countries}
+      defaultToggleState={defaultToggleState}
     />
   );
 };

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -177,7 +177,6 @@ export const ChangePlanForm = ({
                   clearPromoCode: clearPromoCode,
                 }}
               />
-              {useSavedCC ? 'TRUE' : 'FALSE'}
               <FeatureChangeContextProvider selectedBundle={selectedBundle}>
                 <FeatureChangeSection />
                 {!isDowngradeToFree && (

--- a/src/pages/billing/forms/NewChangePlanForm.js
+++ b/src/pages/billing/forms/NewChangePlanForm.js
@@ -177,6 +177,7 @@ export const ChangePlanForm = ({
                   clearPromoCode: clearPromoCode,
                 }}
               />
+              {useSavedCC ? 'TRUE' : 'FALSE'}
               <FeatureChangeContextProvider selectedBundle={selectedBundle}>
                 <FeatureChangeSection />
                 {!isDowngradeToFree && (
@@ -188,7 +189,7 @@ export const ChangePlanForm = ({
                       canUpdateBillingInfo={canUpdateBillingInfo}
                       submitting={submitting}
                       isNewChangePlanForm={true} //TODO: remove this when removing the OldChangePlanForm
-                      useSavedCC={useSavedCC}
+                      defaultToggleState={!useSavedCC}
                       handleCardToggle={handleCardToggle}
                     />
                   </AccessControl>


### PR DESCRIPTION
Fix for TypeError: Cannot read property 'securityCode' of undefined

### What Changed
 - Added a default state to CreditCard Section.

### How To Test
 - Navigate to /account/billing/plan.
 1. Select a new Plan.
2. Click on Use Another Credit Card. Click on a field.
3. Click Change.
4. Select Another Plan.
5. Submit the form. Check you see the above error in console.

### To Do
- [ ] Address feedback
