### PR TITLE
SE-531: Fix filtered by message for blacklist alerts

### DIFF
--- a/src/pages/alerts/components/AlertDetails.js
+++ b/src/pages/alerts/components/AlertDetails.js
@@ -76,8 +76,11 @@ export const AlertDetails = ({ alert, id, subaccountIdToString, hasSubaccounts }
       undefined
     );
 
+    console.log(filters);
     //Removes filter which contain string 'any'. Currently only appears on blacklist alerts
-    const cleanedFilters = filters.filter(({ filter_values }) => filter_values[0] !== 'any');
+    const cleanedFilters = filters.filter(
+      ({ filter_values }) => !(metric === 'blacklist' && filter_values[0] === 'any'),
+    );
 
     //Only show 'and' if it's not the first filter or if there's a subaccounts filter
     const filtersTags = cleanedFilters.map((filter, i) => (

--- a/src/pages/alerts/components/AlertDetails.js
+++ b/src/pages/alerts/components/AlertDetails.js
@@ -76,10 +76,12 @@ export const AlertDetails = ({ alert, id, subaccountIdToString, hasSubaccounts }
       undefined
     );
 
-    console.log(filters);
     //Removes filter which contain string 'any'. Currently only appears on blacklist alerts
+
+    const blacklistFilters = ['blacklist_provider', 'blacklist_resource'];
     const cleanedFilters = filters.filter(
-      ({ filter_values }) => !(metric === 'blacklist' && filter_values[0] === 'any'),
+      ({ filter_values, filter_type }) =>
+        !(blacklistFilters.includes(filter_type) && filter_values[0] === 'any'),
     );
 
     //Only show 'and' if it's not the first filter or if there's a subaccounts filter

--- a/src/pages/alerts/components/AlertDetails.js
+++ b/src/pages/alerts/components/AlertDetails.js
@@ -76,8 +76,11 @@ export const AlertDetails = ({ alert, id, subaccountIdToString, hasSubaccounts }
       undefined
     );
 
+    //Removes filter which contain string 'any'. Currently only appears on blacklist alerts
+    const cleanedFilters = filters.filter(({ filter_values }) => filter_values[0] !== 'any');
+
     //Only show 'and' if it's not the first filter or if there's a subaccounts filter
-    const filtersTags = filters.map((filter, i) => (
+    const filtersTags = cleanedFilters.map((filter, i) => (
       <span key={filter.filter_type}>
         {(shouldShowSubaccounts || i > 0) && 'and'}{' '}
         <h6 className={styles.BoldInline}>{FILTERS_FRIENDLY_NAMES[filter.filter_type]}</h6>{' '}


### PR DESCRIPTION
### What Changed
 - Blacklist alerts will not rendered "Filtered By parts if 

### How To Test
 - Create a blacklist alert (available on appteam account)
 - Create alert with no filters no filters, or only filters on one of blacklist provider or blacklist resources