### PR TITLE
SA-1196: Health Score display for subaccount reporting users

### DIFF
--- a/src/selectors/currentUser.js
+++ b/src/selectors/currentUser.js
@@ -1,7 +1,9 @@
+import { isSubaccountUser } from 'src/helpers/conditions/user';
+
 export const userCookieConsentFlagSelector = state => !!state.currentUser.cookie_consent;
 
 export const usernameSelector = state =>
   state.currentUser.username || state.tfa.username || state.auth.username;
 
 export const subaccountReportingIdSelector = ({ currentUser = {} }) =>
-  currentUser.access_level === 'subaccount_reporting' ? currentUser.subaccount_id : -1;
+  isSubaccountUser({ currentUser }) ? currentUser.subaccount_id : -1;

--- a/src/selectors/currentUser.js
+++ b/src/selectors/currentUser.js
@@ -1,3 +1,7 @@
-export const userCookieConsentFlagSelector = (state) => !!state.currentUser.cookie_consent;
+export const userCookieConsentFlagSelector = state => !!state.currentUser.cookie_consent;
 
-export const usernameSelector = (state) => state.currentUser.username || state.tfa.username || state.auth.username;
+export const usernameSelector = state =>
+  state.currentUser.username || state.tfa.username || state.auth.username;
+
+export const subaccountReportingIdSelector = ({ currentUser = {} }) =>
+  currentUser.access_level === 'subaccount_reporting' ? currentUser.subaccount_id : -1;

--- a/src/selectors/signals.js
+++ b/src/selectors/signals.js
@@ -4,6 +4,7 @@ import { fillByDate } from 'src/helpers/date';
 import { roundToPlaces } from 'src/helpers/units';
 import { getDoD } from 'src/helpers/signals';
 import { selectSubaccountIdFromQuery } from 'src/selectors/subaccounts';
+import { subaccountReportingIdSelector } from 'src/selectors/currentUser';
 import { HEALTH_SCORE_COLORS_V3 } from 'src/pages/signals/constants/healthScoreThresholds';
 import _ from 'lodash';
 import moment from 'moment';
@@ -15,31 +16,39 @@ export const getSelectedDateFromRouter = (state, props) => _.get(props, 'locatio
 export const getOptions = (state, { now = moment().subtract(1, 'day'), ...options } = {}) => ({
   ...state.signalOptions,
   now,
-  ...options
+  ...options,
 });
 
 // Redux store
-export const getSpamHitsData = (state) => _.get(state, 'signals.spamHits', {});
-export const getEngagementRecencyData = (state) => _.get(state, 'signals.engagementRecency', {});
-export const getEngagementRateByCohortData = (state) => _.get(state, 'signals.engagementRateByCohort', {});
-export const getUnsubscribeRateByCohortData = (state) => _.get(state, 'signals.unsubscribeRateByCohort', {});
-export const getComplaintsByCohortData = (state) => _.get(state, 'signals.complaintsByCohort', {});
-export const getHealthScoreData = (state) => _.get(state, 'signals.healthScore', {});
-export const getCurrentHealthScoreData = (state) => _.get(state, 'signals.currentHealthScore', {});
+export const getSpamHitsData = state => _.get(state, 'signals.spamHits', {});
+export const getEngagementRecencyData = state => _.get(state, 'signals.engagementRecency', {});
+export const getEngagementRateByCohortData = state =>
+  _.get(state, 'signals.engagementRateByCohort', {});
+export const getUnsubscribeRateByCohortData = state =>
+  _.get(state, 'signals.unsubscribeRateByCohort', {});
+export const getComplaintsByCohortData = state => _.get(state, 'signals.complaintsByCohort', {});
+export const getHealthScoreData = state => _.get(state, 'signals.healthScore', {});
+export const getCurrentHealthScoreData = state => _.get(state, 'signals.currentHealthScore', {});
 
 // Details
 export const selectSpamHitsDetails = createSelector(
-  [getSpamHitsData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
+  [
+    getSpamHitsData,
+    getFacetFromParams,
+    getFacetIdFromParams,
+    selectSubaccountIdFromQuery,
+    getOptions,
+  ],
   ({ loading, error, data }, facet, facetId, subaccountId, { from, to }) => {
-    const match = data.find((item) => String(item[facet]) === facetId) || {};
+    const match = data.find(item => String(item[facet]) === facetId) || {};
     const history = match.history || [];
     const normalizedHistory = history.map(({ dt: date, ...values }) => ({
       ...values,
       date,
       // note, this is an exception most other cases these relative metrics are provided by the API
-      relative_trap_hits_parked: (values.trap_hits_parked / values.injections),
-      relative_trap_hits_recycled: (values.trap_hits_recycled / values.injections),
-      relative_trap_hits_typo: (values.trap_hits_typo / values.injections)
+      relative_trap_hits_parked: values.trap_hits_parked / values.injections,
+      relative_trap_hits_recycled: values.trap_hits_recycled / values.injections,
+      relative_trap_hits_typo: values.trap_hits_typo / values.injections,
     }));
 
     const filledHistory = fillByDate({
@@ -53,41 +62,49 @@ export const selectSpamHitsDetails = createSelector(
         relative_trap_hits_recycled: null,
         trap_hits_recycled: null,
         relative_trap_hits_typo: null,
-        trap_hits_typo: null
+        trap_hits_typo: null,
       },
-      from, to
+      from,
+      to,
     });
 
-    const isEmpty = filledHistory.every((values) => values.trap_hits === null);
+    const isEmpty = filledHistory.every(values => values.trap_hits === null);
 
     return {
       details: {
         data: filledHistory,
         empty: isEmpty && !loading,
         error,
-        loading
+        loading,
       },
       facet,
       facetId,
-      subaccountId
+      subaccountId,
     };
-  }
+  },
 );
 
 export const selectEngagementRecencyDetails = createSelector(
-  [getEngagementRecencyData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
+  [
+    getEngagementRecencyData,
+    getFacetFromParams,
+    getFacetIdFromParams,
+    selectSubaccountIdFromQuery,
+    getOptions,
+  ],
   ({ loading, error, data }, facet, facetId, subaccountId, { from, to }) => {
-    const match = data.find((item) => String(item[facet]) === facetId) || {};
+    const match = data.find(item => String(item[facet]) === facetId) || {};
 
-    const calculatePercentages = (data) => data.map(({ c_total, dt, ...absolutes }) => {
-      let values = {};
+    const calculatePercentages = data =>
+      data.map(({ c_total, dt, ...absolutes }) => {
+        let values = {};
 
-      for (const key in absolutes) {
-        values = { ...values, [key]: absolutes[key] / c_total };
-      }
+        for (const key in absolutes) {
+          values = { ...values, [key]: absolutes[key] / c_total };
+        }
 
-      return { ...values, c_total, dt };
-    });
+        return { ...values, c_total, dt };
+      });
 
     const history = calculatePercentages(match.history || []);
     const normalizedHistory = history.map(({ dt: date, ...values }) => ({ date, ...values }));
@@ -100,25 +117,26 @@ export const selectEngagementRecencyDetails = createSelector(
         c_90d: null,
         c_365d: null,
         c_uneng: null,
-        c_total: null
+        c_total: null,
       },
-      from, to
+      from,
+      to,
     });
 
-    const isEmpty = filledHistory.every((values) => values.c_total === null);
+    const isEmpty = filledHistory.every(values => values.c_total === null);
 
     return {
       details: {
         data: filledHistory,
         empty: isEmpty && !loading,
         error,
-        loading
+        loading,
       },
       facet,
       facetId,
-      subaccountId
+      subaccountId,
     };
-  }
+  },
 );
 
 // Engagement behavior charts do not contain data within the last 3 days (including today)
