### PR TITLE
FE-858 - Adding promise resolution to Cypress run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ jobs:
     # though no need to prematurely optimize at this point.
     - stage: test-and-build
       name: 'Integration Testing - Accounts, Events, Navigation, and Alerts'
-      env: SPEC_BATCH='Paul Walker'
-      script: npm run test-integration-ci
+      script: npm run test-integration-ci -- --specBatch='Paul Walker'
     # - stage: test-and-build
     #   name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
     #   env: SPEC_BATCH='Vin Diesel'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_script: greenkeeper-lockfile-update
 
 jobs:
   include:
-    - stage: test-and-build
-      name: 'Unit Testing'
-      script: npm run test-ci
+    # - stage: test-and-build
+    #   name: 'Unit Testing'
+    #   script: npm run test-ci
     # Running Cypress tests in parallel by running them in batches to reduce pipeline duration.
     # This could probably be improved by writing a Node script to handle a config,
     # though no need to prematurely optimize at this point.
@@ -30,10 +30,10 @@ jobs:
       name: 'Integration Testing - Accounts, Events, Navigation, and Alerts'
       env: SPEC_BATCH='Paul Walker'
       script: npm run test-integration-ci
-    - stage: test-and-build
-      name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
-      env: SPEC_BATCH='Vin Diesel'
-      script: npm run test-integration-ci
+    # - stage: test-and-build
+    #   name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
+    #   env: SPEC_BATCH='Vin Diesel'
+    #   script: npm run test-integration-ci
 
 after_script: greenkeeper-lockfile-upload
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_script: greenkeeper-lockfile-update
 
 jobs:
   include:
-    # - stage: test-and-build
-    #   name: 'Unit Testing'
-    #   script: npm run test-ci
+    - stage: test-and-build
+      name: 'Unit Testing'
+      script: npm run test-ci
     # Running Cypress tests in parallel by running them in batches to reduce pipeline duration.
     # This could probably be improved by writing a Node script to handle a config,
     # though no need to prematurely optimize at this point.
@@ -30,10 +30,10 @@ jobs:
       name: 'Integration Testing - Accounts, Events, Navigation, and Alerts'
       env: SPEC_BATCH='Paul Walker'
       script: npm run test-integration-ci
-    # - stage: test-and-build
-    #   name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
-    #   env: SPEC_BATCH='Vin Diesel'
-    #   script: npm run test-integration-ci
+    - stage: test-and-build
+      name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
+      env: SPEC_BATCH='Vin Diesel'
+      script: npm run test-integration-ci
 
 after_script: greenkeeper-lockfile-upload
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,18 @@ before_script: greenkeeper-lockfile-update
 
 jobs:
   include:
-    # - stage: test-and-build
-    #   name: 'Unit Testing'
-    #   script: npm run test-ci
+    - stage: test-and-build
+      name: 'Unit Testing'
+      script: npm run test-ci
     # Running Cypress tests in parallel by running them in batches to reduce pipeline duration.
     # This could probably be improved by writing a Node script to handle a config,
     # though no need to prematurely optimize at this point.
     - stage: test-and-build
       name: 'Integration Testing - Accounts, Events, Navigation, and Alerts'
       script: npm run test-integration-ci -- --specBatch='Paul Walker'
-    # - stage: test-and-build
-    #   name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
-    #   env: SPEC_BATCH='Vin Diesel'
-    #   script: npm run test-integration-ci
+    - stage: test-and-build
+      name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
+      script: npm run test-integration-ci -- --specBatch='Vin Diesel'
 
 after_script: greenkeeper-lockfile-upload
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,7 @@ jobs:
     - stage: test-and-build
       name: 'Unit Testing'
       script: npm run test-ci
-    # Running Cypress tests in parallel by running them in batches to reduce pipeline duration.
-    # This could probably be improved by writing a Node script to handle a config,
-    # though no need to prematurely optimize at this point.
+      # Running Cypress tests in parallel by running them in batches to reduce pipeline duration.
     - stage: test-and-build
       name: 'Integration Testing - Accounts, Events, Navigation, and Alerts'
       script: npm run test-integration-ci -- --specBatch='Paul Walker'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,20 +20,20 @@ before_script: greenkeeper-lockfile-update
 
 jobs:
   include:
