### PR TITLE
AC-1196: "Validate" button on RV list & single views subscribes to RV bundle

### DIFF
--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -1,9 +1,13 @@
 import chainActions from 'src/actions/helpers/chainActions';
-import billingCreate from './billingCreate';
 import { addProductToSubscription } from './billing';
+import billingCreate from './billingCreate';
 import billingUpdate from './billingUpdate';
 
-export default function addRVtoSubscription(values, updateCreditCard = false, isRVonSubscription) {
+export default function addRVtoSubscription(
+  values,
+  updateCreditCard = false,
+  isRVonSubscription = false,
+) {
   return (dispatch, getState) => {
     const state = getState();
 

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -23,18 +23,14 @@ export default function addRVtoSubscription(values, updateCreditCard = false, is
     };
 
     if (!state.account.billing) {
-      console.log('no billing!');
       return dispatch(chainActions(createAccountInZuora, addRV)());
     }
 
     if (updateCreditCard && !isRVonSubscription) {
-      console.log('updateCC & add RV');
-      // return dispatch(chainActions(updateCC, addRV));
-      return dispatch(chainActions(updateCC)());
+      return dispatch(chainActions(updateCC, addRV)());
     }
 
     if (updateCreditCard && isRVonSubscription) {
-      console.log('updateCC & DONT add RV');
       return dispatch(chainActions(updateCC)());
     }
 

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -32,7 +32,7 @@ export default function addRVtoSubscription({
     }
 
     if (updateCreditCard && isRVonSubscription) {
-      return dispatch(chainActions(updateCC)());
+      return dispatch(billingUpdate(values));
     }
 
     return dispatch(updateSubscription(rvProduct));

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -15,9 +15,6 @@ export default function addRVtoSubscription({
       bundle: 'rv-0519',
     };
 
-    const addRV = () => {
-      return updateSubscription(rvProduct);
-    };
     const createAccountInZuora = () => {
       return billingCreate(values);
     };
@@ -27,11 +24,11 @@ export default function addRVtoSubscription({
     };
 
     if (!state.account.billing) {
-      return dispatch(chainActions(createAccountInZuora, addRV)());
+      return dispatch(chainActions(createAccountInZuora, updateSubscription(rvProduct))());
     }
 
     if (updateCreditCard && !isRVonSubscription) {
-      return dispatch(chainActions(updateCC, addRV)());
+      return dispatch(chainActions(updateCC, updateSubscription(rvProduct))());
     }
 
     if (updateCreditCard && isRVonSubscription) {

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -1,8 +1,9 @@
 import chainActions from 'src/actions/helpers/chainActions';
 import billingCreate from './billingCreate';
 import { addProductToSubscription } from './billing';
+import billingUpdate from './billingUpdate';
 
-export default function addRVtoSubscription(values) {
+export default function addRVtoSubscription(values, updateCreditCard = false, isRVonSubscription) {
   return (dispatch, getState) => {
     const state = getState();
 
@@ -17,8 +18,24 @@ export default function addRVtoSubscription(values) {
       return billingCreate(values);
     };
 
+    const updateCC = () => {
+      return billingUpdate(values);
+    };
+
     if (!state.account.billing) {
+      console.log('no billing!');
       return dispatch(chainActions(createAccountInZuora, addRV)());
+    }
+
+    if (updateCreditCard && !isRVonSubscription) {
+      console.log('updateCC & add RV');
+      // return dispatch(chainActions(updateCC, addRV));
+      return dispatch(chainActions(updateCC)());
+    }
+
+    if (updateCreditCard && isRVonSubscription) {
+      console.log('updateCC & DONT add RV');
+      return dispatch(chainActions(updateCC)());
     }
 
     return dispatch(addProductToSubscription(rvProduct));

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -6,9 +6,21 @@ export default function addRVtoSubscription(values) {
   return (dispatch, getState) => {
     const state = getState();
 
-    const rvProduct = { product: 'recipient_validation', plan: state.subscription.code };
-    if (state.account.billing) {
-      return dispatch(chainActions([billingCreate(values), addProductToSubscription(rvProduct)])());
+    const rvProduct = {
+      bundle: 'rv-0519',
+    };
+
+    const addRV = () => {
+      return addProductToSubscription(rvProduct);
+    };
+    const createAccountInZuora = () => {
+      return billingCreate(values);
+    };
+
+    if (!state.account.billing) {
+      return dispatch(chainActions(createAccountInZuora, addRV)());
     }
+
+    return dispatch(addProductToSubscription(rvProduct));
   };
 }

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -1,0 +1,14 @@
+import chainActions from 'src/actions/helpers/chainActions';
+import billingCreate from './billingCreate';
+import { addProductToSubscription } from './billing';
+
+export default function addRVtoSubscription(values) {
+  return (dispatch, getState) => {
+    const state = getState();
+
+    const rvProduct = { product: 'recipient_validation', plan: state.subscription.code };
+    if (state.account.billing) {
+      return dispatch(chainActions([billingCreate(values), addProductToSubscription(rvProduct)])());
+    }
+  };
+}

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -3,11 +3,11 @@ import { updateSubscription } from './billing';
 import billingCreate from './billingCreate';
 import billingUpdate from './billingUpdate';
 
-export default function addRVtoSubscription(
+export default function addRVtoSubscription({
   values,
   updateCreditCard = false,
   isRVonSubscription = false,
-) {
+}) {
   return (dispatch, getState) => {
     const state = getState();
 

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -1,5 +1,5 @@
 import chainActions from 'src/actions/helpers/chainActions';
-import { addProductToSubscription } from './billing';
+import { updateSubscription } from './billing';
 import billingCreate from './billingCreate';
 import billingUpdate from './billingUpdate';
 
@@ -16,7 +16,7 @@ export default function addRVtoSubscription(
     };
 
     const addRV = () => {
-      return addProductToSubscription(rvProduct);
+      return updateSubscription(rvProduct);
     };
     const createAccountInZuora = () => {
       return billingCreate(values);
@@ -38,6 +38,6 @@ export default function addRVtoSubscription(
       return dispatch(chainActions(updateCC)());
     }
 
-    return dispatch(addProductToSubscription(rvProduct));
+    return dispatch(updateSubscription(rvProduct));
   };
 }

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -258,8 +258,8 @@ export function addProductToSubscription(data) {
   return sparkpostApiRequest({
     type: 'ADD_PRODUCT_TO_SUBSCRIPTION',
     meta: {
-      method: 'POST',
-      url: '/v1/billing/subscription/control/product',
+      method: 'PUT',
+      url: '/v1/billing/subscription/bundle',
       data,
     },
   });

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -253,14 +253,3 @@ export function updateBillingSubscription(data) {
     },
   });
 }
-
-export function addProductToSubscription(data) {
-  return sparkpostApiRequest({
-    type: 'ADD_PRODUCT_TO_SUBSCRIPTION',
-    meta: {
-      method: 'PUT',
-      url: '/v1/billing/subscription/bundle',
-      data,
-    },
-  });
-}

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -253,3 +253,14 @@ export function updateBillingSubscription(data) {
     },
   });
 }
+
+export function addProductToSubscription(data) {
+  return sparkpostApiRequest({
+    type: 'ADD_PRODUCT_TO_SUBSCRIPTION',
+    meta: {
+      method: 'POST',
+      url: '/v1/billing/subscription/control/product',
+      data,
+    },
+  });
+}

--- a/src/actions/tests/addRVtoSubscription.test.js
+++ b/src/actions/tests/addRVtoSubscription.test.js
@@ -1,0 +1,75 @@
+import addRVtoSubscription from '../addRVtoSubscription';
+import * as billingActions from 'src/actions/billing';
+import billingUpdate from 'src/actions/billingUpdate';
+import billingCreate from 'src/actions/billingCreate';
+
+jest.mock('src/actions/billing');
+jest.mock('src/actions/billingUpdate');
+jest.mock('src/actions/billingCreate');
+
+describe('Action Creator: Add RV to subcription', () => {
+  let dispatch, getState, account;
+
+  beforeEach(() => {
+    dispatch = jest.fn(a => a);
+    billingActions.updateSubscription = jest.fn();
+  });
+
+  it('create zuora account and add rv bundle to subscription', () => {
+    const props = { values: {}, updateCreditCard: false, isRVonSubscription: false };
+    const thunk = addRVtoSubscription(props);
+    account = {};
+    getState = () => ({ account });
+
+    thunk(dispatch, getState);
+
+    expect(billingCreate).toHaveBeenCalledWith(props.values);
+    expect(billingActions.updateSubscription).toHaveBeenCalledWith({
+      bundle: 'rv-0519',
+    });
+  });
+
+  it('update credit card and add RV to subscription', () => {
+    const props = { values: {}, updateCreditCard: true, isRVonSubscription: false };
+    const thunk = addRVtoSubscription(props);
+    account = { billing: {} };
+    getState = () => ({ account });
+
+    thunk(dispatch, getState);
+
+    expect(billingUpdate).toHaveBeenCalledWith(props.values);
+    expect(billingActions.updateSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bundle: 'rv-0519',
+      }),
+    );
+  });
+
+  it('update credit card only when RV is on subscription', () => {
+    const props = { values: {}, updateCreditCard: true, isRVonSubscription: true };
+    const thunk = addRVtoSubscription(props);
+    account = { billing: {} };
+    getState = () => ({ account });
+
+    thunk(dispatch, getState);
+
+    expect(billingUpdate).toHaveBeenCalledWith(props.values);
+    expect(billingActions.updateSubscription).not.toHaveBeenCalled();
+  });
+
+  it('update only RV on subscription when using saved Credit Card', () => {
+    const props = { values: {}, updateCreditCard: false, isRVonSubscription: false };
+    const thunk = addRVtoSubscription(props);
+    account = { billing: {} };
+    getState = () => ({ account });
+
+    thunk(dispatch, getState);
+
+    expect(billingActions.updateSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bundle: 'rv-0519',
+      }),
+    );
+    expect(billingUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/billing/CreditCardSection.js
+++ b/src/components/billing/CreditCardSection.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Panel } from '@sparkpost/matchbox';
 import { PaymentForm } from './PaymentForm';
 import BillingAddressForm from './BillingAddressForm';
@@ -21,6 +21,10 @@ function CreditCardSection({
     : null;
 
   const [useAnotherCC, setUseAnotherCC] = useState(Boolean(defaultToggleState));
+
+  useEffect(() => {
+    setUseAnotherCC(defaultToggleState);
+  }, [defaultToggleState]);
 
   if (!credit_card || useAnotherCC)
     return (

--- a/src/components/billing/CreditCardSection.js
+++ b/src/components/billing/CreditCardSection.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Panel } from '@sparkpost/matchbox';
 import { PaymentForm } from './PaymentForm';
 import BillingAddressForm from './BillingAddressForm';
@@ -13,20 +13,13 @@ function CreditCardSection({
   defaultToggleState = false,
 }) {
   const handleUseAnotherCC = () => {
-    setUseAnotherCC(!useAnotherCC);
-    handleCardToggle(!useAnotherCC);
+    handleCardToggle(!Boolean(defaultToggleState));
   };
   const savedPaymentAction = credit_card
     ? [{ content: 'Use Saved Payment Method', onClick: handleUseAnotherCC, color: 'orange' }]
     : null;
 
-  const [useAnotherCC, setUseAnotherCC] = useState(Boolean(defaultToggleState));
-
-  useEffect(() => {
-    setUseAnotherCC(defaultToggleState);
-  }, [defaultToggleState]);
-
-  if (!credit_card || useAnotherCC)
+  if (!credit_card || Boolean(defaultToggleState))
     return (
       <Panel title="Add a Credit Card" actions={savedPaymentAction}>
         <Panel.Section>

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -724,7 +724,7 @@ const routes = [
   {
     path: '/recipient-validation/single/:email',
     component: SingleResultPage,
-    condition: hasGrants('recipient-validation/preview'),
+    condition: hasGrants('recipient-validation/preview'), //recipient-validation/manage grant needs to be added here before standalone rv goes out
     layout: App,
     title: 'Results | Recipient Validation',
     supportDocsSearch: 'Recipient Validation',

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -732,7 +732,7 @@ const routes = [
     supportDocsSearch: 'Recipient Validation',
   },
   {
-    path: '/recipient-validation/list/:listId',
+    path: '/recipient-validation-srv/list/:listId',
     component: UploadedListPageSRV,
     condition: all(
       hasGrants('recipient-validation/preview'),
@@ -751,7 +751,7 @@ const routes = [
     supportDocsSearch: 'Recipient Validation',
   },
   {
-    path: '/recipient-validation/:category',
+    path: '/recipient-validation-srv/:category',
     component: RecipientValidationPageSRV,
     condition: all(
       hasGrants('recipient-validation/preview'),

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -33,6 +33,8 @@ import {
   trackingDomains,
   users,
   webhooks,
+  RecipientValidationPageSRV,
+  UploadedListPageSRV,
 } from 'src/pages';
 
 import LogoutPage from 'src/pages/logout/LogoutPage';
@@ -731,10 +733,32 @@ const routes = [
   },
   {
     path: '/recipient-validation/list/:listId',
+    component: UploadedListPageSRV,
+    condition: all(
+      hasGrants('recipient-validation/preview'),
+      isAccountUiOptionSet('standalone_rv'),
+    ), // must manual keep in sync with nav item
+    layout: App,
+    title: 'Validation Status | List | Recipient Validation',
+    supportDocsSearch: 'Recipient Validation',
+  },
+  {
+    path: '/recipient-validation/list/:listId',
     component: UploadedListPage,
     condition: hasGrants('recipient-validation/preview'),
     layout: App,
     title: 'Validation Status | List | Recipient Validation',
+    supportDocsSearch: 'Recipient Validation',
+  },
+  {
+    path: '/recipient-validation/:category',
+    component: RecipientValidationPageSRV,
+    condition: all(
+      hasGrants('recipient-validation/preview'),
+      isAccountUiOptionSet('standalone_rv'),
+    ), // must manual keep in sync with nav item
+    layout: App,
+    title: 'Recipient Validation',
     supportDocsSearch: 'Recipient Validation',
   },
   {

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -33,8 +33,6 @@ import {
   trackingDomains,
   users,
   webhooks,
-  RecipientValidationPageSRV,
-  UploadedListPageSRV,
 } from 'src/pages';
 
 import LogoutPage from 'src/pages/logout/LogoutPage';
@@ -732,33 +730,11 @@ const routes = [
     supportDocsSearch: 'Recipient Validation',
   },
   {
-    path: '/recipient-validation-srv/list/:listId',
-    component: UploadedListPageSRV,
-    condition: all(
-      hasGrants('recipient-validation/preview'),
-      isAccountUiOptionSet('standalone_rv'),
-    ), // must manual keep in sync with nav item
-    layout: App,
-    title: 'Validation Status | List | Recipient Validation',
-    supportDocsSearch: 'Recipient Validation',
-  },
-  {
     path: '/recipient-validation/list/:listId',
     component: UploadedListPage,
     condition: hasGrants('recipient-validation/preview'),
     layout: App,
     title: 'Validation Status | List | Recipient Validation',
-    supportDocsSearch: 'Recipient Validation',
-  },
-  {
-    path: '/recipient-validation-srv/:category',
-    component: RecipientValidationPageSRV,
-    condition: all(
-      hasGrants('recipient-validation/preview'),
-      isAccountUiOptionSet('standalone_rv'),
-    ), // must manual keep in sync with nav item
-    layout: App,
-    title: 'Recipient Validation',
     supportDocsSearch: 'Recipient Validation',
   },
   {

--- a/src/helpers/billing.js
+++ b/src/helpers/billing.js
@@ -189,6 +189,6 @@ export function stripImmediatePlanChange(search) {
   return qs.stringify(options);
 }
 
-export function isProductionOnSubscription(state, productName = 'recipient_validation') {
+export function isProductOnSubscription(state, productName = 'recipient_validation') {
   return _.find(_.get(state, 'billing.subscription.products') || {}, { product: productName });
 }

--- a/src/helpers/billing.js
+++ b/src/helpers/billing.js
@@ -189,6 +189,6 @@ export function stripImmediatePlanChange(search) {
   return qs.stringify(options);
 }
 
-export function isProductOnSubscription(state, productName = 'recipient_validation') {
+export const isProductOnSubscription = (productName = 'recipient_validation') => state => {
   return _.find(_.get(state, 'billing.subscription.products') || {}, { product: productName });
-}
+};

--- a/src/helpers/billing.js
+++ b/src/helpers/billing.js
@@ -188,3 +188,7 @@ export function stripImmediatePlanChange(search) {
   const { immediatePlanChange: _immediatePlanChange, ...options } = qs.parse(search);
   return qs.stringify(options);
 }
+
+export function isProductionOnSubscription(state, productName = 'recipient_validation') {
+  return _.find(_.get(state, 'billing.subscription.products') || {}, { product: productName });
+}

--- a/src/helpers/billing.js
+++ b/src/helpers/billing.js
@@ -5,7 +5,7 @@ import Payment from 'payment';
 import qs from 'query-string';
 
 export function formatDataForCors(values) {
-  const { email, planpicker, card, billingAddress, discountId, billingId } = values;
+  const { email, planpicker = {}, card, billingAddress, discountId, billingId } = values;
 
   // For CORS Endpoint + sift
   const corsData = {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,14 +31,8 @@ export { default as DefaultRedirect } from './defaultRedirect/DefaultRedirect';
 export { default as SmtpPage } from './smtp/SmtpPage';
 export { default as passwordReset } from './passwordReset';
 export { default as PremiumSupportPage } from './support/PremiumSupportPage';
-export {
-  default as RecipientValidationPage,
-  RecipientValidationPageSRV,
-} from './recipientValidation/RecipientValidationPage';
+export { default as RecipientValidationPage } from './recipientValidation/RecipientValidationPage.container';
 export { default as SingleResultPage } from './recipientValidation/SingleResult';
-export {
-  default as UploadedListPage,
-  UploadedListPageSRV,
-} from './recipientValidation/UploadedListPage';
+export { default as UploadedListPage } from './recipientValidation/UploadedListPage.container';
 export { default as snippets } from './snippets';
 export { default as inboxPlacement } from './inboxPlacement';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,8 +31,14 @@ export { default as DefaultRedirect } from './defaultRedirect/DefaultRedirect';
 export { default as SmtpPage } from './smtp/SmtpPage';
 export { default as passwordReset } from './passwordReset';
 export { default as PremiumSupportPage } from './support/PremiumSupportPage';
-export { default as RecipientValidationPage } from './recipientValidation/RecipientValidationPage';
+export {
+  default as RecipientValidationPage,
+  RecipientValidationPageSRV,
+} from './recipientValidation/RecipientValidationPage';
 export { default as SingleResultPage } from './recipientValidation/SingleResult';
-export { default as UploadedListPage } from './recipientValidation/UploadedListPage';
+export {
+  default as UploadedListPage,
+  UploadedListPageSRV,
+} from './recipientValidation/UploadedListPage';
 export { default as snippets } from './snippets';
 export { default as inboxPlacement } from './inboxPlacement';

--- a/src/pages/recipientValidation/RecipientValidationPage.container.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.container.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import RecipientValidationPage, { RecipientValidationPageSRV } from './RecipientValidationPage';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+
+const RVPageContainer = props =>
+  props.isStandAloneRVSet ? (
+    <RecipientValidationPageSRV {...props} />
+  ) : (
+    <RecipientValidationPage {...props} />
+  );
+
+const mapStateToProps = state => {
+  return {
+    isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
+  };
+};
+
+export default connect(mapStateToProps, null)(RVPageContainer);

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -15,6 +15,10 @@ import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import styles from './RecipientValidationPage.module.scss';
 import ValidateSection from './components/ValidateSection';
 import { getBillingInfo } from 'src/actions/account';
+import { reduxForm } from 'redux-form';
+import { FORMS } from 'src/constants';
+
+const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
 
 const tabs = [
   { content: <span className={styles.TabPadding}>List</span>, key: 'list' },
@@ -162,7 +166,13 @@ export class RecipientValidationPage extends Component {
         </Case>
       </ConditionSwitch>
     ) : (
-      this.renderRecipientValidation()
+      <form
+        onSubmit={() => {
+          console.log('submitted');
+        }}
+      >
+        {this.renderRecipientValidation()}
+      </form>
     );
   }
 }
@@ -174,4 +184,9 @@ const mapStateToProps = (state, props) => ({
   billingLoading: state.account.billingLoading,
 });
 
-export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));
+// export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));
+
+const formOptions = { form: FORMNAME, enableReinitialize: true };
+export default withRouter(
+  connect(mapStateToProps, { getBillingInfo })(reduxForm(formOptions)(RecipientValidationPage)),
+);

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -109,11 +109,11 @@ export class RecipientValidationPage extends Component {
           ? (_.find(plans, { code: subscription.code }) || {}).billingId
           : (_.find(plans, { product: 'recipient_validation' }) || {}).billingId,
       };
-      let action = this.props.addRVtoSubscription(
-        newValues,
-        !this.state.useSavedCC,
-        isRVonSubscription,
-      );
+      let action = this.props.addRVtoSubscription({
+        values: newValues,
+        updateCreditCard: !this.state.useSavedCC,
+        isRVonSubscription: isRVonSubscription,
+      });
       return action.then(() => this.validate(values));
     }
   };

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -17,7 +17,7 @@ import ValidateSection from './components/ValidateSection';
 import { getBillingInfo } from 'src/actions/account';
 import { reduxForm } from 'redux-form';
 import { FORMS } from 'src/constants';
-import { isProductionOnSubscription } from 'src/helpers/billing';
+import { isProductOnSubscription } from 'src/helpers/billing';
 import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
 import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
@@ -246,7 +246,7 @@ const mapStateToProps = (state, props) => ({
   account: state.account,
   billing: state.account.billing || {},
   billingLoading: state.account.billingLoading,
-  isRVonSubscription: isProductionOnSubscription(state, 'recipient_validation'),
+  isRVonSubscription: isProductOnSubscription(state, 'recipient_validation'),
   initialValues: rvAddPaymentFormInitialValues(state),
 });
 

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -46,13 +46,8 @@ export class RecipientValidationPage extends Component {
       this.setState({ useSavedCC: Boolean(this.props.billing.credit_card) });
   }
   handleTabs(tabIdx) {
-    const { history, isStandAloneRVSet } = this.props;
-
-    if (!isStandAloneRVSet) {
-      history.replace(`/recipient-validation/${tabs[tabIdx].key}`);
-    } else {
-      history.replace(`/recipient-validation-srv/${tabs[tabIdx].key}`);
-    }
+    const { history } = this.props;
+    history.replace(`/recipient-validation/${tabs[tabIdx].key}`);
     this.setState({ selectedTab: tabIdx });
   }
 

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -62,12 +62,16 @@ export class RecipientValidationPage extends Component {
       case 0:
         return <ListTab handleSubmit={handleSubmit} reset={reset} />;
       case 1:
-        return <SingleAddressTab handleSubmit={handleSubmit} />;
+        return <SingleAddressTab />;
       case 2:
-        return <ApiDetails handleSubmit={handleSubmit} formname={FORMNAME} />;
+        return <ApiDetails formname={FORMNAME} />;
       default:
         return null;
     }
+  };
+
+  onSubmit = () => {
+    console.log('submitted');
   };
 
   handleModal = (showPriceModal = false) => this.setState({ showPriceModal });
@@ -185,11 +189,7 @@ export class RecipientValidationPage extends Component {
         </Case>
       </ConditionSwitch>
     ) : (
-      <form
-        onSubmit={() => {
-          console.log('submitted');
-        }}
-      >
+      <form onSubmit={this.props.handleSubmit(this.onSubmit)}>
         {this.renderRecipientValidation()}
       </form>
     );
@@ -203,10 +203,8 @@ const mapStateToProps = (state, props) => ({
   billingLoading: state.account.billingLoading,
 });
 
-//UNCOMMENT BEFORE MERGING WITH MASTER
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));
 
-//COMMENT BOTH BEFORE MERGING WITH MASTER
 const formOptions = { form: FORMNAME, enableReinitialize: true };
 export const RecipientValidationPageSRV = withRouter(
   connect(mapStateToProps, { getBillingInfo })(reduxForm(formOptions)(RecipientValidationPage)),

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -18,9 +18,9 @@ import { getBillingInfo } from 'src/actions/account';
 import { reduxForm } from 'redux-form';
 import { FORMS } from 'src/constants';
 import { isRVonSubscription } from 'src/selectors/accountBillingInfo';
-import { validate } from '@babel/types';
 import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
+import _ from 'lodash';
 
 const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
 
@@ -34,16 +34,25 @@ export class RecipientValidationPage extends Component {
   state = {
     selectedTab: this.props.tab || 0,
     showPriceModal: false,
+    useSavedCC: Boolean(this.props.billing.credit_card),
   };
 
   componentDidMount() {
     this.props.getBillingInfo();
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.billing !== prevProps.billing)
+      this.setState({ useSavedCC: Boolean(this.props.billing.credit_card) });
+  }
   handleTabs(tabIdx) {
-    const { history } = this.props;
+    const { history, isStandAloneRVSet } = this.props;
 
-    history.replace(`/recipient-validation/${tabs[tabIdx].key}`);
+    if (!isStandAloneRVSet) {
+      history.replace(`/recipient-validation/${tabs[tabIdx].key}`);
+    } else {
+      history.replace(`/recipient-validation-srv/${tabs[tabIdx].key}`);
+    }
     this.setState({ selectedTab: tabIdx });
   }
 
@@ -60,6 +69,8 @@ export class RecipientValidationPage extends Component {
     }
   };
 
+  handleToggleCC = val => this.setState({ useSavedCC: !val });
+
   renderTabContentSRV = tabId => {
     const { handleSubmit, reset } = this.props;
     switch (tabId) {
@@ -74,22 +85,39 @@ export class RecipientValidationPage extends Component {
     }
   };
 
-  validate = () => {
-    console.log('validated');
+  validate = values => {
+    switch (this.state.selectedTab) {
+      case 1:
+        this.props.history.push(`/recipient-validation/single/${values.address}`);
+        break;
+
+      default:
+        break;
+    }
   };
 
   onSubmit = values => {
-    console.log('onSubmit');
-    const cardValues = values.card ? { ...values, card: prepareCardInfo(values.card) } : values;
-
-    const newValues = {
-      ...cardValues,
-    };
-    if (this.props.isRVonSubscription) {
-      validate();
+    const {
+      billing: { plans, subscription },
+      isRVonSubscription,
+    } = this.props;
+    if (this.state.useSavedCC && isRVonSubscription) {
+      this.validate(values);
     } else {
-      let action = this.props.addRVtoSubscription(newValues);
-      return action;
+      const cardValues = values.card ? { ...values, card: prepareCardInfo(values.card) } : values;
+
+      const newValues = {
+        ...cardValues,
+        billingId: subscription
+          ? (_.find(plans, { code: subscription.code }) || {}).billingId
+          : (_.find(plans, { product: 'recipient_validation' }) || {}).billingId,
+      };
+      let action = this.props.addRVtoSubscription(
+        newValues,
+        !this.state.useSavedCC,
+        isRVonSubscription,
+      );
+      return action.then(() => this.validate(values));
     }
   };
 
@@ -179,14 +207,14 @@ export class RecipientValidationPage extends Component {
           </Panel>
         )}
         {selectedTab === 0 && <JobsTableCollection />}
-
         {(selectedTab === 1 || selectedTab === 2) && isStandAloneRVSet && !billingLoading && (
           <ValidateSection
             credit_card={billing.credit_card}
-            handleValidate={() => {}}
             submitButtonName={selectedTab === 2 ? 'Create API Key' : 'Validate'}
             submitDisabled={submitDisabled}
             formname={FORMNAME}
+            handleCardToggle={this.handleToggleCC}
+            defaultToggleState={!this.state.useSavedCC}
           />
         )}
 
@@ -218,6 +246,7 @@ export class RecipientValidationPage extends Component {
 const mapStateToProps = (state, props) => ({
   tab: tabs.findIndex(({ key }) => key === props.match.params.category) || 0,
   isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
+  account: state.account,
   billing: state.account.billing || {},
   billingLoading: state.account.billingLoading,
   isRVonSubscription: isRVonSubscription(state),

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -54,7 +54,7 @@ export class RecipientValidationPage extends Component {
       case 1:
         return <SingleAddressForm />;
       case 2:
-        return <ApiDetails isStandAloneRVSet={this.props.isStandAloneRVSet} />;
+        return <ApiDetails />;
       default:
         return null;
     }
@@ -175,7 +175,7 @@ export class RecipientValidationPage extends Component {
                 </div>
               )}
             </div>
-            <Panel.Section>{this.renderTabContent(selectedTab)}</Panel.Section>
+            <Panel.Section>{this.renderTabContentSRV(selectedTab)}</Panel.Section>
           </Panel>
         )}
         {selectedTab === 0 && <JobsTableCollection />}

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -47,10 +47,10 @@ export class RecipientValidationPage extends Component {
       this.setState({ useSavedCC: Boolean(this.props.billing.credit_card) });
   }
   handleTabs(tabIdx) {
-    const { history } = this.props;
+    const { history, isStandAloneRVSet } = this.props;
     history.replace(`/recipient-validation/${tabs[tabIdx].key}`);
     this.setState({ selectedTab: tabIdx });
-    this.props.reset();
+    if (isStandAloneRVSet) this.props.reset();
   }
 
   renderTabContent = tabId => {

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -17,6 +17,9 @@ import ValidateSection from './components/ValidateSection';
 import { getBillingInfo } from 'src/actions/account';
 import { reduxForm } from 'redux-form';
 import { FORMS } from 'src/constants';
+import { isRVonSubscription } from 'src/selectors/accountBillingInfo';
+import { validate } from '@babel/types';
+// import addRVtoSubscription from '../../actions/addRVtoSubscription';
 
 const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
 
@@ -70,20 +73,17 @@ export class RecipientValidationPage extends Component {
     }
   };
 
+  validate = () => {
+    console.log('validated');
+  };
+
   onSubmit = () => {
-    // if(!zuoraAccountExists) zuoraAccountExists =(account.billing) // move this check in createZuoraWithRVSubscription
-    // {
-    // below can be labelled as createZuoraWithRVSubscription
-    //    createZuoraAccount();
-    //    addRVbundleToSubscription();
-    // }else {
-    //  if(isRVBundleOnSubscription){  create a selector to check if it exists in current bundle
-    //        validate();
-    //      }else{
-    //  addRVBundleToSubscription();
-    //  validate();
-    // }
-    // }
+    if (this.props.isRVonSubscription) {
+      validate();
+    } else {
+      console.log('no!');
+      // addRVtoSubscription(values,validate);
+    }
   };
 
   handleModal = (showPriceModal = false) => this.setState({ showPriceModal });
@@ -213,6 +213,7 @@ const mapStateToProps = (state, props) => ({
   isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
   billing: state.account.billing || {},
   billingLoading: state.account.billingLoading,
+  isRVonSubscription: isRVonSubscription(state),
 });
 
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -17,7 +17,7 @@ import ValidateSection from './components/ValidateSection';
 import { getBillingInfo } from 'src/actions/account';
 import { reduxForm } from 'redux-form';
 import { FORMS } from 'src/constants';
-import { isRVonSubscription } from 'src/selectors/accountBillingInfo';
+import { isProductionOnSubscription } from 'src/helpers/billing';
 import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
 import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
@@ -246,7 +246,7 @@ const mapStateToProps = (state, props) => ({
   account: state.account,
   billing: state.account.billing || {},
   billingLoading: state.account.billingLoading,
-  isRVonSubscription: isRVonSubscription(state),
+  isRVonSubscription: isProductionOnSubscription(state, 'recipient_validation'),
   initialValues: rvAddPaymentFormInitialValues(state),
 });
 

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -250,13 +250,11 @@ const mapStateToProps = (state, props) => ({
   initialValues: rvAddPaymentFormInitialValues(state),
 });
 
-export default withRouter(
-  connect(mapStateToProps, { getBillingInfo, getBillingSubscription })(RecipientValidationPage),
-);
+export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));
 
 const formOptions = { form: FORMNAME, enableReinitialize: true };
 export const RecipientValidationPageSRV = withRouter(
-  connect(mapStateToProps, { getBillingInfo, addRVtoSubscription })(
+  connect(mapStateToProps, { getBillingInfo, addRVtoSubscription, getBillingSubscription })(
     reduxForm(formOptions)(RecipientValidationPage),
   ),
 );

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -18,6 +18,7 @@ import { getBillingInfo } from 'src/actions/account';
 import { reduxForm } from 'redux-form';
 import { FORMS } from 'src/constants';
 import { isRVonSubscription } from 'src/selectors/accountBillingInfo';
+import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
 import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
 import _ from 'lodash';
@@ -49,6 +50,7 @@ export class RecipientValidationPage extends Component {
     const { history } = this.props;
     history.replace(`/recipient-validation/${tabs[tabIdx].key}`);
     this.setState({ selectedTab: tabIdx });
+    this.props.reset();
   }
 
   renderTabContent = tabId => {
@@ -245,6 +247,7 @@ const mapStateToProps = (state, props) => ({
   billing: state.account.billing || {},
   billingLoading: state.account.billingLoading,
   isRVonSubscription: isRVonSubscription(state),
+  initialValues: rvAddPaymentFormInitialValues(state),
 });
 
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -4,8 +4,8 @@ import { withRouter } from 'react-router-dom';
 import { Page, Tabs, Panel, Modal, Button } from '@sparkpost/matchbox';
 import { Close, Launch } from '@sparkpost/matchbox-icons';
 import JobsTableCollection from './components/JobsTableCollection';
-import ListForm from './components/ListForm';
-import SingleAddressForm from './components/SingleAddressForm';
+import ListForm, { ListTab } from './components/ListForm';
+import SingleAddressForm, { SingleAddressTab } from './components/SingleAddressForm';
 import ApiDetails from './components/ApiDetails';
 import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
 import RVDisabledPage from './components/RVDisabledPage';
@@ -51,6 +51,22 @@ export class RecipientValidationPage extends Component {
         return <SingleAddressForm />;
       case 2:
         return <ApiDetails isStandAloneRVSet={this.props.isStandAloneRVSet} />;
+      default:
+        return null;
+    }
+  };
+
+  renderTabContentSRV = tabId => {
+    const { handleSubmit, reset } = this.props;
+    switch (tabId) {
+      case 0:
+        return <ListTab handleSubmit={handleSubmit} reset={reset} />;
+      case 1:
+        return <SingleAddressTab handleSubmit={handleSubmit} />;
+      case 2:
+        return <ApiDetails handleSubmit={handleSubmit} formname={FORMNAME} />;
+      default:
+        return null;
     }
   };
 
@@ -78,7 +94,8 @@ export class RecipientValidationPage extends Component {
 
   renderRecipientValidation = () => {
     const { selectedTab, showPriceModal } = this.state;
-    const { isStandAloneRVSet, billing, billingLoading } = this.props;
+    const { isStandAloneRVSet, billing, billingLoading, valid, pristine, submitting } = this.props;
+    const submitDisabled = pristine || !valid || submitting;
 
     return (
       <Page
@@ -145,6 +162,8 @@ export class RecipientValidationPage extends Component {
             credit_card={billing.credit_card}
             handleValidate={() => {}}
             submitButtonName={selectedTab === 2 ? 'Create API Key' : 'Validate'}
+            submitDisabled={submitDisabled}
+            formname={FORMNAME}
           />
         )}
 
@@ -184,9 +203,11 @@ const mapStateToProps = (state, props) => ({
   billingLoading: state.account.billingLoading,
 });
 
-// export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));
+//UNCOMMENT BEFORE MERGING WITH MASTER
+export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));
 
+//COMMENT BOTH BEFORE MERGING WITH MASTER
 const formOptions = { form: FORMNAME, enableReinitialize: true };
-export default withRouter(
+export const RecipientValidationPageSRV = withRouter(
   connect(mapStateToProps, { getBillingInfo })(reduxForm(formOptions)(RecipientValidationPage)),
 );

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -19,7 +19,8 @@ import { reduxForm } from 'redux-form';
 import { FORMS } from 'src/constants';
 import { isRVonSubscription } from 'src/selectors/accountBillingInfo';
 import { validate } from '@babel/types';
-// import addRVtoSubscription from '../../actions/addRVtoSubscription';
+import { prepareCardInfo } from 'src/helpers/billing';
+import addRVtoSubscription from 'src/actions/addRVtoSubscription';
 
 const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
 
@@ -77,12 +78,18 @@ export class RecipientValidationPage extends Component {
     console.log('validated');
   };
 
-  onSubmit = () => {
+  onSubmit = values => {
+    console.log('onSubmit');
+    const cardValues = values.card ? { ...values, card: prepareCardInfo(values.card) } : values;
+
+    const newValues = {
+      ...cardValues,
+    };
     if (this.props.isRVonSubscription) {
       validate();
     } else {
-      console.log('no!');
-      // addRVtoSubscription(values,validate);
+      let action = this.props.addRVtoSubscription(newValues);
+      return action;
     }
   };
 
@@ -220,5 +227,7 @@ export default withRouter(connect(mapStateToProps, { getBillingInfo })(Recipient
 
 const formOptions = { form: FORMNAME, enableReinitialize: true };
 export const RecipientValidationPageSRV = withRouter(
-  connect(mapStateToProps, { getBillingInfo })(reduxForm(formOptions)(RecipientValidationPage)),
+  connect(mapStateToProps, { getBillingInfo, addRVtoSubscription })(
+    reduxForm(formOptions)(RecipientValidationPage),
+  ),
 );

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -71,7 +71,19 @@ export class RecipientValidationPage extends Component {
   };
 
   onSubmit = () => {
-    console.log('submitted');
+    // if(!zuoraAccountExists) zuoraAccountExists =(account.billing) // move this check in createZuoraWithRVSubscription
+    // {
+    // below can be labelled as createZuoraWithRVSubscription
+    //    createZuoraAccount();
+    //    addRVbundleToSubscription();
+    // }else {
+    //  if(isRVBundleOnSubscription){  create a selector to check if it exists in current bundle
+    //        validate();
+    //      }else{
+    //  addRVBundleToSubscription();
+    //  validate();
+    // }
+    // }
   };
 
   handleModal = (showPriceModal = false) => this.setState({ showPriceModal });

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -3,25 +3,24 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { Page, Tabs, Panel, Modal, Button } from '@sparkpost/matchbox';
 import { Close, Launch } from '@sparkpost/matchbox-icons';
+import { reduxForm } from 'redux-form';
+import _ from 'lodash';
+import { hasAccountOptionEnabled, isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { prepareCardInfo, isProductOnSubscription } from 'src/helpers/billing';
+import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
+import { getBillingInfo } from 'src/actions/account';
+import addRVtoSubscription from 'src/actions/addRVtoSubscription';
+import { getSubscription as getBillingSubscription } from 'src/actions/billing';
 import JobsTableCollection from './components/JobsTableCollection';
 import ListForm, { ListTab } from './components/ListForm';
 import SingleAddressForm, { SingleAddressTab } from './components/SingleAddressForm';
 import ApiDetails from './components/ApiDetails';
-import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
 import RVDisabledPage from './components/RVDisabledPage';
-import ConditionSwitch, { Case, defaultCase } from 'src/components/auth/ConditionSwitch';
 import RecipientValidationPriceTable from './components/RecipientValidationPriceTable';
-import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import ConditionSwitch, { Case, defaultCase } from 'src/components/auth/ConditionSwitch';
 import styles from './RecipientValidationPage.module.scss';
 import ValidateSection from './components/ValidateSection';
-import { getBillingInfo } from 'src/actions/account';
-import { reduxForm } from 'redux-form';
 import { FORMS } from 'src/constants';
-import { isProductOnSubscription } from 'src/helpers/billing';
-import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
-import { prepareCardInfo } from 'src/helpers/billing';
-import addRVtoSubscription from 'src/actions/addRVtoSubscription';
-import _ from 'lodash';
 
 const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
 
@@ -40,6 +39,7 @@ export class RecipientValidationPage extends Component {
 
   componentDidMount() {
     this.props.getBillingInfo();
+    if (this.props.isStandAloneRVSet) this.props.getBillingSubscription();
   }
 
   componentDidUpdate(prevProps) {
@@ -246,11 +246,13 @@ const mapStateToProps = (state, props) => ({
   account: state.account,
   billing: state.account.billing || {},
   billingLoading: state.account.billingLoading,
-  isRVonSubscription: isProductOnSubscription(state, 'recipient_validation'),
+  isRVonSubscription: isProductOnSubscription('recipient_validation')(state),
   initialValues: rvAddPaymentFormInitialValues(state),
 });
 
-export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));
+export default withRouter(
+  connect(mapStateToProps, { getBillingInfo, getBillingSubscription })(RecipientValidationPage),
+);
 
 const formOptions = { form: FORMNAME, enableReinitialize: true };
 export const RecipientValidationPageSRV = withRouter(

--- a/src/pages/recipientValidation/UploadedListPage.container.js
+++ b/src/pages/recipientValidation/UploadedListPage.container.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import UploadedListPage, { UploadedListPageSRV } from './UploadedListPage';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { withRouter } from 'react-router-dom';
+
+const UploadedListPageContainer = props =>
+  props.isStandAloneRVSet ? <UploadedListPageSRV {...props} /> : <UploadedListPage {...props} />;
+
+const mapStateToProps = state => {
+  return {
+    isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
+  };
+};
+
+export default withRouter(connect(mapStateToProps, null)(UploadedListPageContainer));

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -17,6 +17,7 @@ import ValidateSection from './components/ValidateSection';
 import { FORMS } from 'src/constants';
 import { reduxForm } from 'redux-form';
 import { isRVonSubscription } from 'src/selectors/accountBillingInfo';
+import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
 import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
 import _ from 'lodash';
@@ -81,7 +82,7 @@ export class UploadedListPage extends Component {
       billing: { credit_card },
     } = this.props;
 
-    const { valid, pristine, submitting, isRVFormPresent } = this.props;
+    const { valid, pristine, submitting } = this.props;
     const submitDisabled = pristine || !valid || submitting;
     return (
       <Page
@@ -113,7 +114,7 @@ export class UploadedListPage extends Component {
           <ValidateSection
             credit_card={credit_card}
             formname={FORMNAME}
-            submitDisabled={submitDisabled && isRVFormPresent}
+            submitDisabled={submitDisabled && !this.state.useSavedCC}
             handleCardToggle={this.handleToggleCC}
             defaultToggleState={!this.state.useSavedCC}
           />
@@ -159,8 +160,8 @@ const mapStateToProps = (state, props) => {
     jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId],
     isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
     billing: state.account.billing || {},
-    isRVFormPresent: Boolean(state.form[FORMNAME]) && !_.isEmpty(state.form[FORMNAME]),
     isRVonSubscription: isRVonSubscription(state),
+    initialValues: rvAddPaymentFormInitialValues(state),
   };
 };
 

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -29,10 +29,12 @@ export class UploadedListPage extends Component {
     useSavedCC: Boolean(this.props.billing.credit_card),
   };
   componentDidMount() {
-    const { getJobStatus, listId, getBillingInfo } = this.props;
+    const { getJobStatus, listId, getBillingInfo, getBillingSubscription } = this.props;
     getJobStatus(listId);
-    getBillingInfo();
-    if (this.props.isStandAloneRVSet) this.props.getBillingSubscription();
+    if (this.props.isStandAloneRVSet) {
+      getBillingSubscription();
+      getBillingInfo();
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -16,7 +16,7 @@ import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import ValidateSection from './components/ValidateSection';
 import { FORMS } from 'src/constants';
 import { reduxForm } from 'redux-form';
-import { isRVonSubscription } from 'src/selectors/accountBillingInfo';
+import { isProductionOnSubscription } from 'src/helpers/billing';
 import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
 import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
@@ -160,7 +160,7 @@ const mapStateToProps = (state, props) => {
     jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId],
     isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
     billing: state.account.billing || {},
-    isRVonSubscription: isRVonSubscription(state),
+    isRVonSubscription: isProductionOnSubscription(state, 'recipient_validation'),
     initialValues: rvAddPaymentFormInitialValues(state),
   };
 };

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -32,6 +32,10 @@ export class UploadedListPage extends Component {
     triggerJob(listId);
   };
 
+  onSubmit = () => {
+    console.log('somewhere else');
+  };
+
   render() {
     const {
       job,
@@ -61,39 +65,41 @@ export class UploadedListPage extends Component {
     }
 
     return (
-      <Page
-        title="Recipient Validation"
-        breadcrumbAction={{ content: 'Back', component: PageLink, to: '/recipient-validation' }}
-      >
-        <Panel>
-          <Panel.Section>
-            <div className={styles.dateHeader}>
-              <strong>{formatDate(job.updatedAt)}</strong>
-              <span> at </span>
-              <strong>{formatTime(job.updatedAt)}</strong>
-            </div>
-          </Panel.Section>
+      <form onSubmit={this.props.handleSubmit(this.onSubmit)}>
+        <Page
+          title="Recipient Validation"
+          breadcrumbAction={{ content: 'Back', component: PageLink, to: '/recipient-validation' }}
+        >
+          <Panel>
+            <Panel.Section>
+              <div className={styles.dateHeader}>
+                <strong>{formatDate(job.updatedAt)}</strong>
+                <span> at </span>
+                <strong>{formatTime(job.updatedAt)}</strong>
+              </div>
+            </Panel.Section>
 
-          <Panel.Section>
-            {job.status === 'queued_for_batch' && (
-              <UploadedListForm job={job} onSubmit={this.handleSubmit} />
-            )}
+            <Panel.Section>
+              {job.status === 'queued_for_batch' && (
+                <UploadedListForm job={job} onSubmit={this.handleSubmit} />
+              )}
 
-            {job.status === 'error' && <ListError />}
+              {job.status === 'error' && <ListError />}
 
-            {job.status !== 'queued_for_batch' && job.status !== 'error' && (
-              <ListProgress job={job} />
-            )}
-          </Panel.Section>
-        </Panel>
-        {isStandAloneRVSet && (
-          <ValidateSection
-            credit_card={credit_card}
-            formname={FORMNAME}
-            submitDisabled={submitDisabled && isRVFormPresent}
-          />
-        )}
-      </Page>
+              {job.status !== 'queued_for_batch' && job.status !== 'error' && (
+                <ListProgress job={job} />
+              )}
+            </Panel.Section>
+          </Panel>
+          {isStandAloneRVSet && (
+            <ValidateSection
+              credit_card={credit_card}
+              formname={FORMNAME}
+              submitDisabled={submitDisabled && isRVFormPresent}
+            />
+          )}
+        </Page>
+      </form>
     );
   }
 }

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -74,17 +74,56 @@ export class UploadedListPage extends Component {
     }
   };
 
-  render() {
+  renderUploadedListPage = () => {
     const {
       job,
-      jobLoadingStatus,
-      listId,
       isStandAloneRVSet,
       billing: { credit_card },
     } = this.props;
 
     const { valid, pristine, submitting, isRVFormPresent } = this.props;
     const submitDisabled = pristine || !valid || submitting;
+    return (
+      <Page
+        title="Recipient Validation"
+        breadcrumbAction={{ content: 'Back', component: PageLink, to: '/recipient-validation' }}
+      >
+        <Panel>
+          <Panel.Section>
+            <div className={styles.dateHeader}>
+              <strong>{formatDate(job.updatedAt)}</strong>
+              <span> at </span>
+              <strong>{formatTime(job.updatedAt)}</strong>
+            </div>
+          </Panel.Section>
+
+          <Panel.Section>
+            {job.status === 'queued_for_batch' && (
+              <UploadedListForm job={job} onSubmit={this.handleSubmit} />
+            )}
+
+            {job.status === 'error' && <ListError />}
+
+            {job.status !== 'queued_for_batch' && job.status !== 'error' && (
+              <ListProgress job={job} />
+            )}
+          </Panel.Section>
+        </Panel>
+        {isStandAloneRVSet && job.status === 'queued_for_batch' && (
+          <ValidateSection
+            credit_card={credit_card}
+            formname={FORMNAME}
+            submitDisabled={submitDisabled && isRVFormPresent}
+            handleCardToggle={this.handleToggleCC}
+            defaultToggleState={!this.state.useSavedCC}
+          />
+        )}
+      </Page>
+    );
+  };
+
+  render() {
+    const { job, jobLoadingStatus, listId, isStandAloneRVSet } = this.props;
 
     if (!job && jobLoadingStatus === 'fail') {
       return (
@@ -101,46 +140,13 @@ export class UploadedListPage extends Component {
     if (!job) {
       return <Loading />;
     }
-
-    return (
-      <form onSubmit={this.props.handleSubmit(this.onSubmit)}>
-        <Page
-          title="Recipient Validation"
-          breadcrumbAction={{ content: 'Back', component: PageLink, to: '/recipient-validation' }}
-        >
-          <Panel>
-            <Panel.Section>
-              <div className={styles.dateHeader}>
-                <strong>{formatDate(job.updatedAt)}</strong>
-                <span> at </span>
-                <strong>{formatTime(job.updatedAt)}</strong>
-              </div>
-            </Panel.Section>
-
-            <Panel.Section>
-              {job.status === 'queued_for_batch' && (
-                <UploadedListForm job={job} onSubmit={this.handleSubmit} />
-              )}
-
-              {job.status === 'error' && <ListError />}
-
-              {job.status !== 'queued_for_batch' && job.status !== 'error' && (
-                <ListProgress job={job} />
-              )}
-            </Panel.Section>
-          </Panel>
-          {isStandAloneRVSet && job.status === 'queued_for_batch' && (
-            <ValidateSection
-              credit_card={credit_card}
-              formname={FORMNAME}
-              submitDisabled={submitDisabled && isRVFormPresent}
-              handleCardToggle={this.handleToggleCC}
-              defaultToggleState={!this.state.useSavedCC}
-            />
-          )}
-        </Page>
-      </form>
-    );
+    if (isStandAloneRVSet)
+      return (
+        <form onSubmit={this.props.handleSubmit(this.onSubmit)}>
+          {this.renderUploadedListPage()}
+        </form>
+      );
+    return this.renderUploadedListPage();
   }
 }
 

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -13,8 +13,12 @@ import ListProgress from './components/ListProgress';
 import UploadedListForm from './components/UploadedListForm';
 import styles from './UploadedListPage.module.scss';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
-
 import ValidateSection from './components/ValidateSection';
+import { FORMS } from 'src/constants';
+import { reduxForm } from 'redux-form';
+import _ from 'lodash';
+
+const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
 
 export class UploadedListPage extends Component {
   componentDidMount() {
@@ -36,6 +40,9 @@ export class UploadedListPage extends Component {
       isStandAloneRVSet,
       billing: { credit_card },
     } = this.props;
+
+    const { valid, pristine, submitting, isRVFormPresent } = this.props;
+    const submitDisabled = pristine || !valid || submitting;
 
     if (!job && jobLoadingStatus === 'fail') {
       return (
@@ -80,7 +87,11 @@ export class UploadedListPage extends Component {
           </Panel.Section>
         </Panel>
         {isStandAloneRVSet && (
-          <ValidateSection credit_card={credit_card} handleValidate={() => {}} />
+          <ValidateSection
+            credit_card={credit_card}
+            formname={FORMNAME}
+            submitDisabled={submitDisabled && isRVFormPresent}
+          />
         )}
       </Page>
     );
@@ -96,9 +107,17 @@ const mapStateToProps = (state, props) => {
     jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId],
     isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
     billing: state.account.billing || {},
+    isRVFormPresent: Boolean(state.form[FORMNAME]) && !_.isEmpty(state.form[FORMNAME]),
   };
 };
 
 export default connect(mapStateToProps, { getJobStatus, triggerJob, getBillingInfo })(
   UploadedListPage,
 );
+
+const formOptions = { form: FORMNAME, enableReinitialize: true };
+export const UploadedListPageSRV = connect(mapStateToProps, {
+  getJobStatus,
+  triggerJob,
+  getBillingInfo,
+})(reduxForm(formOptions)(UploadedListPage));

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -16,10 +16,10 @@ import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import ValidateSection from './components/ValidateSection';
 import { FORMS } from 'src/constants';
 import { reduxForm } from 'redux-form';
-import { isProductOnSubscription } from 'src/helpers/billing';
+import { isProductOnSubscription, prepareCardInfo } from 'src/helpers/billing';
 import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
-import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
+import { getSubscription as getBillingSubscription } from 'src/actions/billing';
 import _ from 'lodash';
 
 const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
@@ -32,6 +32,7 @@ export class UploadedListPage extends Component {
     const { getJobStatus, listId, getBillingInfo } = this.props;
     getJobStatus(listId);
     getBillingInfo();
+    if (this.props.isStandAloneRVSet) this.props.getBillingSubscription();
   }
 
   componentDidUpdate(prevProps) {
@@ -160,7 +161,7 @@ const mapStateToProps = (state, props) => {
     jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId],
     isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
     billing: state.account.billing || {},
-    isRVonSubscription: isProductOnSubscription(state, 'recipient_validation'),
+    isRVonSubscription: isProductOnSubscription('recipient_validation')(state),
     initialValues: rvAddPaymentFormInitialValues(state),
   };
 };
@@ -175,4 +176,5 @@ export const UploadedListPageSRV = connect(mapStateToProps, {
   triggerJob,
   getBillingInfo,
   addRVtoSubscription,
+  getBillingSubscription,
 })(reduxForm(formOptions)(UploadedListPage));

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -63,11 +63,11 @@ export class UploadedListPage extends Component {
             ? (_.find(plans, { code: subscription.code }) || {}).billingId
             : (_.find(plans, { product: 'recipient_validation' }) || {}).billingId,
         };
-        let action = this.props.addRVtoSubscription(
-          newValues,
-          !this.state.useSavedCC,
-          isRVonSubscription,
-        );
+        let action = this.props.addRVtoSubscription({
+          values: newValues,
+          updateCreditCard: !this.state.useSavedCC,
+          isRVonSubscription: isRVonSubscription,
+        });
         return action.then(() => this.handleSubmit());
       }
     } else {

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -16,7 +16,7 @@ import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import ValidateSection from './components/ValidateSection';
 import { FORMS } from 'src/constants';
 import { reduxForm } from 'redux-form';
-import { isProductionOnSubscription } from 'src/helpers/billing';
+import { isProductOnSubscription } from 'src/helpers/billing';
 import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
 import { prepareCardInfo } from 'src/helpers/billing';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
@@ -160,7 +160,7 @@ const mapStateToProps = (state, props) => {
     jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId],
     isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
     billing: state.account.billing || {},
-    isRVonSubscription: isProductionOnSubscription(state, 'recipient_validation'),
+    isRVonSubscription: isProductOnSubscription(state, 'recipient_validation'),
     initialValues: rvAddPaymentFormInitialValues(state),
   };
 };

--- a/src/pages/recipientValidation/components/ApiDetails.js
+++ b/src/pages/recipientValidation/components/ApiDetails.js
@@ -3,7 +3,8 @@ import { Grid, Button } from '@sparkpost/matchbox';
 import { Link } from 'react-router-dom';
 import styles from './ApiDetails.module.scss';
 import CodeBlock from './CodeBlock';
-
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { connect } from 'react-redux';
 const Tab = () => <span className={styles.tab} />;
 const White = ({ children }) => <span className={styles.white}>{children}</span>;
 
@@ -95,4 +96,8 @@ export const ApiIntegrationDocs = ({ isStandAloneRVSet }) => {
   );
 };
 
-export default ApiIntegrationDocs;
+const mapStateToProps = state => {
+  return { isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state) };
+};
+
+export default connect(mapStateToProps, null)(ApiIntegrationDocs);

--- a/src/pages/recipientValidation/components/ListForm.js
+++ b/src/pages/recipientValidation/components/ListForm.js
@@ -8,7 +8,7 @@ import { uploadList, resetUploadError } from 'src/actions/recipientValidation';
 import { showAlert } from 'src/actions/globalAlert';
 import config from 'src/config';
 import { withRouter } from 'react-router-dom';
-
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 const formName = 'recipientValidationListForm';
 
 export class ListForm extends Component {
@@ -45,21 +45,24 @@ export class ListForm extends Component {
     }
   }
 
+  renderListTabBody = () => {
+    return (
+      <Field
+        component={FileUploadWrapper}
+        name="csv"
+        validate={[maxFileSize(config.maxRecipVerifUploadSizeBytes), fileExtension('csv', 'txt')]}
+        uploading={this.props.uploading}
+        data-id="recipient-list-dropzone"
+      />
+    );
+  };
+
   render() {
+    const { isStandAloneRVSet } = this.props;
     return (
       <Panel.Section>
-        <form>
-          <Field
-            component={FileUploadWrapper}
-            name="csv"
-            validate={[
-              maxFileSize(config.maxRecipVerifUploadSizeBytes),
-              fileExtension('csv', 'txt'),
-            ]}
-            uploading={this.props.uploading}
-            data-id="recipient-list-dropzone"
-          />
-        </form>
+        {!isStandAloneRVSet && <form>{this.renderListTabBody()}</form>}
+        {isStandAloneRVSet && this.renderListTabBody()}
       </Panel.Section>
     );
   }
@@ -74,6 +77,7 @@ const mapStateToProps = state => {
     file: selector(state, 'csv'),
     listError: state.recipientValidation.listError,
     uploading: state.recipientValidation.uploadLoading,
+    isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
   };
 };
 

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -64,7 +64,6 @@ export class SingleAddressForm extends Component {
                 {buttonContent}
               </Button>
             </div>
-            )}
           </form>
         )}
         {isStandAloneRVSet && this.singleAddressBody()}
@@ -80,5 +79,8 @@ const mapStateToProps = state => {
 };
 
 const WrappedForm = reduxForm({ form: formName })(SingleAddressForm);
-
 export default withRouter(connect(mapStateToProps, { singleAddress })(WrappedForm));
+
+export const SingleAddressTab = withRouter(
+  connect(mapStateToProps, { singleAddress })(SingleAddressForm),
+);

--- a/src/pages/recipientValidation/components/SingleAddressForm.js
+++ b/src/pages/recipientValidation/components/SingleAddressForm.js
@@ -15,6 +15,40 @@ export class SingleAddressForm extends Component {
   singleAddressForm = values =>
     this.props.history.push(`/recipient-validation/single/${values.address}`);
 
+  singleAddressBody = () => {
+    const { isStandAloneRVSet } = this.props;
+    return (
+      <>
+        <div className={classNames(styles.Header, isStandAloneRVSet && styles.HeaderSRV)}>
+          Validate a Single Address
+        </div>
+        <p className={classNames(styles.Subheader, isStandAloneRVSet && styles.SubheaderSRV)}>
+          Enter the email address below you would like to validate.
+        </p>
+        <div className={classNames(styles.Field, isStandAloneRVSet && styles.FieldSRV)}>
+          <Label className={styles.FieldLabel} id="email-address-field">
+            Email Address
+          </Label>
+
+          <Field
+            id="email-address-field"
+            style={
+              !isStandAloneRVSet && {
+                height: '3.2rem',
+                paddingLeft: '1.5em',
+                fontSize: '.9em',
+              }
+            }
+            name="address"
+            component={TextFieldWrapper}
+            placeholder={'harry.potter@hogwarts.edu'}
+            validate={[required, email, maxLength(254)]}
+            normalize={(value = '') => value.trim()}
+          />
+        </div>{' '}
+      </>
+    );
+  };
   render() {
     const { valid, pristine, submitting, handleSubmit, isStandAloneRVSet } = this.props;
     const submitDisabled = pristine || !valid || submitting;
@@ -22,42 +56,18 @@ export class SingleAddressForm extends Component {
 
     return (
       <Panel.Section>
-        <form onSubmit={handleSubmit(this.singleAddressForm)}>
-          <div className={classNames(styles.Header, isStandAloneRVSet && styles.HeaderSRV)}>
-            Validate a Single Address
-          </div>
-          <p className={classNames(styles.Subheader, isStandAloneRVSet && styles.SubheaderSRV)}>
-            Enter the email address below you would like to validate.
-          </p>
-          <div className={classNames(styles.Field, isStandAloneRVSet && styles.FieldSRV)}>
-            <Label className={styles.FieldLabel} id="email-address-field">
-              Email Address
-            </Label>
-
-            <Field
-              id="email-address-field"
-              style={
-                !isStandAloneRVSet && {
-                  height: '3.2rem',
-                  paddingLeft: '1.5em',
-                  fontSize: '.9em',
-                }
-              }
-              name="address"
-              component={TextFieldWrapper}
-              placeholder={'harry.potter@hogwarts.edu'}
-              validate={[required, email, maxLength(254)]}
-              normalize={(value = '') => value.trim()}
-            />
-          </div>
-          {!isStandAloneRVSet && (
+        {!isStandAloneRVSet && (
+          <form onSubmit={handleSubmit(this.singleAddressForm)}>
+            {this.singleAddressBody()}
             <div className={styles.Submit}>
               <Button size="large" fullWidth primary submit disabled={submitDisabled}>
                 {buttonContent}
               </Button>
             </div>
-          )}
-        </form>
+            )}
+          </form>
+        )}
+        {isStandAloneRVSet && this.singleAddressBody()}
       </Panel.Section>
     );
   }

--- a/src/pages/recipientValidation/components/ValidateSection.js
+++ b/src/pages/recipientValidation/components/ValidateSection.js
@@ -37,18 +37,18 @@ function ValidateSection({
     );
   }
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <>
       <CreditCardSection
         creditCard={credit_card}
         handleCardToggle={() => {}}
         formname={FORMNAME}
         countries={billingCountries || []}
       />
-      <Button color="orange" type="submit">
+      <Button color="orange" type="submit" onClick={handleSubmit(onSubmit)}>
         {/* functionality to validate to be added in AC-1196 and AC-1197*/}
         {submitButtonName}
       </Button>
-    </form>
+    </>
   );
 }
 

--- a/src/pages/recipientValidation/components/ValidateSection.js
+++ b/src/pages/recipientValidation/components/ValidateSection.js
@@ -40,7 +40,7 @@ function ValidateSection({
         countries={billingCountries || []}
         defaultToggleState={defaultToggleState}
       />
-      <Button size="large" primary submit disabled={submitDisabled}>
+      <Button primary submit disabled={submitDisabled}>
         {/* functionality to validate to be added in AC-1196 and AC-1197*/}
         {submitButtonName}
       </Button>

--- a/src/pages/recipientValidation/components/ValidateSection.js
+++ b/src/pages/recipientValidation/components/ValidateSection.js
@@ -14,6 +14,8 @@ function ValidateSection({
   submitButtonName = 'Validate',
   submitDisabled,
   formname: FORMNAME,
+  handleCardToggle,
+  defaultToggleState,
 }) {
   useEffect(() => {
     getBillingCountries();
@@ -33,9 +35,10 @@ function ValidateSection({
     <>
       <CreditCardSection
         creditCard={credit_card}
-        handleCardToggle={() => {}}
+        handleCardToggle={handleCardToggle}
         formname={FORMNAME}
         countries={billingCountries || []}
+        defaultToggleState={defaultToggleState}
       />
       <Button size="large" primary submit disabled={submitDisabled}>
         {/* functionality to validate to be added in AC-1196 and AC-1197*/}

--- a/src/pages/recipientValidation/components/ValidateSection.js
+++ b/src/pages/recipientValidation/components/ValidateSection.js
@@ -2,26 +2,19 @@ import React, { useEffect } from 'react';
 import CreditCardSection from 'src/components/billing/CreditCardSection';
 import { Button } from '@sparkpost/matchbox';
 import { connect } from 'react-redux';
-import { FORMS } from 'src/constants';
-import { reduxForm } from 'redux-form';
 import { updatePaymentInitialValues } from 'src/selectors/accountBillingForms';
 import { selectIsSelfServeBilling } from 'src/selectors/accountBillingInfo';
 import { getBillingCountries } from 'src/actions/billing';
 
-const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
-
 function ValidateSection({
-  handleSubmit,
   credit_card,
-  handleValidate,
   billingCountries,
   getBillingCountries,
   isManuallyBilled,
   submitButtonName = 'Validate',
+  submitDisabled,
+  formname: FORMNAME,
 }) {
-  const onSubmit = () => {
-    handleValidate();
-  };
   useEffect(() => {
     getBillingCountries();
   }, [getBillingCountries]);
@@ -44,7 +37,7 @@ function ValidateSection({
         formname={FORMNAME}
         countries={billingCountries || []}
       />
-      <Button color="orange" type="submit" onClick={handleSubmit(onSubmit)}>
+      <Button size="large" primary submit disabled={submitDisabled}>
         {/* functionality to validate to be added in AC-1196 and AC-1197*/}
         {submitButtonName}
       </Button>
@@ -52,7 +45,6 @@ function ValidateSection({
   );
 }
 
-const formOptions = { form: FORMNAME, enableReinitialize: true };
 const mapStateToProps = state => {
   return {
     initialValues: updatePaymentInitialValues(state),
@@ -61,6 +53,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, { getBillingCountries })(
-  reduxForm(formOptions)(ValidateSection),
-);
+export default connect(mapStateToProps, { getBillingCountries })(ValidateSection);

--- a/src/pages/recipientValidation/components/tests/ApiDetails.test.js
+++ b/src/pages/recipientValidation/components/tests/ApiDetails.test.js
@@ -1,11 +1,11 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import ApiDetails from '../ApiDetails';
+import { ApiIntegrationDocs } from '../ApiDetails';
 
 describe('ApiDetails tab', () => {
   it('should render page correctly', () => {
-    const wrapper = shallow(<ApiDetails />);
+    const wrapper = shallow(<ApiIntegrationDocs />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/pages/recipientValidation/components/tests/__snapshots__/SingleAddressForm.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/SingleAddressForm.test.js.snap
@@ -46,6 +46,7 @@ exports[`SingleAddressForm renders correctly 1`] = `
         }
       />
     </div>
+     
     <div
       className="Submit"
     >

--- a/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
+++ b/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
@@ -63,6 +63,7 @@ describe('Page: Recipient Email Verification', () => {
         getBillingInfo: jest.fn(),
         billing: {},
         isStandAloneRVSet: true,
+        handleSubmit: jest.fn(),
       };
       subject = props => shallow(<RecipientValidationPage {...defaultProps} {...props} />);
     });
@@ -70,7 +71,7 @@ describe('Page: Recipient Email Verification', () => {
     it('when billingLoading is true ValidateSection is not rendered', () => {
       const instance = subject({ billingLoading: true });
       instance.setState({ selectedTab: 1 });
-      expect(instance.find('Connect(ReduxForm)')).not.toExist();
+      expect(instance.find('Connect(ValidateSection)')).not.toExist();
     });
 
     it('renders a API Docs button in Panel when API Integration Tab is selected', () => {
@@ -86,7 +87,7 @@ describe('Page: Recipient Email Verification', () => {
 
     it('renders a ValidateSection', () => {
       const instance = subject({ tab: 2 });
-      expect(instance.find('Connect(ReduxForm)')).toExist();
+      expect(instance.find('Connect(ValidateSection)')).toExist();
     });
   });
 });

--- a/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
+++ b/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
@@ -19,6 +19,7 @@ describe('Page: Recipient Email Verification', () => {
       },
       getBillingInfo: jest.fn(),
       billing: {},
+      reset: jest.fn(),
     };
 
     wrapper = shallow(<RecipientValidationPage {...props} />);

--- a/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
+++ b/src/pages/recipientValidation/tests/RecipientValidationPage.test.js
@@ -65,6 +65,7 @@ describe('Page: Recipient Email Verification', () => {
         billing: {},
         isStandAloneRVSet: true,
         handleSubmit: jest.fn(),
+        getBillingSubscription: jest.fn(),
       };
       subject = props => shallow(<RecipientValidationPage {...defaultProps} {...props} />);
     });

--- a/src/pages/recipientValidation/tests/UploadedListPage.test.js
+++ b/src/pages/recipientValidation/tests/UploadedListPage.test.js
@@ -17,6 +17,7 @@ describe('UploadedListPage', () => {
         jobLoadingStatus="success"
         triggerJob={() => {}}
         billing={{}}
+        handleSubmit={() => {}}
         {...props}
       />,
     );
@@ -81,8 +82,18 @@ describe('UploadedListPage', () => {
   });
 
   describe('when standaloneRV flag is set', () => {
-    it('render a ValidateSection', () => {
-      expect(subject({ isStandAloneRVSet: true }).find('Connect(ReduxForm)')).toHaveLength(1);
+    it('render a ValidateSection when job status is queued for batch', () => {
+      expect(
+        subject({
+          isStandAloneRVSet: true,
+          job: {
+            jobId: 'B1C1_D1C1',
+            status: 'queued_for_batch',
+            updatedAt: '1997-11-21T15:55:06Z',
+          },
+          listId: 'B1C1_D1C1',
+        }).find('Connect(ValidateSection)'),
+      ).toHaveLength(1);
     });
   });
 });

--- a/src/pages/recipientValidation/tests/UploadedListPage.test.js
+++ b/src/pages/recipientValidation/tests/UploadedListPage.test.js
@@ -8,6 +8,7 @@ describe('UploadedListPage', () => {
       <UploadedListPage
         getJobStatus={() => {}}
         getBillingInfo={() => {}}
+        getBillingSubscription={() => {}}
         listId="A1C1_D1C1"
         job={{
           jobId: 'A1C1_D1C1',

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -28,9 +28,6 @@ const selectOnZuoraPlan = selectCondition(onZuoraPlan);
 const selectBillingSubscription = state => state.billing.subscription || {};
 const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'];
 const getRecipientValidationUsage = state => _.get(state, 'account.rvUsage.recipient_validation');
-export const isRVonSubscription = state =>
-  _.find(_.get(state, 'billing.subscription.products') || {}, { product: 'recipient_validation' });
-
 export const currentSubscriptionSelector = state => state.account.subscription;
 
 /**

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -28,6 +28,8 @@ const selectOnZuoraPlan = selectCondition(onZuoraPlan);
 const selectBillingSubscription = state => state.billing.subscription || {};
 const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'];
 const getRecipientValidationUsage = state => _.get(state, 'account.rvUsage.recipient_validation');
+export const isRVonSubscription = state =>
+  _.find(_.get(state, 'billing.subscription.products') || {}, { product: 'recipient_validation' });
 
 export const currentSubscriptionSelector = state => state.account.subscription;
 

--- a/src/selectors/recipientValidation.js
+++ b/src/selectors/recipientValidation.js
@@ -1,11 +1,10 @@
 import { createSelector } from 'reselect';
 import { formatApiTimestamp, toMilliseconds } from 'src/helpers/date';
+import { getFirstCountry, getFirstStateForCountry } from './accountBillingForms';
+const getRecipientValidationJobs = state => state.recipientValidation.jobResults;
 
-const getRecipientValidationJobs = (state) => state.recipientValidation.jobResults;
-
-export const selectRecipientValidationJobs = createSelector(
-  getRecipientValidationJobs,
-  (jobs) => Object.keys(jobs).reduce((acc, key) => {
+export const selectRecipientValidationJobs = createSelector(getRecipientValidationJobs, jobs =>
+  Object.keys(jobs).reduce((acc, key) => {
     const {
       address_count,
       batch_status,
@@ -27,13 +26,29 @@ export const selectRecipientValidationJobs = createSelector(
         rejectedUrl: rejected_external_url,
         status: batch_status ? batch_status.toLowerCase() : undefined,
         uploadedFile: uploaded_file,
-        uploadedAt: upload_timestamp ? formatApiTimestamp(toMilliseconds(upload_timestamp)) : undefined
-      }
+        uploadedAt: upload_timestamp
+          ? formatApiTimestamp(toMilliseconds(upload_timestamp))
+          : undefined,
+      },
     ];
-  }, [])
+  }, []),
 );
 
 export const selectRecipientValidationJobById = createSelector(
   [selectRecipientValidationJobs, (state, jobId) => jobId],
-  (jobs, jobId) => jobs.find((job) => job.jobId === jobId)
+  (jobs, jobId) => jobs.find(job => job.jobId === jobId),
 );
+
+export function rvAddPaymentFormInitialValues(state) {
+  const firstCountry = getFirstCountry(state);
+  const firstState = getFirstStateForCountry(state, firstCountry);
+
+  return {
+    billingAddress: {
+      firstName: state.currentUser.first_name,
+      lastName: state.currentUser.last_name,
+      country: firstCountry,
+      state: firstState,
+    },
+  };
+}


### PR DESCRIPTION
AC-1196: "Validate" button on RV list & single views subscribes to RV bundle

### What Changed
- "Validate" button on the list and single RV tabs checks if there is a Zuora account
          * If there is no Zuora account, create an account and add the RV bundle to the subscription
          * If there is a Zuora account, check if RV is on the subscription. If not, add the RV bundle to the subscription.
          * When RV bundle is successfully added to the subscription, process the RVs.

### How To Test
 - Enable ui flag `standalone_rv`
 - Navigate to the list tab and single validation tab on RecipientValidationPage. (mostly you will see errors since backend is still in progress.)
 - Check the logic of addRVtoSubscription

### To Do
- [ ] Address Feedback
