### PR TITLE
AC-1266 - Added API Integration tab

### DIFF
--- a/src/config/navItems/account.js
+++ b/src/config/navItems/account.js
@@ -2,8 +2,8 @@ import { OpenInNew, ExitToApp } from '@sparkpost/matchbox-icons';
 import { LINKS } from 'src/constants';
 import { openSupportPanel } from 'src/actions/support';
 import { isHeroku } from 'src/helpers/conditions/user';
-import not from 'src/helpers/conditions/not';
-
+import { all, hasGrants, not } from 'src/helpers/conditions';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 /***
  * These values are pulled in through the accountNavItems selector, which will map
  * each "to" value here to a corresponding route in "config/routes.js", if
@@ -49,6 +49,7 @@ export default [
     label: 'Data and Privacy',
     to: '/account/data-privacy',
     section: 1,
+    condition: all(hasGrants('users/manage'), isAccountUiOptionSet('data_privacy')),
   },
   {
     label: 'Get Help',

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -539,6 +539,10 @@ const routes = [
   },
   {
     path: '/account/data-privacy',
+    redirect: '/account/data-privacy/single-recipient',
+  },
+  {
+    path: '/account/data-privacy/:category',
     component: DataPrivacyPage,
     condition: all(hasGrants('users/manage'), isAccountUiOptionSet('data_privacy')), //TODO: Remove account UI option
     layout: App,

--- a/src/pages/dataPrivacy/DataPrivacyPage.js
+++ b/src/pages/dataPrivacy/DataPrivacyPage.js
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { withRouter } from 'react-router-dom';
-import { Page, Tabs, Panel, Button } from '@sparkpost/matchbox';
-import { Launch } from '@sparkpost/matchbox-icons';
+import { Page, Tabs, Panel } from '@sparkpost/matchbox';
 import styles from './DataPrivacyPage.module.scss';
+import ApiDetailsTab from './components/ApiDetailsTab';
 const tabs = [
   { content: 'Single Recipient', key: 'single-recipient' },
   { content: 'Multiple Recipients', key: 'multiple-recipients' },
   { content: 'API Integration', key: 'api' },
 ];
-const DataPrivacy = props => {
+export const DataPrivacyPage = props => {
   const [tabIndex, setTabIndex] = useState(
     tabs.findIndex(x => x.key === props.match.params.category) || 0,
   );
@@ -23,25 +23,7 @@ const DataPrivacy = props => {
   const renderTabs = tabIdx => {
     switch (tabIdx) {
       case 2:
-        return (
-          <Panel.Section>
-            <div className={styles.Header}>Integrate Now</div>
-            <p>
-              {'Information on how to use this API key. '}
-              <a
-                href="https://developers.sparkpost.com/api/data-privacy"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                {'Link to documentation'}
-                <Launch className={styles.LaunchIcon} />
-              </a>
-            </p>
-            <Button color="orange" onClick={() => props.history.push(`/account/api-keys/create`)}>
-              {'Generate key'}
-            </Button>
-          </Panel.Section>
-        );
+        return <ApiDetailsTab history={props.history} />;
 
       default:
         return <Panel.Section></Panel.Section>;
@@ -68,4 +50,4 @@ const DataPrivacy = props => {
   );
 };
 
-export default withRouter(DataPrivacy);
+export default withRouter(DataPrivacyPage);

--- a/src/pages/dataPrivacy/DataPrivacyPage.js
+++ b/src/pages/dataPrivacy/DataPrivacyPage.js
@@ -1,10 +1,71 @@
-import React from 'react';
-import { Page } from '@sparkpost/matchbox';
+import React, { useState, useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+import { Page, Tabs, Panel, Button } from '@sparkpost/matchbox';
+import { Launch } from '@sparkpost/matchbox-icons';
+import styles from './DataPrivacyPage.module.scss';
+const tabs = [
+  { content: 'Single Recipient', key: 'single-recipient' },
+  { content: 'Multiple Recipients', key: 'multiple-recipients' },
+  { content: 'API Integration', key: 'api' },
+];
+const DataPrivacy = props => {
+  const [tabIndex, setTabIndex] = useState(
+    tabs.findIndex(x => x.key === props.match.params.category) || 0,
+  );
+  useEffect(() => {
+    props.history.replace(`/account/data-privacy/${tabs[tabIndex].key}`);
+  }, [props.history, tabIndex]);
 
-const DataPrivacy = () => (
-  <Page title="Data and Privacy">
-    <div />
-  </Page>
-);
+  const handleTabs = tabIdx => {
+    setTabIndex(tabIdx);
+  };
 
-export default DataPrivacy;
+  const renderTabs = tabIdx => {
+    switch (tabIdx) {
+      case 2:
+        return (
+          <Panel.Section>
+            <div className={styles.Header}>Integrate Now</div>
+            <p>
+              {'Information on how to use this API key. '}
+              <a
+                href="https://developers.sparkpost.com/api/data-privacy"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {'Link to documentation'}
+                <Launch className={styles.LaunchIcon} />
+              </a>
+            </p>
+            <Button color="orange" onClick={() => props.history.push(`/account/api-keys/create`)}>
+              {'Generate key'}
+            </Button>
+          </Panel.Section>
+        );
+
+      default:
+        return <Panel.Section></Panel.Section>;
+    }
+  };
+
+  return (
+    <Page title="Data and Privacy">
+      <p className={styles.LeadText}>
+        Fill in this form to request deletion of recipient data or opt-out of third party data usage
+        of recipient's personal information. Your request will be completed within 30 days.
+      </p>
+      <Tabs
+        selected={tabIndex}
+        connectBelow={true}
+        tabs={tabs.map(({ content }, idx) => ({
+          content,
+          onClick: () => handleTabs(idx),
+        }))}
+      />
+
+      <Panel>{renderTabs(tabIndex)}</Panel>
+    </Page>
+  );
+};
+
+export default withRouter(DataPrivacy);

--- a/src/pages/dataPrivacy/DataPrivacyPage.module.scss
+++ b/src/pages/dataPrivacy/DataPrivacyPage.module.scss
@@ -1,0 +1,18 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.LeadText {
+  max-width: 60%;
+  margin-bottom: 2rem;
+  font-size: font-size(300);
+  line-height: line-height(300);
+}
+
+.Header {
+  margin: spacing(large) 0;
+  font-weight: 600;
+}
+
+.LaunchIcon {
+  margin-left: spacing(small);
+  color: color(blue);
+}

--- a/src/pages/dataPrivacy/DataPrivacyPage.module.scss
+++ b/src/pages/dataPrivacy/DataPrivacyPage.module.scss
@@ -6,13 +6,3 @@
   font-size: font-size(300);
   line-height: line-height(300);
 }
-
-.Header {
-  margin: spacing(large) 0;
-  font-weight: 600;
-}
-
-.LaunchIcon {
-  margin-left: spacing(small);
-  color: color(blue);
-}

--- a/src/pages/dataPrivacy/components/ApiDetailsTab.js
+++ b/src/pages/dataPrivacy/components/ApiDetailsTab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Panel, Button } from '@sparkpost/matchbox';
 import styles from './ApiDetailsTab.module.scss';
-import ExternalLink from '../../../components/externalLink/ExternalLink';
+import ExternalLink from 'src/components/externalLink/ExternalLink';
 
 const ApiDetailsTab = ({ history }) => (
   <Panel.Section>

--- a/src/pages/dataPrivacy/components/ApiDetailsTab.js
+++ b/src/pages/dataPrivacy/components/ApiDetailsTab.js
@@ -1,21 +1,19 @@
 import React from 'react';
 import { Panel, Button } from '@sparkpost/matchbox';
-import { Launch } from '@sparkpost/matchbox-icons';
 import styles from './ApiDetailsTab.module.scss';
+import ExternalLink from '../../../components/externalLink/ExternalLink';
 
 const ApiDetailsTab = ({ history }) => (
   <Panel.Section>
     <div className={styles.Header}>Integrate Now</div>
     <p>
-      {'Information on how to use this API key. '}
-      <a
+      {'Information on how to use this API key.'}
+      <ExternalLink
         href="https://developers.sparkpost.com/api/data-privacy"
-        rel="noopener noreferrer"
-        target="_blank"
+        className={styles.LaunchIcon}
       >
         {'Link to documentation'}
-        <Launch className={styles.LaunchIcon} />
-      </a>
+      </ExternalLink>
     </p>
     <Button color="orange" onClick={() => history.push(`/account/api-keys/create`)}>
       {'Generate key'}

--- a/src/pages/dataPrivacy/components/ApiDetailsTab.js
+++ b/src/pages/dataPrivacy/components/ApiDetailsTab.js
@@ -7,12 +7,9 @@ const ApiDetailsTab = ({ history }) => (
   <Panel.Section>
     <div className={styles.Header}>Integrate Now</div>
     <p>
-      {'Information on how to use this API key.'}
-      <ExternalLink
-        href="https://developers.sparkpost.com/api/data-privacy"
-        className={styles.LaunchIcon}
-      >
-        {'Link to documentation'}
+      {'Information on how to use this API key. '}
+      <ExternalLink href="https://developers.sparkpost.com/api/data-privacy">
+        {'Link to documentation '}
       </ExternalLink>
     </p>
     <Button color="orange" onClick={() => history.push(`/account/api-keys/create`)}>

--- a/src/pages/dataPrivacy/components/ApiDetailsTab.js
+++ b/src/pages/dataPrivacy/components/ApiDetailsTab.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Panel, Button } from '@sparkpost/matchbox';
+import { Launch } from '@sparkpost/matchbox-icons';
+import styles from './ApiDetailsTab.module.scss';
+
+const ApiDetailsTab = ({ history }) => (
+  <Panel.Section>
+    <div className={styles.Header}>Integrate Now</div>
+    <p>
+      {'Information on how to use this API key. '}
+      <a
+        href="https://developers.sparkpost.com/api/data-privacy"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {'Link to documentation'}
+        <Launch className={styles.LaunchIcon} />
+      </a>
+    </p>
+    <Button color="orange" onClick={() => history.push(`/account/api-keys/create`)}>
+      {'Generate key'}
+    </Button>
+  </Panel.Section>
+);
+
+export default ApiDetailsTab;

--- a/src/pages/dataPrivacy/components/ApiDetailsTab.module.scss
+++ b/src/pages/dataPrivacy/components/ApiDetailsTab.module.scss
@@ -1,0 +1,11 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.Header {
+  margin: spacing(large) 0;
+  font-weight: 600;
+}
+
+.LaunchIcon {
+  margin-left: spacing(small);
+  color: color(blue);
+}

--- a/src/pages/dataPrivacy/components/ApiDetailsTab.module.scss
+++ b/src/pages/dataPrivacy/components/ApiDetailsTab.module.scss
@@ -4,8 +4,3 @@
   margin: spacing(large) 0;
   font-weight: 600;
 }
-
-.LaunchIcon {
-  margin-left: spacing(small);
-  color: color(blue);
-}

--- a/src/pages/dataPrivacy/components/tests/ApiDetailsTab.test.js
+++ b/src/pages/dataPrivacy/components/tests/ApiDetailsTab.test.js
@@ -1,0 +1,25 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import ApiDetailsTab from '../ApiDetailsTab';
+
+describe('Page: Recipient Email Verification', () => {
+  const defaultProps = {
+    history: {
+      replace: jest.fn(),
+    },
+  };
+
+  const subject = () => {
+    return shallow(<ApiDetailsTab {...defaultProps} />);
+  };
+
+  it('renders Generate Key Button', () => {
+    const wrapper = subject();
+    expect(wrapper.find({ children: 'Generate key' })).toExist();
+  });
+
+  it('renders a link to api documentation for data privacy', () => {
+    const wrapper = subject();
+    expect(wrapper.find({ href: 'https://developers.sparkpost.com/api/data-privacy' })).toExist();
+  });
+});

--- a/src/pages/dataPrivacy/tests/DataPrivacyPage.test.js
+++ b/src/pages/dataPrivacy/tests/DataPrivacyPage.test.js
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { DataPrivacyPage } from '../DataPrivacyPage';
+import ApiDetailsTab from '../components/ApiDetailsTab';
+
+describe('Page: Recipient Email Verification', () => {
+  const defaultProps = {
+    history: {
+      replace: jest.fn(),
+    },
+  };
+
+  const subject = props => {
+    return shallow(<DataPrivacyPage {...defaultProps} {...props} />);
+  };
+
+  it('renders Api tab correctly', () => {
+    const props = {
+      match: {
+        params: { category: 'api' },
+      },
+    };
+    const wrapper = subject(props);
+    expect(wrapper.find(ApiDetailsTab)).toExist();
+  });
+});


### PR DESCRIPTION
AC-1266 - Added API Integration tab

### What Changed
 - Added API Integration tab
 - Link is included for the sparkpost documentation
 - Button links to the API key create page

### How To Test
 - Enable account ui option - data_privacy
 - Navigate to /account/data-privacy
 - Check if it matches the mocks https://sparkpost.invisionapp.com/share/BCVKAJRH4E9#/screens/404037210

### To Do
- [ ] Address Feedback
