### PR TITLE
FE-850: Added account status and status reason to pendo

### DIFF
--- a/src/components/pendo/Pendo.js
+++ b/src/components/pendo/Pendo.js
@@ -18,7 +18,7 @@ export class Pendo extends React.Component {
       username,
       userAccessLevel,
       status,
-      statusReason,
+      statusReasonCategory,
     } = this.props;
     const pendo = window.pendo;
     const { tenantId, release } = config;
@@ -46,7 +46,7 @@ export class Pendo extends React.Component {
         serviceLevel: accountSvcLevel,
         accountCreatedAt,
         status,
-        statusReason,
+        statusReasonCategory,
       },
       visitor: {
         id: `${tenantId}_${accountId}_${username}`,
@@ -67,7 +67,7 @@ const mapStateToProps = state => ({
   accessControlReady: state.accessControlReady,
   accountCreatedAt: state.account.created,
   status: state.account.status,
-  statusReason: state.account.status_reason,
+  statusReasonCategory: state.account.status_reason_category,
   accountId: state.account.customer_id,
   accountPlanCode: currentPlanCodeSelector(state),
   accountSvcLevel: state.account.service_level,

--- a/src/components/pendo/Pendo.js
+++ b/src/components/pendo/Pendo.js
@@ -17,6 +17,8 @@ export class Pendo extends React.Component {
       accountPlanCode,
       username,
       userAccessLevel,
+      status,
+      statusReason,
     } = this.props;
     const pendo = window.pendo;
     const { tenantId, release } = config;
@@ -43,6 +45,8 @@ export class Pendo extends React.Component {
         plan: accountPlanCode,
         serviceLevel: accountSvcLevel,
         accountCreatedAt,
+        status,
+        statusReason,
       },
       visitor: {
         id: `${tenantId}_${accountId}_${username}`,
@@ -62,6 +66,8 @@ export class Pendo extends React.Component {
 const mapStateToProps = state => ({
   accessControlReady: state.accessControlReady,
   accountCreatedAt: state.account.created,
+  status: state.account.status,
+  statusReason: state.account.status_reason,
   accountId: state.account.customer_id,
   accountPlanCode: currentPlanCodeSelector(state),
   accountSvcLevel: state.account.service_level,

--- a/src/components/pendo/tests/Pendo.test.js
+++ b/src/components/pendo/tests/Pendo.test.js
@@ -19,6 +19,7 @@ describe('Component: Pendo', () => {
         accountSvcLevel="enterprise"
         username="fredo-mcgurk"
         userAccessLevel="admin"
+        status="active"
         {...props}
       />,
     );

--- a/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
+++ b/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
@@ -8,6 +8,8 @@ Array [
       "id": "test_999999",
       "plan": "1meellion",
       "serviceLevel": "enterprise",
+      "status": "active",
+      "statusReason": undefined,
       "tenant": "test",
     },
     "visitor": Object {

--- a/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
+++ b/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
@@ -9,7 +9,7 @@ Array [
       "plan": "1meellion",
       "serviceLevel": "enterprise",
       "status": "active",
-      "statusReason": undefined,
+      "statusReasonCategory": undefined,
       "tenant": "test",
     },
     "visitor": Object {


### PR DESCRIPTION
### What Changed
 - Added status and status reason to pendo account information

### How To Test
 - Create a new account
 - Terminate account through account control endpoint
 - Login to the account
 - In console, use command `pendo.enableDebugger();`
 - Using debugger, check that account information was sent to pendo