### PR TITLE
FE-886 - Component wrapper for Matchbox Select

### DIFF
--- a/src/components/collection/FilterSortCollection.js
+++ b/src/components/collection/FilterSortCollection.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Select, Panel, Table, Grid } from '@sparkpost/matchbox';
+import { Panel, Table, Grid } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 import { Collection } from 'src/components/index';
 import _ from 'lodash';
 import styles from './FilterSortCollection.module.scss';

--- a/src/components/datePicker/DatePicker.js
+++ b/src/components/datePicker/DatePicker.js
@@ -9,7 +9,8 @@ import {
   isSameDate,
 } from 'src/helpers/date';
 import { roundBoundaries } from 'src/helpers/metrics';
-import { Button, TextField, Select, Popover, WindowEvent, Error } from '@sparkpost/matchbox';
+import { Button, TextField, Popover, WindowEvent, Error } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 import DateSelector from 'src/components/dateSelector/DateSelector';
 import ManualEntryForm from './ManualEntryForm';
 import { FORMATS } from 'src/constants';

--- a/src/components/matchbox/Select.js
+++ b/src/components/matchbox/Select.js
@@ -4,7 +4,7 @@ import { Select as HibanaSelect } from '@sparkpost/matchbox-hibana';
 import { useHibana } from 'src/context/HibanaContext';
 import { omitSystemProps } from 'src/helpers/hibana';
 
-export default function ProgressBar(props) {
+export default function Select(props) {
   const [state] = useHibana();
   const { isHibanaEnabled } = state;
 

--- a/src/components/matchbox/Select.js
+++ b/src/components/matchbox/Select.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Select as OGSelect } from '@sparkpost/matchbox';
+import { Select as HibanaSelect } from '@sparkpost/matchbox-hibana';
+import { useHibana } from 'src/context/HibanaContext';
+import { omitSystemProps } from 'src/helpers/hibana';
+
+export default function ProgressBar(props) {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  if (!isHibanaEnabled) {
+    return <OGSelect {...omitSystemProps(props)} />;
+  }
+  return <HibanaSelect {...props} />;
+}

--- a/src/components/matchbox/index.js
+++ b/src/components/matchbox/index.js
@@ -6,3 +6,4 @@ export { default as Label } from './Label';
 export { default as ProgressBar } from './ProgressBar.js';
 export { default as Snackbar } from './Snackbar';
 export { default as Stack } from './Stack';
+export { default as Select } from './Select';

--- a/src/components/matchbox/tests/Select.test.js
+++ b/src/components/matchbox/tests/Select.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import Select from '../Select';
+import { render } from '@testing-library/react';
+import { useHibana } from 'src/context/HibanaContext';
+
+jest.mock('src/context/HibanaContext');
+jest.mock('@sparkpost/matchbox', () => ({
+  Select: () => <div>default Select</div>,
+}));
+jest.mock('@sparkpost/matchbox-hibana', () => ({
+  Select: () => <div>hibana Select</div>,
+}));
+
+describe('Select Matchbox component wrapper', () => {
+  const defaultProps = {
+    icon: '',
+    title: 'Select Component',
+    id: 'Select',
+    subtitle: 'click to expand',
+  };
+  const subject = () => {
+    return render(<Select {...defaultProps}> This is the content. </Select>);
+  };
+
+  it('should only render hibana component when hibana is enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
+    const { queryByText } = subject();
+    expect(queryByText('hibana Select')).toBeInTheDocument();
+    expect(queryByText('default Select')).not.toBeInTheDocument();
+  });
+  it('should only render matchbox component when hibana is not enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+    const { queryByText } = subject();
+    expect(queryByText('hibana Select')).not.toBeInTheDocument();
+    expect(queryByText('default Select')).toBeInTheDocument();
+  });
+});