@@ -128,24 +146,45 @@ const excludeLastNDays = (date, n) =>
 const engagementBehaviorDataLagDays = 3;
 
 export const selectEngagementRateByCohortDetails = createSelector(
-  [selectEngagementRecencyDetails, getEngagementRateByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ details: { loading: loadingEngRecency, error: errorEngRecency, data: dataEngRecency }}, { loading, error, data }, facet, facetId, subaccountId, { from, to }) => {
-    const match = data.find((item) => String(item[facet]) === facetId) || {};
+  [
+    selectEngagementRecencyDetails,
+    getEngagementRateByCohortData,
+    getFacetFromParams,
+    getFacetIdFromParams,
+    selectSubaccountIdFromQuery,
+    getOptions,
+  ],
+  (
+    { details: { loading: loadingEngRecency, error: errorEngRecency, data: dataEngRecency } },
+    { loading, error, data },
+    facet,
+    facetId,
+    subaccountId,
+    { from, to },
+  ) => {
+    const match = data.find(item => String(item[facet]) === facetId) || {};
 
     // Rename date key
-    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
+    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({
+      date,
+      ...values,
+    }));
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
       fill: {
-        p_new_eng: null, p_14d_eng: null, p_90d_eng: null, p_365d_eng: null, p_uneng_eng: null, p_total_eng: null
+        p_new_eng: null,
+        p_14d_eng: null,
+        p_90d_eng: null,
+        p_365d_eng: null,
+        p_uneng_eng: null,
+        p_total_eng: null,
       },
       from,
-      to: excludeLastNDays(to, engagementBehaviorDataLagDays)
+      to: excludeLastNDays(to, engagementBehaviorDataLagDays),
     });
 
-    const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_eng));
-
+    const isEmpty = filledHistory.every(values => _.isNil(values.p_total_eng));
 
     return {
       details: {
@@ -153,23 +192,39 @@ export const selectEngagementRateByCohortDetails = createSelector(
         dataEngRecency,
         empty: isEmpty && !loading,
         error: error || errorEngRecency,
-        loading: loading || loadingEngRecency
+        loading: loading || loadingEngRecency,
       },
       facet,
       facetId,
-      subaccountId
+      subaccountId,
     };
-  }
+  },
 );
 
 export const selectUnsubscribeRateByCohortDetails = createSelector(
-  [selectEngagementRecencyDetails, getUnsubscribeRateByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ details: { loading: loadingEngRecency, error: errorEngRecency, data: dataEngRecency }}, { loading, error, data }, facet, facetId, subaccountId, { from, to }) => {
-    const match = data.find((item) => String(item[facet]) === facetId) || {};
+  [
+    selectEngagementRecencyDetails,
+    getUnsubscribeRateByCohortData,
+    getFacetFromParams,
+    getFacetIdFromParams,
+    selectSubaccountIdFromQuery,
+    getOptions,
+  ],
+  (
+    { details: { loading: loadingEngRecency, error: errorEngRecency, data: dataEngRecency } },
+    { loading, error, data },
+    facet,
+    facetId,
+    subaccountId,
+    { from, to },
+  ) => {
+    const match = data.find(item => String(item[facet]) === facetId) || {};
 
     // Rename date key
-    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
-
+    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({
+      date,
+      ...values,
+    }));
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
@@ -179,13 +234,13 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
         p_90d_unsub: null,
         p_365d_unsub: null,
         p_uneng_unsub: null,
-        p_total_unsub: null
+        p_total_unsub: null,
       },
       from,
-      to: excludeLastNDays(to, engagementBehaviorDataLagDays)
+      to: excludeLastNDays(to, engagementBehaviorDataLagDays),
     });
 
-    const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_unsub));
+    const isEmpty = filledHistory.every(values => _.isNil(values.p_total_unsub));
 
     return {
       details: {
@@ -193,22 +248,38 @@ export const selectUnsubscribeRateByCohortDetails = createSelector(
         dataEngRecency,
         empty: isEmpty && !loading,
         error: error || errorEngRecency,
-        loading: loading || loadingEngRecency
+        loading: loading || loadingEngRecency,
       },
       facet,
       facetId,
-      subaccountId
+      subaccountId,
     };
-  }
+  },
 );
 
 export const selectComplaintsByCohortDetails = createSelector(
-  [selectEngagementRecencyDetails, getComplaintsByCohortData, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ details: { loading: loadingEngRecency, error: errorEngRecency, data: dataEngRecency }}, { loading, error, data }, facet, facetId, subaccountId, { from, to }) => {
-    const match = data.find((item) => String(item[facet]) === facetId) || {};
+  [
+    selectEngagementRecencyDetails,
+    getComplaintsByCohortData,
+    getFacetFromParams,
+    getFacetIdFromParams,
+    selectSubaccountIdFromQuery,
+    getOptions,
+  ],
+  (
+    { details: { loading: loadingEngRecency, error: errorEngRecency, data: dataEngRecency } },
+    { loading, error, data },
+    facet,
+    facetId,
+    subaccountId,
+    { from, to },
+  ) => {
+    const match = data.find(item => String(item[facet]) === facetId) || {};
     // Rename date key
-    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({ date, ...values }));
-
+    const normalizedHistory = _.get(match, 'history', []).map(({ dt: date, ...values }) => ({
+      date,
+      ...values,
+    }));
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
@@ -218,13 +289,13 @@ export const selectComplaintsByCohortDetails = createSelector(
         p_90d_fbl: null,
         p_365d_fbl: null,
         p_uneng_fbl: null,
-        p_total_fbl: null
+        p_total_fbl: null,
       },
       from,
-      to: excludeLastNDays(to, engagementBehaviorDataLagDays)
+      to: excludeLastNDays(to, engagementBehaviorDataLagDays),
     });
 
