### PR TITLE
AC-1238: Update the Recipient Validation Page for manually billed customers

### DIFF
--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -13,9 +13,11 @@ export default function addRVtoSubscription({
 
     const refreshGrants = () => {
       // when adding recipient validation bundle, grants need to be refreshed
-      return dispatch(getGrants({ role: state.currentUser.access_level })).then(() =>
-        dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }),
-      );
+      return dispatch(
+        getGrants({ role: state.currentUser.access_level }).catch(() =>
+          dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_ERROR' }),
+        ),
+      ).then(() => dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }));
     };
 
     dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_PENDING' });
@@ -27,23 +29,28 @@ export default function addRVtoSubscription({
         .then(recipientValidationPlan =>
           dispatch(billingCreate({ ...values, billingId: recipientValidationPlan.billing_id })),
         )
-        .then(refreshGrants);
+        .then(refreshGrants)
+        .catch(() => dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_ERROR' }));
     }
 
     // updating credit card and adding recipient validation bundle
     if (updateCreditCard && !isRVonSubscription) {
-      return dispatch(billingUpdate({ ...values, bundle: 'rv-0519' })).then(refreshGrants);
+      return dispatch(billingUpdate({ ...values, bundle: 'rv-0519' }))
+        .then(refreshGrants)
+        .catch(() => dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_ERROR' }));
     }
 
     // only updating credit card
     // note, billing/subscription/bundle will error if bundle already exists
     if (updateCreditCard && isRVonSubscription) {
-      return dispatch(billingUpdate(values)).then(() =>
-        dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }),
-      );
+      return dispatch(billingUpdate(values))
+        .then(() => dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }))
+        .catch(() => dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_ERROR' }));
     }
 
     // using credit card on file and adding recipient validation bundle
-    return dispatch(updateSubscription({ bundle: 'rv-0519' })).then(refreshGrants);
+    return dispatch(updateSubscription({ bundle: 'rv-0519' }))
+      .then(refreshGrants)
+      .catch(() => dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_ERROR' }));
   };
 }

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -13,8 +13,12 @@ export default function addRVtoSubscription({
 
     const refreshGrants = () => {
       // when adding recipient validation bundle, grants need to be refreshed
-      return dispatch(getGrants({ role: state.currentUser.access_level }));
+      return dispatch(getGrants({ role: state.currentUser.access_level })).then(() =>
+        dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }),
+      );
     };
