### PR TITLE
FE-853 Fix ComboBoxTypeahead to use redux-form initalValues.

### DIFF
--- a/src/components/reduxFormWrappers/tests/__snapshots__/ComboBoxTypeaheadWrapper.test.js.snap
+++ b/src/components/reduxFormWrappers/tests/__snapshots__/ComboBoxTypeaheadWrapper.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ComboBoxTypeaheadWrapper renders Combobox typeahead 1`] = `
 <ComboBoxTypeahead
   defaultSelected={Array []}
+  isExclusiveItem={[Function]}
   itemToString={[Function]}
   label="Options"
   maxNumberOfResults={100}
@@ -19,7 +20,6 @@ exports[`ComboBoxTypeaheadWrapper renders Combobox typeahead 1`] = `
       },
     ]
   }
-  selectedMap={[Function]}
   value={
     Array [
       "option-one",

--- a/src/components/typeahead/ComboBoxTypeahead.js
+++ b/src/components/typeahead/ComboBoxTypeahead.js
@@ -6,7 +6,6 @@ import { useDebouncedCallback } from 'use-debounce';
 import sortMatch from 'src/helpers/sortMatch';
 
 export const ComboBoxTypeahead = ({
-  defaultSelected,
   disabled,
   error,
   itemToString,
@@ -17,13 +16,14 @@ export const ComboBoxTypeahead = ({
   placeholder,
   readOnly,
   results,
-  selectedMap
+  selectedMap,
+  value,
 }) => {
   const [inputValue, setInputValue] = useState('');
   const [menuItems, setMenuItems] = useState([]);
-  const [selectedItems, setSelectedItems] = useState(defaultSelected);
-  const [updateMenuItems] = useDebouncedCallback((value) => {
-    const items = value ? sortMatch(results, value, itemToString) : results;
+  const [selectedItems, setSelectedItems] = useState(value);
+  const [updateMenuItems] = useDebouncedCallback(input => {
+    const items = input ? sortMatch(results, input, itemToString) : results;
     const nextMenuItems = items.slice(0, maxNumberOfResults);
     setMenuItems(nextMenuItems);
   }, 300);
@@ -31,8 +31,8 @@ export const ComboBoxTypeahead = ({
   // Updated list of selected menu items when combo box is being controlled
   // note, state must be initialized with defaultSelected to avoid a runaway effect
   useEffect(() => {
-    setSelectedItems(defaultSelected);
-  }, [setSelectedItems, defaultSelected]);
+    setSelectedItems(value);
+  }, [setSelectedItems, value]);
 
   // Report change to selected items (important for redux-form Fields)
   useEffect(() => {
@@ -45,13 +45,10 @@ export const ComboBoxTypeahead = ({
   }, [updateMenuItems, inputValue, results, selectedItems]);
 
   // note, not all items are objects
-  const isExclusiveItem = (item) => (
-    typeof item === 'object' && Boolean(item.isExclusiveItem)
-  );
+  const isExclusiveItem = item => typeof item === 'object' && Boolean(item.isExclusiveItem);
 
-  const isSelectedItem = (item) => (
-    selectedItems.some((selectedItem) => selectedMap(selectedItem) === selectedMap(item))
-  );
+  const isSelectedItem = item =>
+    selectedItems.some(selectedItem => selectedMap(selectedItem) === selectedMap(item));
 
   // Must use state reducer to avoid menu automatically closing
   // see, https://github.com/downshift-js/downshift#statechangetypes
@@ -66,7 +63,7 @@ export const ComboBoxTypeahead = ({
           ...changes,
           inputValue: '', // unset input value, now that it has been saved in selected items
           isOpen: true, // leave menu open
-          selectedItem: null
+          selectedItem: null,
         };
       }
       case Downshift.stateChangeTypes.changeInput:
@@ -84,20 +81,25 @@ export const ComboBoxTypeahead = ({
     highlightedIndex,
     inputValue,
     isOpen,
-    openMenu
+    openMenu,
   }) => {
     const hasSelectedItems = Boolean(selectedItems.length);
     const isSelectedItemExclusive = isExclusiveItem(selectedItems[0]);
     const items = menuItems
-      .filter((item) => (
-        !isSelectedItemExclusive && !isSelectedItem(item) && !(hasSelectedItems && isExclusiveItem(item))
-      ))
-      .map((item, index) => getItemProps({
-        content: itemToString(item),
-        highlighted: highlightedIndex === index,
-        index,
-        item
-      }));
+      .filter(
+        item =>
+          !isSelectedItemExclusive &&
+          !isSelectedItem(item) &&
+          !(hasSelectedItems && isExclusiveItem(item)),
+      )
+      .map((item, index) =>
+        getItemProps({
+          content: itemToString(item),
+          highlighted: highlightedIndex === index,
+          index,
+          item,
+        }),
+      );
     const isMenuOpen = isOpen && Boolean(items.length);
 
     const inputProps = getInputProps({
@@ -106,18 +108,20 @@ export const ComboBoxTypeahead = ({
       id: name,
       itemToString,
       label,
-      onFocus: () => { openMenu(); },
+      onFocus: () => {
+        openMenu();
+      },
       placeholder: hasSelectedItems ? '' : placeholder,
       readOnly: readOnly || isSelectedItemExclusive,
-      removeItem: (itemToRemove) => {
+      removeItem: itemToRemove => {
         const mappedItemToRemove = selectedMap(itemToRemove);
-        const nextSelectedItems = selectedItems.filter((selectedItem) => (
-          selectedMap(selectedItem) !== mappedItemToRemove)
+        const nextSelectedItems = selectedItems.filter(
+          selectedItem => selectedMap(selectedItem) !== mappedItemToRemove,
         );
         setSelectedItems(nextSelectedItems);
       },
       selectedItems,
-      value: inputValue || ''
+      value: inputValue || '',
     });
 
     return (
@@ -129,11 +133,7 @@ export const ComboBoxTypeahead = ({
   };
 
   return (
-    <Downshift
-      defaultHighlightedIndex={0}
-      itemToString={itemToString}
-      stateReducer={stateReducer}
-    >
+    <Downshift defaultHighlightedIndex={0} itemToString={itemToString} stateReducer={stateReducer}>
       {typeaheadfn}
     </Downshift>
   );
@@ -150,14 +150,14 @@ ComboBoxTypeahead.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   results: PropTypes.array,
-  selectedMap: PropTypes.func
+  selectedMap: PropTypes.func,
 };
 
 ComboBoxTypeahead.defaultProps = {
   defaultSelected: [],
-  itemToString: (item) => item,
+  itemToString: item => item,
   maxNumberOfResults: 100,
   placeholder: '',
   results: [],
-  selectedMap: (item) => item
+  selectedMap: item => item,
 };

--- a/src/components/typeahead/ComboBoxTypeahead.js
+++ b/src/components/typeahead/ComboBoxTypeahead.js
@@ -8,6 +8,7 @@ import sortMatch from 'src/helpers/sortMatch';
 export const ComboBoxTypeahead = ({
   disabled,
   error,
+  isExclusiveItem,
   itemToString,
   label,
   maxNumberOfResults,
@@ -16,7 +17,6 @@ export const ComboBoxTypeahead = ({
   placeholder,
   readOnly,
   results,
-  selectedMap,
   value,
 }) => {
   const [inputValue, setInputValue] = useState('');
@@ -36,19 +36,15 @@ export const ComboBoxTypeahead = ({
 
   // Report change to selected items (important for redux-form Fields)
   useEffect(() => {
-    onChange(selectedItems.map(selectedMap));
-  }, [onChange, selectedMap, selectedItems]);
+    onChange(selectedItems);
+  }, [onChange, selectedItems]);
 
   // Update list of menu items when available list of items (results), input value or select items changes
   useEffect(() => {
     updateMenuItems(inputValue);
   }, [updateMenuItems, inputValue, results, selectedItems]);
 
-  // note, not all items are objects
-  const isExclusiveItem = item => typeof item === 'object' && Boolean(item.isExclusiveItem);
-
-  const isSelectedItem = item =>
-    selectedItems.some(selectedItem => selectedMap(selectedItem) === selectedMap(item));
+  const isSelectedItem = item => selectedItems.some(selectedItem => selectedItem === item);
 
   // Must use state reducer to avoid menu automatically closing
   // see, https://github.com/downshift-js/downshift#statechangetypes
@@ -114,9 +110,9 @@ export const ComboBoxTypeahead = ({
       placeholder: hasSelectedItems ? '' : placeholder,
       readOnly: readOnly || isSelectedItemExclusive,
       removeItem: itemToRemove => {
-        const mappedItemToRemove = selectedMap(itemToRemove);
+        const mappedItemToRemove = itemToRemove;
         const nextSelectedItems = selectedItems.filter(
-          selectedItem => selectedMap(selectedItem) !== mappedItemToRemove,
+          selectedItem => selectedItem !== mappedItemToRemove,
         );
         setSelectedItems(nextSelectedItems);
       },
@@ -142,6 +138,7 @@ export const ComboBoxTypeahead = ({
 ComboBoxTypeahead.propTypes = {
   defaultSelected: PropTypes.array,
   disabled: PropTypes.bool,
+  isExclusiveItem: PropTypes.func,
   itemToString: PropTypes.func,
   label: PropTypes.string,
   maxNumberOfResults: PropTypes.number,
@@ -150,14 +147,13 @@ ComboBoxTypeahead.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   results: PropTypes.array,
-  selectedMap: PropTypes.func,
 };
 
 ComboBoxTypeahead.defaultProps = {
   defaultSelected: [],
+  isExclusiveItem: () => false,
   itemToString: item => item,
   maxNumberOfResults: 100,
   placeholder: '',
   results: [],
-  selectedMap: item => item,
 };

--- a/src/components/typeahead/tests/ComboBoxTypeahead.test.js
+++ b/src/components/typeahead/tests/ComboBoxTypeahead.test.js
@@ -74,10 +74,9 @@ describe('ComboBoxTypeahead', () => {
 
   it('renders filtered menu items without exclusive items', () => {
     const wrapper = subject({
-      value: [{ content: 'B' }],
-      itemToString: item => item.content,
-      results: [{ content: 'A', isExclusiveItem: true }, { content: 'B' }, { content: 'C' }],
-      selectedMap: item => item.content,
+      value: ['B'],
+      results: ['A', 'B', 'C'],
+      isExclusiveItem: item => item === 'A',
     });
 
     expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(1);
@@ -97,8 +96,8 @@ describe('ComboBoxTypeahead', () => {
 
   it('closes menu when exclusive item is selected', () => {
     const wrapper = subject({
-      itemToString: item => item.content,
-      results: [{ content: 'My Example', isExclusiveItem: true }],
+      results: ['My Example'],
+      isExclusiveItem: item => item === 'My Example',
     });
     selectMenuItem(wrapper, 0);
     expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', false);
@@ -137,8 +136,8 @@ describe('ComboBoxTypeahead', () => {
 
   it('enabled read only mode for text field when an exclusive item is selected', () => {
     const wrapper = subject({
-      itemToString: item => item.content,
-      results: [{ content: 'My Example', isExclusiveItem: true }],
+      results: ['My Example'],
+      isExclusiveItem: item => item === 'My Example',
     });
     selectMenuItem(wrapper, 0);
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('readOnly', true);

--- a/src/components/typeahead/tests/ComboBoxTypeahead.test.js
+++ b/src/components/typeahead/tests/ComboBoxTypeahead.test.js
@@ -7,26 +7,27 @@ import { ComboBoxTypeahead } from '../ComboBoxTypeahead';
 jest.mock('use-debounce');
 
 describe('ComboBoxTypeahead', () => {
-  const subject = (props = {}) => mount(
-    <ComboBoxTypeahead
-      defaultSelected={[]}
-      onChange={() => {}}
-      results={[
-        'apple',
-        'banana',
-        'blue ',
-        'cauliflower',
-        'grape',
-        'grapefruit',
-        'orange',
-        'pineapple'
-      ]}
-      {...props}
-    />
-  );
+  const subject = (props = {}) =>
+    mount(
+      <ComboBoxTypeahead
+        value={[]}
+        onChange={() => {}}
+        results={[
+          'apple',
+          'banana',
+          'blue ',
+          'cauliflower',
+          'grape',
+          'grapefruit',
+          'orange',
+          'pineapple',
+        ]}
+        {...props}
+      />,
+    );
 
   const changeInputValue = (wrapper, nextValue) => {
-    const fakeEvent = { target: { value: nextValue }};
+    const fakeEvent = { target: { value: nextValue } };
 
     act(() => {
       // simulate a input value change
@@ -51,7 +52,7 @@ describe('ComboBoxTypeahead', () => {
 
   beforeEach(() => {
     // need to memoize with useCallback
-    useDebouncedCallback.mockImplementation((fn) => [useCallback(fn, [])]);
+    useDebouncedCallback.mockImplementation(fn => [useCallback(fn, [])]);
   });
 
   it('renders max number of menu items', () => {
@@ -66,21 +67,17 @@ describe('ComboBoxTypeahead', () => {
   });
 
   it('renders filtered menu items without selected items', () => {
-    const wrapper = subject({ defaultSelected: ['grape']});
+    const wrapper = subject({ value: ['grape'] });
     changeInputValue(wrapper, 'grape');
     expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(1);
   });
 
   it('renders filtered menu items without exclusive items', () => {
     const wrapper = subject({
-      defaultSelected: [{ content: 'B' }],
-      itemToString: (item) => item.content,
-      results: [
-        { content: 'A', isExclusiveItem: true },
-        { content: 'B' },
-        { content: 'C' }
-      ],
-      selectedMap: (item) => item.content
+      value: [{ content: 'B' }],
+      itemToString: item => item.content,
+      results: [{ content: 'A', isExclusiveItem: true }, { content: 'B' }, { content: 'C' }],
+      selectedMap: item => item.content,
     });
 
     expect(wrapper.find('ComboBoxMenu').prop('items')).toHaveLength(1);
@@ -100,8 +97,8 @@ describe('ComboBoxTypeahead', () => {
 
   it('closes menu when exclusive item is selected', () => {
     const wrapper = subject({
-      itemToString: (item) => item.content,
-      results: [{ content: 'My Example', isExclusiveItem: true }]
+      itemToString: item => item.content,
+      results: [{ content: 'My Example', isExclusiveItem: true }],
     });
     selectMenuItem(wrapper, 0);
     expect(wrapper.find('ComboBoxMenu')).toHaveProp('isOpen', false);
@@ -140,8 +137,8 @@ describe('ComboBoxTypeahead', () => {
 
   it('enabled read only mode for text field when an exclusive item is selected', () => {
     const wrapper = subject({
-      itemToString: (item) => item.content,
-      results: [{ content: 'My Example', isExclusiveItem: true }]
+      itemToString: item => item.content,
+      results: [{ content: 'My Example', isExclusiveItem: true }],
     });
     selectMenuItem(wrapper, 0);
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('readOnly', true);
@@ -153,7 +150,7 @@ describe('ComboBoxTypeahead', () => {
   });
 
   it('does not render placeholder message when items have been selected', () => {
-    const wrapper = subject({ defaultSelected: ['apple'], placeholder: 'Do something!' });
+    const wrapper = subject({ value: ['apple'], placeholder: 'Do something!' });
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('placeholder', '');
   });
 
@@ -161,7 +158,7 @@ describe('ComboBoxTypeahead', () => {
     const wrapper = subject();
     const selectedItems = ['apple', 'banana'];
 
-    wrapper.setProps({ defaultSelected: selectedItems });
+    wrapper.setProps({ value: selectedItems });
     wrapper.update();
 
     expect(wrapper.find('ComboBoxTextField')).toHaveProp('selectedItems', selectedItems);
@@ -169,7 +166,7 @@ describe('ComboBoxTypeahead', () => {
 
   it('calls onChange on mount', () => {
     const onChange = jest.fn();
-    subject({ defaultSelected: ['pineapple'], onChange });
+    subject({ value: ['pineapple'], onChange });
     expect(onChange).toHaveBeenCalledWith(['pineapple']);
   });
 
@@ -184,7 +181,7 @@ describe('ComboBoxTypeahead', () => {
 
   it('calls onChange when selected item is removed', () => {
     const onChange = jest.fn();
-    const wrapper = subject({ defaultSelected: ['apple', 'pineapple'], onChange });
+    const wrapper = subject({ value: ['apple', 'pineapple'], onChange });
 
     act(() => {
       wrapper.find('ComboBoxTextField').prop('removeItem')('pineapple');

--- a/src/pages/alerts/components/AlertForm.js
+++ b/src/pages/alerts/components/AlertForm.js
@@ -158,7 +158,7 @@ export class AlertForm extends Component {
                     {!formSpec.hideSubaccountFilter && hasSubaccounts && (
                       <SubaccountField disabled={submitting} />
                     )}
-                    <FilterFields disabled={submitting} initialValues={initialValues} />
+                    <FilterFields disabled={submitting} />
                   </div>
                 )}
                 <div className={styles.Notifications}>

--- a/src/pages/alerts/components/fields/FilterFields.js
+++ b/src/pages/alerts/components/fields/FilterFields.js
@@ -44,8 +44,6 @@ export class FilterFields extends Component {
       sendingDomainsLoading,
       sendingIps,
       disabled,
-      // note, ComboBoxTypeaheadWrapper needs these values to set defaultSelected
-      initialValues,
     } = this.props;
 
     const formSpec = getFormSpec(metric);
@@ -118,7 +116,6 @@ export class FilterFields extends Component {
               component={ComboBoxTypeaheadWrapper}
               results={filterTypeaheadResults[single_filter.filter_type] || []}
               key={single_filter.filter_type}
-              defaultSelected={single_filter.filter_values}
               {...extraProps[single_filter.filter_type]}
             />
           </div>
@@ -147,7 +144,6 @@ export class FilterFields extends Component {
             component={ComboBoxTypeaheadWrapper}
             results={filterTypeaheadResults[value]}
             label={label}
-            defaultSelected={initialValues[value]}
             {...extraProps[value]}
           />
         ));

--- a/src/pages/alerts/components/fields/SubaccountsField.js
+++ b/src/pages/alerts/components/fields/SubaccountsField.js
@@ -1,60 +1,61 @@
-import React, { Component } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
-import { Field, formValueSelector } from 'redux-form';
+import { Field } from 'redux-form';
 import ComboBoxTypeaheadWrapper from 'src/components/reduxFormWrappers/ComboBoxTypeaheadWrapper';
 import { getSubaccounts } from 'src/selectors/subaccounts';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
-import { FORM_NAME } from '../../constants/formConstants';
 
-const subaccountToString = (subaccount) => {
-  if (!subaccount) {
-    return '';
-  }
-  return subaccount.id > 0 ? `${subaccount.name} (${subaccount.id})` : subaccount.name;
+const isExclusiveItem = item => {
+  return item < 0;
 };
 
-const subaccountMap = (item) => item.id;
+const SubaccountsField = props => {
+  const { listSubaccounts, disabled, subaccounts } = props;
 
-export class SubaccountsField extends Component {
-  componentDidMount() {
-    this.props.listSubaccounts();
-  }
+  useEffect(() => {
+    listSubaccounts();
+  }, [listSubaccounts]);
 
-  render() {
-    const { disabled, subaccounts, subaccountsFieldValue } = this.props;
-    const subaccountItems = [
-      { id: -1, name: 'Master and all subaccounts', isExclusiveItem: true },
-      { id: -2, name: 'Any subaccount', isExclusiveItem: true },
+  const subaccountItems = useMemo(() => {
+    return [
+      { id: -1, name: 'Master and all subaccounts' },
+      { id: -2, name: 'Any subaccount' },
       { id: 0, name: 'Master account' },
-      ...subaccounts
+      ...subaccounts,
     ];
+  }, [subaccounts]);
 
-    //Maps from an array of subaccount ids to an array of full subaccount objects
-    const selectedSubaccounts = subaccountsFieldValue.map((subaccountId) =>
-      /*Find the correct subaccount object within all available subaccounts. If not found, return a default object with
-      an id and a placeholder name.
-      */
-      subaccountItems.find(({ id }) => id === subaccountId) || { id: subaccountId, name: 'id:' });
+  const subaccountToString = useCallback(
+    subaccountId => {
+      if (subaccountId === undefined) {
+        return '';
+      }
+      const subaccount = subaccountItems.find(({ id }) => id === subaccountId) || {};
+      return subaccountId > 0 ? `${subaccount.name} (${subaccount.id})` : subaccount.name;
+    },
+    [subaccountItems],
+  );
 
-    return (
-      <Field
-        name='subaccounts'
-        component={ComboBoxTypeaheadWrapper}
-        results={subaccountItems}
-        itemToString={subaccountToString}
-        selectedMap={subaccountMap}
-        disabled={disabled}
-        placeholder='Type To Search'
-        defaultSelected={selectedSubaccounts}
-        label='Subaccounts'
-      />
-    );
-  }
-}
+  const subAccountOptions = useMemo(() => {
+    return subaccountItems.map(({ id }) => id);
+  }, [subaccountItems]);
 
-const mapStateToProps = (state) => ({
+  return (
+    <Field
+      component={ComboBoxTypeaheadWrapper}
+      disabled={disabled}
+      isExclusiveItem={isExclusiveItem}
+      itemToString={subaccountToString}
+      label="Subaccounts"
+      name="subaccounts"
+      placeholder="Type To Search"
+      results={subAccountOptions}
+    />
+  );
+};
+
+const mapStateToProps = state => ({
   subaccounts: getSubaccounts(state) || [],
-  subaccountsFieldValue: formValueSelector(FORM_NAME)(state, 'subaccounts') || []
 });
 
 export default connect(mapStateToProps, { listSubaccounts })(SubaccountsField);

--- a/src/pages/alerts/components/fields/SubaccountsField.js
+++ b/src/pages/alerts/components/fields/SubaccountsField.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Field } from 'redux-form';
 import ComboBoxTypeaheadWrapper from 'src/components/reduxFormWrappers/ComboBoxTypeaheadWrapper';
@@ -16,29 +16,22 @@ export const SubaccountsField = props => {
     listSubaccounts();
   }, [listSubaccounts]);
 
-  const subaccountItems = useMemo(() => {
-    return [
-      { id: -1, name: 'Master and all subaccounts' },
-      { id: -2, name: 'Any subaccount' },
-      { id: 0, name: 'Master account' },
-      ...subaccounts,
-    ];
-  }, [subaccounts]);
+  const subaccountItems = [
+    { id: -1, name: 'Master and all subaccounts' },
+    { id: -2, name: 'Any subaccount' },
+    { id: 0, name: 'Master account' },
+    ...subaccounts,
+  ];
 
-  const subaccountToString = useCallback(
-    subaccountId => {
-      if (subaccountId === undefined) {
-        return '';
-      }
-      const subaccount = subaccountItems.find(({ id }) => id === subaccountId) || {};
-      return subaccountId > 0 ? `${subaccount.name} (${subaccount.id})` : subaccount.name;
-    },
-    [subaccountItems],
-  );
+  const subaccountToString = subaccountId => {
+    if (subaccountId === undefined) {
+      return '';
+    }
+    const subaccount = subaccountItems.find(({ id }) => id === subaccountId) || {};
+    return subaccountId > 0 ? `${subaccount.name} (${subaccount.id})` : subaccount.name;
+  };
 
-  const subAccountOptions = useMemo(() => {
-    return subaccountItems.map(({ id }) => id);
-  }, [subaccountItems]);
+  const subAccountOptions = subaccountItems.map(({ id }) => id);
 
   return (
     <Field

--- a/src/pages/alerts/components/fields/SubaccountsField.js
+++ b/src/pages/alerts/components/fields/SubaccountsField.js
@@ -9,7 +9,7 @@ const isExclusiveItem = item => {
   return item < 0;
 };
 
-const SubaccountsField = props => {
+export const SubaccountsField = props => {
   const { listSubaccounts, disabled, subaccounts } = props;
 
   useEffect(() => {

--- a/src/pages/alerts/components/fields/tests/FilterFields.test.js
+++ b/src/pages/alerts/components/fields/tests/FilterFields.test.js
@@ -22,7 +22,6 @@ describe('Filter Fields Component', () => {
     listSendingIps: jest.fn(),
     change: jest.fn(),
     myFilter: ['random value'],
-    initialValues: {},
   };
 
   const subject = options => shallow(<FilterFields {...props} {...options} />);
@@ -100,9 +99,6 @@ describe('Filter Fields Component', () => {
           { resource: 'example.com' },
           { resource: 'test.example.com' },
         ],
-        initialValues: {
-          blacklist_provider: ['a', 'b', 'c'],
-        },
       });
 
     it('displays only blacklist codes', () => {
@@ -120,15 +116,6 @@ describe('Filter Fields Component', () => {
         '1.2.3.4',
         'example.com',
         'test.example.com',
-      ]);
-    });
-
-    it('initializes blacklist filters', () => {
-      const wrapper = blackListFilters();
-      expect(wrapper.find({ name: 'blacklist_provider' })).toHaveProp('defaultSelected', [
-        'a',
-        'b',
-        'c',
       ]);
     });
 

--- a/src/pages/alerts/components/fields/tests/SubaccountsField.test.js
+++ b/src/pages/alerts/components/fields/tests/SubaccountsField.test.js
@@ -1,45 +1,70 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { reduxForm } from 'redux-form';
 import { SubaccountsField } from '../SubaccountsField';
+import renderWithRedux from 'src/__testHelpers__/renderWithRedux';
 
 describe('Subaccount Field', () => {
-  const subject = (props = {}) => shallow(
-    <SubaccountsField
-      disabled={false}
-      listSubaccounts={() => {}}
-      subaccounts={[
-        { id: 1, name: 'My Subacount' }
-      ]}
-      subaccountsFieldValue={[]}
-      {...props}
-    />
-  );
+  const defaultProps = {
+    disabled: false,
+    listSubaccounts: () => {},
+    subaccounts: [{ id: 1, name: 'My Subaccount' }],
+  };
+
+  const subject = (props = {}) => shallow(<SubaccountsField {...defaultProps} {...props} />);
 
   it('renders combo box field', () => {
     expect(subject()).toMatchSnapshot();
   });
 
-  it('calls listSubaccounts on mount', () => {
-    const listSubaccounts = jest.fn();
-    subject({ listSubaccounts });
-    expect(listSubaccounts).toHaveBeenCalled();
-  });
-
-  it('renders combo box field with mapped field values', () => {
-    const wrapper = subject({ subaccountsFieldValue: [0, 1]});
-    expect(wrapper).toHaveProp('defaultSelected', [
-      { id: 0, name: 'Master account' },
-      { id: 1, name: 'My Subacount' }
-    ]);
-  });
-
-  it('renders combo box field with unknown field values', () => {
-    const wrapper = subject({ subaccountsFieldValue: [999]});
-    expect(wrapper).toHaveProp('defaultSelected', [{ id: 999, name: 'id:' }]);
-  });
-
   it('renders disabled combo box field', () => {
     const wrapper = subject({ disabled: true });
     expect(wrapper).toHaveProp('disabled', true);
+  });
+
+  it('calls listSubaccounts on mount', () => {
+    const listSubaccounts = jest.fn();
+    const initialState = { form: { foo: { values: { subaccounts: [] } } } };
+    const defaultReducer = () => initialState;
+    const ReduxFormWrapper = reduxForm({
+      form: 'foo',
+    })(SubaccountsField);
+
+    renderWithRedux({
+      reducer: defaultReducer,
+      initialState,
+      component: <ReduxFormWrapper {...defaultProps} listSubaccounts={listSubaccounts} />,
+    });
+    expect(listSubaccounts).toHaveBeenCalled();
+  });
+
+  describe('isExclusiveItem function', () => {
+    const wrapper = subject();
+    const isExclusiveItem = wrapper.prop('isExclusiveItem');
+
+    it('returns true for subaccount ids -1 and -2', () => {
+      expect(isExclusiveItem(-1)).toEqual(true);
+      expect(isExclusiveItem(-2)).toEqual(true);
+    });
+
+    it('returns false for subaccount ids > 0', () => {
+      expect(isExclusiveItem(0)).toEqual(false);
+      expect(isExclusiveItem(101)).toEqual(false);
+    });
+  });
+
+  describe('itemToString function', () => {
+    const wrapper = subject();
+    const itemToString = wrapper.prop('itemToString');
+
+    it('returns only the name for master, master&all, and any', () => {
+      expect(itemToString(-1)).toEqual('Master and all subaccounts');
+      expect(itemToString(-2)).toEqual('Any subaccount');
+      expect(itemToString(0)).toEqual('Master account');
+    });
+
+    it('returns false for subaccount ids > 0', () => {
+      expect(itemToString(1)).toEqual('My Subaccount (1)');
+    });
   });
 });

--- a/src/pages/alerts/components/fields/tests/__snapshots__/SubaccountsField.test.js.snap
+++ b/src/pages/alerts/components/fields/tests/__snapshots__/SubaccountsField.test.js.snap
@@ -3,34 +3,19 @@
 exports[`Subaccount Field renders combo box field 1`] = `
 <Field
   component={[Function]}
