### PR TITLE
AC-1263: Add data privacy page

### DIFF
--- a/src/config/navItems/account.js
+++ b/src/config/navItems/account.js
@@ -28,27 +28,32 @@ export default [
   {
     label: 'Account Settings',
     to: '/account/settings',
-    section: 1
+    section: 1,
   },
   {
     label: 'Profile',
     to: '/account/profile',
-    section: 1
+    section: 1,
   },
   {
     label: 'Billing',
     to: '/account/billing',
-    section: 1
+    section: 1,
   },
   {
     label: 'Manage Users',
     to: '/account/users',
-    section: 1
+    section: 1,
+  },
+  {
+    label: 'Data and Privacy',
+    to: '/account/data-privacy',
+    section: 1,
   },
   {
     label: 'Get Help',
     section: 2,
-    action: openSupportPanel
+    action: openSupportPanel,
   },
   {
     label: 'API Docs',
@@ -56,13 +61,13 @@ export default [
     to: LINKS.API_DOCS,
     icon: OpenInNew,
     section: 2,
-    condition: not(isHeroku)
+    condition: not(isHeroku),
   },
   {
     label: 'Log Out',
     to: '/logout',
     icon: ExitToApp,
     section: 3,
-    condition: not(isHeroku)
-  }
+    condition: not(isHeroku),
+  },
 ];

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -40,6 +40,7 @@ import LogoutPage from 'src/pages/logout/LogoutPage';
 import onboarding from 'src/pages/onboarding';
 import { default as emailVerification } from 'src/components/emailVerification/EmailVerification';
 import SecretBillingPlanOrBillingSummaryPage from '../SecretBillingPlanOrBillingSummaryPage';
+import DataPrivacyPage from 'src/pages/dataPrivacy/DataPrivacyPage';
 
 import { all, hasGrants, not } from 'src/helpers/conditions';
 import {
@@ -538,7 +539,7 @@ const routes = [
   },
   {
     path: '/account/data-privacy',
-    component: AccountSettingsPage,
+    component: DataPrivacyPage,
     condition: all(hasGrants('users/manage'), isAccountUiOptionSet('data_privacy')), //TODO: Remove account UI option
     layout: App,
     title: 'Data and Privacy',

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -537,6 +537,13 @@ const routes = [
     supportDocSearch: 'account settings',
   },
   {
+    path: '/account/data-privacy',
+    component: AccountSettingsPage,
+    condition: all(hasGrants('users/manage'), isAccountUiOptionSet('data_privacy')), //TODO: Remove account UI option
+    layout: App,
+    title: 'Data and Privacy',
+  },
+  {
     path: '/account/cancel',
     component: ImmediateCancelAccountPage,
     condition: all(hasGrants('account/manage'), not(isEnterprise), not(isHeroku), not(isAzure)),

--- a/src/pages/dataPrivacy/DataPrivacyPage.js
+++ b/src/pages/dataPrivacy/DataPrivacyPage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Page } from '@sparkpost/matchbox';
+
+const DataPrivacy = () => (
+  <Page title="Data and Privacy">
+    <div />
+  </Page>
+);
+
+export default DataPrivacy;


### PR DESCRIPTION
### What Changed
 - Added page as `/account/data-privacy`

### How To Test
 - Enable UI flag `data_privacy`
 - Check that top right dropdown includes link for `Data and Privacy`