### PR TITLE
TR-2221 - Filter out falsy values from the templates content object

### DIFF
--- a/cypress/fixtures/templates/stubbed-template-1/200.get.content-null-values.json
+++ b/cypress/fixtures/templates/stubbed-template-1/200.get.content-null-values.json
@@ -1,0 +1,22 @@
+{
+  "results": {
+    "id": "stubbed-template-1",
+    "name": "Stubbed Template 1",
+    "description": "This is a description",
+    "published": true,
+    "options": { "click_tracking": true, "transactional": true, "open_tracking": true },
+    "shared_with_subaccounts": false,
+    "last_update_time": "2020-02-17T01:56:50+00:00",
+    "has_published": true,
+    "has_draft": true,
+    "content": {
+      "from": {
+        "email": "fake-user@bounce.uat.sparkspam.com"
+      },
+      "subject": "Stubbed Template 1",
+      "text": "Hello there",
+      "amp_html": null,
+      "html": null
+    }
+  }
+}

--- a/cypress/tests/integration/templates/editDraftPage.spec.js
+++ b/cypress/tests/integration/templates/editDraftPage.spec.js
@@ -65,7 +65,7 @@ describe('The templates edit draft page', () => {
   it('redirects to the list page if the template fails to load', () => {
     cy.stubRequest({
       statusCode: 400,
-      url: '/api/v1/templates/stubbed-template-1*',
+      url: '/api/v1/templates/stubbed-template-1',
       fixture: 'templates/stubbed-template-1/400.get.json',
     });
 
@@ -74,6 +74,20 @@ describe('The templates edit draft page', () => {
     cy.findByText('Unable to load template').should('be.visible');
     cy.get('main').within(() => cy.findByText('Templates').should('be.visible')); // To avoid checking for "Templates" in the navigation
     cy.findByText('Stubbed Template 1').should('not.be.visible');
+  });
+
+  it.only('does not render an error if the server returns content with null values', () => {
+    cy.stubRequest({
+      url: '/api/v1/templates/stubbed-template-1*',
+      fixture: 'templates/stubbed-template-1/200.get.content-null-values.json',
+      requestAlias: 'hello',
+    });
+
+    cy.visit(PAGE_URL);
+
+    cy.wait(300); // The duration of the debounce function that triggers AMP validation
+
+    cy.findByText('Stubbed Template 1 (DRAFT)').should('be.visible');
   });
 
   describe('template settings', () => {

--- a/cypress/tests/integration/templates/editDraftPage.spec.js
+++ b/cypress/tests/integration/templates/editDraftPage.spec.js
@@ -76,7 +76,7 @@ describe('The templates edit draft page', () => {
     cy.findByText('Stubbed Template 1').should('not.be.visible');
   });
 
-  it('does not render an error if the server returns content with null values', () => {
+  it.only('does not render an error if the server returns content with null values', () => {
     cy.stubRequest({
       url: '/api/v1/templates/stubbed-template-1*',
       fixture: 'templates/stubbed-template-1/200.get.content-null-values.json',
@@ -87,7 +87,9 @@ describe('The templates edit draft page', () => {
 
     cy.wait(300); // The duration of the debounce function that triggers AMP validation
 
-    cy.findByText('Stubbed Template 1 (DRAFT)').should('be.visible');
+    // NOTE: No assertion necessary.
+    // The test will fail if the exception occurs.
+    // If the exception does not occur, then everything proceeds smoothly.
   });
 
   describe('template settings', () => {

--- a/cypress/tests/integration/templates/editDraftPage.spec.js
+++ b/cypress/tests/integration/templates/editDraftPage.spec.js
@@ -76,7 +76,7 @@ describe('The templates edit draft page', () => {
     cy.findByText('Stubbed Template 1').should('not.be.visible');
   });
 
-  it.only('does not render an error if the server returns content with null values', () => {
+  it('does not render an error if the server returns content with null values', () => {
     cy.stubRequest({
       url: '/api/v1/templates/stubbed-template-1*',
       fixture: 'templates/stubbed-template-1/200.get.content-null-values.json',

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -8,77 +8,80 @@ import { filterTemplatesBySubaccount } from 'src/helpers/templates';
 import { getSubaccountsIndexedById, getSubaccountName } from './subaccounts';
 
 export const getDraftTemplateById = (state, id) => _.get(state, ['templates', 'byId', id, 'draft']);
-export const getPublishedTemplateById = (state, id) => _.get(state, ['templates', 'byId', id, 'published']);
+export const getPublishedTemplateById = (state, id) =>
+  _.get(state, ['templates', 'byId', id, 'published']);
 
-export const getTemplates = (state) => state.templates.list;
+export const getTemplates = state => state.templates.list;
 export const selectTemplates = createSelector(
   [getTemplates, getSubaccountsIndexedById],
-  (templates, subaccounts) => templates.map((template) => ({
-    ...template,
-    subaccount_name: getSubaccountName(subaccounts,template['subaccount_id'])
-  }))
+  (templates, subaccounts) =>
+    templates.map(template => ({
+      ...template,
+      subaccount_name: getSubaccountName(subaccounts, template['subaccount_id']),
+    })),
 );
-export const selectPublishedTemplates = (state) => _.filter(state.templates.list, (template) => template.has_published);
+export const selectPublishedTemplates = state =>
+  // eslint-disable-next-line lodash/prop-shorthand
+  _.filter(state.templates.list, template => template.has_published);
 
-const createTemplateSelector = (getter) => createSelector(
-  [getter, selectDefaultTemplateOptions],
-  (template, defaultOptions) => {
-    if (!template) { return; }
-    return { ...template, options: { ...defaultOptions, ...template.options }};
-  }
-);
+const createTemplateSelector = getter =>
+  createSelector([getter, selectDefaultTemplateOptions], (template, defaultOptions) => {
+    if (!template) {
+      return;
+    }
+
+    return { ...template, options: { ...defaultOptions, ...template.options } };
+  });
+
 export const selectDraftTemplateById = createTemplateSelector(getDraftTemplateById);
 export const selectPublishedTemplateById = createTemplateSelector(getPublishedTemplateById);
 
-export const selectDraftTemplatePreview = (state, id, defaultValue) => (
-  state.templates.contentPreview.draft[id] || defaultValue
-);
-export const selectPublishedTemplatePreview = (state, id, defaultValue) => (
-  state.templates.contentPreview.published[id] || defaultValue
-);
-export const selectPreviewLineErrors = (state) => (
-  _.get(state, 'templates.contentPreview.error.response.data.errors', [])
-);
+export const selectDraftTemplatePreview = (state, id, defaultValue) =>
+  state.templates.contentPreview.draft[id] || defaultValue;
+export const selectPublishedTemplatePreview = (state, id, defaultValue) =>
+  state.templates.contentPreview.published[id] || defaultValue;
+export const selectPreviewLineErrors = state =>
+  _.get(state, 'templates.contentPreview.error.response.data.errors', []);
 
 export const selectDefaultTestData = () => JSON.stringify(config.templates.testData, null, 2);
-export const selectTemplateTestData = (state) => JSON.stringify(state.templates.testData || config.templates.testData, null, 2);
+export const selectTemplateTestData = state =>
+  JSON.stringify(state.templates.testData || config.templates.testData, null, 2);
 
-export const selectAndCloneDraftById = createSelector(
-  [selectDraftTemplateById],
-  (draft) => {
-    if (!draft) { return; }
-    return { ...draft, name: `${draft.name} Copy`, id: `${draft.id}-copy` };
+export const selectAndCloneDraftById = createSelector([selectDraftTemplateById], draft => {
+  if (!draft) {
+    return;
   }
-);
+  return { ...draft, name: `${draft.name} Copy`, id: `${draft.id}-copy` };
+});
 
 // Selects sending domains for From Email typeahead
 export const selectDomainsBySubaccount = createSelector(
   [getDomains, selectSubaccountIdFromProps],
-  (domains, subaccountId) => _.filter(domains, (domain) => {
+  (domains, subaccountId) =>
+    _.filter(domains, domain => {
+      if (!isVerified(domain)) {
+        return false;
+      }
 
-    if (!isVerified(domain)) {
-      return false;
-    }
-
-    return subaccountId
-      ? domain.shared_with_subaccounts || domain.subaccount_id === Number(subaccountId)
-      : !domain.subaccount_id;
-  })
+      return subaccountId
+        ? domain.shared_with_subaccounts || domain.subaccount_id === Number(subaccountId)
+        : !domain.subaccount_id;
+    }),
 );
 
 /**
  * Returns domains by subaccount, but if no verified domain exists, return sparkpost default domain
  */
 export const selectDomainsBySubaccountWithDefault = createSelector(
-  [selectDomainsBySubaccount], (domains) => {
+  [selectDomainsBySubaccount],
+  domains => {
     if (!domains || !domains.length) {
       return [{ domain: config.sandbox.domain }];
     } else {
       return domains;
     }
-  }
+  },
 );
-
 
 /**
  * Selects subaccountId from the selector's second arguement, in place of props
@@ -92,36 +95,36 @@ export const selectSubaccountId = (state, subaccountId) => subaccountId;
  */
 export const selectPublishedTemplatesBySubaccount = createSelector(
   [selectPublishedTemplates, selectSubaccountId, hasSubaccounts],
-  (templates, subaccountId, subaccountsExist) => filterTemplatesBySubaccount({ templates, subaccountId, hasSubaccounts: subaccountsExist })
+  (templates, subaccountId, subaccountsExist) =>
+    filterTemplatesBySubaccount({ templates, subaccountId, hasSubaccounts: subaccountsExist }),
 );
 
 /**
  * Prepare templates collection for listing with published and draft as separate item.
  * @return array
  */
-export const selectTemplatesForListTable = createSelector(
-  [selectTemplates], (templates) => {
-    const templatesForListing = [];
-    templates.forEach((template) => {
-      const isPublished = template.published;
-      const hasPublished = template.has_published;
-      const hasDraft = template.has_draft;
+export const selectTemplatesForListTable = createSelector([selectTemplates], templates => {
+  const templatesForListing = [];
+  templates.forEach(template => {
+    const isPublished = template.published;
+    const hasPublished = template.has_published;
+    const hasDraft = template.has_draft;
 
-      if (hasPublished) {
-        templatesForListing.push({
-          ...template,
-          list_name: template.name,
-          list_status: (hasDraft && !isPublished) ? 'published_with_draft' : 'published'
-        });
-      }
+    if (hasPublished) {
+      templatesForListing.push({
+        ...template,
+        list_name: template.name,
+        list_status: hasDraft && !isPublished ? 'published_with_draft' : 'published',
+      });
+    }
 
-      if (!isPublished) {
-        templatesForListing.push({
-          ...template,
-          list_name: hasPublished ? `${template.name} (DRAFT)` : template.name,
-          list_status: 'draft'
-        });
-      }
-    });
-    return templatesForListing;
+    if (!isPublished) {
+      templatesForListing.push({
+        ...template,
+        list_name: hasPublished ? `${template.name} (DRAFT)` : template.name,
+        list_status: 'draft',
+      });
+    }
   });
+  return templatesForListing;
+});

--- a/src/selectors/templates.js
+++ b/src/selectors/templates.js
@@ -30,7 +30,17 @@ const createTemplateSelector = getter =>
       return;
     }
 
-    return { ...template, options: { ...defaultOptions, ...template.options } };
+    const templateContent = _.isEmpty(template.content)
+      ? undefined
+      : // Remove falsy values from the content object
+        // See: https://stackoverflow.com/questions/30812765/how-to-remove-undefined-and-null-values-from-an-object-using-lodash#answer-31209300
+        { content: _.omitBy(template.content, _.isNil) };
+
+    return {
+      ...template,
+      ...templateContent,
+      options: { ...defaultOptions, ...template.options },
+    };
   });
 
 export const selectDraftTemplateById = createTemplateSelector(getDraftTemplateById);

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -81,7 +81,7 @@ describe('Templates selectors', () => {
             draft: {
               name: 'Bear',
               id: 'bear',
-              published: false,
+              published: true,
               content: {
                 text: 'Hello, world',
                 amp_html: null,
@@ -208,7 +208,7 @@ describe('Templates selectors', () => {
     });
 
     it('does not return keys with falsy values in the content object', () => {
-      expect(selector.selectDraftTemplate(store, 'bear')).toEqual({
+      expect(selector.selectDraftTemplateById(store, 'bear')).toEqual({
         id: 'bear',
         name: 'Bear',
         options: {

--- a/src/selectors/tests/templates.test.js
+++ b/src/selectors/tests/templates.test.js
@@ -5,12 +5,13 @@ describe('Templates selectors', () => {
   let store;
   beforeEach(() => {
     store = {
-      account: { // yuck
+      account: {
+        // yuck
         options: {
           click_tracking: true,
           rest_tracking_default: true,
-          transactional_default: false
-        }
+          transactional_default: false,
+        },
       },
       templates: {
         list: [
@@ -18,27 +19,27 @@ describe('Templates selectors', () => {
             name: 'unpublished',
             has_published: false,
             shared_with_subaccounts: false,
-            subaccount_id: 101
+            subaccount_id: 101,
           },
           {
             name: 'publishedSubaccount',
             has_published: true,
             shared_with_subaccounts: false,
-            subaccount_id: 101
+            subaccount_id: 101,
           },
           {
             name: 'publishedMaster',
             has_published: true,
             shared_with_subaccounts: false,
             subaccount_id: 0,
-            published: true
+            published: true,
           },
           {
             name: 'publishedShared',
             has_published: true,
             shared_with_subaccounts: true,
-            subaccount_id: 0
-          }
+            subaccount_id: 0,
+          },
         ],
         testData: { test: 'data' },
         byId: {
@@ -46,13 +47,13 @@ describe('Templates selectors', () => {
             draft: {
               name: 'Ape',
               id: 'ape',
-              published: false
+              published: false,
             },
             published: {
               name: 'Ape',
               id: 'ape',
-              published: true
-            }
+              published: true,
+            },
           },
           lion: {
             draft: {
@@ -62,8 +63,8 @@ describe('Templates selectors', () => {
               options: {
                 click_tracking: false,
                 open_tracking: false,
-                transactional: false
-              }
+                transactional: false,
+              },
             },
             published: {
               id: 'lion',
@@ -72,56 +73,78 @@ describe('Templates selectors', () => {
               options: {
                 click_tracking: false,
                 open_tracking: false,
-                transactional: false
-              }
-            }
-          }
+                transactional: false,
+              },
+            },
+          },
+          bear: {
+            draft: {
+              name: 'Bear',
+              id: 'bear',
+              published: false,
+              content: {
+                text: 'Hello, world',
+                amp_html: null,
+              },
+            },
+            published: {
+              name: 'Bear',
+              id: 'bear',
+              published: true,
+              content: {
+                text: 'Hello, world',
+                amp_html: null,
+              },
+            },
+          },
         },
         contentPreview: {
           draft: {
             ape: {
               html: '<h1>Southeastern Asia</h1>',
-              subject: 'New Location: Come visit me'
-            }
+              subject: 'New Location: Come visit me',
+            },
           },
           published: {
             ape: {
               html: '<h1>Baltimore Zoo</h1>.',
-              subject: 'Come visit me'
-            }
-          }
-        }
+              subject: 'Come visit me',
+            },
+          },
+        },
       },
       sendingDomains: {
         list: [
           {
             domain: 'shared.com',
             shared_with_subaccounts: true,
-            status: { ownership_verified: true, compliance_status: 'valid' }
+            status: { ownership_verified: true, compliance_status: 'valid' },
           },
           {
             domain: 'masterOnly.com',
-            status: { ownership_verified: true, compliance_status: 'valid' }
+            status: { ownership_verified: true, compliance_status: 'valid' },
           },
           {
             domain: 'assignedToSub.com',
             subaccount_id: 101,
-            status: { ownership_verified: true, compliance_status: 'valid' }
+            status: { ownership_verified: true, compliance_status: 'valid' },
           },
           {
             domain: 'notvalid.com',
-            status: { ownership_verified: false, compliance_status: 'valid' }
-          }
-        ]
+            status: { ownership_verified: false, compliance_status: 'valid' },
+          },
+        ],
       },
       currentUser: {
-        has_subaccounts: true
+        has_subaccounts: true,
       },
-      subaccounts: { list: [
-        { name: 'sub 1', id: 101 },
-        { name: 'sub 2', id: 501 }
-      ]},
-      form: { testform: { values: {}}}
+      subaccounts: {
+        list: [
+          { name: 'sub 1', id: 101 },
+          { name: 'sub 2', id: 501 },
+        ],
+      },
+      form: { testform: { values: {} } },
     };
   });
 
@@ -130,7 +153,7 @@ describe('Templates selectors', () => {
       expect(selector.getDraftTemplateById(store, 'ape')).toEqual({
         name: 'Ape',
         id: 'ape',
-        published: false
+        published: false,
       });
     });
 
@@ -144,7 +167,7 @@ describe('Templates selectors', () => {
       expect(selector.getPublishedTemplateById(store, 'ape')).toEqual({
         name: 'Ape',
         id: 'ape',
-        published: true
+        published: true,
       });
     });
 
@@ -161,9 +184,9 @@ describe('Templates selectors', () => {
         options: {
           click_tracking: false,
           open_tracking: false,
-          transactional: false
+          transactional: false,
         },
-        published: false
+        published: false,
       });
     });
 
@@ -174,14 +197,30 @@ describe('Templates selectors', () => {
         options: {
           click_tracking: true,
           open_tracking: true,
-          transactional: false
+          transactional: false,
         },
-        published: false
+        published: false,
       });
     });
 
     it('returns undefined when template is not present', () => {
       expect(selector.selectDraftTemplateById(store, 'unknown')).toBeUndefined();
+    });
+
+    it('does not return keys with falsy values in the content object', () => {
+      expect(selector.selectDraftTemplate(store, 'bear')).toEqual({
+        id: 'bear',
+        name: 'Bear',
+        options: {
+          click_tracking: true,
+          open_tracking: true,
+          transactional: false,
+        },
+        content: {
+          text: 'Hello, world',
+        },
+        published: true,
+      });
     });
   });
 
@@ -193,9 +232,9 @@ describe('Templates selectors', () => {
         options: {
           click_tracking: false,
           open_tracking: false,
-          transactional: false
+          transactional: false,
         },
-        published: true
+        published: true,
       });
     });
 
@@ -206,32 +245,56 @@ describe('Templates selectors', () => {
         options: {
           click_tracking: true,
           open_tracking: true,
-          transactional: false
+          transactional: false,
         },
-        published: true
+        published: true,
       });
     });
 
     it('returns undefined when template is not present', () => {
       expect(selector.selectPublishedTemplateById(store, 'unknown')).toBeUndefined();
     });
+
+    it('does not return keys with falsy values in the content object', () => {
+      expect(selector.selectPublishedTemplateById(store, 'bear')).toEqual({
+        id: 'bear',
+        name: 'Bear',
+        options: {
+          click_tracking: true,
+          open_tracking: true,
+          transactional: false,
+        },
+        content: {
+          text: 'Hello, world',
+        },
+        published: true,
+      });
+    });
   });
 
-  cases('.selectDraftTemplatePreview', ({ defaultValue, id }) => {
-    expect(selector.selectDraftTemplatePreview(store, id, defaultValue)).toMatchSnapshot();
-  }, {
-    'returns preview of draft template': { id: 'ape' },
-    'returns undefined when unknown': { id: 'unknown' },
-    'returns default value when unknown': { id: 'unknown', defaultValue: {}}
-  });
+  cases(
+    '.selectDraftTemplatePreview',
+    ({ defaultValue, id }) => {
+      expect(selector.selectDraftTemplatePreview(store, id, defaultValue)).toMatchSnapshot();
+    },
+    {
+      'returns preview of draft template': { id: 'ape' },
+      'returns undefined when unknown': { id: 'unknown' },
+      'returns default value when unknown': { id: 'unknown', defaultValue: {} },
+    },
+  );
 
-  cases('.selectPublishedTemplatePreview', ({ defaultValue, id }) => {
-    expect(selector.selectPublishedTemplatePreview(store, id, defaultValue)).toMatchSnapshot();
-  }, {
-    'returns preview of draft template': { id: 'ape' },
-    'returns undefined when unknown': { id: 'unknown' },
-    'returns default value when unknown': { id: 'unknown', defaultValue: {}}
-  });
+  cases(
+    '.selectPublishedTemplatePreview',
+    ({ defaultValue, id }) => {
+      expect(selector.selectPublishedTemplatePreview(store, id, defaultValue)).toMatchSnapshot();
+    },
+    {
+      'returns preview of draft template': { id: 'ape' },
+      'returns undefined when unknown': { id: 'unknown' },
+      'returns default value when unknown': { id: 'unknown', defaultValue: {} },
+    },
+  );
 
   describe('selectAndCloneDraftById', () => {
     it('returns clone of draft with updated name and id', () => {
@@ -241,9 +304,9 @@ describe('Templates selectors', () => {
         options: {
           click_tracking: true,
           open_tracking: true,
-          transactional: false
+          transactional: false,
         },
-        published: false
+        published: false,
       });
     });
 
@@ -276,7 +339,7 @@ describe('Templates selectors', () => {
     });
 
     it('should return default data', () => {
-      expect(selector.selectTemplateTestData({ templates: {}})).toMatchSnapshot();
+      expect(selector.selectTemplateTestData({ templates: {} })).toMatchSnapshot();
     });
   });
 
@@ -313,10 +376,10 @@ describe('Templates selectors', () => {
     it('should return an array of errors', () => {
       const errors = [
         { line: 1, message: 'Oh no!' },
-        { line: 2, message: 'Oh no!' }
+        { line: 2, message: 'Oh no!' },
       ];
 
-      store.templates.contentPreview.error = { response: { data: { errors }}};
+      store.templates.contentPreview.error = { response: { data: { errors } } };
 
       expect(selector.selectPreviewLineErrors(store)).toEqual(errors);
     });
@@ -328,7 +391,10 @@ describe('Templates selectors', () => {
     });
 
     it('returns template(s) with draft version only', () => {
-      store.templates.list = store.templates.list.map((template) => ({ ...template, has_published: false }));
+      store.templates.list = store.templates.list.map(template => ({
+        ...template,
+        has_published: false,
+      }));
       store.templates.list[1].has_draft = true;
       expect(selector.selectTemplatesForListTable(store)).toMatchSnapshot();
     });
@@ -337,21 +403,30 @@ describe('Templates selectors', () => {
       store.templates.list[2].has_draft = true;
       expect(selector.selectTemplatesForListTable(store)).toMatchSnapshot();
     });
-
   });
 
   describe('selectDomainsBySubaccountWithDefault', () => {
     it('returns verified domains when exist', () => {
-      expect(selector.selectDomainsBySubaccountWithDefault(store, {}).map((dom) => dom.domain)).toEqual(['shared.com', 'masterOnly.com']);
+      expect(
+        selector.selectDomainsBySubaccountWithDefault(store, {}).map(dom => dom.domain),
+      ).toEqual(['shared.com', 'masterOnly.com']);
     });
 
     it('returns subaccount verified domains when exist', () => {
       const expectedDomains = ['shared.com', 'assignedToSub.com'];
-      expect(selector.selectDomainsBySubaccountWithDefault(store, { subaccountId: 101 }).map((dom) => dom.domain)).toEqual(expectedDomains);
+      expect(
+        selector
+          .selectDomainsBySubaccountWithDefault(store, { subaccountId: 101 })
+          .map(dom => dom.domain),
+      ).toEqual(expectedDomains);
     });
 
     it('returns sandbox domain when no verified sending domain exists', () => {
-      expect(selector.selectDomainsBySubaccountWithDefault({ ...store, sendingDomains: { list: []}}, {}).map((dom) => dom.domain)).toEqual(['sparkpostbox.com']);
+      expect(
+        selector
+          .selectDomainsBySubaccountWithDefault({ ...store, sendingDomains: { list: [] } }, {})
+          .map(dom => dom.domain),
+      ).toEqual(['sparkpostbox.com']);
     });
   });
 });


### PR DESCRIPTION
[TR-2221](https://jira.int.messagesystems.com/browse/TR-2221)

### What Changed
- Adds unit test cases for the templates selector
- Adds Cypress test to check for exception
- Resolves bug by filtering out falsy values from the `template.content` object received from a request

### How To Test
- Run Cypress integration tests locally - `npm run test-integration`
- Comment out line 41 of `src/selectors/templates.js`
- Run the `editDraftPage.spec.js` tests in Cypress and see the test fail due to the uncaught exception
- Re-introduce line 41 of `src/selectors/templates.js`
- Run the `editDraftPage.spec.js` tests in Cypress again and see everything pass

### To Do
- [ ] Incorporate feedback