-  defaultSelected={Array []}
   disabled={false}
+  isExclusiveItem={[Function]}
   itemToString={[Function]}
   label="Subaccounts"
   name="subaccounts"
   placeholder="Type To Search"
   results={
     Array [
-      Object {
-        "id": -1,
-        "isExclusiveItem": true,
-        "name": "Master and all subaccounts",
-      },
-      Object {
-        "id": -2,
-        "isExclusiveItem": true,
-        "name": "Any subaccount",
-      },
-      Object {
-        "id": 0,
-        "name": "Master account",
-      },
-      Object {
-        "id": 1,
-        "name": "My Subacount",
-      },
+      -1,
+      -2,
+      0,
+      1,
     ]
   }
-  selectedMap={[Function]}
 />
 `;

--- a/src/pages/alerts/components/tests/__snapshots__/AlertForm.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertForm.test.js.snap
@@ -107,7 +107,6 @@ exports[`Alert Form Component should render the alert form component correctly 1
             />
             <Connect(FilterFields)
               disabled={false}
-              initialValues={Object {}}
             />
           </div>
           <div


### PR DESCRIPTION

### What Changed
 - Updated ComboboxTypeahead to use redux-form initial values.
 - Removed the the selectedMap prop and isExclusiveItem check.
 - Added isExclusiveItem function prop.
 - ComboboxTypeahead only accepts strings, not objects.

### How To Test
 - Check that the comboboxs in alerts works correctly.
 - Run Cypress tests to verify.
