### PR TITLE
AC-1125 -  Add Payment Functionality Recipient Validation -  API Integration Tab

### DIFF
--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -46,7 +46,7 @@ export class RecipientValidationPage extends Component {
       case 1:
         return <SingleAddressForm />;
       case 2:
-        return <ApiDetails />;
+        return <ApiDetails isStandAloneRVSet={this.props.isStandAloneRVSet} />;
     }
   };
 
@@ -106,6 +106,13 @@ export class RecipientValidationPage extends Component {
           <ValidateSection credit_card={billing.credit_card} handleValidate={() => {}} />
         )}
 
+        {selectedTab === 2 && isStandAloneRVSet && (
+          <ValidateSection
+            credit_card={billing.credit_card}
+            handleValidate={() => {}}
+            submitButtonName={'Create API Key'}
+          />
+        )}
         <Modal open={showPriceModal} onClose={() => this.handleModal(false)}>
           {this.renderRVPriceModal()}
         </Modal>

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { Page, Tabs, Panel, Modal, Button } from '@sparkpost/matchbox';
-import { Close } from '@sparkpost/matchbox-icons';
+import { Close, Launch } from '@sparkpost/matchbox-icons';
 import JobsTableCollection from './components/JobsTableCollection';
 import ListForm from './components/ListForm';
 import SingleAddressForm from './components/SingleAddressForm';
