### PR TITLE
FE-875 - Component wrapper for Matchbox Inline component

### DIFF
--- a/src/components/matchbox/Inline.js
+++ b/src/components/matchbox/Inline.js
@@ -2,11 +2,9 @@ import React from 'react';
 import { Inline as HibanaInline } from '@sparkpost/matchbox-hibana';
 import { useHibana } from 'src/context/HibanaContext';
 
-const Inline = props => {
+export default function Inline(props) {
   const [state] = useHibana();
   const { isHibanaEnabled } = state;
 
   return isHibanaEnabled ? <HibanaInline {...props} /> : <>{props.children}</>;
-};
-
-export default Inline;
+}

--- a/src/components/matchbox/Inline.js
+++ b/src/components/matchbox/Inline.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Inline as HibanaInline } from '@sparkpost/matchbox-hibana';
+import { useHibana } from 'src/context/HibanaContext';
+
+const Inline = props => {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  return isHibanaEnabled ? <HibanaInline {...props} /> : <>{props.children}</>;
+};
+
+export default Inline;

--- a/src/components/matchbox/README.md
+++ b/src/components/matchbox/README.md
@@ -49,7 +49,9 @@ import { ProgressBar } from 'src/components/matchbox';
 function MyComponent() {
   return (
     <div>
-      <ProgressBar mb="100" />
+      <h1>My Component!</h1>
+
+      <ProgressBar mt="100" />
     </div>
   );
 }

--- a/src/components/matchbox/README.md
+++ b/src/components/matchbox/README.md
@@ -1,0 +1,59 @@
+# Matchbox Component Wrappers
+
+Components in this folder are wrappers for [Matchbox](https://design.sparkpost.com/) components in
+order to:
+
+1. Provide a single point of entry for Matchbox dependencies
+2. Provide Hibana context to each Matchbox component for theme switching
+
+## Conditionally Rendering Hibana Components
+
+Render Hibana vs. default Matchbox components using the
+[`useHibana` hook](https://github.com/SparkPost/2web2ui/wiki/Hibana) which accesses the user's
+Hibana theme context:
+
+```js
+import React from 'react';
+import { ProgressBar as OGProgressBar } from '@sparkpost/matchbox';
+import { ProgressBar as HibanaProgressBar } from '@sparkpost/matchbox-hibana';
+import { useHibana } from 'src/context/HibanaContext';
+import { omit } from './omit'; // WIP: This is conceptual at this point in time.
+
+export default function ProgressBar(props) {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  if (!isHibanaEnabled) {
+    return <OGProgressBar {...omit(props)} />;
+  }
+
+  return <HibanaProgressBar {...props}>
+}
+```
+
+The custom `omit` function is used to prevent certain props from rendering to the DOM
+unintentionally, first removing styled system props via the `@styled-system/props` package
+([See the repo on GitHub](https://github.com/styled-system/styled-system/tree/master/packages/props)).
+For props that need to be passed and would also be ommitted by this package, props continue to be
+passed as expected.
+
+## Using the Component
+
+In the app, instead of importing directly from `@sparkpost/matchbox`, import from
+`src/components/matchbox`:
+
+```js
+import React from 'react';
+import { ProgressBar } from 'src/components/matchbox';
+
+function MyComponent() {
+  return (
+    <div>
+      <ProgressBar mb="100" />
+    </div>
+  );
+}
+```
+
+In this scenario, the `mb` prop will be passed to the component only when the Hibana theme is
+enabled. When disabled, the new [Styled System](https://styled-system.com/) props are not passed.

--- a/src/components/matchbox/index.js
+++ b/src/components/matchbox/index.js
@@ -1,2 +1,3 @@
 export { default as Box } from './Box.js';
+export { default as Inline } from './Inline';
 export { default as ProgressBar } from './ProgressBar.js';

--- a/src/components/matchbox/tests/Inline.test.js
+++ b/src/components/matchbox/tests/Inline.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Inline from '../Inline';
+import { render } from '@testing-library/react';
+import { useHibana } from 'src/context/HibanaContext';
+jest.mock('src/context/HibanaContext');
+jest.mock('@sparkpost/matchbox-hibana', () => ({
+  Inline: props => <div data-id="hibana-inline" {...props} />,
+}));
+
+describe('Inline Matchbox component wrapper', () => {
+  const subject = props => {
+    const defaults = { padding: '600' };
+
+    return render(
+      <Inline {...defaults} {...props}>
+        Children...
+      </Inline>,
+    );
+  };
+
+  it('renders the Hibana version of the Inline component correctly when hibana is enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
+
+    const { queryByText, queryByTestId } = subject();
+    expect(queryByTestId('hibana-inline')).toBeInTheDocument();
+    expect(queryByText('Children...')).toBeInTheDocument();
+  });
+
+  it('only renders passed in children when hibana is not enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+
+    const { queryByText, queryByTestId } = subject();
+    expect(queryByTestId('hibana-inline')).not.toBeInTheDocument();
+    expect(queryByText('Children...')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
[FE-875](https://jira.int.messagesystems.com/browse/FE-875)

### What Changed
- Adds `<Inline/>` component wrapper from Matchbox
- Adds Matchbox component wrapper README based on UX/FE sync discussion

### How To Test
1. Go to any page and add the following (I did it with `DashboardPage.js`):
```js
<Inline>
  <h3>Hello!</h3>
  <h3>Hello!</h3>
  <h3>Hello!</h3>
</Inline>
```
2. Toggle between the Hibana and non-Hibana versions of the app - verify that the styles from Matchbox apply (everything should line up in a row!)

### To Do
- [ ] Incorporate feedback
