### PR TITLE
FE-848 Add upgrade plan button for free users.

### DIFF
--- a/cypress/tests/integration/navigation/navigation.spec.js
+++ b/cypress/tests/integration/navigation/navigation.spec.js
@@ -92,7 +92,7 @@ describe('Mobile Navigation', () => {
     cy.wait('@stubbedAccountRequest'); // ...the request is made twice! So wait again for the second
   }
 
-  describe.only('navigation behavior', () => {
+  describe('navigation behavior', () => {
     beforeEach(() => {
       cy.viewport(500, 1000);
       cy.stubAuth();

--- a/cypress/tests/integration/navigation/navigation.spec.js
+++ b/cypress/tests/integration/navigation/navigation.spec.js
@@ -92,7 +92,7 @@ describe('Mobile Navigation', () => {
     cy.wait('@stubbedAccountRequest'); // ...the request is made twice! So wait again for the second
   }
 
-  describe('navigation behavior', () => {
+  describe.only('navigation behavior', () => {
     beforeEach(() => {
       cy.viewport(500, 1000);
       cy.stubAuth();
@@ -723,6 +723,29 @@ describe('Mobile Navigation', () => {
       cy.visit(PAGE_URL);
 
       cy.queryByText('Inbox Placement').should('not.be.visible');
+    });
+
+    it('renders the "Upgrade Plan" link and Upgrade tag when the users is on the free plan', () => {
+      cy.stubRequest({
+        url: '/api/v1/account*',
+        fixture: 'account/200.get.test-plan.json',
+      });
+
+      cy.visit(PAGE_URL);
+
+      cy.get('[data-id="top-nav"]').within(() => {
+        cy.assertLink({
+          content: 'Upgrade Plan',
+          href: '/account/billing/plan',
+        });
+      });
+
+      openAccountMenu();
+
+      cy.get(accountDropdownListSelector).within(() => {
+        cy.queryByText('Billing').should('be.visible');
+        cy.queryByText('Upgrade').should('be.visible');
+      });
     });
   });
 });

--- a/src/components/navigation/components/AccountDropdown.js
+++ b/src/components/navigation/components/AccountDropdown.js
@@ -44,8 +44,9 @@ export class AccountDropdown extends Component {
     const { accountNavItems, dispatch } = this.props;
     const items = accountNavItems.map(
       ({ action, label, external, icon: Icon, labs, to, secondaryLabel, ...rest }) => {
-        const markup = (
+        const content = (
           <>
+            {label}
             {Icon && (
               <div className={styles.FloatIcon}>
                 <Icon size={15} />
@@ -62,12 +63,6 @@ export class AccountDropdown extends Component {
               </div>
             )}
           </>
-        );
-
-        const content = (
-          <Fragment>
-            {label} {markup}
-          </Fragment>
         );
 
         const listItem = { content, label, external, to, ...rest };

--- a/src/components/navigation/components/AccountDropdown.js
+++ b/src/components/navigation/components/AccountDropdown.js
@@ -10,18 +10,29 @@ import styles from './AccountDropdown.module.scss';
 export class AccountDropdown extends Component {
   state = {
     // Using controlled open state so we can close the popover on click
-    open: false
-  }
+    open: false,
+  };
 
   toggleDropdown = () => {
     this.setState({ open: !this.state.open });
-  }
+  };
 
   renderActivator = () => (
     <WindowSizeContext.Consumer>
       {({ mobile }) => (
-        <button className={styles.Email} onClick={this.toggleDropdown} data-id="nav-button-accounts">
-          {(mobile || !this.props.email) ? <Person size={24}/> : <Fragment>{this.props.email}&nbsp;<ArrowDropDown/></Fragment>}
+        <button
+          className={styles.Email}
+          onClick={this.toggleDropdown}
+          data-id="nav-button-accounts"
+        >
+          {mobile || !this.props.email ? (
+            <Person size={24} />
+          ) : (
+            <Fragment>
+              {this.props.email}&nbsp;
+              <ArrowDropDown />
+            </Fragment>
+          )}
 
           <ScreenReaderOnly>Settings</ScreenReaderOnly>
         </button>
@@ -31,33 +42,59 @@ export class AccountDropdown extends Component {
 
   getItems() {
     const { accountNavItems, dispatch } = this.props;
-    const items = accountNavItems.map(({ action, label, external, icon: Icon, labs, to, ...rest }) => {
-      const labsMarkup = labs
-        ? <div className={styles.FloatIcon}><Tag color='blue'>LABS</Tag></div>
-        : null;
+    const items = accountNavItems.map(
+      ({ action, label, external, icon: Icon, labs, to, secondaryLabel, ...rest }) => {
+        const markup = (
+          <>
+            {Icon && (
+              <div className={styles.FloatIcon}>
+                <Icon size={15} />
+              </div>
+            )}
+            {labs && (
+              <div className={styles.FloatIcon}>
+                <Tag color="blue">LABS</Tag>
+              </div>
+            )}
+            {secondaryLabel && (
+              <div className={styles.FloatIcon}>
+                <div className={styles.SecondaryLabel}>{secondaryLabel}</div>
+              </div>
+            )}
+          </>
+        );
 
-      const content = Icon
-        ? <Fragment>{label}<div className={styles.FloatIcon}><Icon size={15} /></div></Fragment>
-        : <Fragment>{label} {labsMarkup}</Fragment>;
-      const listItem = { content, label, external, to, ...rest };
+        const content = (
+          <Fragment>
+            {label} {markup}
+          </Fragment>
+        );
 
-      if (!external && to) {
-        listItem.component = Link;
-      }
+        const listItem = { content, label, external, to, ...rest };
 
-      if (action) {
-        listItem.onClick = () => dispatch(action());
-      }
+        if (!external && to) {
+          listItem.component = Link;
+        }
 
-      return listItem;
-    });
+        if (action) {
+          listItem.onClick = () => dispatch(action());
+        }
+
+        return listItem;
+      },
+    );
 
     return items;
   }
 
   render() {
     return (
-      <Popover left trigger={this.renderActivator()} open={this.state.open} onClose={this.toggleDropdown}>
+      <Popover
+        left
+        trigger={this.renderActivator()}
+        open={this.state.open}
+        onClose={this.toggleDropdown}
+      >
         <ActionList
           className={styles.AccountList}
           onClick={this.toggleDropdown}
@@ -69,9 +106,9 @@ export class AccountDropdown extends Component {
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   email: state.currentUser.email,
-  accountNavItems: selectAccountNavItems(state)
+  accountNavItems: selectAccountNavItems(state),
 });
 
 export default connect(mapStateToProps)(AccountDropdown);

--- a/src/components/navigation/components/AccountDropdown.module.scss
+++ b/src/components/navigation/components/AccountDropdown.module.scss
@@ -28,4 +28,10 @@
 .FloatIcon {
   float: right;
   margin-top: -0.1em;
+  padding-right: spacing(small);
+}
+
+.SecondaryLabel {
+  font-size: font-size(200);
+  color: color(blue, dark);
 }

--- a/src/components/navigation/components/Top.js
+++ b/src/components/navigation/components/Top.js
@@ -9,7 +9,7 @@ import AccountDropdown from './AccountDropdown';
 import styles from './Top.module.scss';
 import { DEFAULT_REDIRECT_ROUTE } from 'src/constants';
 import { AccessControl } from 'src/components/auth';
-
+import { any } from 'src/helpers/conditions';
 import { onPlan } from 'src/helpers/conditions/account';
 
 export class Top extends Component {
@@ -46,7 +46,7 @@ export class Top extends Component {
       </Link>
 
       <div className={styles.RightSideWrapper}>
-        <AccessControl condition={onPlan('free500-0419')}>
+        <AccessControl condition={any(onPlan('free500-0419'), onPlan('free500-SPCEU-0419'))}>
           <Link to="/account/billing/plan" className={styles.UpgradePlanLink}>
             <div className={styles.UpgradePlan}>Upgrade Plan</div>
           </Link>

--- a/src/components/navigation/components/Top.js
+++ b/src/components/navigation/components/Top.js
@@ -14,7 +14,11 @@ import { onPlan } from 'src/helpers/conditions/account';
 
 export class Top extends Component {
   renderMobile = () => (
-    <div className={styles.Top} onClick={this.props.open ? this.props.toggleMobileNav : undefined}>
+    <div
+      className={styles.Top}
+      data-id="top-nav"
+      onClick={this.props.open ? this.props.toggleMobileNav : undefined}
+    >
       <IconButton
         onClick={!this.props.open ? this.props.toggleMobileNav : undefined}
         className={styles.Menu}
@@ -36,7 +40,7 @@ export class Top extends Component {
   );
 
   renderDesktop = () => (
-    <div className={styles.Top}>
+    <div className={styles.Top} data-id="top-nav">
       <Link to={DEFAULT_REDIRECT_ROUTE} className={styles.Logo} data-id="nav-link-logo">
         <SparkPost.Logo type="halfWhite" />
       </Link>

--- a/src/components/navigation/components/Top.js
+++ b/src/components/navigation/components/Top.js
@@ -8,6 +8,9 @@ import { openSupportPanel } from 'src/actions/support';
 import AccountDropdown from './AccountDropdown';
 import styles from './Top.module.scss';
 import { DEFAULT_REDIRECT_ROUTE } from 'src/constants';
+import { AccessControl } from 'src/components/auth';
+
+import { onPlan } from 'src/helpers/conditions/account';
 
 export class Top extends Component {
   renderMobile = () => (
@@ -39,6 +42,11 @@ export class Top extends Component {
       </Link>
 
       <div className={styles.RightSideWrapper}>
+        <AccessControl condition={onPlan('free500-0419')}>
+          <Link to="/account/billing/plan" className={styles.UpgradePlanLink}>
+            <div className={styles.UpgradePlan}>Upgrade Plan</div>
+          </Link>
+        </AccessControl>
         <IconButton
           title="Opens a dialog"
           onClick={this.openSupportPanel}

--- a/src/components/navigation/components/Top.module.scss
+++ b/src/components/navigation/components/Top.module.scss
@@ -85,3 +85,15 @@
 .SupportIcon {
   fill: currentColor;
 }
+
+.UpgradePlanLink {
+  padding-right: spacing(larger);
+  margin-top: rem(2);
+}
+
+.UpgradePlan {
+  color: color(orange, light);
+  &:hover {
+    color: color(orange, dark);
+  }
+}

--- a/src/components/navigation/components/tests/AccountDropdown.test.js
+++ b/src/components/navigation/components/tests/AccountDropdown.test.js
@@ -16,24 +16,29 @@ describe('AccountDropdown', () => {
       accountNavItems: [
         {
           label: 'link',
-          to: 'link'
+          to: 'link',
         },
         {
           label: 'link2',
           to: 'link2',
           external: true,
-          icon: MockIcon
+          icon: MockIcon,
         },
         {
           label: 'link3',
-          action: jest.fn(() => link3Action)
+          action: jest.fn(() => link3Action),
         },
         {
           label: 'link4',
           to: 'link',
-          labs: true
-        }
-      ]
+          labs: true,
+        },
+        {
+          label: 'link4',
+          to: 'link',
+          secondaryLabel: 'label1',
+        },
+      ],
     };
 
     wrapper = shallow(<AccountDropdown {...props} />);
@@ -58,7 +63,10 @@ describe('AccountDropdown', () => {
   });
 
   it('should dispatch nav item action on click', () => {
-    const link3 = wrapper.instance().getItems().find((item) => item.label === 'link3');
+    const link3 = wrapper
+      .instance()
+      .getItems()
+      .find(item => item.label === 'link3');
     link3.onClick();
 
     expect(props.accountNavItems[2].action).toHaveBeenCalled();
@@ -87,7 +95,10 @@ describe('AccountDropdown', () => {
     });
 
     it('should toggle dropdown on click', () => {
-      consumer.children().find('[data-id="nav-button-accounts"]').simulate('click');
+      consumer
+        .children()
+        .find('[data-id="nav-button-accounts"]')
+        .simulate('click');
       expect(wrapper).toHaveState({ open: true });
     });
   });

--- a/src/components/navigation/components/tests/__snapshots__/AccountDropdown.test.js.snap
+++ b/src/components/navigation/components/tests/__snapshots__/AccountDropdown.test.js.snap
@@ -65,7 +65,6 @@ exports[`AccountDropdown should render correctly 1`] = `
           "component": [Function],
           "content": <React.Fragment>
             link
-             
           </React.Fragment>,
           "external": undefined,
           "label": "link",
@@ -89,7 +88,6 @@ exports[`AccountDropdown should render correctly 1`] = `
         Object {
           "content": <React.Fragment>
             link3
-             
           </React.Fragment>,
           "external": undefined,
           "label": "link3",
@@ -100,7 +98,6 @@ exports[`AccountDropdown should render correctly 1`] = `
           "component": [Function],
           "content": <React.Fragment>
             link4
-             
             <div
               className="FloatIcon"
             >
@@ -109,6 +106,24 @@ exports[`AccountDropdown should render correctly 1`] = `
               >
                 LABS
               </Tag>
+            </div>
+          </React.Fragment>,
+          "external": undefined,
+          "label": "link4",
+          "to": "link",
+        },
+        Object {
+          "component": [Function],
+          "content": <React.Fragment>
+            link4
+            <div
+              className="FloatIcon"
+            >
+              <div
+                className="SecondaryLabel"
+              >
+                label1
+              </div>
             </div>
           </React.Fragment>,
           "external": undefined,

--- a/src/components/navigation/components/tests/__snapshots__/Top.test.js.snap
+++ b/src/components/navigation/components/tests/__snapshots__/Top.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Top should render close icon when open 1`] = `
 <div
   className="Top"
+  data-id="top-nav"
   onClick={[MockFunction]}
 >
   <IconButton
@@ -36,6 +37,7 @@ exports[`Top should render close icon when open 1`] = `
 exports[`Top should render correctly on desktop 1`] = `
 <div
   className="Top"
+  data-id="top-nav"
 >
   <Link
     className="Logo"
@@ -85,6 +87,7 @@ exports[`Top should render correctly on desktop 1`] = `
 exports[`Top should render correctly on mobile 1`] = `
 <div
   className="Top"
+  data-id="top-nav"
 >
   <IconButton
     aria-expanded="false"

--- a/src/components/navigation/components/tests/__snapshots__/Top.test.js.snap
+++ b/src/components/navigation/components/tests/__snapshots__/Top.test.js.snap
@@ -50,6 +50,21 @@ exports[`Top should render correctly on desktop 1`] = `
   <div
     className="RightSideWrapper"
   >
+    <AccessControl
+      condition={[Function]}
+    >
+      <Link
+        className="UpgradePlanLink"
+        replace={false}
+        to="/account/billing/plan"
+      >
+        <div
+          className="UpgradePlan"
+        >
+          Upgrade Plan
+        </div>
+      </Link>
+    </AccessControl>
     <IconButton
       className="SupportButton"
       data-id="nav-button-help"

--- a/src/config/navItems/account.js
+++ b/src/config/navItems/account.js
@@ -3,7 +3,8 @@ import { LINKS } from 'src/constants';
 import { openSupportPanel } from 'src/actions/support';
 import { isHeroku } from 'src/helpers/conditions/user';
 import { all, hasGrants, not } from 'src/helpers/conditions';
-import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { isAccountUiOptionSet, onPlan } from 'src/helpers/conditions/account';
+
 /***
  * These values are pulled in through the accountNavItems selector, which will map
  * each "to" value here to a corresponding route in "config/routes.js", if
@@ -39,6 +40,14 @@ export default [
     label: 'Billing',
     to: '/account/billing',
     section: 1,
+    condition: onPlan('free500-0419'),
+    secondaryLabel: 'Upgrade',
+  },
+  {
+    label: 'Billing',
+    to: '/account/billing',
+    section: 1,
+    condition: not(onPlan('free500-0419')),
   },
   {
     label: 'Manage Users',

--- a/src/config/navItems/account.js
+++ b/src/config/navItems/account.js
@@ -2,7 +2,7 @@ import { OpenInNew, ExitToApp } from '@sparkpost/matchbox-icons';
 import { LINKS } from 'src/constants';
 import { openSupportPanel } from 'src/actions/support';
 import { isHeroku } from 'src/helpers/conditions/user';
-import { all, hasGrants, not } from 'src/helpers/conditions';
+import { all, hasGrants, not, any } from 'src/helpers/conditions';
 import { isAccountUiOptionSet, onPlan } from 'src/helpers/conditions/account';
 
 /***
@@ -40,14 +40,14 @@ export default [
     label: 'Billing',
     to: '/account/billing',
     section: 1,
-    condition: onPlan('free500-0419'),
+    condition: any(onPlan('free500-0419'), onPlan('free500-SPCEU-0419')), //on free plan
     secondaryLabel: 'Upgrade',
   },
   {
     label: 'Billing',
     to: '/account/billing',
     section: 1,
-    condition: not(onPlan('free500-0419')),
+    condition: not(any(onPlan('free500-0419'), onPlan('free500-SPCEU-0419'))), //not on free plan
   },
   {
     label: 'Manage Users',


### PR DESCRIPTION
### What Changed
 - Added link to change plan page in the top nav for free users.
 - Added upgrade label to the billing section of the account nav dropdown.

### How To Test
 - Login to a free user account (or create a new acount).
 - Check that there is a upgrade plan link on the top nav in orange. 
 - Check that there is an upgrade label in the account dropdown.
 - Login as a paid user. Check that the above do no appear for the paid user. 

### To Do
- [x] UX sign off