-    const isEmpty = filledHistory.every((values) => _.isNil(values.p_total_fbl));
+    const isEmpty = filledHistory.every(values => _.isNil(values.p_total_fbl));
 
     return {
       details: {
@@ -232,26 +303,26 @@ export const selectComplaintsByCohortDetails = createSelector(
         dataEngRecency,
         empty: isEmpty && !loading,
         error: error || errorEngRecency,
-        loading: loading || loadingEngRecency
+        loading: loading || loadingEngRecency,
       },
       facet,
       facetId,
-      subaccountId
+      subaccountId,
     };
-  }
+  },
 );
 
 function rankHealthScore(value) {
   let rank = '';
 
   switch (true) {
-    case (value < 55):
+    case value < 55:
       rank = 'danger';
       break;
-    case (value < 80):
+    case value < 80:
       rank = 'warning';
       break;
-    case (value >= 80):
+    case value >= 80:
       rank = 'good';
       break;
     default:
@@ -263,17 +334,33 @@ function rankHealthScore(value) {
 }
 
 export const selectHealthScoreDetails = createSelector(
-  [getHealthScoreData, selectSpamHitsDetails, getFacetFromParams, getFacetIdFromParams, selectSubaccountIdFromQuery, getOptions],
-  ({ loading, error, data }, { details: spamDetails }, facet, facetId, subaccountId, { from, to }) => {
-    const match = data.find((item) => String(item[facet]) === facetId) || {};
+  [
+    getHealthScoreData,
+    selectSpamHitsDetails,
+    getFacetFromParams,
+    getFacetIdFromParams,
+    selectSubaccountIdFromQuery,
+    getOptions,
+  ],
+  (
+    { loading, error, data },
+    { details: spamDetails },
+    facet,
+    facetId,
+    subaccountId,
+    { from, to },
+  ) => {
+    const match = data.find(item => String(item[facet]) === facetId) || {};
 
     const history = _.get(match, 'history', []);
-    const normalizedHistory = history.map(({ dt: date, weights, total_injection_count: injections, ...values }) => ({
-      date,
-      weights: _.sortBy(weights, ({ weight }) => parseFloat(weight)),
-      injections,
-      ...values
-    }));
+    const normalizedHistory = history.map(
+      ({ dt: date, weights, total_injection_count: injections, ...values }) => ({
+        date,
+        weights: _.sortBy(weights, ({ weight }) => parseFloat(weight)),
+        injections,
+        ...values,
+      }),
+    );
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
@@ -286,93 +373,99 @@ export const selectHealthScoreDetails = createSelector(
           { weight_type: 'Block Bounces', weight: null, weight_value: null },
           { weight_type: 'List Quality', weight: null, weight_value: null },
           { weight_type: 'eng cohorts: new, 14-day', weight: null, weight_value: null },
-          { weight_type: 'eng cohorts: unengaged', weight: null, weight_value: null }
+          { weight_type: 'eng cohorts: unengaged', weight: null, weight_value: null },
         ],
         health_score: null,
-        injections: null
+        injections: null,
       },
-      from, to
+      from,
+      to,
     });
 
     // Merge in rankings
-    const mergedHistory = filledHistory.map((healthData) => ({ ranking: rankHealthScore(roundToPlaces(healthData.health_score * 100, 1)), ...healthData }));
+    const mergedHistory = filledHistory.map(healthData => ({
+      ranking: rankHealthScore(roundToPlaces(healthData.health_score * 100, 1)),
+      ...healthData,
+    }));
 
-    const isEmpty = mergedHistory.every((values) => values.health_score === null);
+    const isEmpty = mergedHistory.every(values => values.health_score === null);
 
     return {
       details: {
         data: mergedHistory,
         empty: isEmpty && !loading && !spamDetails.loading,
         error,
-        loading: loading || spamDetails.loading
+        loading: loading || spamDetails.loading,
       },
       facet,
       facetId,
-      subaccountId
+      subaccountId,
     };
-  }
+  },
 );
 
 export const selectHealthScoreDetailsV3 = createSelector(
   [selectHealthScoreDetails],
   ({ details, ...rest }) => {
-
     // Add fill colors
-    const dataWithFill = details.data.map((healthData) => ({
+    const dataWithFill = details.data.map(healthData => ({
       fill: HEALTH_SCORE_COLORS_V3[healthData.ranking || 'danger'],
-      ...healthData
+      ...healthData,
     }));
 
     return {
       details: {
         ...details,
-        data: dataWithFill
+        data: dataWithFill,
       },
-      ...rest
+      ...rest,
     };
-  }
+  },
 );
 
 export const selectEngagementRecencyOverviewData = createSelector(
-  getEngagementRecencyData, getOptions,
-  ({ data }, { from, to }) => data.map(({ WoW, ...rowOfData }) => {
-    const history = rowOfData.history || [];
-    const normalizedHistory = history.map(({ dt: date, ...values }) => {
-      const relative_engaged_recipients = (values.c_14d / values.c_total) * 100;
+  getEngagementRecencyData,
+  getOptions,
+  ({ data }, { from, to }) =>
+    data.map(({ WoW, ...rowOfData }) => {
+      const history = rowOfData.history || [];
+      const normalizedHistory = history.map(({ dt: date, ...values }) => {
+        const relative_engaged_recipients = (values.c_14d / values.c_total) * 100;
+
+        return {
+          ...values,
+          date,
+          engaged_recipients: values.c_14d,
+          relative_engaged_recipients,
+        };
+      });
+      const filledHistory = fillByDate({
+        dataSet: normalizedHistory,
+        fill: {
+          engaged_recipients: null,
+          relative_engaged_recipients: null,
+        },
+        from,
+        to,
+      });
 
       return {
-        ...values,
-        date,
-        engaged_recipients: values.c_14d,
-        relative_engaged_recipients
+        ...rowOfData,
+        current_engaged_recipients: _.last(filledHistory).engaged_recipients,
+        current_relative_engaged_recipients: _.last(filledHistory).relative_engaged_recipients,
+        history: filledHistory,
+        WoW: _.isNil(WoW) ? null : roundToPlaces(WoW * 100, 0),
       };
-    });
-    const filledHistory = fillByDate({
-      dataSet: normalizedHistory,
-      fill: {
-        engaged_recipients: null,
-        relative_engaged_recipients: null
-      },
-      from, to
-    });
-
-    return {
-      ...rowOfData,
-      current_engaged_recipients: _.last(filledHistory).engaged_recipients,
-      current_relative_engaged_recipients: _.last(filledHistory).relative_engaged_recipients,
-      history: filledHistory,
-      WoW: _.isNil(WoW) ? null : roundToPlaces(WoW * 100, 0)
-    };
-  })
+    }),
 );
 
 export const selectEngagementRecencyOverviewMetaData = createSelector(
   getEngagementRecencyData,
   ({ data }) => {
     const absoluteValues = _.flatMap(data, ({ history }) => history.map(({ c_14d }) => c_14d));
-    const relativeValues = _.flatMap(data, ({ history }) => (
-      history.map(({ c_14d, c_total }) => (c_14d / c_total) * 100)
-    ));
+    const relativeValues = _.flatMap(data, ({ history }) =>
+      history.map(({ c_14d, c_total }) => (c_14d / c_total) * 100),
+    );
     const currentValues = data.reduce((acc, { current_c_14d }) => {
       if (current_c_14d === null) {
         return acc; // ignore
@@ -392,172 +485,193 @@ export const selectEngagementRecencyOverviewMetaData = createSelector(
       currentMax: currentValues.length ? Math.max(...currentValues) : null,
       currentRelativeMax: currentRelativeValues.length ? Math.max(...currentRelativeValues) : null,
       max: absoluteValues.length ? Math.max(...absoluteValues) : null,
-      relativeMax: relativeValues.length ? Math.max(...relativeValues) : null
+      relativeMax: relativeValues.length ? Math.max(...relativeValues) : null,
     };
-  }
+  },
 );
 
 export const selectEngagementRecencyOverview = createSelector(
-  [getEngagementRecencyData, selectEngagementRecencyOverviewData, selectEngagementRecencyOverviewMetaData],
+  [
+    getEngagementRecencyData,
+    selectEngagementRecencyOverviewData,
+    selectEngagementRecencyOverviewMetaData,
+  ],
   (engagementRecencyData, data, metaData) => ({
     ...engagementRecencyData,
     data,
-    metaData
-  })
+    metaData,
+  }),
 );
 
 export const selectHealthScoreOverviewData = createSelector(
-  getHealthScoreData, getOptions,
-  ({ data }, { from, to }) => data.map(({ WoW, ...rowOfData }) => {
-    const history = rowOfData.history || [];
-    const normalizedHistory = history.map(({ dt: date, health_score, ...values }) => {
-      const roundedHealthScore = roundToPlaces(health_score * 100, 1);
+  getHealthScoreData,
+  getOptions,
+  ({ data }, { from, to }) =>
+    data.map(({ WoW, ...rowOfData }) => {
+      const history = rowOfData.history || [];
+      const normalizedHistory = history.map(({ dt: date, health_score, ...values }) => {
+        const roundedHealthScore = roundToPlaces(health_score * 100, 1);
+
+        return {
+          ...values,
+          date,
+          health_score: roundedHealthScore,
+          ranking: rankHealthScore(roundedHealthScore),
+        };
+      });
+      const filledHistory = fillByDate({
+        dataSet: normalizedHistory,
+        fill: {
+          health_score: null,
+          ranking: null,
+        },
+        from,
+        to,
+      });
 
       return {
-        ...values,
-        date,
-        health_score: roundedHealthScore,
-        ranking: rankHealthScore(roundedHealthScore)
+        ...rowOfData,
+        current_health_score: _.last(filledHistory).health_score,
+        history: filledHistory,
+        average_health_score: roundToPlaces(
+          normalizedHistory.reduce((total, { health_score }) => total + health_score, 0) /
+            normalizedHistory.length,
+          1,
+        ),
+        WoW: _.isNil(WoW) ? null : roundToPlaces(WoW * 100, 0),
+        current_DoD: getDoD(
+          _.last(filledHistory).health_score,
+          filledHistory[filledHistory.length - 2].health_score,
+        ),
       };
-    });
-    const filledHistory = fillByDate({
-      dataSet: normalizedHistory,
-      fill: {
-        health_score: null,
-        ranking: null
-      },
-      from, to
-    });
-
-    return {
-      ...rowOfData,
-      current_health_score: _.last(filledHistory).health_score,
-      history: filledHistory,
-      average_health_score: roundToPlaces(
-        normalizedHistory.reduce((total, { health_score }) => total + health_score, 0) / normalizedHistory.length,
-        1
-      ),
-      WoW: _.isNil(WoW) ? null : roundToPlaces(WoW * 100, 0),
-      current_DoD: getDoD(_.last(filledHistory).health_score, filledHistory[filledHistory.length - 2].health_score)
-    };
-  })
+    }),
 );
 
 export const selectCurrentHealthScoreDashboard = createSelector(
-  [getCurrentHealthScoreData, getOptions],
-  ({ data, loading, error }, { from, to }) => {
-    const accountData = _.find(data, ['sid', -1]) || {};
+  [getCurrentHealthScoreData, subaccountReportingIdSelector, getOptions],
+  ({ data, loading, error }, subaccountId, { from, to }) => {
+    const accountData = _.find(data, ['sid', subaccountId]) || {};
     const history = accountData.history || [];
 
-    const normalizedHistory = history.map(({ dt: date, health_score, total_injection_count: injections, ...values }) => {
-      const roundedHealthScore = roundToPlaces(health_score * 100, 1);
-      return {
-        ...values,
-        date,
-        health_score: roundedHealthScore,
-        ranking: rankHealthScore(roundedHealthScore),
-        injections
-      };
-    });
+    const normalizedHistory = history.map(
+      ({ dt: date, health_score, total_injection_count: injections, ...values }) => {
+        const roundedHealthScore = roundToPlaces(health_score * 100, 1);
+        return {
+          ...values,
+          date,
+          health_score: roundedHealthScore,
+          ranking: rankHealthScore(roundedHealthScore),
+          injections,
+        };
+      },
+    );
 
     const filledHistory = fillByDate({
       dataSet: normalizedHistory,
       fill: {
         health_score: null,
         ranking: null,
-        injections: null
+        injections: null,
       },
-      from, to
+      from,
+      to,
     });
 
     const latestHealthScore = _.get(_.last(filledHistory), 'health_score');
 
     return {
       ...accountData,
-      loading, error,
+      loading,
+      error,
       current_health_score: latestHealthScore,
       history: filledHistory,
       WoW: _.isNil(accountData.WoW) ? null : roundToPlaces(accountData.WoW * 100, 0),
-      current_DoD: getDoD(latestHealthScore, _.get(filledHistory, `[${filledHistory.length - 2}].health_score`))
+      current_DoD: getDoD(
+        latestHealthScore,
+        _.get(filledHistory, `[${filledHistory.length - 2}].health_score`),
+      ),
     };
-  }
+  },
 );
 
 export const selectHealthScoreOverview = createSelector(
   [getHealthScoreData, selectHealthScoreOverviewData],
   (healthScoreData, data) => ({
     ...healthScoreData,
-    data
-  })
+    data,
+  }),
 );