-    - stage: test-and-build
-      name: 'Unit Testing'
-      script: npm run test-ci
-      # Running Cypress tests in parallel by running them in batches to reduce pipeline duration.
-      # This could probably be improved by writing a Node script to handle a config,
-      # though no need to prematurely optimize at this point.
+    # - stage: test-and-build
+    #   name: 'Unit Testing'
+    #   script: npm run test-ci
+    # Running Cypress tests in parallel by running them in batches to reduce pipeline duration.
+    # This could probably be improved by writing a Node script to handle a config,
+    # though no need to prematurely optimize at this point.
     - stage: test-and-build
       name: 'Integration Testing - Accounts, Events, Navigation, and Alerts'
       env: SPEC_BATCH='Paul Walker'
       script: npm run test-integration-ci
-    - stage: test-and-build
-      name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
-      env: SPEC_BATCH='Vin Diesel'
-      script: npm run test-integration-ci
+    # - stage: test-and-build
+    #   name: 'Integration Testing - Templates, Recipients, and Signals Analytics'
+    #   env: SPEC_BATCH='Vin Diesel'
+    #   script: npm run test-integration-ci
 
 after_script: greenkeeper-lockfile-upload
 

--- a/config/cypressBatches.js
+++ b/config/cypressBatches.js
@@ -1,9 +1,9 @@
 module.exports = {
   'Paul Walker': [
-    // 'cypress/tests/integration/accounts/**/*',
+    'cypress/tests/integration/accounts/**/*',
     'cypress/tests/integration/alerts/**/*',
-    // 'cypress/tests/integration/events/**/*',
-    // 'cypress/tests/integration/navigation/**/*',
+    'cypress/tests/integration/events/**/*',
+    'cypress/tests/integration/navigation/**/*',
   ],
   'Vin Diesel': [
     'cypress/tests/integration/recipients/**/*',

--- a/config/cypressBatches.js
+++ b/config/cypressBatches.js
@@ -1,9 +1,9 @@
 module.exports = {
   'Paul Walker': [
-    'cypress/tests/integration/accounts/**/*',
+    // 'cypress/tests/integration/accounts/**/*',
     'cypress/tests/integration/alerts/**/*',
-    'cypress/tests/integration/events/**/*',
-    'cypress/tests/integration/navigation/**/*',
+    // 'cypress/tests/integration/events/**/*',
+    // 'cypress/tests/integration/navigation/**/*',
   ],
   'Vin Diesel': [
     'cypress/tests/integration/recipients/**/*',

--- a/cypress/tests/integration/alerts/detailsPage.spec.js
+++ b/cypress/tests/integration/alerts/detailsPage.spec.js
@@ -72,7 +72,7 @@ describe('The alerts details pages', () => {
       cy.findByLabelText('Alert Name').should('have.value', 'This is an alert Copy');
     });
 
-    it('renders a success message and re-routes to the list page when an alert is successfully deleted', () => {
+    it.only('renders a success message and re-routes to the list page when an alert is successfully deleted', () => {
       cy.stubRequest({
         method: 'DELETE',
         url: API_URL,
@@ -84,7 +84,7 @@ describe('The alerts details pages', () => {
       cy.findByText('Are you sure you want to delete this alert?').should('be.visible');
       cy.findByText('Cancel').click();
       cy.queryByText('Are you sure you want to delete this alert?').should('not.be.visible');
-      cy.get('main').within(() => cy.findByText('Delete').click());
+      cy.findByText('Delete').click();
       cy.get('#modal-portal').within(() => cy.findByText('Delete').click());
 
       cy.findByText('Alert: This is an alert Deleted').should('be.visible');

--- a/cypress/tests/integration/alerts/detailsPage.spec.js
+++ b/cypress/tests/integration/alerts/detailsPage.spec.js
@@ -72,7 +72,7 @@ describe('The alerts details pages', () => {
       cy.findByLabelText('Alert Name').should('have.value', 'This is an alert Copy');
     });
 
-    it.only('renders a success message and re-routes to the list page when an alert is successfully deleted', () => {
+    it('renders a success message and re-routes to the list page when an alert is successfully deleted', () => {
       cy.stubRequest({
         method: 'DELETE',
         url: API_URL,
@@ -84,7 +84,9 @@ describe('The alerts details pages', () => {
       cy.findByText('Are you sure you want to delete this alert?').should('be.visible');
       cy.findByText('Cancel').click();
       cy.queryByText('Are you sure you want to delete this alert?').should('not.be.visible');
-      cy.findByText('Delete').click();
+      // Grabbing delete button outside of the modal - this is technically a bug as
+      // the Modal needs to not be encounterable by Cypress or screen readers at this point
+      cy.get('main').within(() => cy.findByText('Delete').click());
       cy.get('#modal-portal').within(() => cy.findByText('Delete').click());
 
       cy.findByText('Alert: This is an alert Deleted').should('be.visible');

--- a/cypress/tests/integration/alerts/detailsPage.spec.js
+++ b/cypress/tests/integration/alerts/detailsPage.spec.js
@@ -84,7 +84,7 @@ describe('The alerts details pages', () => {
       cy.findByText('Are you sure you want to delete this alert?').should('be.visible');
       cy.findByText('Cancel').click();
       cy.queryByText('Are you sure you want to delete this alert?').should('not.be.visible');
-      cy.findByText('Delete').click();
+      cy.get('main').within(() => cy.findByText('Delete').click());
       cy.get('#modal-portal').within(() => cy.findByText('Delete').click());
 
       cy.findByText('Alert: This is an alert Deleted').should('be.visible');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-e2e-ci": "npm run start-app & wait-on http://localhost:3100 && npm run test-e2e-headless",
     "test-integration": "npm run test-cy-env && cypress open --config integrationFolder=cypress/tests/integration",
     "test-integration-headless": "node scripts/cypressIntegration.js",
-    "test-integration-ci": "npm run start-app & wait-on http://localhost:3100 && sleep 90 && node scripts/cypressIntegration.js --spec $SPEC_BATCH",
+    "test-integration-ci": "npm run start-app & wait-on http://localhost:3100 && sleep 90 && node scripts/cypressIntegration.js --specBatch=$SPEC_BATCH",
     "storybook-dev": "start-storybook --port 3101 --config-dir .storybook --docs --quiet",
     "storybook-build": "build-storybook --config-dir .storybook --output-dir .out --docs",
     "travis": "npm run test-ci && npm run build"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-e2e-ci": "npm run start-app & wait-on http://localhost:3100 && npm run test-e2e-headless",
     "test-integration": "npm run test-cy-env && cypress open --config integrationFolder=cypress/tests/integration",
     "test-integration-headless": "node scripts/cypressIntegration.js",
-    "test-integration-ci": "npm run start-app & wait-on http://localhost:3100 && sleep 90 && node scripts/cypressIntegration.js --specBatch=$SPEC_BATCH",
+    "test-integration-ci": "npm run start-app & wait-on http://localhost:3100 && sleep 90 && node scripts/cypressIntegration.js",
     "storybook-dev": "start-storybook --port 3101 --config-dir .storybook --docs --quiet",
     "storybook-build": "build-storybook --config-dir .storybook --output-dir .out --docs",
     "travis": "npm run test-ci && npm run build"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-e2e-ci": "npm run start-app & wait-on http://localhost:3100 && npm run test-e2e-headless",
     "test-integration": "npm run test-cy-env && cypress open --config integrationFolder=cypress/tests/integration",
     "test-integration-headless": "node scripts/cypressIntegration.js",
-    "test-integration-ci": "npm run start-app & wait-on http://localhost:3100 && sleep 90 && node scripts/cypressIntegration.js --specBatch $SPEC_BATCH",
+    "test-integration-ci": "npm run start-app & wait-on http://localhost:3100 && sleep 90 && node scripts/cypressIntegration.js --spec $SPEC_BATCH",
     "storybook-dev": "start-storybook --port 3101 --config-dir .storybook --docs --quiet",
     "storybook-build": "build-storybook --config-dir .storybook --output-dir .out --docs",
     "travis": "npm run test-ci && npm run build"

--- a/scripts/cypressIntegration.js
+++ b/scripts/cypressIntegration.js
@@ -3,6 +3,13 @@ const { argv } = require('yargs');
 const batches = require('../config/cypressBatches');
 
 function runCypress({ specs }) {
+  if (!specs) {
+    console.error(
+      'No matching spec files found. Please pass in a valid value with the `--specBatch` flag',
+    );
+    process.exit(1);
+  }
+
   console.log('Running specs:', specs);
 
   return cypress

--- a/scripts/cypressIntegration.js
+++ b/scripts/cypressIntegration.js
@@ -13,10 +13,11 @@ function runCypress({ specs }) {
       },
       spec: specs ? specs.join(',') : undefined,
     })
-    .then(() => {
-      process.exit(0);
+    .then(results => {
+      process.exit(results.totalFailed);
     })
-    .catch(() => {
+    .catch(err => {
+      console.error(err);
       process.exit(1);
     });
 }

--- a/scripts/cypressIntegration.js
+++ b/scripts/cypressIntegration.js
@@ -11,14 +11,10 @@ function runCypress({ specs }) {
       },
       spec: specs ? specs.join(',') : undefined,
     })
-    .then(results => {
-      console.log('then!');
-      console.log(results);
+    .then(() => {
       process.exit(0);
     })
-    .catch(err => {
-      console.log('catch!');
-      console.error(err);
+    .catch(() => {
       process.exit(1);
     });
 }

--- a/scripts/cypressIntegration.js
+++ b/scripts/cypressIntegration.js
@@ -14,4 +14,6 @@ function runCypress({ specs }) {
 
 const targetSpecs = batches[argv.specBatch];
 
-runCypress({ specs: targetSpecs });
+runCypress({ specs: targetSpecs })
+  .then(results => console.log(results))
+  .catch(err => console.error(err));

--- a/scripts/cypressIntegration.js
+++ b/scripts/cypressIntegration.js
@@ -3,6 +3,8 @@ const { argv } = require('yargs');
 const batches = require('../config/cypressBatches');
 
 function runCypress({ specs }) {
+  console.log('Running specs:', specs);
+
   return cypress
     .run({
       config: {

--- a/scripts/cypressIntegration.js
+++ b/scripts/cypressIntegration.js
@@ -15,5 +15,11 @@ function runCypress({ specs }) {
 const targetSpecs = batches[argv.specBatch];
 
 runCypress({ specs: targetSpecs })
-  .then(results => console.log(results))
-  .catch(err => console.error(err));
+  .then(results => {
+    console.log(results);
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/cypressIntegration.js
+++ b/scripts/cypressIntegration.js
@@ -3,23 +3,26 @@ const { argv } = require('yargs');
 const batches = require('../config/cypressBatches');
 
 function runCypress({ specs }) {
-  return cypress.run({
-    config: {
-      video: false,
-      integrationFolder: 'cypress/tests/integration',
-    },
-    spec: specs ? specs.join(',') : undefined,
-  });
+  return cypress
+    .run({
+      config: {
+        video: false,
+        integrationFolder: 'cypress/tests/integration',
+      },
+      spec: specs ? specs.join(',') : undefined,
+    })
+    .then(results => {
+      console.log('then!');
+      console.log(results);
+      process.exit(0);
+    })
+    .catch(err => {
+      console.log('catch!');
+      console.error(err);
+      process.exit(1);
+    });
 }
 
 const targetSpecs = batches[argv.specBatch];
 
-runCypress({ specs: targetSpecs })
-  .then(results => {
-    console.log(results);
-    process.exit(0);
-  })
-  .catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+runCypress({ specs: targetSpecs });


### PR DESCRIPTION
[FE-858](https://jira.int.messagesystems.com/browse/FE-858)

### What Changed
- Properly passes spec batch keys to the Cypress integration test script
- Adds additional edge case handling to the Cypress integration test script
- Manually exits the Cypress node process when encountering an error based on the number of failed tests being > 0
- Fixed failing test in alerts details page

### How To Test
- Verify that builds from prior commits failed when a test failed: https://travis-ci.org/SparkPost/2web2ui/builds/653200064?utm_source=github_status&utm_medium=notification
- Verify integration tests are properly split - they were being run simultaneously by multiple runners!

### To Do
- [ ] Incorporate feedback