--- a/src/components/reduxFormWrappers/SelectWrapper.js
+++ b/src/components/reduxFormWrappers/SelectWrapper.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Select } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 
 export default function SelectWrapper({ input, meta, ...rest }) {
   const { active, error, touched } = meta;

--- a/src/pages/inboxPlacement/components/TestDetails.js
+++ b/src/pages/inboxPlacement/components/TestDetails.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { format } from 'date-fns';
-import { Grid, Panel, Select, TextField, Label, ScreenReaderOnly } from '@sparkpost/matchbox';
+import { Grid, Panel, TextField, Label, ScreenReaderOnly } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 import _ from 'lodash';
 
 import FolderPlacementBarChart from './FolderPlacementBarChart';

--- a/src/pages/reports/messageEvents/components/SearchQuery.js
+++ b/src/pages/reports/messageEvents/components/SearchQuery.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { Button, Grid } from '@sparkpost/matchbox';
+import { Stack } from 'src/components/matchbox';
 import { AddCircleOutline, HighlightOff } from '@sparkpost/matchbox-icons';
 import styles from './SearchForm.module.scss';
 import { Field } from 'redux-form';
@@ -34,46 +35,49 @@ const getPlaceholderText = _.memoize(key => {
 
 export default ({ fields }) => (
   <Fragment>
-    {fields.map((member, index) => (
-      <Grid key={index}>
-        <Grid.Column xs={3} md={3} lg={3}>
-          <div className={styles.Selector}>
-            <label htmlFor={`select-a-filter-${index}`} className={styles.ScreenReaderOnly}>
-              Filter By
+    <Stack space="400">
+      {fields.map((member, index) => (
+        <Grid key={index}>
+          <Grid.Column xs={3} md={3} lg={3}>
+            <div className={styles.Selector}>
+              <label htmlFor={`select-a-filter-${index}`} className={styles.ScreenReaderOnly}>
+                Filter By
+              </label>
+
+              <Field
+                id={`select-a-filter-${index}`}
+                name={`${member}.key`}
+                component={SelectWrapper}
+                options={getAvailableOptions(fields.getAll(), index)}
+              />
+            </div>
+          </Grid.Column>
+          <Grid.Column xs={12} md={12} lg={7}>
+            <label htmlFor={`filter-field-${index}`} className={styles.ScreenReaderOnly}>
+              Filter
             </label>
 
             <Field
-              id={`select-a-filter-${index}`}
-              name={`${member}.key`}
-              component={SelectWrapper}
-              options={getAvailableOptions(fields.getAll(), index)}
+              id={`filter-field-${index}`}
+              name={`${member}.value`}
+              type="text"
+              placeholder={getPlaceholderText(fields.get(index).key)}
+              component={TextFieldWrapper}
+              validate={makeQueryValidator(fields.get(index))}
             />
-          </div>
-        </Grid.Column>
-        <Grid.Column xs={12} md={12} lg={7}>
-          <label htmlFor={`filter-field-${index}`} className={styles.ScreenReaderOnly}>
-            Filter
-          </label>
+          </Grid.Column>
+          <Grid.Column xs={12} md={12} lg={2}>
+            <p>
+              <Button color="red" flat onClick={() => fields.remove(index)}>
+                Remove
+                <HighlightOff className={styles.Icon} />
+              </Button>
+            </p>
+          </Grid.Column>
+        </Grid>
+      ))}
+    </Stack>
 
-          <Field
-            id={`filter-field-${index}`}
-            name={`${member}.value`}
-            type="text"
-            placeholder={getPlaceholderText(fields.get(index).key)}
-            component={TextFieldWrapper}
-            validate={makeQueryValidator(fields.get(index))}
-          />
-        </Grid.Column>
-        <Grid.Column xs={12} md={12} lg={2}>
-          <p>
-            <Button color="red" flat onClick={() => fields.remove(index)}>
-              Remove
-              <HighlightOff className={styles.Icon} />
-            </Button>
-          </p>
-        </Grid.Column>
-      </Grid>
-    ))}
     <Button className={styles.AddButton} color="blue" flat onClick={() => fields.push({})}>
       {' '}
       Add Filter

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/SearchQuery.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/SearchQuery.test.js.snap
@@ -2,223 +2,227 @@
 
 exports[`SearchForm should render correctly with existing filters 1`] = `
 <Fragment>
-  <Grid
-    key="0"
+  <Stack
+    space="400"
   >
-    <Grid.Column
-      lg={3}
-      md={3}
-      xs={3}
+    <Grid
+      key="0"
     >
-      <div
-        className="Selector"
+      <Grid.Column
+        lg={3}
+        md={3}
+        xs={3}
+      >
+        <div
+          className="Selector"
+        >
+          <label
+            className="ScreenReaderOnly"
+            htmlFor="select-a-filter-0"
+          >
+            Filter By
+          </label>
+          <Field
+            component={[Function]}
+            id="select-a-filter-0"
+            name="searchQuery[0].key"
+            options={
+              Array [
+                Object {
+                  "label": "Recipient Domains",
+                  "value": "recipient_domains",
+                },
+              ]
+            }
+          />
+        </div>
+      </Grid.Column>
+      <Grid.Column
+        lg={7}
+        md={12}
+        xs={12}
       >
         <label
           className="ScreenReaderOnly"
-          htmlFor="select-a-filter-0"
+          htmlFor="filter-field-0"
         >
-          Filter By
+          Filter
         </label>
         <Field
           component={[Function]}
-          id="select-a-filter-0"
-          name="searchQuery[0].key"
-          options={
-            Array [
-              Object {
-                "label": "Recipient Domains",
-                "value": "recipient_domains",
-              },
-            ]
-          }
+          id="filter-field-0"
+          name="searchQuery[0].value"
+          placeholder="Insert recipient domains placeholder"
+          type="text"
+          validate={[Function]}
         />
-      </div>
-    </Grid.Column>
-    <Grid.Column
-      lg={7}
-      md={12}
-      xs={12}
-    >
-      <label
-        className="ScreenReaderOnly"
-        htmlFor="filter-field-0"
+      </Grid.Column>
+      <Grid.Column
+        lg={2}
+        md={12}
+        xs={12}
       >
-        Filter
-      </label>
-      <Field
-        component={[Function]}
-        id="filter-field-0"
-        name="searchQuery[0].value"
-        placeholder="Insert recipient domains placeholder"
-        type="text"
-        validate={[Function]}
-      />
-    </Grid.Column>
-    <Grid.Column
-      lg={2}
-      md={12}
-      xs={12}
+        <p>
+          <Button
+            color="red"
+            flat={true}
+            onClick={[Function]}
+            size="default"
+          >
+            Remove
+            <HighlightOff
+              className="Icon"
+            />
+          </Button>
+        </p>
+      </Grid.Column>
+    </Grid>
+    <Grid
+      key="1"
     >
-      <p>
-        <Button
-          color="red"
-          flat={true}
-          onClick={[Function]}
-          size="default"
+      <Grid.Column
+        lg={3}
+        md={3}
+        xs={3}
+      >
+        <div
+          className="Selector"
         >
-          Remove
-          <HighlightOff
-            className="Icon"
+          <label
+            className="ScreenReaderOnly"
+            htmlFor="select-a-filter-1"
+          >
+            Filter By
+          </label>
+          <Field
+            component={[Function]}
+            id="select-a-filter-1"
+            name="searchQuery[1].key"
+            options={
+              Array [
+                Object {
+                  "label": "Subjects",
+                  "value": "subjects",
+                },
+              ]
+            }
           />
-        </Button>
-      </p>
-    </Grid.Column>
-  </Grid>
-  <Grid
-    key="1"
-  >
-    <Grid.Column
-      lg={3}
-      md={3}
-      xs={3}
-    >
-      <div
-        className="Selector"
+        </div>
+      </Grid.Column>
+      <Grid.Column
+        lg={7}
+        md={12}
+        xs={12}
       >
         <label
           className="ScreenReaderOnly"
-          htmlFor="select-a-filter-1"
+          htmlFor="filter-field-1"
         >
-          Filter By
+          Filter
         </label>
         <Field
           component={[Function]}
-          id="select-a-filter-1"
-          name="searchQuery[1].key"
-          options={
-            Array [
-              Object {
-                "label": "Subjects",
-                "value": "subjects",
-              },
-            ]
-          }
+          id="filter-field-1"
+          name="searchQuery[1].value"
+          placeholder="Insert subjects placeholder"
+          type="text"
+          validate={[Function]}
         />
-      </div>
-    </Grid.Column>
-    <Grid.Column
-      lg={7}
-      md={12}
-      xs={12}
-    >
-      <label
-        className="ScreenReaderOnly"
-        htmlFor="filter-field-1"
+      </Grid.Column>
+      <Grid.Column
+        lg={2}
+        md={12}
+        xs={12}
       >
-        Filter
-      </label>
-      <Field
-        component={[Function]}
-        id="filter-field-1"
-        name="searchQuery[1].value"
-        placeholder="Insert subjects placeholder"
-        type="text"
-        validate={[Function]}
-      />
-    </Grid.Column>
-    <Grid.Column
-      lg={2}
-      md={12}
-      xs={12}
+        <p>
+          <Button
+            color="red"
+            flat={true}
+            onClick={[Function]}
+            size="default"
+          >
+            Remove
+            <HighlightOff
+              className="Icon"
+            />
+          </Button>
+        </p>
+      </Grid.Column>
+    </Grid>
+    <Grid
+      key="2"
     >
-      <p>
-        <Button
-          color="red"
-          flat={true}
-          onClick={[Function]}
-          size="default"
+      <Grid.Column
+        lg={3}
+        md={3}
+        xs={3}
+      >
+        <div
+          className="Selector"
         >
-          Remove
-          <HighlightOff
-            className="Icon"
+          <label
+            className="ScreenReaderOnly"
+            htmlFor="select-a-filter-2"
+          >
+            Filter By
+          </label>
+          <Field
+            component={[Function]}
+            id="select-a-filter-2"
+            name="searchQuery[2].key"
+            options={
+              Array [
+                Object {
+                  "disabled": true,
+                  "label": "Select a Filter",
+                  "value": "",
+                },
+              ]
+            }
           />
-        </Button>
-      </p>
-    </Grid.Column>
-  </Grid>
-  <Grid
-    key="2"
-  >
-    <Grid.Column
-      lg={3}
-      md={3}
-      xs={3}
-    >
-      <div
-        className="Selector"
+        </div>
+      </Grid.Column>
+      <Grid.Column
+        lg={7}
+        md={12}
+        xs={12}
       >
         <label
           className="ScreenReaderOnly"
-          htmlFor="select-a-filter-2"
+          htmlFor="filter-field-2"
         >
-          Filter By
+          Filter
         </label>
         <Field
           component={[Function]}
-          id="select-a-filter-2"
-          name="searchQuery[2].key"
-          options={
-            Array [
-              Object {
-                "disabled": true,
-                "label": "Select a Filter",
-                "value": "",
-              },
-            ]
-          }
+          id="filter-field-2"
+          name="searchQuery[2].value"
+          placeholder="Select Filter Type"
+          type="text"
+          validate={[Function]}
         />
-      </div>
-    </Grid.Column>
-    <Grid.Column
-      lg={7}
-      md={12}
-      xs={12}
-    >
-      <label
-        className="ScreenReaderOnly"
-        htmlFor="filter-field-2"
+      </Grid.Column>
+      <Grid.Column
+        lg={2}
+        md={12}
+        xs={12}
       >
-        Filter
-      </label>
-      <Field
-        component={[Function]}
-        id="filter-field-2"
-        name="searchQuery[2].value"
-        placeholder="Select Filter Type"
-        type="text"
-        validate={[Function]}
-      />
-    </Grid.Column>
-    <Grid.Column
-      lg={2}
-      md={12}
-      xs={12}
-    >
-      <p>
-        <Button
-          color="red"
-          flat={true}
-          onClick={[Function]}
-          size="default"
-        >
-          Remove
-          <HighlightOff
-            className="Icon"
-          />
-        </Button>
-      </p>
-    </Grid.Column>
-  </Grid>
+        <p>
+          <Button
+            color="red"
+            flat={true}
+            onClick={[Function]}
+            size="default"
+          >
+            Remove
+            <HighlightOff
+              className="Icon"
+            />
+          </Button>
+        </p>
+      </Grid.Column>
+    </Grid>
+  </Stack>
   <Button
     className="AddButton"
     color="blue"
@@ -237,6 +241,9 @@ exports[`SearchForm should render correctly with existing filters 1`] = `
 
 exports[`SearchForm should render correctly with no filters 1`] = `
 <Fragment>
+  <Stack
+    space="400"
+  />
   <Button
     className="AddButton"
     color="blue"

--- a/src/pages/reports/summary/components/GroupByOption.js
+++ b/src/pages/reports/summary/components/GroupByOption.js
@@ -1,57 +1,60 @@
 import React, { Component } from 'react';
 import styles from './Table.module.scss';
-import { Checkbox, Grid, Select } from '@sparkpost/matchbox';
+import { Checkbox, Grid } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 import _ from 'lodash';
 import { GROUP_CONFIG } from './tableConfig';
 
-
 export class GroupByOption extends Component {
-
   state = {
-    topDomainsOnly: true
-  }
+    topDomainsOnly: true,
+  };
 
-  handleGroupChange = (e) => {
+  handleGroupChange = e => {
     this.props._getTableData({ groupBy: e.target.value });
-  }
+  };
 
   handleDomainsCheckboxChange = () => {
     const topDomainsOnly = !this.state.topDomainsOnly;
     this.setState({ topDomainsOnly });
     const groupBy = topDomainsOnly ? 'watched-domain' : 'domain';
     this.props._getTableData({ groupBy });
-  }
+  };
 
   getSelectOptions = () => {
     const { hasSubaccounts } = this.props;
     const { topDomainsOnly } = this.state;
 
-    const filteredOptionsKeys = _.reduce(GROUP_CONFIG, (accumulator, value, key) => {
-      if (
-        (key === 'subaccount' && !hasSubaccounts) ||
-        (key === 'domain' && topDomainsOnly) ||
-        (key === 'watched-domain' && !topDomainsOnly)
-      ) {
-        return accumulator; // ignore
-      }
-      accumulator.push(key);
-      return accumulator;
-    },[]);
+    const filteredOptionsKeys = _.reduce(
+      GROUP_CONFIG,
+      (accumulator, value, key) => {
+        if (
+          (key === 'subaccount' && !hasSubaccounts) ||
+          (key === 'domain' && topDomainsOnly) ||
+          (key === 'watched-domain' && !topDomainsOnly)
+        ) {
+          return accumulator; // ignore
+        }
+        accumulator.push(key);
+        return accumulator;
+      },
+      [],
+    );
 
-    const options = filteredOptionsKeys.map((key) => ({
+    const options = filteredOptionsKeys.map(key => ({
       value: key,
-      label: GROUP_CONFIG[key].label
+      label: GROUP_CONFIG[key].label,
     }));
 
     return options;
-  }
+  };
 
   renderDomainsCheckbox() {
     const { tableLoading, groupBy } = this.props;
     const { topDomainsOnly } = this.state;
 
     //Only show 'Top Domains Only' checkbox when on the recipient domains grouping
-    if ((groupBy !== 'watched-domain' && groupBy !== 'domain')) {
+    if (groupBy !== 'watched-domain' && groupBy !== 'domain') {
       return null;
     }
     return (
@@ -73,11 +76,12 @@ export class GroupByOption extends Component {
       <Grid>
         <Grid.Column xs={12} md={5} lg={4}>
           <Select
-            label='Group By'
+            label="Group By"
             options={this.getSelectOptions()}
             value={groupBy}
             disabled={tableLoading}
-            onChange={this.handleGroupChange}/>
+            onChange={this.handleGroupChange}
+          />
         </Grid.Column>
         <Grid.Column xs={12} md={4} mdOffset={3} lg={3} lgOffset={5}>
           {this.renderDomainsCheckbox()}

--- a/src/pages/sendingDomains/components/BounceSetupInstructionPanel.js
+++ b/src/pages/sendingDomains/components/BounceSetupInstructionPanel.js
@@ -1,12 +1,17 @@
 import React, { useState } from 'react';
-import { Select } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 import LabelledValue from 'src/components/labelledValue/LabelledValue';
 import LineBreak from 'src/components/lineBreak';
 import getConfig from 'src/helpers/getConfig';
 import SetupInstructionPanel from './SetupInstructionPanel';
 
 const BounceSetupInstructionPanel = ({
-  domain: { id, status, subaccount_id }, hasAutoVerifyEnabled, isByoipAccount, loading, showAlert, verify
+  domain: { id, status, subaccount_id },
+  hasAutoVerifyEnabled,
+  isByoipAccount,
+  loading,
+  showAlert,
+  verify,
 }) => {
   const initVerificationType = isByoipAccount && status.mx_status === 'valid' ? 'MX' : 'CNAME';
   const [verificationType, setVerificationType] = useState(initVerificationType);
@@ -15,22 +20,20 @@ const BounceSetupInstructionPanel = ({
   const handleVerification = () => {
     const type = verificationType.toLowerCase();
 
-    return (
-      verify({ id, subaccount: subaccount_id, type }).then((result) => {
-        if (result[`${type}_status`] === 'valid') {
-          showAlert({
-            type: 'success',
-            message: `You have successfully verified ${verificationType} record of ${id}`
-          });
-        } else {
-          showAlert({
-            type: 'error',
-            message: `Unable to verify ${verificationType} record of ${id}`,
-            details: result.dns[`${type}_error`]
-          });
-        }
-      })
-    );
+    return verify({ id, subaccount: subaccount_id, type }).then(result => {
+      if (result[`${type}_status`] === 'valid') {
+        showAlert({
+          type: 'success',
+          message: `You have successfully verified ${verificationType} record of ${id}`,
+        });
+      } else {
+        showAlert({
+          type: 'error',
+          message: `Unable to verify ${verificationType} record of ${id}`,
+          details: result.dns[`${type}_error`],
+        });
+      }
+    });
   };
 
   return (
@@ -47,7 +50,9 @@ const BounceSetupInstructionPanel = ({
           <Select
             name="select-bounce-verification-type"
             options={['CNAME', 'MX']}
-            onChange={(event) => { setVerificationType(event.currentTarget.value); }}
+            onChange={event => {
+              setVerificationType(event.currentTarget.value);
+            }}
             value={verificationType}
           />
         </LabelledValue>

--- a/src/pages/signals/components/IntegrationPageFilter.js
+++ b/src/pages/signals/components/IntegrationPageFilter.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
-import { Grid, Panel, Select, TextField } from '@sparkpost/matchbox';
+import { Grid, Panel, TextField } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 import PropTypes from 'prop-types';
 import { onEnter } from 'src/helpers/keyEvents';
 import { stringToArray } from 'src/helpers/string';

--- a/src/pages/signals/components/filters/FacetFilter.js
+++ b/src/pages/signals/components/filters/FacetFilter.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
-import { Grid, Select, TextField } from '@sparkpost/matchbox';
+import { Grid, TextField } from '@sparkpost/matchbox';
+import { Select } from 'src/components/matchbox';
 import { Search } from '@sparkpost/matchbox-icons';
 import { onEnter } from 'src/helpers/keyEvents';
 import withSignalOptions from '../../containers/withSignalOptions';

--- a/src/pages/signals/components/filters/tests/DateFilter.test.js
+++ b/src/pages/signals/components/filters/tests/DateFilter.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { DateFilter } from '../DateFilter';
 import { roundBoundaries } from 'src/helpers/metrics';
 import moment from 'moment';
+import TestApp from 'src/__testHelpers__/TestApp';
 
 describe('DateFilter', () => {
   let props;
@@ -11,26 +12,38 @@ describe('DateFilter', () => {
     props = {
       changeSignalOptions: jest.fn(),
       signalOptions: {},
-      now: '2018-01-01T05:00:00Z'
+      now: '2018-01-01T05:00:00Z',
     };
   });
 
-  const subject = (options = {}) => mount(<DateFilter left {...props} {...options} />);
+  const subject = (options = {}) =>
+    mount(
+      <TestApp>
+        <DateFilter left {...props} {...options} />
+      </TestApp>,
+    );
 
   it('renders datepicker', () => {
-    expect(subject().find('AppDatePicker').props()).toMatchSnapshot();
+    expect(
+      subject()
+        .find('AppDatePicker')
+        .props(),
+    ).toMatchSnapshot();
   });
 
   it('sets a relative range', () => {
     const wrapper = subject();
     const options = { relativeRange: '90days' };
-    const { from, to } = roundBoundaries(moment('2017-10-02T04:00:00Z'),moment('2017-12-31T05:59:59.999Z'));
+    const { from, to } = roundBoundaries(
+      moment('2017-10-02T04:00:00Z'),
+      moment('2017-12-31T05:59:59.999Z'),
+    );
 
     wrapper.find('AppDatePicker').prop('onChange')(options);
     expect(props.changeSignalOptions).toHaveBeenCalledWith({
       ...options,
       from: from.toDate(),
-      to: to.toDate()
+      to: to.toDate(),
     });
   });
 
@@ -39,7 +52,7 @@ describe('DateFilter', () => {
     const options = {
       relativeRange: 'custom',
       from: new Date('2015-01-04T05:00:00Z'),
-      to: new Date('2015-01-09T05:00:00Z')
+      to: new Date('2015-01-09T05:00:00Z'),
     };
 
     wrapper.find('AppDatePicker').prop('onChange')(options);

--- a/src/pages/signals/tests/IntegrationPage.test.js
+++ b/src/pages/signals/tests/IntegrationPage.test.js
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import useRouter from 'src/hooks/useRouter';
 import IntegrationPage from '../IntegrationPage';
+import TestApp from 'src/__testHelpers__/TestApp';
 
 jest.mock('src/hooks/useRouter');
 
@@ -22,13 +23,15 @@ describe('IntegrationPage', () => {
     });
 
     return mount(
-      <IntegrationPage
-        getIngestBatchEvents={() => {}}
-        eventsByPage={[]}
-        loadingStatus="success"
-        totalCount={0}
-        {...props}
-      />,
+      <TestApp>
+        <IntegrationPage
+          getIngestBatchEvents={() => {}}
+          eventsByPage={[]}
+          loadingStatus="success"
+          totalCount={0}
+          {...props}
+        />
+      </TestApp>,
     );
   };
 


### PR DESCRIPTION
FE-886 - Component wrapper for Matchbox Select

### What Changed
 - Select has a single, globally accessible point of entry within the app
 - Select is only imported from Matchbox in one place - replaced all instances of the Select directly imported from matchbox with this new global component
- New props available to the Hibana version of the component are exposed - and subsequently ignored by the original component (https://jira.int.messagesystems.com/browse/FE-816)
- Ensure no unusual positioning UI defects are introduced as a result of this change - both for when using Hibana and when using the default theme

### How To Test
 - enable hibana ui flag 
`{
	"options": {
		"ui":{
"hibana":{
	"hasThemeControls": true
}
		}
	}
 }`
- Check all instances of Select for ui defects with and without hibana enabled

### To-do
- [ ] Address Feedback