-
 
 export const selectSpamHitsOverviewData = createSelector(
-  getSpamHitsData, getOptions,
-  ({ data }, { from, to }) => data.map(({ WoW, ...rowOfData }) => {
-    const history = rowOfData.history || [];
-    const normalizedHistory = history.map(({ dt: date, relative_trap_hits, ...values }) => ({
-      ...values,
-      date,
-      // Less than one tenth percent of hits to injections is good
-      ranking: relative_trap_hits > .001 ? 'bad' : 'good',
-      relative_trap_hits: relative_trap_hits * 100
-    }));
-    const filledHistory = fillByDate({
-      dataSet: normalizedHistory,
-      fill: {
-        injections: null,
-        ranking: null,
-        relative_trap_hits: null,
-        trap_hits: null
-      },
-      from, to
-    });
-
-    return {
-      ...rowOfData,
-      current_relative_trap_hits: _.last(filledHistory).relative_trap_hits,
-      history: filledHistory,
-      total_injections: history.reduce((total, { injections }) => total + injections, 0),
-      WoW: _.isNil(WoW) ? null : roundToPlaces(WoW * 100, 0)
-    };
-  })
-);
-
-export const selectSpamHitsOverviewMetaData = createSelector(
   getSpamHitsData,
-  ({ data }) => {
-    const absoluteValues = _.flatMap(data, ({ history }) => history.map(({ trap_hits }) => trap_hits));
-    const relativeValues = _.flatMap(data, ({ history }) => history.map(({ relative_trap_hits }) => relative_trap_hits * 100));
-    const currentValues = data.reduce((acc, { current_trap_hits }) => {
-      if (current_trap_hits === null) {
-        return acc; // ignore
-      }
+  getOptions,
+  ({ data }, { from, to }) =>
+    data.map(({ WoW, ...rowOfData }) => {
+      const history = rowOfData.history || [];
+      const normalizedHistory = history.map(({ dt: date, relative_trap_hits, ...values }) => ({
+        ...values,
+        date,
+        // Less than one tenth percent of hits to injections is good
+        ranking: relative_trap_hits > 0.001 ? 'bad' : 'good',
+        relative_trap_hits: relative_trap_hits * 100,
+      }));
+      const filledHistory = fillByDate({
+        dataSet: normalizedHistory,
+        fill: {
+          injections: null,
+          ranking: null,
+          relative_trap_hits: null,
+          trap_hits: null,
+        },
+        from,
+        to,
+      });
 
-      return [...acc, current_trap_hits];
-    }, []);
-    const currentRelativeValues = data.reduce((acc, { current_relative_trap_hits }) => {
-      if (current_relative_trap_hits === null) {
-        return acc; // ignore
-      }
-
-      return [...acc, current_relative_trap_hits * 100];
-    }, []);
-
-    return {
-      currentMax: currentValues.length ? Math.max(...currentValues) : null,
-      currentRelativeMax: currentRelativeValues.length ? Math.max(...currentRelativeValues) : null,
-      max: absoluteValues.length ? Math.max(...absoluteValues) : null,
-      relativeMax: relativeValues.length ? Math.max(...relativeValues) : null
-    };
-  }
+      return {
+        ...rowOfData,
+        current_relative_trap_hits: _.last(filledHistory).relative_trap_hits,
+        history: filledHistory,
+        total_injections: history.reduce((total, { injections }) => total + injections, 0),
+        WoW: _.isNil(WoW) ? null : roundToPlaces(WoW * 100, 0),
+      };
+    }),
 );
