### PR TITLE
AC-1212: Added type query param to bundles endpoint

### DIFF
--- a/cypress/tests/integration/accounts/change-billingplan-page.spec.js
+++ b/cypress/tests/integration/accounts/change-billingplan-page.spec.js
@@ -12,7 +12,7 @@ describe('Billing Page', () => {
     });
 
     cy.stubRequest({
-      url: '/api/v1/billing/bundles',
+      url: '/api/v1/billing/bundles**',
       fixture: 'billing/bundles/200.get.json',
       fixtureAlias: 'bundlesGet',
     });

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -216,12 +216,13 @@ export function getBillingCountries() {
   });
 }
 
-export function getBundles() {
+export function getBundles({ ...params }) {
   return sparkpostApiRequest({
     type: 'GET_BUNDLES',
     meta: {
       method: 'GET',
       url: '/v1/billing/bundles',
+      params,
     },
   });
 }

--- a/src/pages/billing/context/ChangePlanContext.js
+++ b/src/pages/billing/context/ChangePlanContext.js
@@ -27,7 +27,7 @@ export const ChangePlanProvider = ({
     getBillingInfo();
   }, [getBillingInfo]);
   useEffect(() => {
-    getBundles();
+    getBundles({ type: 'messaging' });
   }, [getBundles]);
   useEffect(() => {
     getPlans();


### PR DESCRIPTION
### What Changed
 - Billing page hits the billing endpoint with query param for type=messaging

### How To Test
 - Go to `/account/billing/plan/`
 - Check that network request is made for `/billing/bundles?type=messaging`