### PR TITLE
 AC-1270-  Fixing Error when adding credit card on RV lists

### DIFF
--- a/cypress/tests/integration/recipients/recipient-validation/list-page-routes/listRoute.spec.js
+++ b/cypress/tests/integration/recipients/recipient-validation/list-page-routes/listRoute.spec.js
@@ -161,6 +161,6 @@ describe('The recipient validation /list route', () => {
 
     cy.visit(ROUTE_URL);
 
-    cy.findByText('Something went wrong.');
+    cy.findAllByText('Something went wrong.');
   });
 });

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -96,6 +96,7 @@ export const FORMS = {
   EDIT_USER: 'userEditForm',
   EVENTS_SEARCH: 'eventsSearchForm',
   RV_ADDPAYMENTFORM: 'rvAddPaymentForm',
+  RV_ADDPAYMENTFORM_UPLOADLISTPAGE: 'rvAddPaymentFormUploadListPage',
 };
 
 //These filters are the searchable filters in the 'more filters' modal on the Events Search page

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -22,7 +22,7 @@ import addRVtoSubscription from 'src/actions/addRVtoSubscription';
 import { getSubscription as getBillingSubscription } from 'src/actions/billing';
 import _ from 'lodash';
 
-const FORMNAME = FORMS.RV_ADDPAYMENTFORM;
+const FORMNAME = FORMS.RV_ADDPAYMENTFORM_UPLOADLISTPAGE;
 
 export class UploadedListPage extends Component {
   state = {

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -74,10 +74,10 @@ export class UploadedListPage extends Component {
       job,
       isStandAloneRVSet,
       billing: { credit_card },
+      billingLoading,
+      valid,
+      submitting,
     } = this.props;
-
-    const { valid, pristine, submitting } = this.props;
-    const submitDisabled = pristine || !valid || submitting;
     return (
       <Page
         title="Recipient Validation"
@@ -104,11 +104,11 @@ export class UploadedListPage extends Component {
             )}
           </Panel.Section>
         </Panel>
-        {isStandAloneRVSet && job.status === 'queued_for_batch' && (
+        {isStandAloneRVSet && job.status === 'queued_for_batch' && !billingLoading && (
           <ValidateSection
             credit_card={credit_card}
             formname={FORMNAME}
-            submitDisabled={submitDisabled && !this.state.useSavedCC}
+            submitDisabled={!valid || submitting}
             handleCardToggle={this.handleToggleCC}
             defaultToggleState={!this.state.useSavedCC}
           />
@@ -154,6 +154,7 @@ const mapStateToProps = (state, props) => {
     jobLoadingStatus: state.recipientValidation.jobLoadingStatus[listId],
     isStandAloneRVSet: isAccountUiOptionSet('standalone_rv')(state),
     billing: state.account.billing || {},
+    billingLoading: state.account.billingLoading,
     isRVonSubscription: isProductOnSubscription('recipient_validation')(state),
     initialValues: rvAddPaymentFormInitialValues(state),
   };

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -27,7 +27,6 @@ const FORMNAME = FORMS.RV_ADDPAYMENTFORM_UPLOADLISTPAGE;
 export class UploadedListPage extends Component {
   state = {
     useSavedCC: Boolean(this.props.billing.credit_card),
-    submitStatus: 'idle',
   };
   componentDidMount() {
     const { getJobStatus, listId, getBillingInfo, getBillingSubscription } = this.props;
@@ -51,7 +50,6 @@ export class UploadedListPage extends Component {
   };
 
   onSubmit = formValues => {
-    this.setState({ submitStatus: 'pending' });
     const { addRVtoSubscription, isRVonSubscription, isStandAloneRVSet } = this.props;
     const { useSavedCC } = this.state;
 

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -27,6 +27,7 @@ const FORMNAME = FORMS.RV_ADDPAYMENTFORM_UPLOADLISTPAGE;
 export class UploadedListPage extends Component {
   state = {
     useSavedCC: Boolean(this.props.billing.credit_card),
+    submitStatus: 'idle',
   };
   componentDidMount() {
     const { getJobStatus, listId, getBillingInfo, getBillingSubscription } = this.props;
@@ -46,10 +47,13 @@ export class UploadedListPage extends Component {
 
   handleSubmit = () => {
     const { listId, triggerJob } = this.props;
-    triggerJob(listId);
+    triggerJob(listId)
+      .then(() => this.setState({ submitStatus: 'done' }))
+      .catch(() => this.setState({ submitStatus: 'error' }));
   };
 
   onSubmit = formValues => {
+    this.setState({ submitStatus: 'pending' });
     const { addRVtoSubscription, isRVonSubscription, isStandAloneRVSet } = this.props;
     const { useSavedCC } = this.state;
 
@@ -66,7 +70,9 @@ export class UploadedListPage extends Component {
       values,
       updateCreditCard: !useSavedCC,
       isRVonSubscription: isRVonSubscription,
-    }).then(() => this.handleSubmit());
+    })
+      .then(() => this.handleSubmit())
+      .catch(() => this.setState({ submitStatus: 'error' }));
   };
 
   renderUploadedListPage = () => {
@@ -78,6 +84,7 @@ export class UploadedListPage extends Component {
       valid,
       submitting,
     } = this.props;
+    if (this.state.submitStatus === 'pending') return <Loading />;
     return (
       <Page
         title="Recipient Validation"

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -47,9 +47,7 @@ export class UploadedListPage extends Component {
 
   handleSubmit = () => {
     const { listId, triggerJob } = this.props;
-    triggerJob(listId)
-      .then(() => this.setState({ submitStatus: 'done' }))
-      .catch(() => this.setState({ submitStatus: 'error' }));
+    triggerJob(listId);
   };
 
   onSubmit = formValues => {
@@ -70,9 +68,7 @@ export class UploadedListPage extends Component {
       values,
       updateCreditCard: !useSavedCC,
       isRVonSubscription: isRVonSubscription,
-    })
-      .then(() => this.handleSubmit())
-      .catch(() => this.setState({ submitStatus: 'error' }));
+    }).then(() => this.handleSubmit());
   };
 
   renderUploadedListPage = () => {
@@ -84,7 +80,6 @@ export class UploadedListPage extends Component {
       valid,
       submitting,
     } = this.props;
-    if (this.state.submitStatus === 'pending') return <Loading />;
     return (
       <Page
         title="Recipient Validation"

--- a/src/pages/recipientValidation/tests/UploadedListPage.test.js
+++ b/src/pages/recipientValidation/tests/UploadedListPage.test.js
@@ -73,7 +73,7 @@ describe('UploadedListPage', () => {
     });
 
     it('calls triggerJob when form is submitted', () => {
-      const triggerJob = jest.fn();
+      const triggerJob = jest.fn(a => Promise.resolve(a));
       const wrapper = queuedSubject({ triggerJob });
 
       wrapper.find('Connect(UploadedListForm)').simulate('submit');

--- a/src/pages/recipientValidation/tests/UploadedListPage.test.js
+++ b/src/pages/recipientValidation/tests/UploadedListPage.test.js
@@ -73,7 +73,7 @@ describe('UploadedListPage', () => {
     });
 
     it('calls triggerJob when form is submitted', () => {
-      const triggerJob = jest.fn(a => Promise.resolve(a));
+      const triggerJob = jest.fn();
       const wrapper = queuedSubject({ triggerJob });
 
       wrapper.find('Connect(UploadedListForm)').simulate('submit');


### PR DESCRIPTION
 AC-1270-  Fixing Error when adding credit card on RV lists

### What Changed
 - What changes did you make to satisfy the AC?
     - Renamed the UploadedListForm to FORMS.RV_ADDPAYMENTFORM_UPLOADLISTPAGE
     - Added billing loading condition and removed the pristine check for submitDisabled.

### How To Test
- Sign up (on free bundle)
- Enable account option ui.standalone_rv
- Refresh the UI.
- View new RV page, upload a list. Do not add credit card yet.
- Select "Back" to go to /recipient-validation/list
- Select the action "Review" on the uploaded list
- Check the "State" field without selecting a country. You should see a default state (Alabama).
- Attempt to add credit card and "Validate." 

### To Do
- [ ] Address Feedback