+
+export const selectSpamHitsOverviewMetaData = createSelector(getSpamHitsData, ({ data }) => {
+  const absoluteValues = _.flatMap(data, ({ history }) =>
+    history.map(({ trap_hits }) => trap_hits),
+  );
+  const relativeValues = _.flatMap(data, ({ history }) =>
+    history.map(({ relative_trap_hits }) => relative_trap_hits * 100),
+  );
+  const currentValues = data.reduce((acc, { current_trap_hits }) => {
+    if (current_trap_hits === null) {
+      return acc; // ignore
+    }
+
+    return [...acc, current_trap_hits];
+  }, []);
+  const currentRelativeValues = data.reduce((acc, { current_relative_trap_hits }) => {
+    if (current_relative_trap_hits === null) {
+      return acc; // ignore
+    }
+
+    return [...acc, current_relative_trap_hits * 100];
+  }, []);
+
+  return {
+    currentMax: currentValues.length ? Math.max(...currentValues) : null,
+    currentRelativeMax: currentRelativeValues.length ? Math.max(...currentRelativeValues) : null,
+    max: absoluteValues.length ? Math.max(...absoluteValues) : null,
+    relativeMax: relativeValues.length ? Math.max(...relativeValues) : null,
+  };
+});
 
 export const selectSpamHitsOverview = createSelector(
   [getSpamHitsData, selectSpamHitsOverviewData, selectSpamHitsOverviewMetaData],
   (spamHitsData, data, metaData) => ({
     ...spamHitsData,
     data,
-    metaData
-  })
+    metaData,
+  }),
 );

