### PR TITLE
SE-566: Added default filters

### DIFF
--- a/cypress/tests/integration/events/listPage.spec.js
+++ b/cypress/tests/integration/events/listPage.spec.js
@@ -244,21 +244,30 @@ describe('The events page', () => {
         const selectLabel = 'Filter By';
         const textFieldLabel = 'Filter';
 
-        cy.findAllByLabelText(selectLabel).should('have.length', 1);
-        cy.findAllByLabelText(textFieldLabel).should('have.length', 1);
+        cy.findAllByLabelText(selectLabel).should('have.length', 4);
+        cy.findAllByLabelText(textFieldLabel).should('have.length', 4);
 
         cy.findByText('Add Filter').click();
 
-        cy.findAllByLabelText(selectLabel).should('have.length', 2);
-        cy.findAllByLabelText(textFieldLabel).should('have.length', 2);
+        cy.findAllByLabelText(selectLabel).should('have.length', 5);
+        cy.findAllByLabelText(textFieldLabel).should('have.length', 5);
 
         cy.findAllByText('Remove')
           .first()
           .click();
 
-        cy.findAllByLabelText(selectLabel).should('have.length', 1);
-        cy.findAllByLabelText(textFieldLabel).should('have.length', 1);
+        cy.findAllByLabelText(selectLabel).should('have.length', 4);
+        cy.findAllByLabelText(textFieldLabel).should('have.length', 4);
 
+        cy.findAllByText('Remove')
+          .first()
+          .click();
+        cy.findAllByText('Remove')
+          .first()
+          .click();
+        cy.findAllByText('Remove')
+          .first()
+          .click();
         cy.findByText('Remove').click();
 
         cy.findByLabelText(selectLabel).should('not.be.visible');
@@ -269,6 +278,17 @@ describe('The events page', () => {
         cy.findByText('Cancel').click();
 
         cy.findByText('Advanced Filters').should('not.be.visible');
+      });
+
+      it('does not add in default filters if there are alreday filters', () => {
+        const selectLabel = 'Filter By';
+        const textFieldLabel = 'Filter';
+
+        cy.visit(`${PAGE_URL}?subjects=test`);
+        cy.findByText('Add Filters').click();
+
+        cy.findAllByLabelText(selectLabel).should('have.length', 2);
+        cy.findAllByLabelText(textFieldLabel).should('have.length', 2);
       });
 
       it('closes the modal and applies filters when clicking "Apply Filters" by re-requesting events data', () => {

--- a/cypress/tests/integration/events/listPage.spec.js
+++ b/cypress/tests/integration/events/listPage.spec.js
@@ -1,6 +1,18 @@
 const PAGE_URL = '/reports/message-events';
 
 describe('The events page', () => {
+  // Removes the first 3 filters (which are there by default).
+  const removePresetFilters = () => {
+    cy.findAllByText('Remove')
+      .first()
+      .click();
+    cy.findAllByText('Remove')
+      .first()
+      .click();
+    cy.findAllByText('Remove')
+      .first()
+      .click();
+  };
   beforeEach(() => {
     cy.stubAuth();
     cy.login({ isStubbed: true });
@@ -259,15 +271,7 @@ describe('The events page', () => {
         cy.findAllByLabelText(selectLabel).should('have.length', 4);
         cy.findAllByLabelText(textFieldLabel).should('have.length', 4);
 
-        cy.findAllByText('Remove')
-          .first()
-          .click();
-        cy.findAllByText('Remove')
-          .first()
-          .click();
-        cy.findAllByText('Remove')
-          .first()
-          .click();
+        removePresetFilters();
         cy.findByText('Remove').click();
 
         cy.findByLabelText(selectLabel).should('not.be.visible');
@@ -295,6 +299,7 @@ describe('The events page', () => {
         // `force` shouldn't be necessary, but due to component markup it is - Hibana component redesign may make this unnecessary
         cy.findByLabelText('AMP Click').check({ force: true });
         cy.findByLabelText('Out of Band').check({ force: true });
+        removePresetFilters();
         cy.findByLabelText('Filter By').select('Recipient Domains');
         cy.findByLabelText('Filter').type('gmail.com');
         cy.findByText('Add Filter').click();
@@ -326,6 +331,7 @@ describe('The events page', () => {
       it('removes all filters when clicking "Clear All Filters"', () => {
         cy.findByLabelText('AMP Click').check({ force: true });
         cy.findByLabelText('Out of Band').check({ force: true });
+        removePresetFilters();
         cy.findByLabelText('Filter By').select('Recipient Domains');
         cy.findByLabelText('Filter').type('gmail.com');
         cy.findByText('Apply Filters').click();

--- a/src/helpers/tests/validation.test.js
+++ b/src/helpers/tests/validation.test.js
@@ -55,8 +55,12 @@ const cases = {
     bad: ['test.id', 'NOT_!@#$%^&*()_VALID', 'test id', ':doge:'],
   },
   eventsQuery: {
-    good: [[{ key: 'reason', value: 'fo*o' }], [{ key: 'campaigns', value: 'foo, bar' }]],
-    bad: [[{ key: 'reason' }], [{ value: 'foo' }]],
+    good: [
+      [{ key: 'reason', value: 'fo*o' }],
+      [{ key: 'campaigns', value: 'foo, bar' }],
+      [{ key: 'reason' }],
+    ],
+    bad: [[{ value: 'foo' }]],
     multiArg: true,
   },
   abTestDefaultTemplate: {

--- a/src/helpers/validation.js
+++ b/src/helpers/validation.js
@@ -57,9 +57,6 @@ export function recipientEmail(value) {
 }
 
 export function eventsQuery(filter) {
-  if (!filter.value && filter.key) {
-    return 'Required';
-  }
   if (filter.value && !filter.key) {
     return 'Select a Filter';
   }

--- a/src/pages/billing/helpers/tests/totalRecipientValidationCost.test.js
+++ b/src/pages/billing/helpers/tests/totalRecipientValidationCost.test.js
@@ -24,7 +24,5 @@ describe('calculateNewCost', () => {
   it('should new cost difference', () => {
     expect(calculateNewCost(12333, 123)).toEqual('$0.74');
     expect(calculateNewCost(0, 123)).toEqual('$1.23');
-
   });
 });
-

--- a/src/pages/reports/messageEvents/components/AdvancedFiltersModal.js
+++ b/src/pages/reports/messageEvents/components/AdvancedFiltersModal.js
@@ -9,7 +9,7 @@ import _ from 'lodash';
 
 export class AdvancedFiltersModal extends Component {
   state = {
-    modalOpen: false
+    modalOpen: false,
   };
 
   componentDidMount() {
@@ -20,16 +20,16 @@ export class AdvancedFiltersModal extends Component {
     this.setState({ modalOpen: !this.state.modalOpen });
   };
 
-  handleApply = (values) => {
+  handleApply = values => {
     const { searchQuery, ...events } = values;
-    const filteredSearchQuery = searchQuery.filter((filter) => !_.isEmpty(filter));
+    const filteredSearchQuery = searchQuery.filter(({ value }) => Boolean(value));
     const filters = getFiltersFromSearchQueries(filteredSearchQuery);
-    const enabledEventsArray = Object.keys(events).filter((key) => Boolean(events[key]));
+    const enabledEventsArray = Object.keys(events).filter(key => Boolean(events[key]));
     this.props.updateMessageEventsSearchOptions({ events: enabledEventsArray, ...filters });
     this.toggleModal();
   };
 
-  handleKeyDown = (e) => {
+  handleKeyDown = e => {
     const { modalOpen } = this.state;
     if (!modalOpen) {
       return;
@@ -43,12 +43,14 @@ export class AdvancedFiltersModal extends Component {
       <Fragment>
         <Button onClick={this.toggleModal}>Add Filters</Button>
         <Modal open={modalOpen} onClose={this.toggleModal}>
-          <WindowEvent event='keydown' handler={this.handleKeyDown} />
-          <SearchForm handleApply = {this.handleApply} handleCancel = {this.toggleModal} />
+          <WindowEvent event="keydown" handler={this.handleKeyDown} />
+          <SearchForm handleApply={this.handleApply} handleCancel={this.toggleModal} />
         </Modal>
       </Fragment>
     );
   }
 }
 
-export default connect(null, { updateMessageEventsSearchOptions, getDocumentation })(AdvancedFiltersModal);
+export default connect(null, { updateMessageEventsSearchOptions, getDocumentation })(
+  AdvancedFiltersModal,
+);

--- a/src/pages/reports/messageEvents/components/SearchForm.js
+++ b/src/pages/reports/messageEvents/components/SearchForm.js
@@ -10,25 +10,32 @@ import { selectMessageEventListing } from 'src/selectors/eventListing';
 import { getDocumentation, updateMessageEventsSearchOptions } from 'src/actions/messageEvents';
 import SearchQuery from './SearchQuery';
 
-export class SearchForm extends Component {
+const defaultFilters = [
+  { key: 'recipient_domains' },
+  { key: 'from_addresses' },
+  { key: 'subjects' },
+];
 
+export class SearchForm extends Component {
   render() {
     const { handleSubmit, handleApply, handleCancel, eventListing } = this.props;
     return (
       <form onSubmit={handleSubmit(handleApply)}>
-        <Panel title='Advanced Filters'>
+        <Panel title="Advanced Filters">
           <Panel.Section>
-            <EventTypeFilters eventTypeDocs={eventListing}/>
+            <EventTypeFilters eventTypeDocs={eventListing} />
           </Panel.Section>
           <Panel.Section>
-            <FieldArray component={SearchQuery} name="searchQuery"/>
-            <p>
-              All filters accept comma-separated values.
-            </p>
+            <FieldArray component={SearchQuery} name="searchQuery" />
+            <p>All filters accept comma-separated values.</p>
           </Panel.Section>
           <Panel.Section>
-            <Button primary submit >Apply Filters</Button>
-            <Button className={styles.Cancel} onClick={handleCancel}>Cancel</Button>
+            <Button primary submit>
+              Apply Filters
+            </Button>
+            <Button className={styles.Cancel} onClick={handleCancel}>
+              Cancel
+            </Button>
           </Panel.Section>
         </Panel>
       </form>
@@ -36,13 +43,18 @@ export class SearchForm extends Component {
   }
 }
 
-const mapStateToProps = (state) => ({
-  initialValues: {
-    searchQuery: [...getSearchQueriesFromFilters(state.messageEvents.search), {}],
-    ...getBooleanEventsObject(state.messageEvents.search.events)
-  },
-  eventListing: selectMessageEventListing(state)
-});
+const mapStateToProps = state => {
+  const queryFilters = getSearchQueriesFromFilters(state.messageEvents.search);
+  const initialFilters = queryFilters.length ? queryFilters : defaultFilters;
 
-export default connect(mapStateToProps, { updateMessageEventsSearchOptions, getDocumentation })(reduxForm({ form: FORMS.EVENTS_SEARCH,
-  touchOnChange: true })(SearchForm));
+  return {
+    initialValues: {
+      searchQuery: [...initialFilters, {}],
+      ...getBooleanEventsObject(state.messageEvents.search.events),
+    },
+    eventListing: selectMessageEventListing(state),
+  };
+};
+export default connect(mapStateToProps, { updateMessageEventsSearchOptions, getDocumentation })(
+  reduxForm({ form: FORMS.EVENTS_SEARCH, touchOnChange: true })(SearchForm),
+);

--- a/src/pages/reports/messageEvents/helpers/transformData.js
+++ b/src/pages/reports/messageEvents/helpers/transformData.js
@@ -10,11 +10,15 @@ import { getEmptyFilters } from 'src/helpers/messageEvents';
  * @returns {Object} An object containing the search parameters as keys and the search terms as values.
  */
 export function getFiltersFromSearchQueries(searchQueries = []) {
-
   // Build a single object containing a key for each filter, initialised to an empty array
   const emptyFilters = getEmptyFilters(EVENTS_SEARCH_FILTERS);
   // Collect queries into an array of objects of form {key: value}
-  const queries = searchQueries.map(({ key, value }) => ({ [key]: stringToArray(value) }));
+  const queries = searchQueries.reduce((queryArray, { key, value }) => {
+    if (key && value) {
+      queryArray.push({ [key]: stringToArray(value) });
+    }
+    return queryArray;
+  }, []);
 
   return Object.assign(emptyFilters, ...queries);
 }
@@ -25,12 +29,14 @@ export function getFiltersFromSearchQueries(searchQueries = []) {
  * @returns {Object[]} - An array of query objects.
  */
 export function getSearchQueriesFromFilters(filters) {
-
   //Filters out all search terms that are not part of the search query in AdvancedFilters
   const { dateOptions: _dateOptions, recipients: _recipients, events: _events, ...rest } = filters;
 
   const nonEmptyFilters = removeEmptyFilters(rest);
-  const newSearchQueries = _.map(nonEmptyFilters, (value, key) => ({ key, value: value.join(',') }));
+  const newSearchQueries = _.map(nonEmptyFilters, (value, key) => ({
+    key,
+    value: value.join(','),
+  }));
   return newSearchQueries;
 }
 
@@ -40,8 +46,7 @@ export function getSearchQueriesFromFilters(filters) {
  * @returns {Object[]} - An array of event objects in the form of {key: 'foo',label: 'bar'}.
  */
 export function getFiltersAsArray(filters) {
-  const filtersAsArray = _.map(filters, ({ label }, key) =>
-    ({ value: key, label }));
+  const filtersAsArray = _.map(filters, ({ label }, key) => ({ value: key, label }));
   return filtersAsArray;
 }
 
@@ -51,12 +56,12 @@ export function getFiltersAsArray(filters) {
  * @returns {Object} - An event object with the key = the event type and the value = boolean, ex: {foo:true, bar:false}.
  */
 export function getBooleanEventsObject(events) {
-  return (events.reduce((accumulator, event) => {
+  return events.reduce((accumulator, event) => {
     accumulator[event] = true;
     return accumulator;
-  }, {}));
+  }, {});
 }
 
 export function removeEmptyFilters(allFilters) {
-  return _.pickBy(allFilters, (value) => value.length > 0);
+  return _.pickBy(allFilters, value => value.length > 0);
 }

--- a/src/pages/reports/messageEvents/helpers/transformData.js
+++ b/src/pages/reports/messageEvents/helpers/transformData.js
@@ -13,12 +13,7 @@ export function getFiltersFromSearchQueries(searchQueries = []) {
   // Build a single object containing a key for each filter, initialised to an empty array
   const emptyFilters = getEmptyFilters(EVENTS_SEARCH_FILTERS);
   // Collect queries into an array of objects of form {key: value}
-  const queries = searchQueries.reduce((queryArray, { key, value }) => {
-    if (key && value) {
-      queryArray.push({ [key]: stringToArray(value) });
-    }
-    return queryArray;
-  }, []);
+  const queries = searchQueries.map(({ key, value }) => ({ [key]: stringToArray(value) }));
 
   return Object.assign(emptyFilters, ...queries);
 }


### PR DESCRIPTION
### What Changed
 - Message events, add filters
  - Now has default 3 filter categories + 1 empty select
  - Validation now only checks for typed fields. Empty field (regardless of select) will be removed
  - Default filters do not appear if other filters modify the select

### How To Test
 - Navigate to `/message-events`
 - Go to "Add Filters"
 - Verify that the bottom section defaults to multiple filters.
 - Add any filter (preferably just 1) and save
 - Reopen modal
 - Verify that the defaults do not show up
 - Verify that the validation does not pop up on empty text input fields
