### PR TITLE
AC-1235: Biling uploads first 6 digits of card for bin number

### DIFF
--- a/src/helpers/billing.js
+++ b/src/helpers/billing.js
@@ -14,7 +14,7 @@ export function formatDataForCors(values) {
     state: billingAddress.state,
     country: billingAddress.country,
     zip_code: billingAddress.zip,
-    bin: card.number.slice(0, 6),
+    bin: card.number.replace(/\s/g, '').slice(0, 6),
     last_four: card.number.slice(-4),
     plan_id: planpicker.billingId || billingId,
     address1: null,


### PR DESCRIPTION
### What Changed
 - Spaces are removed from card number before pulling first 6 characters

### How To Test
 - Create a new account
 - Select a paid plan and keep an eye on the network requests
 - Check that in the /cors-data request, the bin includes 6 characters with no spaces

You can also check master branch to see that spaces were previously being sent.