--- a/src/selectors/tests/signals.test.js
+++ b/src/selectors/tests/signals.test.js
@@ -7,23 +7,23 @@ describe('Selectors: signals', () => {
     match: {
       params: {
         facet: 'sending_domain',
-        facetId: 'test.com'
-      }
+        facetId: 'test.com',
+      },
     },
     location: {
       state: {
-        date: '2018-02-01'
+        date: '2018-02-01',
       },
-      search: '?subaccount=101'
+      search: '?subaccount=101',
     },
-    now: moment('2018-01-03')
+    now: moment('2018-01-03'),
   };
 
   beforeEach(() => {
     state = {
       signalOptions: {
         to: '2018-01-04',
-        from: '2017-12-27'
+        from: '2017-12-27',
       },
       signals: {
         spamHits: {
@@ -42,7 +42,7 @@ describe('Selectors: signals', () => {
                   trap_hits: 456,
                   trap_hits_parked: 300,
                   trap_hits_recycled: 100,
-                  trap_hits_typo: 56
+                  trap_hits_typo: 56,
                 },
                 {
                   dt: '2018-01-03',
@@ -51,9 +51,9 @@ describe('Selectors: signals', () => {
                   trap_hits: 35,
                   trap_hits_parked: 20,
                   trap_hits_recycled: 15,
-                  trap_hits_typo: 0
-                }
-              ]
+                  trap_hits_typo: 0,
+                },
+              ],
             },
             {
               sending_domain: 'null.test.com',
@@ -68,7 +68,7 @@ describe('Selectors: signals', () => {
                   trap_hits: 856,
                   trap_hits_parked: 56,
                   trap_hits_recycled: 600,
-                  trap_hits_typo: 200
+                  trap_hits_typo: 200,
                 },
                 {
                   dt: '2018-01-02',
@@ -77,13 +77,13 @@ describe('Selectors: signals', () => {
                   trap_hits: 50,
                   trap_hits_parked: 30,
                   trap_hits_recycled: 15,
-                  trap_hits_typo: 5
-                }
-              ]
-            }
+                  trap_hits_typo: 5,
+                },
+              ],
+            },
           ],
           loading: false,
-          error: null
+          error: null,
         },
         engagementRecency: {
           totalCount: 1,
@@ -100,7 +100,7 @@ describe('Selectors: signals', () => {
                   c_uneng: 5,
                   c_14d: 5,
                   c_365d: 5,
-                  dt: '2018-01-01'
+                  dt: '2018-01-01',
                 },
                 {
                   c_total: 50,
@@ -108,13 +108,13 @@ describe('Selectors: signals', () => {
                   c_uneng: 10,
                   c_14d: 10,
                   c_365d: 10,
-                  dt: '2018-01-03'
-                }
-              ]
-            }
+                  dt: '2018-01-03',
+                },
+              ],
+            },
           ],
           loading: false,
-          error: null
+          error: null,
         },
         engagementRateByCohort: {
           totalCount: 1,
@@ -128,7 +128,7 @@ describe('Selectors: signals', () => {
                   p_uneng_eng: 5,
                   p_14d_eng: 5,
                   p_365d_eng: 5,
-                  dt: '2018-01-01'
+                  dt: '2018-01-01',
                 },
                 {
                   p_total_eng: 50,
@@ -136,13 +136,13 @@ describe('Selectors: signals', () => {
                   p_uneng_eng: 10,
                   p_14d_eng: 10,
                   p_365d_eng: 10,
-                  dt: '2018-01-03'
-                }
-              ]
-            }
+                  dt: '2018-01-03',
+                },
+              ],
+            },
           ],
           loading: false,
-          error: null
+          error: null,
         },
         unsubscribeRateByCohort: {
           totalCount: 1,
@@ -156,7 +156,7 @@ describe('Selectors: signals', () => {
                   p_uneng_unsub: 5,
                   p_14d_unsub: 5,
                   p_365d_unsub: 5,
-                  dt: '2018-01-01'
+                  dt: '2018-01-01',
                 },
                 {
                   p_total_unsub: 50,
@@ -164,13 +164,13 @@ describe('Selectors: signals', () => {
                   p_uneng_unsub: 10,
                   p_14d_unsub: 10,
                   p_365d_unsub: 10,
-                  dt: '2018-01-03'
-                }
-              ]
-            }
+                  dt: '2018-01-03',
+                },
+              ],
+            },
           ],
           loading: false,
-          error: null
+          error: null,
         },
         complaintsByCohort: {
           totalCount: 1,
@@ -179,26 +179,26 @@ describe('Selectors: signals', () => {
               sending_domain: 'test.com',
               history: [
                 {
-                  p_total_fbl: .25,
-                  p_new_fbl: .5,
-                  p_uneng_fbl: .5,
-                  p_14d_fbl: .5,
-                  p_365d_fbl: .5,
-                  dt: '2018-01-01'
+                  p_total_fbl: 0.25,
+                  p_new_fbl: 0.5,
+                  p_uneng_fbl: 0.5,
+                  p_14d_fbl: 0.5,
+                  p_365d_fbl: 0.5,
+                  dt: '2018-01-01',
                 },
                 {
-                  p_total_fbl: .5,
-                  p_new_fbl: .1,
-                  p_uneng_fbl: .1,
-                  p_14d_fbl: .1,
-                  p_365d_fbl: .1,
-                  dt: '2018-01-03'
-                }
-              ]
-            }
+                  p_total_fbl: 0.5,
+                  p_new_fbl: 0.1,
+                  p_uneng_fbl: 0.1,
+                  p_14d_fbl: 0.1,
+                  p_365d_fbl: 0.1,
+                  dt: '2018-01-03',
+                },
+              ],
+            },
           ],
           loading: false,