+
+    dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_PENDING' });
 
     // creating standalone recipient validation account with credit card
     if (!state.account.billing) {
@@ -34,7 +38,9 @@ export default function addRVtoSubscription({
     // only updating credit card
     // note, billing/subscription/bundle will error if bundle already exists
     if (updateCreditCard && isRVonSubscription) {
-      return dispatch(billingUpdate(values));
+      return dispatch(billingUpdate(values)).then(() =>
+        dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }),
+      );
     }
 
     // using credit card on file and adding recipient validation bundle

--- a/src/actions/addRVtoSubscription.js
+++ b/src/actions/addRVtoSubscription.js
@@ -13,11 +13,9 @@ export default function addRVtoSubscription({
 
     const refreshGrants = () => {
       // when adding recipient validation bundle, grants need to be refreshed
-      return dispatch(
-        getGrants({ role: state.currentUser.access_level }).catch(() =>
-          dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_ERROR' }),
-        ),
-      ).then(() => dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }));
+      return dispatch(getGrants({ role: state.currentUser.access_level })).then(() =>
+        dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_SUCCESS', formValues: values }),
+      );
     };
 
     dispatch({ type: 'ADD_RV_TO_SUBSCRIPTION_PENDING' });

--- a/src/actions/tests/addRVtoSubscription.test.js
+++ b/src/actions/tests/addRVtoSubscription.test.js
@@ -13,7 +13,7 @@ describe('Action Creator: Add RV to subcription', () => {
   let dispatch;
 
   beforeEach(() => {
-    dispatch = jest.fn(a => a);
+    dispatch = jest.fn(a => Promise.resolve(a));
   });
 
   it('create zuora account and add rv bundle to subscription', async () => {

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -137,7 +137,14 @@ export class RecipientValidationPage extends Component {
 
   renderRecipientValidation = () => {
     const { selectedTab, showPriceModal } = this.state;
-    const { isStandAloneRVSet, billing, billingLoading, valid, submitting } = this.props;
+    const {
+      isStandAloneRVSet,
+      billing,
+      billingLoading,
+      valid,
+      submitting,
+      isRVonSubscription,
+    } = this.props;
 
     return (
       <Page
@@ -206,6 +213,7 @@ export class RecipientValidationPage extends Component {
             formname={FORMNAME}
             handleCardToggle={this.handleToggleCC}
             defaultToggleState={!this.state.useSavedCC}
+            isProductOnSubscription={isRVonSubscription}
           />
         )}
 

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import { hasAccountOptionEnabled, isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import { prepareCardInfo, isProductOnSubscription } from 'src/helpers/billing';
 import { rvAddPaymentFormInitialValues } from 'src/selectors/recipientValidation';
+import { selectIsSelfServeBilling } from 'src/selectors/accountBillingInfo';
 import { getBillingInfo } from 'src/actions/account';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
 import { getSubscription as getBillingSubscription } from 'src/actions/billing';
@@ -96,9 +97,9 @@ export class RecipientValidationPage extends Component {
   };
 
   onSubmit = formValues => {
-    const { addRVtoSubscription, isRVonSubscription } = this.props;
+    const { addRVtoSubscription, isRVonSubscription, isManuallyBilled } = this.props;
 
-    if (this.state.useSavedCC && isRVonSubscription) {
+    if ((this.state.useSavedCC && isRVonSubscription) || (isRVonSubscription && isManuallyBilled)) {
       return this.redirectToNextStep(formValues);
     }
 
@@ -250,6 +251,7 @@ const mapStateToProps = (state, props) => ({
   billingLoading: state.account.billingLoading,
   isRVonSubscription: isProductOnSubscription('recipient_validation')(state),
   initialValues: rvAddPaymentFormInitialValues(state),
+  isManuallyBilled: !selectIsSelfServeBilling(state),
 });
 
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -12,6 +12,7 @@ import { selectIsSelfServeBilling } from 'src/selectors/accountBillingInfo';
 import { getBillingInfo } from 'src/actions/account';
 import addRVtoSubscription from 'src/actions/addRVtoSubscription';
 import { getSubscription as getBillingSubscription } from 'src/actions/billing';
+import { Loading } from 'src/components/loading/Loading';
 import JobsTableCollection from './components/JobsTableCollection';
 import ListForm, { ListTab } from './components/ListForm';
 import SingleAddressForm, { SingleAddressTab } from './components/SingleAddressForm';
@@ -22,7 +23,6 @@ import ConditionSwitch, { Case, defaultCase } from 'src/components/auth/Conditio
 import styles from './RecipientValidationPage.module.scss';
 import ValidateSection from './components/ValidateSection';
 import { FORMS } from 'src/constants';
-
 const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
 
 const tabs = [
@@ -36,6 +36,8 @@ export class RecipientValidationPage extends Component {
     selectedTab: this.props.tab || 0,
     showPriceModal: false,
     useSavedCC: Boolean(this.props.billing.credit_card),
+    formValues: {},
+    submitStatus: 'idle',
   };
 
   componentDidMount() {
@@ -97,6 +99,7 @@ export class RecipientValidationPage extends Component {
   };
 
   onSubmit = formValues => {
+    this.setState({ submitStatus: 'submitting' });
     const { addRVtoSubscription, isRVonSubscription, isManuallyBilled } = this.props;
 
     if ((this.state.useSavedCC && isRVonSubscription) || (isRVonSubscription && isManuallyBilled)) {
@@ -111,7 +114,7 @@ export class RecipientValidationPage extends Component {
       values,
       updateCreditCard: !this.state.useSavedCC,
       isRVonSubscription: isRVonSubscription,
-    }).then(() => this.redirectToNextStep(values));
+    });
   };
 
   handleModal = (showPriceModal = false) => this.setState({ showPriceModal });
@@ -146,6 +149,11 @@ export class RecipientValidationPage extends Component {
       submitting,
       isRVonSubscription,
     } = this.props;
+
+    if (this.props.addRVtoSubscriptionloading === true) return <Loading />;
+
+    if (this.props.addRVtoSubscriptionloading === false && this.state.submitStatus === 'submitting')
+      this.redirectToNextStep(this.props.addRVFormValues);
 
     return (
       <Page
@@ -252,6 +260,8 @@ const mapStateToProps = (state, props) => ({
   isRVonSubscription: isProductOnSubscription('recipient_validation')(state),
   initialValues: rvAddPaymentFormInitialValues(state),
   isManuallyBilled: !selectIsSelfServeBilling(state),
+  addRVtoSubscriptionloading: state.addRVtoSubscription.addRVtoSubscriptionloading,
+  addRVFormValues: state.addRVtoSubscription.formValues,
 });
 
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -47,10 +47,7 @@ export class RecipientValidationPage extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.billing !== prevProps.billing)
       this.setState({ useSavedCC: Boolean(this.props.billing.credit_card) });
-    if (
-      this.props.addRVtoSubscriptionloading === false &&
-      prevProps.addRVtoSubscriptionloading === true
-    )
+    if (!this.props.addRVtoSubscriptionloading && prevProps.addRVtoSubscriptionloading)
       this.redirectToNextStep(this.props.addRVFormValues);
   }
   handleTabs(tabIdx) {
@@ -105,7 +102,7 @@ export class RecipientValidationPage extends Component {
   onSubmit = formValues => {
     const { addRVtoSubscription, isRVonSubscription, isManuallyBilled } = this.props;
 
-    if ((this.state.useSavedCC && isRVonSubscription) || (isRVonSubscription && isManuallyBilled)) {
+    if (isRVonSubscription && (this.state.useSavedCC || isManuallyBilled)) {
       return this.redirectToNextStep(formValues);
     }
 

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -37,7 +37,6 @@ export class RecipientValidationPage extends Component {
     showPriceModal: false,
     useSavedCC: Boolean(this.props.billing.credit_card),
     formValues: {},
-    submitStatus: 'idle',
   };
 
   componentDidMount() {
@@ -48,6 +47,11 @@ export class RecipientValidationPage extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.billing !== prevProps.billing)
       this.setState({ useSavedCC: Boolean(this.props.billing.credit_card) });
+    if (
+      this.props.addRVtoSubscriptionloading === false &&
+      prevProps.addRVtoSubscriptionloading === true
+    )
+      this.redirectToNextStep(this.props.addRVFormValues);
   }
   handleTabs(tabIdx) {
     const { history, isStandAloneRVSet } = this.props;
@@ -99,7 +103,6 @@ export class RecipientValidationPage extends Component {
   };
 
   onSubmit = formValues => {
-    this.setState({ submitStatus: 'submitting' });
     const { addRVtoSubscription, isRVonSubscription, isManuallyBilled } = this.props;
 
     if ((this.state.useSavedCC && isRVonSubscription) || (isRVonSubscription && isManuallyBilled)) {
@@ -149,12 +152,7 @@ export class RecipientValidationPage extends Component {
       submitting,
       isRVonSubscription,
     } = this.props;
-
     if (this.props.addRVtoSubscriptionloading === true) return <Loading />;
-
-    if (this.props.addRVtoSubscriptionloading === false && this.state.submitStatus === 'submitting')
-      this.redirectToNextStep(this.props.addRVFormValues);
-
     return (
       <Page
         title="Recipient Validation"

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -149,7 +149,7 @@ export class RecipientValidationPage extends Component {
       submitting,
       isRVonSubscription,
     } = this.props;
-    if (this.props.addRVtoSubscriptionloading === true) return <Loading />;
+    if (this.props.addRVtoSubscriptionloading) return <Loading />;
     return (
       <Page
         title="Recipient Validation"

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -47,7 +47,11 @@ export class RecipientValidationPage extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.billing !== prevProps.billing)
       this.setState({ useSavedCC: Boolean(this.props.billing.credit_card) });
-    if (!this.props.addRVtoSubscriptionloading && prevProps.addRVtoSubscriptionloading)
+    if (
+      !this.props.addRVtoSubscriptionloading &&
+      prevProps.addRVtoSubscriptionloading &&
+      !this.props.addRVtoSubscriptionerror
+    )
       this.redirectToNextStep(this.props.addRVFormValues);
   }
   handleTabs(tabIdx) {
@@ -257,6 +261,7 @@ const mapStateToProps = (state, props) => ({
   isManuallyBilled: !selectIsSelfServeBilling(state),
   addRVtoSubscriptionloading: state.addRVtoSubscription.addRVtoSubscriptionloading,
   addRVFormValues: state.addRVtoSubscription.formValues,
+  addRVtoSubscriptionerror: state.addRVtoSubscription.error,
 });
 
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -261,7 +261,7 @@ const mapStateToProps = (state, props) => ({
   isManuallyBilled: !selectIsSelfServeBilling(state),
   addRVtoSubscriptionloading: state.addRVtoSubscription.addRVtoSubscriptionloading,
   addRVFormValues: state.addRVtoSubscription.formValues,
-  addRVtoSubscriptionerror: state.addRVtoSubscription.error,
+  addRVtoSubscriptionerror: state.addRVtoSubscription.addRVtoSubscriptionerror,
 });
 
 export default withRouter(connect(mapStateToProps, { getBillingInfo })(RecipientValidationPage));

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -61,11 +61,7 @@ export class UploadedListPage extends Component {
     } = this.props;
     const { useSavedCC } = this.state;
 
-    if (
-      !isStandAloneRVSet ||
-      (useSavedCC && isRVonSubscription) ||
-      (isRVonSubscription && isManuallyBilled)
-    ) {
+    if (!isStandAloneRVSet || (isRVonSubscription && (this.state.useSavedCC || isManuallyBilled))) {
       this.handleSubmit();
       return;
     }

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -90,8 +90,10 @@ export class UploadedListPage extends Component {
       valid,
       submitting,
       isRVonSubscription,
+      addRVtoSubscriptionloading,
     } = this.props;
 
+    if (addRVtoSubscriptionloading) return <Loading />;
     return (
       <Page
         title="Recipient Validation"
@@ -173,6 +175,7 @@ const mapStateToProps = (state, props) => {
     isRVonSubscription: isProductOnSubscription('recipient_validation')(state),
     initialValues: rvAddPaymentFormInitialValues(state),
     isManuallyBilled: !selectIsSelfServeBilling(state),
+    addRVtoSubscriptionloading: state.addRVtoSubscription.addRVtoSubscriptionloading,
   };
 };
 

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -87,9 +87,10 @@ export class UploadedListPage extends Component {
       submitting,
       isRVonSubscription,
       addRVtoSubscriptionloading,
+      addRVtoSubscriptionerror,
     } = this.props;
 
-    if (addRVtoSubscriptionloading) return <Loading />;
+    if (addRVtoSubscriptionloading && !addRVtoSubscriptionerror) return <Loading />;
     return (
       <Page
         title="Recipient Validation"
@@ -172,6 +173,7 @@ const mapStateToProps = (state, props) => {
     initialValues: rvAddPaymentFormInitialValues(state),
     isManuallyBilled: !selectIsSelfServeBilling(state),
     addRVtoSubscriptionloading: state.addRVtoSubscription.addRVtoSubscriptionloading,
+    addRVtoSubscriptionerror: state.addRVtoSubscription.addRVtoSubscriptionerror,
   };
 };
 

--- a/src/pages/recipientValidation/components/ValidateSection.js
+++ b/src/pages/recipientValidation/components/ValidateSection.js
@@ -16,18 +16,27 @@ function ValidateSection({
   formname: FORMNAME,
   handleCardToggle,
   defaultToggleState,
+  isProductOnSubscription,
 }) {
   useEffect(() => {
     getBillingCountries();
   }, [getBillingCountries]);
   if (isManuallyBilled) {
+    if (!isProductOnSubscription)
+      return (
+        <Button
+          external
+          primary
+          to="https://www.sparkpost.com/recipient-validation/#recipient-validation-form"
+        >
+          Contact Sales
+        </Button>
+      );
+
     return (
-      <Button
-        external
-        primary
-        to="https://www.sparkpost.com/recipient-validation/#recipient-validation-form"
-      >
-        Contact Sales
+      <Button primary submit disabled={submitDisabled}>
+        {/* functionality to validate to be added in AC-1196 and AC-1197*/}
+        {submitButtonName}
       </Button>
     );
   }

--- a/src/pages/recipientValidation/components/ValidateSection.js
+++ b/src/pages/recipientValidation/components/ValidateSection.js
@@ -21,9 +21,18 @@ function ValidateSection({
   useEffect(() => {
     getBillingCountries();
   }, [getBillingCountries]);
-  if (isManuallyBilled) {
-    if (!isProductOnSubscription)
-      return (
+  return (
+    <>
+      {!isManuallyBilled && (
+        <CreditCardSection
+          creditCard={credit_card}
+          handleCardToggle={handleCardToggle}
+          formname={FORMNAME}
+          countries={billingCountries || []}
+          defaultToggleState={defaultToggleState}
+        />
+      )}
+      {isManuallyBilled && !isProductOnSubscription ? (
         <Button
           external
           primary
@@ -31,28 +40,11 @@ function ValidateSection({
         >
           Contact Sales
         </Button>
-      );
-
-    return (
-      <Button primary submit disabled={submitDisabled}>
-        {/* functionality to validate to be added in AC-1196 and AC-1197*/}
-        {submitButtonName}
-      </Button>
-    );
-  }
-  return (
-    <>
-      <CreditCardSection
-        creditCard={credit_card}
-        handleCardToggle={handleCardToggle}
-        formname={FORMNAME}
-        countries={billingCountries || []}
-        defaultToggleState={defaultToggleState}
-      />
-      <Button primary submit disabled={submitDisabled}>
-        {/* functionality to validate to be added in AC-1196 and AC-1197*/}
-        {submitButtonName}
-      </Button>
+      ) : (
+        <Button primary submit disabled={submitDisabled}>
+          {submitButtonName}
+        </Button>
+      )}
     </>
   );
 }

--- a/src/pages/recipientValidation/tests/UploadedListPage.test.js
+++ b/src/pages/recipientValidation/tests/UploadedListPage.test.js
@@ -73,7 +73,7 @@ describe('UploadedListPage', () => {
     });
 
     it('calls triggerJob when form is submitted', () => {
-      const triggerJob = jest.fn();
+      const triggerJob = jest.fn(a => Promise.resolve(a));
       const wrapper = queuedSubject({ triggerJob });
 
       wrapper.find('Connect(UploadedListForm)').simulate('submit');

--- a/src/reducers/addRVtoSubscription.js
+++ b/src/reducers/addRVtoSubscription.js
@@ -1,16 +1,19 @@
 const initialState = {
   addRVtoSubscriptionloading: null,
   formValues: {},
+  error: false,
 };
 
 export default (state = initialState, { type, formValues }) => {
   switch (type) {
     case 'ADD_RV_TO_SUBSCRIPTION_SUCCESS':
-      return { ...state, addRVtoSubscriptionloading: false, formValues: formValues };
+      return { ...state, addRVtoSubscriptionloading: false, formValues: formValues, error: false };
 
     case 'ADD_RV_TO_SUBSCRIPTION_PENDING':
-      return { ...state, addRVtoSubscriptionloading: true, formValues: formValues };
+      return { ...state, addRVtoSubscriptionloading: true, formValues: formValues, error: false };
 
+    case 'ADD_RV_TO_SUBSCRIPTION_ERROR':
+      return { ...state, addRVtoSubscriptionloading: false, error: true };
     default:
       return state;
   }

--- a/src/reducers/addRVtoSubscription.js
+++ b/src/reducers/addRVtoSubscription.js
@@ -1,19 +1,29 @@
 const initialState = {
   addRVtoSubscriptionloading: null,
   formValues: {},
-  error: false,
+  addRVtoSubscriptionerror: false,
 };
 
 export default (state = initialState, { type, formValues }) => {
   switch (type) {
     case 'ADD_RV_TO_SUBSCRIPTION_SUCCESS':
-      return { ...state, addRVtoSubscriptionloading: false, formValues: formValues, error: false };
+      return {
+        ...state,
+        addRVtoSubscriptionloading: false,
+        formValues: formValues,
+        addRVtoSubscriptionerror: false,
+      };
 
     case 'ADD_RV_TO_SUBSCRIPTION_PENDING':
-      return { ...state, addRVtoSubscriptionloading: true, formValues: formValues, error: false };
+      return {
+        ...state,
+        addRVtoSubscriptionloading: true,
+        formValues: formValues,
+        addRVtoSubscriptionerror: false,
+      };
 
     case 'ADD_RV_TO_SUBSCRIPTION_ERROR':
-      return { ...state, addRVtoSubscriptionloading: false, error: true };
+      return { ...state, addRVtoSubscriptionloading: false, addRVtoSubscriptionerror: true };
     default:
       return state;
   }

--- a/src/reducers/addRVtoSubscription.js
+++ b/src/reducers/addRVtoSubscription.js
@@ -1,0 +1,17 @@
+const initialState = {
+  addRVtoSubscriptionloading: null,
+  formValues: {},
+};
+
+export default (state = initialState, { type, formValues }) => {
+  switch (type) {
+    case 'ADD_RV_TO_SUBSCRIPTION_SUCCESS':
+      return { ...state, addRVtoSubscriptionloading: false, formValues: formValues };
+
+    case 'ADD_RV_TO_SUBSCRIPTION_PENDING':
+      return { ...state, addRVtoSubscriptionloading: true, formValues: formValues };
+
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,6 +6,7 @@ import accessControlReady from './accessControlReady';
 import account from './account';
 import accountSingleSignOn from './accountSingleSignOn';
 import abTesting from './abTesting';
+import addRVtoSubscription from './addRVtoSubscription';
 import alerts from './alerts';
 import apiKeys from './api-keys';
 import auth from './auth';
@@ -54,6 +55,7 @@ const appReducer = combineReducers({
   accessControlReady,
   account,
   accountSingleSignOn,
+  addRVtoSubscription,
   alerts,
   apiKeys,
   auth,


### PR DESCRIPTION
AC-1238: Update the Recipient Validation Page for manually billed customers

### What Changed
- Update the RV page for manually billed customers who have rv on their subscription. 
      -Do not show the Credit Card Section
      -Show the Validate and Create API key buttons.
      -Added loading state for UploadedListPage and RecipientValidationPage as discussed on [uxfe](https://msys.slack.com/archives/GLLAW6UAX/p1582658131001000)

### How To Test
- Enable 'standalone_rv' ui flag.
- Create a manually billed account using https://github.com/SparkPost/sparkpost-admin-api- 
   documentation/blob/master/services/billing_api.md#create-a-manually-billed-account-post .
- Add rv to user subscription (use PUT /billing/subscription/bundle)

### To Do
- [ ] Address Feedback