### PR TITLE
FE-830-4 - Use position sticky for Hibana banner

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import ErrorBoundary from 'src/components/errorBoundaries/ErrorBoundary';
 import AppRoutes from 'src/components/appRoutes';
 import { HibanaProvider } from 'src/context/HibanaContext';
 import { HibanaTheme } from 'src/components/hibana';
+import { HibanaBanner, HibanaToggle, HibanaDescription } from 'src/components/hibana';
 import GlobalBanner from 'src/context/GlobalBanner';
 
 import config from 'src/config';
@@ -43,6 +44,11 @@ const App = ({ RouterComponent = BrowserRouter }) => (
               </GlobalBanner>
               <Support />
               <GlobalAlertWrapper />
+
+              <HibanaBanner>
+                <HibanaDescription />
+                <HibanaToggle />
+              </HibanaBanner>
             </div>
           </RouterComponent>
         </Poll>

--- a/src/components/hibana/HibanaComponents.module.scss
+++ b/src/components/hibana/HibanaComponents.module.scss
@@ -7,7 +7,7 @@ $static-button-size: 40px;
 
 .HibanaBanner.HibanaBanner {
   width: 100%;
-  position: fixed;
+  position: sticky;
   bottom: 0;
   right: 0;
   z-index: 500;

--- a/src/components/layout/Layout.js
+++ b/src/components/layout/Layout.js
@@ -3,7 +3,6 @@ import { withRouter } from 'react-router-dom';
 import Form from './Form';
 import findRouteByPath from 'src/helpers/findRouteByPath';
 import { Helmet } from 'react-helmet';
-import { HibanaBanner, HibanaToggle, HibanaDescription } from 'src/components/hibana';
 
 /**
  * Returns layout component from routes config
@@ -21,11 +20,6 @@ export const Layout = ({ children, location }) => {
       )}
 
       {children}
-
-      <HibanaBanner>
-        <HibanaDescription />
-        <HibanaToggle />
-      </HibanaBanner>
     </LayoutComponent>
   );
 };

--- a/src/components/layout/tests/__snapshots__/Layout.test.js.snap
+++ b/src/components/layout/tests/__snapshots__/Layout.test.js.snap
@@ -14,10 +14,6 @@ exports[`Component: Layout should render a regular route with a specified layout
   <h1>
     My layout children
   </h1>
-  <Connect(HibanaBanner)>
-    <HibanaDescription />
-    <HibanaToggle />
-  </Connect(HibanaBanner)>
 </App>
 `;
 
@@ -35,10 +31,6 @@ exports[`Component: Layout should render a route that does not specify a layout 
   <h1>
     My layout children
   </h1>
-  <Connect(HibanaBanner)>
-    <HibanaDescription />
-    <HibanaToggle />
-  </Connect(HibanaBanner)>
 </Form>
 `;
 
@@ -47,9 +39,5 @@ exports[`Component: Layout should render a route that does not specify a title 1
   <h1>
     My layout children
   </h1>
-  <Connect(HibanaBanner)>
-    <HibanaDescription />
-    <HibanaToggle />
-  </Connect(HibanaBanner)>
 </App>
 `;


### PR DESCRIPTION
[FE-830](https://jira.int.messagesystems.com/browse/FE-830) Follow Up

### What Changed
- Uses `position: sticky` to position the Hibana banner
- Moves the Hibana banner component to a different portion of the app

### How To Test
- Verify that the Hibana banner scrolls with the window when scrolling through page
- Verify that the Hibana banner does not cover page content at the bottom of the page.

### To Do
- [ ] Incorporate feedback