-          error: null
+          error: null,
         },
         healthScore: {
           totalCount: 1,
@@ -217,35 +217,35 @@ describe('Selectors: signals', () => {
                     {
                       weight_type: 'eng cohorts: new, 14-day',
                       weight: 0.5,
-                      weight_value: 0.5
+                      weight_value: 0.5,
                     },
                     {
                       weight_type: 'Transient Failures',
                       weight: 0.7,
-                      weight_value: 0.5
+                      weight_value: 0.5,
                     },
                     {
                       weight_type: 'Other bounces',
                       weight: -0.1,
-                      weight_value: 0.5
-                    }
-                  ]
+                      weight_value: 0.5,
+                    },
+                  ],
                 },
                 {
                   dt: '2018-01-02',
                   health_score: 0.8,
                   weights: [],
-                  total_injection_count: 12345
+                  total_injection_count: 12345,
                 },
                 {
                   dt: '2018-01-03',
                   health_score: 0.98, // good
                   weights: [],
-                  total_injection_count: 35000
-                }
-              ]
-            }
-          ]
+                  total_injection_count: 35000,
+                },
+              ],
+            },
+          ],
         },
         currentHealthScore: {
           totalCount: 1,
@@ -261,25 +261,52 @@ describe('Selectors: signals', () => {
                   dt: '2018-01-01',
                   health_score: 0.74321, // bad
                   total_injection_count: 100,
-                  weights: []
+                  weights: [],
                 },
                 {
                   dt: '2018-01-02',
                   health_score: 0.8,
                   total_injection_count: 100,
-                  weights: []
+                  weights: [],
                 },
                 {
                   dt: '2018-01-03',
                   health_score: 0.98, // good
                   weights: [],
-                  total_injection_count: 100
-                }
-              ]
-            }
-          ]
-        }
-      }
+                  total_injection_count: 100,
+                },
+              ],
+            },
+            {
+              sid: 101,
+              current_weights: [],
+              current_health_score: 0.8,
+              sending_domain: 'test.com',
+              WoW: -0.07,
+              history: [
+                {
+                  dt: '2018-01-01',
+                  health_score: 0.74321, // bad
+                  total_injection_count: 100,
+                  weights: [],
+                },
+                {
+                  dt: '2018-01-02',
+                  health_score: 0.8,
+                  total_injection_count: 100,
+                  weights: [],
+                },
+                {
+                  dt: '2018-01-03',
+                  health_score: 0.8,
+                  weights: [],
+                  total_injection_count: 100,
+                },
+              ],
+            },
+          ],
+        },
+      },
     };
   });
 
@@ -289,12 +316,12 @@ describe('Selectors: signals', () => {
     });
 
     it('should be empty with only fill data when not loading', () => {
-      const stateWhenEmpty = { ...state, signals: { spamHits: { data: [], loading: false }}};
+      const stateWhenEmpty = { ...state, signals: { spamHits: { data: [], loading: false } } };
       expect(selectors.selectSpamHitsDetails(stateWhenEmpty, props)).toMatchSnapshot();
     });
 
     it('should not be empty when loading', () => {
-      const stateWhenLoading = { ...state, signals: { spamHits: { data: [], loading: true }}};
+      const stateWhenLoading = { ...state, signals: { spamHits: { data: [], loading: true } } };
       expect(selectors.selectSpamHitsDetails(stateWhenLoading, props).details.empty).toBe(false);
     });
   });
@@ -305,13 +332,21 @@ describe('Selectors: signals', () => {
     });
 
     it('should be empty with only fill data when not loading', () => {
-      const stateWhenEmpty = { ...state, signals: { engagementRecency: { data: [], loading: false }}};
+      const stateWhenEmpty = {
+        ...state,
+        signals: { engagementRecency: { data: [], loading: false } },
+      };
       expect(selectors.selectEngagementRecencyDetails(stateWhenEmpty, props)).toMatchSnapshot();
     });
 
     it('should not be empty when loading', () => {
-      const stateWhenLoading = { ...state, signals: { engagementRecency: { data: [], loading: true }}};
-      expect(selectors.selectEngagementRecencyDetails(stateWhenLoading, props).details.empty).toBe(false);
+      const stateWhenLoading = {
+        ...state,
+        signals: { engagementRecency: { data: [], loading: true } },
+      };
+      expect(selectors.selectEngagementRecencyDetails(stateWhenLoading, props).details.empty).toBe(
+        false,
+      );
     });
   });
 
@@ -325,10 +360,12 @@ describe('Selectors: signals', () => {
         ...state,
         signals: {
           engagementRateByCohort: { data: [], loading: false },
-          engagementRecency: { data: [], loading: false }
-        }
+          engagementRecency: { data: [], loading: false },
+        },
       };
-      expect(selectors.selectEngagementRateByCohortDetails(stateWhenEmpty, props).details.empty).toBe(true);
+      expect(
+        selectors.selectEngagementRateByCohortDetails(stateWhenEmpty, props).details.empty,
+      ).toBe(true);
     });
 
     it('should not be empty when loading', () => {
@@ -336,10 +373,12 @@ describe('Selectors: signals', () => {
         ...state,
         signals: {
           engagementRateByCohort: { data: [], loading: true },
-          engagementRecency: { data: [], loading: true }
-        }
+          engagementRecency: { data: [], loading: true },
+        },
       };
-      expect(selectors.selectEngagementRateByCohortDetails(stateWhenLoading, props).details.empty).toBe(false);
+      expect(
+        selectors.selectEngagementRateByCohortDetails(stateWhenLoading, props).details.empty,
+      ).toBe(false);
     });
 
     it('should cutoff to date if to is within 3 days of today', () => {
@@ -360,9 +399,12 @@ describe('Selectors: signals', () => {
         ...state,
         signals: {
           unsubscribeRateByCohort: { data: [], loading: false },
-          engagementRecency: { data: [], loading: false }
-        }};
-      expect(selectors.selectUnsubscribeRateByCohortDetails(stateWhenEmpty, props).details.empty).toBe(true);
+          engagementRecency: { data: [], loading: false },
+        },
+      };
+      expect(
+        selectors.selectUnsubscribeRateByCohortDetails(stateWhenEmpty, props).details.empty,
+      ).toBe(true);
     });
 
     it('should not be empty when loading', () => {
@@ -370,9 +412,12 @@ describe('Selectors: signals', () => {
         ...state,
         signals: {
           unsubscribeRateByCohort: { data: [], loading: true },
-          engagementRecency: { data: [], loading: true }
-        }};
-      expect(selectors.selectUnsubscribeRateByCohortDetails(stateWhenLoading, props).details.empty).toBe(false);
+          engagementRecency: { data: [], loading: true },
+        },
+      };
+      expect(
+        selectors.selectUnsubscribeRateByCohortDetails(stateWhenLoading, props).details.empty,
+      ).toBe(false);
     });
 
     it('should cutoff to date if to is within 3 days of today', () => {
@@ -393,10 +438,12 @@ describe('Selectors: signals', () => {
         ...state,
         signals: {
           complaintsByCohort: { data: [], loading: false },
-          engagementRecency: { data: [], loading: false }
-        }
+          engagementRecency: { data: [], loading: false },
+        },
       };
-      expect(selectors.selectComplaintsByCohortDetails(stateWhenEmpty, props).details.empty).toBe(true);
+      expect(selectors.selectComplaintsByCohortDetails(stateWhenEmpty, props).details.empty).toBe(
+        true,
+      );
     });
 
     it('should not be empty when loading', () => {
@@ -404,10 +451,12 @@ describe('Selectors: signals', () => {
         ...state,
         signals: {
           complaintsByCohort: { data: [], loading: true },
-          engagementRecency: { data: [], loading: true }
-        }
+          engagementRecency: { data: [], loading: true },
+        },
       };
-      expect(selectors.selectComplaintsByCohortDetails(stateWhenLoading, props).details.empty).toBe(false);
+      expect(selectors.selectComplaintsByCohortDetails(stateWhenLoading, props).details.empty).toBe(
+        false,
+      );
     });
 
     it('should cutoff to date if to is within 3 days of today', () => {
@@ -424,12 +473,18 @@ describe('Selectors: signals', () => {
     });
 
     it('should be empty with only fill data when not loading', () => {
-      const stateWhenEmpty = { ...state, signals: { healthScore: { data: [], loading: false }, spamHits: { data: []}}};
+      const stateWhenEmpty = {
+        ...state,
+        signals: { healthScore: { data: [], loading: false }, spamHits: { data: [] } },
+      };
       expect(selectors.selectHealthScoreDetails(stateWhenEmpty, props)).toMatchSnapshot();
     });
 
     it('should not be empty when loading', () => {
-      const stateWhenLoading = { ...state, signals: { healthScore: { data: [], loading: true }, spamHits: { data: []}}};
+      const stateWhenLoading = {
+        ...state,
+        signals: { healthScore: { data: [], loading: true }, spamHits: { data: [] } },
+      };
       expect(selectors.selectHealthScoreDetails(stateWhenLoading, props).details.empty).toBe(false);
     });
   });
