### PR TITLE
AC-1182 "Check out Events" item in "Show Me SparkPost" list (UI)

### DIFF
--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -42,7 +42,6 @@ export const GettingStartedGuide = ({
     }
   };
 
-  //TODO: set isGuideAtBottom to true if all the CheckLists are completed.
   const actions =
     isGuideAtBottom || areAllGuidesCompleted
       ? null

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -24,6 +24,7 @@ export const GettingStartedGuide = ({
     explore_analytics_completed,
     invite_collaborator_completed,
     view_developer_docs_completed,
+    check_events_completed,
   } = onboarding;
 
   const areAllGuidesCompleted =
@@ -31,6 +32,7 @@ export const GettingStartedGuide = ({
     explore_analytics_completed &&
     invite_collaborator_completed &&
     view_developer_docs_completed &&
+    check_events_completed &&
     hasSendingDomains &&
     hasApiKeysForSending;
 
@@ -78,7 +80,13 @@ export const GettingStartedGuide = ({
           window.pendo.onGuideAdvanced(1);
         }
         history.push(`/reports/summary`);
-
+        break;
+      case 'Check Out Events':
+        setOnboardingAccountOption({ check_events_completed: true });
+        if (window.pendo.showGuideById(GUIDE_IDS.CHECKOUT_EVENTS)) {
+          window.pendo.onGuideAdvanced(1);
+        }
+        history.push(`/reports/message-events`);
         break;
       case 'Invite a Collaborator':
         setOnboardingAccountOption({ invite_collaborator_completed: true });
@@ -112,6 +120,7 @@ export const GettingStartedGuide = ({
     send_test_email_completed: send_test_email_completed,
     explore_analytics_completed: explore_analytics_completed,
     invite_collaborator_completed: invite_collaborator_completed,
+    check_events_completed: check_events_completed,
     hasSendingDomains: hasSendingDomains,
     hasApiKeysForSending: hasApiKeysForSending,
     view_developer_docs_completed: view_developer_docs_completed,

--- a/src/pages/dashboard/components/ShowMeSparkpostStep.js
+++ b/src/pages/dashboard/components/ShowMeSparkpostStep.js
@@ -41,6 +41,25 @@ const ExploreAnalyticsItem = () => {
   );
 };
 
+const ViewEventsItem = () => {
+  const { check_events_completed, handleAction } = useGuideContext();
+
+  return (
+    <GuideListItem
+      action={{
+        name: 'Check Out Events',
+        onClick: () => handleAction('Check Out Events'),
+      }}
+      itemCompleted={check_events_completed}
+    >
+      <GuideListItemTitle>Check Out Events</GuideListItemTitle>
+      <GuideListItemDescription>
+        Learn how SparkPost can provide analytics to make the most of your sending strategy.
+      </GuideListItemDescription>
+    </GuideListItem>
+  );
+};
+
 const InviteCollaboratorItem = () => {
   const {
     invite_collaborator_completed,
@@ -86,6 +105,9 @@ export default function ShowMeSparkpostStep() {
       </Panel.Section>
       <Panel.Section>
         <ExploreAnalyticsItem />
+      </Panel.Section>
+      <Panel.Section>
+        <ViewEventsItem />
       </Panel.Section>
       <Panel.Section>
         <InviteCollaboratorItem />

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -71,6 +71,15 @@ describe('GettingStartedGuide', () => {
     expect(window.pendo.onGuideAdvanced).toHaveBeenCalledWith(1);
   });
 
+  it('should navigate to events page when Check Out Events button is clicked', () => {
+    const { getAllByText } = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
+    userEvent.click(getAllByText('Check Out Events')[1]);
+
+    expect(defaultProps.history.push).toHaveBeenCalledWith(`/reports/message-events`);
+    expect(window.pendo.showGuideById).toHaveBeenCalledWith(GUIDE_IDS.CHECKOUT_EVENTS);
+    expect(window.pendo.onGuideAdvanced).toHaveBeenCalledWith(1);
+  });
+
   it('should navigate to users page when Invite a Collaborator is clicked', () => {
     const { queryByText } = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
     userEvent.click(queryByText('Invite a Collaborator'));

--- a/src/pages/dashboard/components/tests/ShowMeSparkpostStep.test.js
+++ b/src/pages/dashboard/components/tests/ShowMeSparkpostStep.test.js
@@ -38,6 +38,10 @@ describe('ShowMeSparkpostStep', () => {
     expect(queryAllByText('Explore Analytics')[0]).toBeInTheDocument();
     expect(true).toBeTruthy();
   });
+  it('should render Checklist with title Check Out Events', () => {
+    const { queryAllByText } = subject_rtl(render);
+    expect(queryAllByText('Check Out Events')[0]).toBeInTheDocument();
+  });
   it('should render Checklist with title Invite a Collaborator', () => {
     const { queryByText } = subject_rtl(render);
     expect(queryByText('Invite a Collaborator')).toBeInTheDocument();

--- a/src/pages/dashboard/constants.js
+++ b/src/pages/dashboard/constants.js
@@ -1,6 +1,7 @@
 export const GUIDE_IDS = {
   SEND_TEST_EMAIL: '6RgwDLtUU5Ynp20auFvU9Qjbpqg',
   EXPLORE_ANALYTICS: 'LHGQClYKBmD_OI1t9oj-DE8mcOY',
+  CHECKOUT_EVENTS: 'wMsJgAtVLFeDKNOoiIxStA2jP-U',
 };
 
 export const BREADCRUMB_ITEMS = {


### PR DESCRIPTION
AC-1182 "Check out Events" item in "Show Me SparkPost" list (UI)

### What Changed
- Added "Check Out Events" Item in Show Me Sparkpost list.
- Events guide show up when navigating to events page (https://sparkpost.invisionapp.com/share/DHULLYL45GB#/screens/390961100) [Note - use http://app.sparkpost.test:3100 to see the guide] 

### How To Test
 On Dashboard, 
- Click Show Me SparkPost in Getting Started Guide
-  Check if the Check Out Events List Item matches mocks
-  click on the button and see if you see the guide on events page
-  after navigation the check should be stored  and item should be completed (shows a green tick)

### To Do
- [ ] Address Feedback
- [ ] Remove the part of guide from summary report page that links to events page. (https://sparkpost.invisionapp.com/share/DHULLYL45GB#/screens/390961099) After this ticket is deployed
