### PR TITLE
SA-1249: Add option to use inbox-placement-ea endpoint with user flag

### DIFF
--- a/src/actions/inboxPlacement.js
+++ b/src/actions/inboxPlacement.js
@@ -5,7 +5,7 @@ import { isUserUiOptionSet } from 'src/helpers/conditions/user';
 export const inboxPlacementApiRequest = ({ type, meta }) => {
   return (dispatch, getState) => {
     const { url } = meta;
-    const newUrl = isUserUiOptionSet('inbox_placement_v2_api')(getState())
+    const newUrl = isUserUiOptionSet('use_inbox_placement_ea')(getState())
       ? url.replace('/inbox-placement', '/inbox-placement-ea')
       : url;
     return dispatch(

--- a/src/actions/inboxPlacement.js
+++ b/src/actions/inboxPlacement.js
@@ -1,8 +1,27 @@
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
 import { PLACEMENT_FILTER_TYPES } from 'src/pages/inboxPlacement/constants/types';
+import { isUserUiOptionSet } from 'src/helpers/conditions/user';
+
+export const inboxPlacementApiRequest = ({ type, meta }) => {
+  return (dispatch, getState) => {
+    const { url } = meta;
+    const newUrl = isUserUiOptionSet('inbox_placement_v2_api')(getState())
+      ? url.replace('/inbox-placement', '/inbox-placement-ea')
+      : url;
+    return dispatch(
+      sparkpostApiRequest({
+        type: type,
+        meta: {
+          ...meta,
+          url: newUrl,
+        },
+      }),
+    );
+  };
+};
 
 export function listTests() {
-  return sparkpostApiRequest({
+  return inboxPlacementApiRequest({
     type: 'LIST_TESTS',
     meta: {
       method: 'GET',
@@ -13,7 +32,7 @@ export function listTests() {
 }
 
 export function getSeedList() {
-  return sparkpostApiRequest({
+  return inboxPlacementApiRequest({
     type: 'GET_SEEDS',
     meta: {
       method: 'GET',
@@ -23,7 +42,7 @@ export function getSeedList() {
 }
 
 export const getInboxPlacementTrends = queryParams =>
-  sparkpostApiRequest({
+  inboxPlacementApiRequest({
     type: 'GET_INBOX_PLACEMENT_TRENDS',
     meta: {
       method: 'GET',
@@ -33,7 +52,7 @@ export const getInboxPlacementTrends = queryParams =>
   });
 
 export const getInboxPlacementTrendsFilterValues = queryParams =>
-  sparkpostApiRequest({
+  inboxPlacementApiRequest({
     type: 'GET_INBOX_PLACEMENT_TRENDS_FILTER_VALUES',
     meta: {
       method: 'GET',
@@ -43,7 +62,7 @@ export const getInboxPlacementTrendsFilterValues = queryParams =>
   });
 
 export const getInboxPlacementTest = id =>
-  sparkpostApiRequest({
+  inboxPlacementApiRequest({
     type: 'GET_INBOX_PLACEMENT_TEST',
     meta: {
       method: 'GET',
@@ -69,7 +88,7 @@ export const getInboxPlacementBySendingIp = id =>
   );
 
 export const getInboxPlacementData = (id, type, action) =>
-  sparkpostApiRequest({
+  inboxPlacementApiRequest({
     type: action,
     meta: {
       method: 'GET',
@@ -78,7 +97,7 @@ export const getInboxPlacementData = (id, type, action) =>
   });
 
 export function stopInboxPlacementTest(id) {
-  return sparkpostApiRequest({
+  return inboxPlacementApiRequest({
     type: 'STOP_INBOX_PLACEMENT_TEST',
     meta: {
       method: 'PUT',
@@ -89,7 +108,7 @@ export function stopInboxPlacementTest(id) {
 }
 
 export function getInboxPlacementTestContent(id) {
-  return sparkpostApiRequest({
+  return inboxPlacementApiRequest({
     type: 'GET_INBOX_PLACEMENT_TEST_CONTENT',
     meta: {
       method: 'GET',
@@ -99,7 +118,7 @@ export function getInboxPlacementTestContent(id) {
 }
 
 export function getAllInboxPlacementMessages(id, filters) {
-  return sparkpostApiRequest({
+  return inboxPlacementApiRequest({
     type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES',
     meta: {
       method: 'GET',
@@ -118,7 +137,7 @@ export function resetState() {
 }
 
 export function getInboxPlacementMessage(testId, messageId) {
-  return sparkpostApiRequest({
+  return inboxPlacementApiRequest({
     type: 'GET_INBOX_PLACEMENT_MESSAGE',
     meta: {
       method: 'GET',

--- a/src/actions/tests/inboxPlacement.test.js
+++ b/src/actions/tests/inboxPlacement.test.js
@@ -1,11 +1,11 @@
 import * as inboxPlacement from '../inboxPlacement';
 import { isUserUiOptionSet } from 'src/helpers/conditions/user';
-jest.mock('src/helpers/conditions/user');
-isUserUiOptionSet.mockImplementation(() => () => false);
+jest.mock('src/helpers/conditions/user', () => ({ isUserUiOptionSet: jest.fn(() => () => false) }));
 jest.mock('src/actions/helpers/sparkpostApiRequest', () => jest.fn(a => a));
-const dispatch = jest.fn(a => a);
 
 describe('Action Creator: Inbox Placement', () => {
+  const dispatch = jest.fn(a => a);
+
   it('it makes request to seed', () => {
     const thunk = inboxPlacement.getSeedList();
     thunk(dispatch, jest.fn);
@@ -168,7 +168,7 @@ describe('Action Creator: Inbox Placement', () => {
   });
 
   it('makes request using inbox-placement-ea route when ui option is set', () => {
-    isUserUiOptionSet.mockImplementation(() => () => true);
+    isUserUiOptionSet.mockImplementationOnce(() => () => true);
     const thunk = inboxPlacement.getInboxPlacementMessage(1, 101);
     thunk(dispatch, jest.fn);
     expect(dispatch).toHaveBeenCalledWith({

--- a/src/actions/tests/inboxPlacement.test.js
+++ b/src/actions/tests/inboxPlacement.test.js
@@ -166,4 +166,20 @@ describe('Action Creator: Inbox Placement', () => {
       },
     });
   });
+
+  it('makes request using inbox-placement-ea route when ui option is set', () => {
+    isUserUiOptionSet.mockImplementation(() => () => true);
+    const thunk = inboxPlacement.getInboxPlacementMessage(1, 101);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'GET_INBOX_PLACEMENT_MESSAGE',
+      meta: {
+        method: 'GET',
+        url: '/v1/inbox-placement-ea/1/messages/101',
+        context: {
+          messageId: 101,
+        },
+      },
+    });
+  });
 });

--- a/src/actions/tests/inboxPlacement.test.js
+++ b/src/actions/tests/inboxPlacement.test.js
@@ -1,12 +1,15 @@
-import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
 import * as inboxPlacement from '../inboxPlacement';
-
+import { isUserUiOptionSet } from 'src/helpers/conditions/user';
+jest.mock('src/helpers/conditions/user');
+isUserUiOptionSet.mockImplementation(() => () => false);
 jest.mock('src/actions/helpers/sparkpostApiRequest', () => jest.fn(a => a));
+const dispatch = jest.fn(a => a);
 
 describe('Action Creator: Inbox Placement', () => {
-  it('it makes request to seed', async () => {
-    await inboxPlacement.getSeedList();
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('it makes request to seed', () => {
+    const thunk = inboxPlacement.getSeedList();
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_SEEDS',
       meta: {
         method: 'GET',
@@ -15,9 +18,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('it makes request to list tests', async () => {
-    await inboxPlacement.listTests();
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('it makes request to list tests', () => {
+    const thunk = inboxPlacement.listTests();
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'LIST_TESTS',
       meta: {
         method: 'GET',
@@ -27,9 +31,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('it makes request to list tests by mailbox provider', async () => {
-    await inboxPlacement.getInboxPlacementByProvider(101);
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('it makes request to list tests by mailbox provider', () => {
+    const thunk = inboxPlacement.getInboxPlacementByProvider(101);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_TESTS_BY_MAILBOX_PROVIDER',
       meta: {
         method: 'GET',
@@ -38,9 +43,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('it makes request to list tests by region', async () => {
-    await inboxPlacement.getInboxPlacementByRegion(101);
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('it makes request to list tests by region', () => {
+    const thunk = inboxPlacement.getInboxPlacementByRegion(101);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_TESTS_BY_REGION',
       meta: {
         method: 'GET',
@@ -49,9 +55,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('it makes request to list tests by sending ip', async () => {
-    await inboxPlacement.getInboxPlacementBySendingIp(101);
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('it makes request to list tests by sending ip', () => {
+    const thunk = inboxPlacement.getInboxPlacementBySendingIp(101);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_TESTS_BY_SENDING_IP',
       meta: {
         method: 'GET',
@@ -60,9 +67,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('it makes request to get trends', async () => {
-    await inboxPlacement.getInboxPlacementTrends({ myparams: 'foo' });
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('it makes request to get trends', () => {
+    const thunk = inboxPlacement.getInboxPlacementTrends({ myparams: 'foo' });
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_TRENDS',
       meta: {
         method: 'GET',
@@ -72,9 +80,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('it makes request to get trends filter values', async () => {
-    await inboxPlacement.getInboxPlacementTrendsFilterValues({ myparams: 'foo' });
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('it makes request to get trends filter values', () => {
+    const thunk = inboxPlacement.getInboxPlacementTrendsFilterValues({ myparams: 'foo' });
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_TRENDS_FILTER_VALUES',
       meta: {
         method: 'GET',
@@ -84,9 +93,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('makes request to get single inbox placement test', async () => {
-    await inboxPlacement.getInboxPlacementTest(1);
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('makes request to get single inbox placement test', () => {
+    const thunk = inboxPlacement.getInboxPlacementTest(1);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_TEST',
       meta: {
         method: 'GET',
@@ -95,9 +105,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('makes request to get single inbox placement test content', async () => {
-    await inboxPlacement.getInboxPlacementTestContent(1);
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('makes request to get single inbox placement test content', () => {
+    const thunk = inboxPlacement.getInboxPlacementTestContent(1);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_TEST_CONTENT',
       meta: {
         method: 'GET',
@@ -106,9 +117,10 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('makes request to stop inbox placement test', async () => {
-    await inboxPlacement.stopInboxPlacementTest(1);
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('makes request to stop inbox placement test', () => {
+    const thunk = inboxPlacement.stopInboxPlacementTest(1);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'STOP_INBOX_PLACEMENT_TEST',
       meta: {
         method: 'PUT',
@@ -118,9 +130,12 @@ describe('Action Creator: Inbox Placement', () => {
     });
   });
 
-  it('makes request to get all messages with filter', async () => {
-    await inboxPlacement.getAllInboxPlacementMessages(1, { 'mailbox-provider': 'sparkpost.com' });
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('makes request to get all messages with filter', () => {
+    const thunk = inboxPlacement.getAllInboxPlacementMessages(1, {
+      'mailbox-provider': 'sparkpost.com',
+    });
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_ALL_INBOX_PLACEMENT_MESSAGES',
       meta: {
         method: 'GET',
@@ -137,9 +152,10 @@ describe('Action Creator: Inbox Placement', () => {
     expect(action).toEqual({ type: 'RESET_INBOX_PLACEMENT' });
   });
 
-  it('makes request to get a specific message', async () => {
-    await inboxPlacement.getInboxPlacementMessage(1, 101);
-    expect(sparkpostApiRequest).toHaveBeenCalledWith({
+  it('makes request to get a specific message', () => {
+    const thunk = inboxPlacement.getInboxPlacementMessage(1, 101);
+    thunk(dispatch, jest.fn);
+    expect(dispatch).toHaveBeenCalledWith({
       type: 'GET_INBOX_PLACEMENT_MESSAGE',
       meta: {
         method: 'GET',


### PR DESCRIPTION
### What Changed
 - Added a helper function that dispatches a thunk that switches out the inbox placement url based on a user UI flag. 
 - Updated tests to match the changes.
 - Removed the async await in the tests. 

### How To Test
 - Create new user or login to a user under appteam account.
 - Add the user ui 'use_inbox_placement_ea' flag through the /users/{username}/control endpoint. 
 - Go to any inbox placement route in the UI. Check that the api calls use `/v1/inbox-placement-ea`

### TODO
- [ ] Add Feature flag to confluence Doc
- [ ] Add instructions on how to create new user with flag to ticket and inform SA team