@@ -91,15 +91,50 @@ export class RecipientValidationPage extends Component {
           problems, including syntax errors and non-existent mailboxes, to drive better
           deliverability, cut down on fraud, and capture every opportunity.
         </p>
+        {!isStandAloneRVSet && (
+          <>
+            <Tabs
+              selected={selectedTab}
+              connectBelow={true}
+              tabs={tabs.map(({ content }, idx) => ({
+                content,
+                onClick: () => this.handleTabs(idx),
+              }))}
+            />
 
-        <Tabs
-          selected={selectedTab}
-          connectBelow={true}
-          tabs={tabs.map(({ content }, idx) => ({ content, onClick: () => this.handleTabs(idx) }))}
-        />
+            <Panel>{this.renderTabContent(selectedTab)}</Panel>
+          </>
+        )}
 
-        <Panel>{this.renderTabContent(selectedTab)}</Panel>
+        {isStandAloneRVSet && (
+          <Panel>
+            <div className={styles.TabsWrapper}>
+              <Tabs
+                selected={selectedTab}
+                connectBelow={true}
+                tabs={tabs.map(({ content }, idx) => ({
+                  content,
+                  onClick: () => this.handleTabs(idx),
+                }))}
+              />
 
+              {selectedTab === 2 && (
+                <div className={styles.TagWrapper}>
+                  <Button
+                    flat
+                    style={{ marginTop: '0.2rem' }}
+                    external
+                    to="https://developers.sparkpost.com/api/recipient-validation/"
+                  >
+                    API Docs &nbsp;
+                    <Launch className={styles.LaunchIcon} />
+                  </Button>
+                </div>
+              )}
+            </div>
+            <Panel.Section>{this.renderTabContent(selectedTab)}</Panel.Section>
+          </Panel>
+        )}
         {selectedTab === 0 && <JobsTableCollection />}
 
         {(selectedTab === 1 || selectedTab === 2) && isStandAloneRVSet && !billingLoading && (

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -126,7 +126,7 @@ export class RecipientValidationPage extends Component {
                     external
                     to="https://developers.sparkpost.com/api/recipient-validation/"
                   >
-                    API Docs &nbsp;
+                    API Docs
                     <Launch className={styles.LaunchIcon} />
                   </Button>
                 </div>

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -122,7 +122,6 @@ export class RecipientValidationPage extends Component {
                 <div className={styles.TagWrapper}>
                   <Button
                     flat
-                    style={{ marginTop: '0.2rem' }}
                     external
                     to="https://developers.sparkpost.com/api/recipient-validation/"
                   >

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -102,17 +102,14 @@ export class RecipientValidationPage extends Component {
 
         {selectedTab === 0 && <JobsTableCollection />}
 
-        {selectedTab === 1 && isStandAloneRVSet && !billingLoading && (
-          <ValidateSection credit_card={billing.credit_card} handleValidate={() => {}} />
-        )}
-
-        {selectedTab === 2 && isStandAloneRVSet && (
+        {(selectedTab === 1 || selectedTab === 2) && isStandAloneRVSet && !billingLoading && (
           <ValidateSection
             credit_card={billing.credit_card}
             handleValidate={() => {}}
-            submitButtonName={'Create API Key'}
+            submitButtonName={selectedTab === 2 ? 'Create API Key' : 'Validate'}
           />
         )}
+
         <Modal open={showPriceModal} onClose={() => this.handleModal(false)}>
           {this.renderRVPriceModal()}
         </Modal>

--- a/src/pages/recipientValidation/RecipientValidationPage.module.scss
+++ b/src/pages/recipientValidation/RecipientValidationPage.module.scss
@@ -19,3 +19,27 @@
 .bodyContainer {
   padding: 2rem 3rem;
 }
+
+.TabsWrapper {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #e1e1e6;
+
+  > div {
+    box-shadow: none;
+    height: 50px; // to match preview control bar and tabs
+    border-bottom: none;
+
+    > a {
+      display: inline-flex;
+      align-items: center;
+      height: 100%;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+  }
+}
+
+.LaunchIcon {
+  color: color(blue);
+}

--- a/src/pages/recipientValidation/RecipientValidationPage.module.scss
+++ b/src/pages/recipientValidation/RecipientValidationPage.module.scss
@@ -41,5 +41,6 @@
 }
 
 .LaunchIcon {
+  margin-left: spacing();
   color: color(blue);
 }

--- a/src/pages/recipientValidation/components/ApiDetails.js
+++ b/src/pages/recipientValidation/components/ApiDetails.js
@@ -58,11 +58,9 @@ export const ApiIntegrationDocs = ({ isStandAloneRVSet }) => {
 
   const buttonRow = (
     <div>
-      {!isStandAloneRVSet && (
-        <Button color="orange" component={Link} to="/account/api-keys/create">
-          Create API Key
-        </Button>
-      )}
+      <Button color="orange" component={Link} to="/account/api-keys/create">
+        Create API Key
+      </Button>
       <Button
         className={!isStandAloneRVSet && styles.ApiDocsLink}
         external
@@ -85,7 +83,7 @@ export const ApiIntegrationDocs = ({ isStandAloneRVSet }) => {
             Block fake emails and catch typos with a single API request.
           </p>
           {exampleMethod}
-          {buttonRow}
+          {!isStandAloneRVSet && buttonRow}
         </Grid.Column>
         <Grid.Column xs={12} md={6} lgOffset={1}>
           <div className={styles.CodeSection}>

--- a/src/pages/recipientValidation/components/ApiDetails.js
+++ b/src/pages/recipientValidation/components/ApiDetails.js
@@ -4,22 +4,43 @@ import { Link } from 'react-router-dom';
 import styles from './ApiDetails.module.scss';
 import CodeBlock from './CodeBlock';
 
-const Tab = () => (<span className={styles.tab} />);
-const White = ({ children }) => (<span className={styles.white} >{children}</span>);
+const Tab = () => <span className={styles.tab} />;
+const White = ({ children }) => <span className={styles.white}>{children}</span>;
 
-export const ApiIntegrationDocs = () => {
+export const ApiIntegrationDocs = ({ isStandAloneRVSet }) => {
   const codeBlock = (
     <small className={styles.blue}>
-      {'{'}<br/>
-      <Tab />"results": {'{'}<br/>
-      <Tab /><Tab />"result": "<White>undeliverable</White>",<br/>
-      <Tab /><Tab />"valid": <White>false</White>,<br/>
-      <Tab /><Tab />"reason": "<White>Invalid Domain</White>",<br/>
-      <Tab /><Tab />"is_role": <White>false</White>,<br/>
-      <Tab /><Tab />"is_disposable": <White>false</White>,<br/>
-      <Tab /><Tab />"is_free": <White>false</White>,<br/>
-      <Tab /><Tab />"did_you_mean": "<White>harry.potter@hogwarts.edu</White>"<br/>
-      <Tab />{'}'}<br/>
+      {'{'}
+      <br />
+      <Tab />
+      "results": {'{'}
+      <br />
+      <Tab />
+      <Tab />
+      "result": "<White>undeliverable</White>",
+      <br />
+      <Tab />
+      <Tab />
+      "valid": <White>false</White>,<br />
+      <Tab />
+      <Tab />
+      "reason": "<White>Invalid Domain</White>",
+      <br />
+      <Tab />
+      <Tab />
+      "is_role": <White>false</White>,<br />
+      <Tab />
+      <Tab />
+      "is_disposable": <White>false</White>,<br />
+      <Tab />
+      <Tab />
+      "is_free": <White>false</White>,<br />
+      <Tab />
+      <Tab />
+      "did_you_mean": "<White>harry.potter@hogwarts.edu</White>"<br />
+      <Tab />
+      {'}'}
+      <br />
       {'}'}
     </small>
   );
@@ -28,17 +49,25 @@ export const ApiIntegrationDocs = () => {
     <div className={styles.SampleRequest}>
       <small>
         <span className={styles.Method}>GET</span>
-        <code>/api/v1/recipient-validation/single/{'{'}address{'}'}</code>
+        <code>
+          /api/v1/recipient-validation/single/{'{'}address{'}'}
+        </code>
       </small>
     </div>
   );
 
   const buttonRow = (
     <div>
-      <Button color='orange' component={Link} to='/account/api-keys/create'>
-        Create API Key
-      </Button>
-      <Button className={styles.ApiDocsLink} external to='https://developers.sparkpost.com/api/recipient-validation/'>
+      {!isStandAloneRVSet && (
+        <Button color="orange" component={Link} to="/account/api-keys/create">
+          Create API Key
+        </Button>
+      )}
+      <Button
+        className={!isStandAloneRVSet && styles.ApiDocsLink}
+        external
+        to="https://developers.sparkpost.com/api/recipient-validation/"
+      >
         API Docs
       </Button>
     </div>
@@ -50,15 +79,17 @@ export const ApiIntegrationDocs = () => {
         <Grid.Column xs={12} md={6} lg={5}>
           <br />
           <div className={styles.Header}>Integrate Now</div>
-          <p>Validate an email the moment you receive it, in real-time.<br/>Block fake emails and catch typos with a single API request.</p>
+          <p>
+            Validate an email the moment you receive it, in real-time.
+            <br />
+            Block fake emails and catch typos with a single API request.
+          </p>
           {exampleMethod}
           {buttonRow}
         </Grid.Column>
         <Grid.Column xs={12} md={6} lgOffset={1}>
           <div className={styles.CodeSection}>
-            <CodeBlock>
-              {codeBlock}
-            </CodeBlock>
+            <CodeBlock>{codeBlock}</CodeBlock>
           </div>
         </Grid.Column>
       </Grid>

--- a/src/pages/recipientValidation/components/ValidateSection.js
+++ b/src/pages/recipientValidation/components/ValidateSection.js
@@ -17,6 +17,7 @@ function ValidateSection({
   billingCountries,
   getBillingCountries,
   isManuallyBilled,
+  submitButtonName = 'Validate',
 }) {
   const onSubmit = () => {
     handleValidate();
@@ -45,7 +46,7 @@ function ValidateSection({
       />
       <Button color="orange" type="submit">
         {/* functionality to validate to be added in AC-1196 and AC-1197*/}
-        Validate
+        {submitButtonName}
       </Button>
     </form>
   );

--- a/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
+++ b/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
@@ -5,6 +5,7 @@ import ListForm from '../components/ListForm';
 import SingleAddressForm from '../components/SingleAddressForm';
 import JobsTableCollection from '../components/JobsTableCollection';
 import ApiDetails from '../components/ApiDetails';
+import { Launch } from '@sparkpost/matchbox-icons';
 
 describe('Page: Recipient Email Verification', () => {
   let wrapper;
@@ -70,6 +71,22 @@ describe('Page: Recipient Email Verification', () => {
       const instance = subject({ billingLoading: true });
       instance.setState({ selectedTab: 1 });
       expect(instance.find('ValidateSection')).not.toExist();
+    });
+
+    it('renders a API Docs button in Panel when API Integration Tab is selected', () => {
+      const instance = subject({ tab: 2 });
+
+      expect(
+        instance
+          .find('Button')
+          .first()
+          .prop('children'),
+      ).toEqual(['API Docs', <Launch className="LaunchIcon" />]);
+    });
+
+    it('renders a ValidateSection', () => {
+      const instance = subject({ tab: 2 });
+      expect(instance.find('Connect(ReduxForm)')).toExist();
     });
   });
 });

--- a/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
+++ b/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
@@ -70,7 +70,7 @@ describe('Page: Recipient Email Verification', () => {
     it('when billingLoading is true ValidateSection is not rendered', () => {
       const instance = subject({ billingLoading: true });
       instance.setState({ selectedTab: 1 });
-      expect(instance.find('ValidateSection')).not.toExist();
+      expect(instance.find('Connect(ReduxForm)')).not.toExist();
     });
 
     it('renders a API Docs button in Panel when API Integration Tab is selected', () => {


### PR DESCRIPTION
AC-1125 -  Add Payment Functionality Recipient Validation -  API Integration Tab

### What Changed
 -  Show the Add Credit Card Form with the Create API key button in API Integration Tab.
  

### How To Test
 - Enable 'standalone_rv' flag.
 - Navigate to /recipient-validation/api
 - Check if it matches mocks, expect the Update Payment Method Button(Changed after discussion with Haley.)

### To Do
- [ ] Address Feedback