@@ -440,13 +495,21 @@ describe('Selectors: signals', () => {
     });
 
     it('should be empty with only fill data when not loading', () => {
-      const stateWhenEmpty = { ...state, signals: { healthScore: { data: [], loading: false }, spamHits: { data: []}}};
+      const stateWhenEmpty = {
+        ...state,
+        signals: { healthScore: { data: [], loading: false }, spamHits: { data: [] } },
+      };
       expect(selectors.selectHealthScoreDetailsV3(stateWhenEmpty, props)).toMatchSnapshot();
     });
 
     it('should not be empty when loading', () => {
-      const stateWhenLoading = { ...state, signals: { healthScore: { data: [], loading: true }, spamHits: { data: []}}};
-      expect(selectors.selectHealthScoreDetailsV3(stateWhenLoading, props).details.empty).toBe(false);
+      const stateWhenLoading = {
+        ...state,
+        signals: { healthScore: { data: [], loading: true }, spamHits: { data: [] } },
+      };
+      expect(selectors.selectHealthScoreDetailsV3(stateWhenLoading, props).details.empty).toBe(
+        false,
+      );
     });
   });
 
@@ -462,7 +525,7 @@ describe('Selectors: signals', () => {
     });
 
     it('returns empty array', () => {
-      const stateWhenEmpty = { ...state, signals: { engagementRecency: { data: []}}};
+      const stateWhenEmpty = { ...state, signals: { engagementRecency: { data: [] } } };
       expect(selectors.selectEngagementRecencyOverviewData(stateWhenEmpty, props)).toEqual([]);
     });
   });
@@ -473,17 +536,17 @@ describe('Selectors: signals', () => {
         currentMax: 10,
         currentRelativeMax: 20,
         max: 10,
-        relativeMax: 20
+        relativeMax: 20,
       });
     });
 
     it('returns null', () => {
-      const stateWhenEmpty = { signals: { engagementRecency: { data: []}}};
+      const stateWhenEmpty = { signals: { engagementRecency: { data: [] } } };
       expect(selectors.selectEngagementRecencyOverviewMetaData(stateWhenEmpty, props)).toEqual({
         currentMax: null,
         currentRelativeMax: null,
         max: null,
-        relativeMax: null
+        relativeMax: null,
       });
     });
   });
@@ -500,7 +563,7 @@ describe('Selectors: signals', () => {
     });
 
     it('returns empty array', () => {
-      const stateWhenEmpty = { ...state, signals: { spamHits: { data: []}}};
+      const stateWhenEmpty = { ...state, signals: { spamHits: { data: [] } } };
       expect(selectors.selectSpamHitsOverviewData(stateWhenEmpty, props)).toEqual([]);
     });
   });
@@ -511,17 +574,17 @@ describe('Selectors: signals', () => {
         currentMax: 35,
         currentRelativeMax: 0.1,
         max: 856,
-        relativeMax: 0.3
+        relativeMax: 0.3,
       });
     });
 
     it('returns null', () => {
-      const stateWhenEmpty = { ...state, signals: { spamHits: { data: []}}};
+      const stateWhenEmpty = { ...state, signals: { spamHits: { data: [] } } };
       expect(selectors.selectSpamHitsOverviewMetaData(stateWhenEmpty, props)).toEqual({
         currentMax: null,
         currentRelativeMax: null,
         max: null,
-        relativeMax: null
+        relativeMax: null,
       });
     });
   });
@@ -538,7 +601,7 @@ describe('Selectors: signals', () => {
     });
 
     it('returns empty array', () => {
-      const stateWhenEmpty = { ...state, signals: { healthScore: { data: []}}};
+      const stateWhenEmpty = { ...state, signals: { healthScore: { data: [] } } };
       expect(selectors.selectHealthScoreOverviewData(stateWhenEmpty, props)).toEqual([]);
     });
   });
@@ -552,6 +615,16 @@ describe('Selectors: signals', () => {
   describe('selectCurrentHealthScoreDashboard', () => {
     it('returns data', () => {
       expect(selectors.selectCurrentHealthScoreDashboard(state, props)).toMatchSnapshot();
+    });
+
+    it('returns data for subaccount reporting users', () => {
+      const stateWithSubReportingUser = {
+        ...state,
+        currentUser: { access_level: 'subaccount_reporting', subaccount_id: 101 },
+      };
+      expect(selectors.selectCurrentHealthScoreDashboard(stateWithSubReportingUser, props)).toEqual(
+        expect.objectContaining({ sid: 101, current_health_score: 80 }),
+      );
     });
   });
 });


### PR DESCRIPTION
### What Changed
 -Selects the correct health score data for subaccount reporting user.

### How To Test
 - Create suabccount Reporting user in an account w/ signals data
 - Go to `/signals/health-score`. Verify that the health score dashboard contains data calculated for that subaccount only.
