### PR TITLE
SA-1203 Dynamically change stop monitoring modal text based on resource

### DIFF
--- a/src/pages/blacklist/components/StopMonitoringModal.js
+++ b/src/pages/blacklist/components/StopMonitoringModal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Modal, Panel } from '@sparkpost/matchbox';
 import { connect } from 'react-redux';
-
+import { domainRegex } from 'src/helpers/regex';
 import { Loading } from 'src/components';
 import styles from './StopMonitoringModal.module.scss';
 import { deleteMonitor } from 'src/actions/blacklist';
@@ -24,11 +24,16 @@ export const StopMonitoringModal = ({
     });
   };
   const renderContent = () => {
+    if (!monitorToDelete) {
+      return null;
+    }
     return (
       <>
         <p>
-          Removing this IP from your watchlist means you won't get notified of changes, but don't
-          worry you can always add it again later.
+          {`Removing this ${
+            monitorToDelete.match(domainRegex) ? 'domain' : 'IP'
+          } from your watchlist means you won't get notified of changes, but don't
+          worry you can always add it again later.`}
         </p>
         <Button className={styles.Confirm} disabled={isPending} onClick={confirmAction} primary>
           Stop Monitoring

--- a/src/pages/blacklist/components/tests/StopMonitoringModal.test.js
+++ b/src/pages/blacklist/components/tests/StopMonitoringModal.test.js
@@ -14,13 +14,25 @@ describe('Stop Monitoring Modal', () => {
     return render(<StopMonitoringModal {...defaults} {...props} />);
   };
 
-  it('renders the modal correctly', () => {
-    const { queryByText } = subject();
+  it('renders the modal correctly for an ip address', () => {
+    const { queryByText } = subject({ monitorToDelete: '1.2.3.4' });
 
-    expect(queryByText('Stop Monitoring sparkpost.io')).toBeInTheDocument();
+    expect(queryByText('Stop Monitoring 1.2.3.4')).toBeInTheDocument();
     expect(
       queryByText(
         "Removing this IP from your watchlist means you won't get notified of changes, but don't worry you can always add it again later.",
+      ),
+    ).toBeInTheDocument();
+    expect(queryByText('Stop Monitoring')).toBeInTheDocument();
+  });
+
+  it('renders the modal correctly for a sending domain', () => {
+    const { queryByText } = subject({ monitorToDelete: 'test.com' });
+
+    expect(queryByText('Stop Monitoring test.com')).toBeInTheDocument();
+    expect(
+      queryByText(
+        "Removing this domain from your watchlist means you won't get notified of changes, but don't worry you can always add it again later.",
       ),
     ).toBeInTheDocument();
     expect(queryByText('Stop Monitoring')).toBeInTheDocument();


### PR DESCRIPTION
### What Changed
 - When clicking "Stop Monitoring" on a resource, the modal text will dynamically change based on if it is a sending domain or IP address.

### How To Test
 - Click "Stop Monitoring" on a sending domain, check text is correct
 - Click "Stop Monitoring" on an IP address, check text is correct
