### PR TITLE
AC-1264 - (UI) Single address tab

### DIFF
--- a/cypress/fixtures/account/200.get.json
+++ b/cypress/fixtures/account/200.get.json
@@ -62,7 +62,8 @@
         "feature_alerts": true,
         "ip_auto_warmup": true,
         "brightback": true,
-        "allow_injection_alerts": true
+        "allow_injection_alerts": true,
+        "data_privacy": true
       },
       "initial_open_pixel_tracking": true,
       "smtp_tracking_default": true,

--- a/cypress/fixtures/data-privacy/200.post.json
+++ b/cypress/fixtures/data-privacy/200.post.json
@@ -1,0 +1,3 @@
+{
+  "results": {"message": "Request saved."}
+}

--- a/cypress/fixtures/data-privacy/400.post.json
+++ b/cypress/fixtures/data-privacy/400.post.json
@@ -1,0 +1,3 @@
+{
+  "errors": [{ "message": "This is an error" }]
+}

--- a/cypress/tests/integration/accounts/data-privacy/SingleRecipientPage.spec.js
+++ b/cypress/tests/integration/accounts/data-privacy/SingleRecipientPage.spec.js
@@ -20,7 +20,7 @@ describe('The single recipient data-privacy page', () => {
       fixture: 'data-privacy/200.post.json',
     });
     cy.get('[value="rtbf"]').check({ force: true });
-    cy.findByLabelText('Email Address').type('myfakeusername@sparkpost.com');
+    cy.findByLabelText('Recipient Email Address').type('myfakeusername@sparkpost.com');
     cy.findByText('Submit Request').click();
     cy.findAllByText('Request Saved').should('be.visible');
   });
@@ -33,7 +33,7 @@ describe('The single recipient data-privacy page', () => {
       fixture: 'data-privacy/400.post.json',
     });
     cy.get('[value="rtbf"]').check({ force: true });
-    cy.findByLabelText('Email Address').type('myfakeusername@sparkpost.com');
+    cy.findByLabelText('Recipient Email Address').type('myfakeusername@sparkpost.com');
     cy.findByText('Submit Request').click();
     cy.findAllByText('Something went wrong.').should('be.visible');
   });

--- a/cypress/tests/integration/accounts/data-privacy/SingleRecipientPage.spec.js
+++ b/cypress/tests/integration/accounts/data-privacy/SingleRecipientPage.spec.js
@@ -1,0 +1,40 @@
+describe('The single recipient data-privacy page', () => {
+  beforeEach(() => {
+    cy.stubAuth();
+    cy.login({ isStubbed: true });
+    cy.visit('/account/data-privacy/single-recipient');
+  });
+
+  it('renders with a relevant page title', () => {
+    cy.title().should('include', 'Data and Privacy');
+  });
+
+  it('renders the single recipient tab', () => {
+    cy.findByText('Single Recipient').should('be.visible');
+  });
+
+  it('renders a success snackbar when request is submitted correctly', () => {
+    cy.stubRequest({
+      method: 'POST',
+      url: '/api/v1/data-privacy/rtbf-request',
+      fixture: 'data-privacy/200.post.json',
+    });
+    cy.get('[value="rtbf"]').check({ force: true });
+    cy.findByLabelText('Email Address').type('myfakeusername@sparkpost.com');
+    cy.findByText('Submit Request').click();
+    cy.findAllByText('Request Saved').should('be.visible');
+  });
+
+  it('renders a error snackbar when request is not submitted correctly', () => {
+    cy.stubRequest({
+      method: 'POST',
+      statusCode: 400,
+      url: '/api/v1/data-privacy/rtbf-request',
+      fixture: 'data-privacy/200.post.json',
+    });
+    cy.get('[value="rtbf"]').check({ force: true });
+    cy.findByLabelText('Email Address').type('myfakeusername@sparkpost.com');
+    cy.findByText('Submit Request').click();
+    cy.findAllByText('Something went wrong.').should('be.visible');
+  });
+});

--- a/cypress/tests/integration/accounts/data-privacy/SingleRecipientPage.spec.js
+++ b/cypress/tests/integration/accounts/data-privacy/SingleRecipientPage.spec.js
@@ -30,7 +30,7 @@ describe('The single recipient data-privacy page', () => {
       method: 'POST',
       statusCode: 400,
       url: '/api/v1/data-privacy/rtbf-request',
-      fixture: 'data-privacy/200.post.json',
+      fixture: 'data-privacy/400.post.json',
     });
     cy.get('[value="rtbf"]').check({ force: true });
     cy.findByLabelText('Email Address').type('myfakeusername@sparkpost.com');

--- a/src/actions/dataPrivacy.js
+++ b/src/actions/dataPrivacy.js
@@ -1,29 +1,34 @@
 import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
 import { showAlert } from 'src/actions/globalAlert';
+import setSubaccountHeader from './helpers/setSubaccountHeader';
 
-export function submitRTBFRequest(values) {
+export function submitRTBFRequest({ subaccountId, ...values }) {
   return dispatch =>
     dispatch(
       sparkpostApiRequest({
         type: 'POST_RTBF_REQUEST',
         meta: {
           method: 'POST',
+          headers: setSubaccountHeader(subaccountId),
           url: '/v1/data-privacy/rtbf-request',
           data: values,
+          include_subaccounts: subaccountId ? true : false,
         },
       }),
     ).then(() => dispatch(showAlert({ type: 'success', message: `Request Saved` })));
 }
 
-export function submitOptOutRequest(values) {
+export function submitOptOutRequest({ subaccountId, ...values }) {
   return dispatch =>
     dispatch(
       sparkpostApiRequest({
         type: 'POST_OPTOUT_REQUEST',
         meta: {
           method: 'POST',
+          headers: setSubaccountHeader(subaccountId),
           url: '/v1/data-privacy/opt-out-request',
           data: values,
+          include_subaccounts: subaccountId ? true : false,
         },
       }),
     ).then(() => dispatch(showAlert({ type: 'success', message: `Request Saved` })));

--- a/src/actions/dataPrivacy.js
+++ b/src/actions/dataPrivacy.js
@@ -1,0 +1,30 @@
+import sparkpostApiRequest from 'src/actions/helpers/sparkpostApiRequest';
+import { showAlert } from 'src/actions/globalAlert';
+
+export function submitRTBFRequest(values) {
+  return dispatch =>
+    dispatch(
+      sparkpostApiRequest({
+        type: 'POST_RTBF_REQUEST',
+        meta: {
+          method: 'POST',
+          url: '/v1/data-privacy/rtbf-request',
+          data: values,
+        },
+      }),
+    ).then(() => dispatch(showAlert({ type: 'success', message: `Request Saved` })));
+}
+
+export function submitOptOutRequest(values) {
+  return dispatch =>
+    dispatch(
+      sparkpostApiRequest({
+        type: 'POST_OPTOUT_REQUEST',
+        meta: {
+          method: 'POST',
+          url: '/v1/data-privacy/opt-out-request',
+          data: values,
+        },
+      }),
+    ).then(() => dispatch(showAlert({ type: 'success', message: `Request Saved` })));
+}

--- a/src/actions/tests/dataPrivacy.test.js
+++ b/src/actions/tests/dataPrivacy.test.js
@@ -1,0 +1,45 @@
+import * as dataPrivacyRequests from '../dataPrivacy';
+import { showAlert } from 'src/actions/globalAlert';
+import { sparkpost as spReq } from 'src/helpers/axiosInstances';
+
+jest.mock('src/helpers/axiosInstances');
+jest.mock('src/actions/globalAlert');
+
+describe('Action Creator: dataPrivacy', () => {
+  let dispatchMock;
+
+  beforeEach(() => {
+    dispatchMock = jest.fn(a => Promise.resolve(a));
+    spReq.mockImplementation = jest.fn(a => Promise.resolve(a));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('.submitRTBFRequest should show appropriate alert on success', async () => {
+    const thunk = dataPrivacyRequests.submitRTBFRequest({
+      subaccountId: 100,
+      recipients: ['fakeAddress@email.com'],
+      include_subaccounts: false,
+    });
+    await thunk(dispatchMock);
+    expect(showAlert).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'Request Saved',
+    });
+  });
+
+  it('.deleteUser should show appropriate alert on success', async () => {
+    const thunk = dataPrivacyRequests.submitOptOutRequest({
+      subaccountId: 100,
+      recipients: ['fakeAddress@email.com'],
+      include_subaccounts: false,
+    });
+    await thunk(dispatchMock);
+    expect(showAlert).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'Request Saved',
+    });
+  });
+});

--- a/src/components/subaccountSection/SubaccountSection.js
+++ b/src/components/subaccountSection/SubaccountSection.js
@@ -9,7 +9,7 @@ import { required } from 'src/helpers/validation';
 const createOptions = [
   { label: 'Assign to Master Account', value: 'master' },
   { label: 'Share with all Subaccounts', value: 'shared' },
-  { label: 'Assign to Subaccount', value: 'subaccount' }
+  { label: 'Assign to Subaccount', value: 'subaccount' },
 ];
 
 /**
@@ -36,17 +36,24 @@ export default class SubaccountSection extends Component {
   renderCreate() {
     const { assignTo } = this.props;
 
-    const typeahead = assignTo === 'subaccount'
-      ? <Field name='subaccount' component={SubaccountTypeaheadWrapper} validate={required} helpText='This assignment is permanent.'/>
-      : null;
+    const typeahead =
+      assignTo === 'subaccount' ? (
+        <Field
+          name="subaccount"
+          component={SubaccountTypeaheadWrapper}
+          validate={required}
+          helpText="This assignment is permanent."
+        />
+      ) : null;
 
     return (
       <div>
         <Field
           component={RadioGroup}
-          name='assignTo'
-          title='Subaccount Assignment'
-          options={createOptions} />
+          name="assignTo"
+          title="Subaccount Assignment"
+          options={this.props.createOptions ? this.props.createOptions : createOptions}
+        />
         {typeahead}
       </div>
     );
@@ -59,37 +66,35 @@ export default class SubaccountSection extends Component {
       return (
         <Field
           component={SubaccountTypeaheadWrapper}
-          name='subaccount'
-          label='Subaccount'
-          helpText='This assignment is permanent.'
-          disabled />
+          name="subaccount"
+          label="Subaccount"
+          helpText="This assignment is permanent."
+          disabled
+        />
       );
     }
 
     return (
       <Field
         component={ToggleBlock}
-        type='checkbox'
-        parse={(value) => !!value} // Prevents unchecked value from equaling ""
-        name='shared_with_subaccounts'
-        label='Share with all subaccounts'
-        disabled={disabled} />
+        type="checkbox"
+        parse={value => !!value} // Prevents unchecked value from equaling ""
+        name="shared_with_subaccounts"
+        label="Share with all subaccounts"
+        disabled={disabled}
+      />
     );
   }
 
   render() {
     const { newTemplate } = this.props;
 
-    return (
-      <Panel.Section>
-        {newTemplate ? this.renderCreate() : this.renderEdit()}
-      </Panel.Section>
-    );
+    return <Panel.Section>{newTemplate ? this.renderCreate() : this.renderEdit()}</Panel.Section>;
   }
 }
 
 SubaccountSection.propTypes = {
   newTemplate: PropTypes.bool,
   assignTo: PropTypes.oneOf(['master', 'shared', 'subaccount', null]),
-  change: PropTypes.func
+  change: PropTypes.func,
 };

--- a/src/components/subaccountSection/SubaccountSection.js
+++ b/src/components/subaccountSection/SubaccountSection.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { Panel } from '@sparkpost/matchbox';
 import { RadioGroup, SubaccountTypeaheadWrapper } from 'src/components';
 import ToggleBlock from 'src/components/toggleBlock/ToggleBlock';
 import { required } from 'src/helpers/validation';
@@ -89,7 +88,7 @@ export default class SubaccountSection extends Component {
   render() {
     const { newTemplate } = this.props;
 
-    return <Panel.Section>{newTemplate ? this.renderCreate() : this.renderEdit()}</Panel.Section>;
+    return <>{newTemplate ? this.renderCreate() : this.renderEdit()}</>;
   }
 }
 

--- a/src/components/subaccountSection/__snapshots__/SubaccountSection.test.js.snap
+++ b/src/components/subaccountSection/__snapshots__/SubaccountSection.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Templates SubaccountSection on create should render radio group 1`] = `
-<Panel.Section>
+<Fragment>
   <div>
     <Field
       component={[Function]}
@@ -25,7 +25,7 @@ exports[`Templates SubaccountSection on create should render radio group 1`] = `
       title="Subaccount Assignment"
     />
   </div>
-</Panel.Section>
+</Fragment>
 `;
 
 exports[`Templates SubaccountSection on create should render subaccount typeahead 1`] = `
@@ -38,7 +38,7 @@ exports[`Templates SubaccountSection on create should render subaccount typeahea
 `;
 
 exports[`Templates SubaccountSection on edit should render a disabled subaccount field 1`] = `
-<Panel.Section>
+<Fragment>
   <Field
     component={[Function]}
     disabled={true}
@@ -46,11 +46,11 @@ exports[`Templates SubaccountSection on edit should render a disabled subaccount
     label="Subaccount"
     name="subaccount"
   />
-</Panel.Section>
+</Fragment>
 `;
 
 exports[`Templates SubaccountSection on edit should render toggle block if not assigned to subaccount 1`] = `
-<Panel.Section>
+<Fragment>
   <Field
     component={[Function]}
     label="Share with all subaccounts"
@@ -58,5 +58,5 @@ exports[`Templates SubaccountSection on edit should render toggle block if not a
     parse={[Function]}
     type="checkbox"
   />
-</Panel.Section>
+</Fragment>
 `;

--- a/src/pages/dataPrivacy/DataPrivacyPage.js
+++ b/src/pages/dataPrivacy/DataPrivacyPage.js
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router-dom';
 import { Page, Tabs, Panel } from '@sparkpost/matchbox';
 import styles from './DataPrivacyPage.module.scss';
 import ApiDetailsTab from './components/ApiDetailsTab';
+import SingleRecipientTab from './components/SingleRecipientTab';
 const tabs = [
   { content: 'Single Recipient', key: 'single-recipient' },
   { content: 'Multiple Recipients', key: 'multiple-recipients' },
@@ -22,6 +23,8 @@ export const DataPrivacyPage = props => {
 
   const renderTabs = tabIdx => {
     switch (tabIdx) {
+      case 0:
+        return <SingleRecipientTab />;
       case 2:
         return <ApiDetailsTab history={props.history} />;
 

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -16,7 +16,7 @@ const requestTypes = [
     label: 'Right to be forgotten',
   },
   {
-    value: 'oo-third-party',
+    value: 'opt-out',
     label: 'Opt-out of third-party use',
   },
 ];
@@ -25,17 +25,21 @@ export function SingleRecipientTab(props) {
   const onSubmit = values => {
     switch (values.requestType) {
       case 'rtbf':
-        props.submitRTBFRequest({
-          recipients: [values.address],
-          request_date: new Date().toISOString(),
-        });
+        props
+          .submitRTBFRequest({
+            recipients: [values.address],
+            request_date: new Date().toISOString(),
+          })
+          .then(() => props.reset());
         break;
-
+      case 'opt-out':
       default:
-        props.submitOptOutRequest({
-          recipients: [values.address],
-          request_date: new Date().toISOString(),
-        });
+        props
+          .submitOptOutRequest({
+            recipients: [values.address],
+            request_date: new Date().toISOString(),
+          })
+          .then(() => props.reset());
         break;
     }
   };

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
 import { RadioGroup } from 'src/components';
 import { Field } from 'redux-form';
@@ -7,6 +8,7 @@ import { TextFieldWrapper } from 'src/components';
 import { Label } from 'src/components/matchbox';
 import { required, email, maxLength } from 'src/helpers/validation';
 import { Button } from '@sparkpost/matchbox';
+import { submitRTBFRequest, submitOptOutRequest } from 'src/actions/dataPrivacy';
 
 const requestTypes = [
   {
@@ -20,7 +22,23 @@ const requestTypes = [
 ];
 
 export function SingleRecipientTab(props) {
-  const onSubmit = () => {};
+  const onSubmit = values => {
+    switch (values.requestType) {
+      case 'rtbf':
+        props.submitRTBFRequest({
+          recipients: [values.address],
+          request_date: new Date().toISOString(),
+        });
+        break;
+
+      default:
+        props.submitOptOutRequest({
+          recipients: [values.address],
+          request_date: new Date().toISOString(),
+        });
+        break;
+    }
+  };
   return (
     <form onSubmit={props.handleSubmit(onSubmit)}>
       <div style={{ padding: '1rem', paddingBottom: 0, paddingTop: '2rem' }}>
@@ -30,6 +48,7 @@ export function SingleRecipientTab(props) {
           title="Select Compliance Type"
           options={requestTypes}
           disabled={false}
+          validate={[required]}
         />
         <Label id="email-address-field">Email Address</Label>
 
@@ -43,7 +62,7 @@ export function SingleRecipientTab(props) {
           normalize={(value = '') => value.trim()}
         />
       </div>
-      <SubaccountSection newTemplate={true} disabled={false} />
+      <SubaccountSection newTemplate={true} disabled={false} validate={[required]} />
       <div style={{ padding: '1rem' }}>
         <Button color="orange" type="submit">
           Submit Request
@@ -59,4 +78,6 @@ const formOptions = {
   form: 'DATA_PRIVACY_SINGLE_RECIPIENT',
   enableReinitialize: true,
 };
-export default reduxForm(formOptions)(SingleRecipientTab);
+export default connect(null, { submitRTBFRequest, submitOptOutRequest })(
+  reduxForm(formOptions)(SingleRecipientTab),
+);

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -7,8 +7,9 @@ import SubaccountSection from 'src/components/subaccountSection';
 import { TextFieldWrapper } from 'src/components';
 import { Label } from 'src/components/matchbox';
 import { required, email, maxLength } from 'src/helpers/validation';
-import { Button } from '@sparkpost/matchbox';
+import { Button, Panel } from '@sparkpost/matchbox';
 import { submitRTBFRequest, submitOptOutRequest } from 'src/actions/dataPrivacy';
+import ButtonWrapper from 'src/components/buttonWrapper';
 
 const requestTypes = [
   {
@@ -37,7 +38,7 @@ export function SingleRecipientTab(props) {
   const onSubmit = values => {
     const subaccountId = !Boolean(values.assignTo)
       ? null
-      : subaccountItems[values.assignTo].id === -2
+      : values.assignTo === 'subaccount'
       ? values.subaccount.id
       : subaccountItems[values.assignTo]['id'];
     switch (values.requestType) {
@@ -63,43 +64,46 @@ export function SingleRecipientTab(props) {
     }
   };
   return (
-    <form onSubmit={props.handleSubmit(onSubmit)}>
-      <div style={{ padding: '1rem', paddingBottom: 0, paddingTop: '2rem' }}>
-        <Field
-          component={RadioGroup}
-          name="requestType"
-          title="Select Compliance Type"
-          options={requestTypes}
-          disabled={false}
-          validate={[required]}
-        />
-        <Label id="email-address-field">Email Address</Label>
+    <Panel.Section>
+      <form onSubmit={props.handleSubmit(onSubmit)}>
+        <div style={{ marginTop: '1rem' }}>
+          <Field
+            component={RadioGroup}
+            name="requestType"
+            title="Select Compliance Type"
+            options={requestTypes}
+            disabled={false}
+            validate={[required]}
+          />
+          <Label id="email-address-field">Email Address</Label>
 
-        <Field
-          id="email-address-field"
-          name="address"
-          style={{ width: '60%' }}
-          component={TextFieldWrapper}
-          placeholder={'email@example.com'}
-          validate={[required, email, maxLength(254)]}
-          normalize={(value = '') => value.trim()}
-        />
-      </div>
-      <SubaccountSection
-        newTemplate={true}
-        disabled={false}
-        validate={[required]}
-        createOptions={createOptions}
-      />
-      <div style={{ padding: '1rem' }}>
-        <Button color="orange" type="submit">
-          Submit Request
-        </Button>
-        <div style={{ marginLeft: '1rem', display: 'inline' }}>
-          <Button onClick={props.reset}>Cancel</Button>
+          <Field
+            id="email-address-field"
+            name="address"
+            style={{ width: '60%' }}
+            component={TextFieldWrapper}
+            placeholder={'email@example.com'}
+            validate={[required, email, maxLength(254)]}
+            normalize={(value = '') => value.trim()}
+          />
+          <SubaccountSection
+            newTemplate={true}
+            disabled={false}
+            validate={[required]}
+            createOptions={createOptions}
+          />
         </div>
-      </div>
-    </form>
+
+        <ButtonWrapper>
+          <Button color="orange" type="submit">
+            Submit Request
+          </Button>
+          <div style={{ marginLeft: '1rem', display: 'inline' }}>
+            <Button onClick={props.reset}>Cancel</Button>
+          </div>
+        </ButtonWrapper>
+      </form>
+    </Panel.Section>
   );
 }
 const formOptions = {

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -4,7 +4,6 @@ import { reduxForm } from 'redux-form';
 import { RadioGroup, TextFieldWrapper } from 'src/components';
 import { Field } from 'redux-form';
 import SubaccountSection from 'src/components/subaccountSection';
-import { Label } from 'src/components/matchbox';
 import { required, email, maxLength } from 'src/helpers/validation';
 import { Button, Panel } from '@sparkpost/matchbox';
 import { submitRTBFRequest, submitOptOutRequest } from 'src/actions/dataPrivacy';
@@ -46,7 +45,7 @@ export function SingleRecipientTab(props) {
       case 'rtbf':
         props
           .submitRTBFRequest({
-            recipients: [values.address],
+            recipients: [values.email],
             subaccountId: subaccountId,
             include_subaccounts: include_subaccounts,
           })
@@ -56,7 +55,7 @@ export function SingleRecipientTab(props) {
       default:
         props
           .submitOptOutRequest({
-            recipients: [values.address],
+            recipients: [values.email],
             subaccountId: subaccountId,
             include_subaccounts: include_subaccounts,
           })
@@ -76,14 +75,16 @@ export function SingleRecipientTab(props) {
             disabled={props.dataPrivacyRequestPending}
             validate={[required]}
           />
-          <Label id="email-address-field">Email Address</Label>
+          <label htmlFor="email" className={styles.ScreenReaderOnly}>
+            Recipient Email Address
+          </label>
 
           <Field
-            id="email-address-field"
-            name="address"
+            name="email"
             style={{ width: '60%' }}
             component={TextFieldWrapper}
             placeholder={'email@example.com'}
+            label={'Recipient Email Address'}
             disabled={props.dataPrivacyRequestPending}
             validate={[required, email, maxLength(254)]}
             normalize={(value = '') => value.trim()}

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -19,9 +19,10 @@ const requestTypes = [
   },
 ];
 
-export function SingleRecipientTab() {
+export function SingleRecipientTab(props) {
+  const onSubmit = () => {};
   return (
-    <form handleSubmit={() => {}}>
+    <form onSubmit={props.handleSubmit(onSubmit)}>
       <div style={{ padding: '1rem', paddingBottom: 0, paddingTop: '2rem' }}>
         <Field
           component={RadioGroup}
@@ -44,9 +45,11 @@ export function SingleRecipientTab() {
       </div>
       <SubaccountSection newTemplate={true} disabled={false} />
       <div style={{ padding: '1rem' }}>
-        <Button color="orange">Submit Request</Button>
+        <Button color="orange" type="submit">
+          Submit Request
+        </Button>
         <div style={{ marginLeft: '1rem', display: 'inline' }}>
-          <Button>Cancel</Button>
+          <Button onClick={props.reset}>Cancel</Button>
         </div>
       </div>
     </form>

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -21,14 +21,32 @@ const requestTypes = [
   },
 ];
 
+const subaccountItems = {
+  shared: { id: -1, name: 'Master and all subaccounts' },
+  subaccount: { id: -2, name: 'Subaccount' },
+  master: { id: 0, name: 'Master account' },
+};
+
+const createOptions = [
+  { label: 'Master Account', value: 'master' },
+  { label: 'Master and All Subaccounts', value: 'shared' },
+  { label: 'Select a Subaccount', value: 'subaccount' },
+];
+
 export function SingleRecipientTab(props) {
   const onSubmit = values => {
+    const subaccountId = !Boolean(values.assignTo)
+      ? null
+      : subaccountItems[values.assignTo].id === -2
+      ? values.subaccount.id
+      : subaccountItems[values.assignTo]['id'];
     switch (values.requestType) {
       case 'rtbf':
         props
           .submitRTBFRequest({
             recipients: [values.address],
             request_date: new Date().toISOString(),
+            subaccountId: subaccountId,
           })
           .then(() => props.reset());
         break;
@@ -38,6 +56,7 @@ export function SingleRecipientTab(props) {
           .submitOptOutRequest({
             recipients: [values.address],
             request_date: new Date().toISOString(),
+            subaccountId: subaccountId,
           })
           .then(() => props.reset());
         break;
@@ -66,7 +85,12 @@ export function SingleRecipientTab(props) {
           normalize={(value = '') => value.trim()}
         />
       </div>
-      <SubaccountSection newTemplate={true} disabled={false} validate={[required]} />
+      <SubaccountSection
+        newTemplate={true}
+        disabled={false}
+        validate={[required]}
+        createOptions={createOptions}
+      />
       <div style={{ padding: '1rem' }}>
         <Button color="orange" type="submit">
           Submit Request

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { reduxForm } from 'redux-form';
+import { RadioGroup } from 'src/components';
+import { Field } from 'redux-form';
+import SubaccountSection from 'src/components/subaccountSection';
+import { TextFieldWrapper } from 'src/components';
+import { Label } from 'src/components/matchbox';
+import { required, email, maxLength } from 'src/helpers/validation';
+import { Button } from '@sparkpost/matchbox';
+
+const requestTypes = [
+  {
+    value: 'rtbf',
+    label: 'Right to be forgotten',
+  },
+  {
+    value: 'oo-third-party',
+    label: 'Opt-out of third-party use',
+  },
+];
+
+export function SingleRecipientTab() {
+  return (
+    <form handleSubmit={() => {}}>
+      <div style={{ padding: '1rem', paddingBottom: 0, paddingTop: '2rem' }}>
+        <Field
+          component={RadioGroup}
+          name="requestType"
+          title="Select Compliance Type"
+          options={requestTypes}
+          disabled={false}
+        />
+        <Label id="email-address-field">Email Address</Label>
+
+        <Field
+          id="email-address-field"
+          name="address"
+          style={{ width: '60%' }}
+          component={TextFieldWrapper}
+          placeholder={'email@example.com'}
+          validate={[required, email, maxLength(254)]}
+          normalize={(value = '') => value.trim()}
+        />
+      </div>
+      <SubaccountSection newTemplate={true} disabled={false} />
+      <div style={{ padding: '1rem' }}>
+        <Button color="orange">Submit Request</Button>
+        <div style={{ marginLeft: '1rem', display: 'inline' }}>
+          <Button>Cancel</Button>
+        </div>
+      </div>
+    </form>
+  );
+}
+const formOptions = {
+  form: 'DATA_PRIVACY_SINGLE_RECIPIENT',
+  enableReinitialize: true,
+};
+export default reduxForm(formOptions)(SingleRecipientTab);

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -100,8 +100,8 @@ export function SingleRecipientTab(props) {
             <Button color="orange" type="submit" disabled={props.dataPrivacyRequestPending}>
               Submit Request
             </Button>
-            <div className={styles.CancelButtonContainer}>
-              <Button onClick={props.reset}>Cancel</Button>
+            <div className={styles.ClearButtonContainer}>
+              <Button onClick={props.reset}>Clear</Button>
             </div>
           </ButtonWrapper>
         </form>

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -22,7 +22,7 @@ const requestTypes = [
 ];
 
 const subaccountItems = {
-  shared: { id: -1, name: 'Master and all subaccounts' },
+  shared: { id: null, name: 'Master and all subaccounts' },
   subaccount: { id: -2, name: 'Subaccount' },
   master: { id: 0, name: 'Master account' },
 };

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -75,7 +75,7 @@ export function SingleRecipientTab(props) {
             name="requestType"
             title="Select Compliance Type"
             options={requestTypes}
-            disabled={false}
+            disabled={props.dataPrivacyRequestPending}
             validate={[required]}
           />
           <Label id="email-address-field">Email Address</Label>
@@ -86,18 +86,19 @@ export function SingleRecipientTab(props) {
             style={{ width: '60%' }}
             component={TextFieldWrapper}
             placeholder={'email@example.com'}
+            disabled={props.dataPrivacyRequestPending}
             validate={[required, email, maxLength(254)]}
             normalize={(value = '') => value.trim()}
           />
           <SubaccountSection
             newTemplate={true}
-            disabled={false}
+            disabled={props.dataPrivacyRequestPending}
             validate={[required]}
             createOptions={createOptions}
           />
 
           <ButtonWrapper>
-            <Button color="orange" type="submit">
+            <Button color="orange" type="submit" disabled={props.dataPrivacyRequestPending}>
               Submit Request
             </Button>
             <div className={styles.CancelButtonContainer}>
@@ -113,6 +114,13 @@ const formOptions = {
   form: 'DATA_PRIVACY_SINGLE_RECIPIENT',
   enableReinitialize: true,
 };
-export default connect(null, { submitRTBFRequest, submitOptOutRequest })(
+const mapStateToProps = state => {
+  return {
+    dataPrivacyRequestSuccess: state.dataPrivacy.dataPrivacyRequestSuccess,
+    dataPrivacyRequestPending: state.dataPrivacy.dataPrivacyRequestPending,
+    dataPrivacyRequestError: state.dataPrivacy.dataPrivacyRequestError,
+  };
+};
+export default connect(mapStateToProps, { submitRTBFRequest, submitOptOutRequest })(
   reduxForm(formOptions)(SingleRecipientTab),
 );

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -41,6 +41,7 @@ export function SingleRecipientTab(props) {
       : values.assignTo === 'subaccount'
       ? values.subaccount.id
       : subaccountItems[values.assignTo];
+    const include_subaccounts = values.assignTo === 'shared';
     switch (values.requestType) {
       case 'rtbf':
         props
@@ -48,6 +49,7 @@ export function SingleRecipientTab(props) {
             recipients: [values.address],
             request_date: new Date().toISOString(),
             subaccountId: subaccountId,
+            include_subaccounts: include_subaccounts,
           })
           .then(() => props.reset());
         break;
@@ -58,6 +60,7 @@ export function SingleRecipientTab(props) {
             recipients: [values.address],
             request_date: new Date().toISOString(),
             subaccountId: subaccountId,
+            include_subaccounts: include_subaccounts,
           })
           .then(() => props.reset());
         break;

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -75,10 +75,6 @@ export function SingleRecipientTab(props) {
             disabled={props.dataPrivacyRequestPending}
             validate={[required]}
           />
-          <label htmlFor="email" className={styles.ScreenReaderOnly}>
-            Recipient Email Address
-          </label>
-
           <Field
             name="email"
             style={{ width: '60%' }}

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -47,7 +47,6 @@ export function SingleRecipientTab(props) {
         props
           .submitRTBFRequest({
             recipients: [values.address],
-            request_date: new Date().toISOString(),
             subaccountId: subaccountId,
             include_subaccounts: include_subaccounts,
           })
@@ -58,7 +57,6 @@ export function SingleRecipientTab(props) {
         props
           .submitOptOutRequest({
             recipients: [values.address],
-            request_date: new Date().toISOString(),
             subaccountId: subaccountId,
             include_subaccounts: include_subaccounts,
           })
@@ -116,9 +114,7 @@ const formOptions = {
 };
 const mapStateToProps = state => {
   return {
-    dataPrivacyRequestSuccess: state.dataPrivacy.dataPrivacyRequestSuccess,
     dataPrivacyRequestPending: state.dataPrivacy.dataPrivacyRequestPending,
-    dataPrivacyRequestError: state.dataPrivacy.dataPrivacyRequestError,
   };
 };
 export default connect(mapStateToProps, { submitRTBFRequest, submitOptOutRequest })(

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
-import { RadioGroup } from 'src/components';
+import { RadioGroup, TextFieldWrapper } from 'src/components';
 import { Field } from 'redux-form';
 import SubaccountSection from 'src/components/subaccountSection';
-import { TextFieldWrapper } from 'src/components';
 import { Label } from 'src/components/matchbox';
 import { required, email, maxLength } from 'src/helpers/validation';
 import { Button, Panel } from '@sparkpost/matchbox';
 import { submitRTBFRequest, submitOptOutRequest } from 'src/actions/dataPrivacy';
 import ButtonWrapper from 'src/components/buttonWrapper';
+import styles from './SingleRecipientTab.module.scss';
 
 const requestTypes = [
   {
@@ -23,9 +23,9 @@ const requestTypes = [
 ];
 
 const subaccountItems = {
-  shared: { id: null, name: 'Master and all subaccounts' },
-  subaccount: { id: -2, name: 'Subaccount' },
-  master: { id: 0, name: 'Master account' },
+  shared: null,
+  subaccount: -2,
+  master: 0,
 };
 
 const createOptions = [
@@ -40,7 +40,7 @@ export function SingleRecipientTab(props) {
       ? null
       : values.assignTo === 'subaccount'
       ? values.subaccount.id
-      : subaccountItems[values.assignTo]['id'];
+      : subaccountItems[values.assignTo];
     switch (values.requestType) {
       case 'rtbf':
         props
@@ -65,8 +65,8 @@ export function SingleRecipientTab(props) {
   };
   return (
     <Panel.Section>
-      <form onSubmit={props.handleSubmit(onSubmit)}>
-        <div style={{ marginTop: '1rem' }}>
+      <div className={styles.FormContainer}>
+        <form onSubmit={props.handleSubmit(onSubmit)}>
           <Field
             component={RadioGroup}
             name="requestType"
@@ -92,17 +92,17 @@ export function SingleRecipientTab(props) {
             validate={[required]}
             createOptions={createOptions}
           />
-        </div>
 
-        <ButtonWrapper>
-          <Button color="orange" type="submit">
-            Submit Request
-          </Button>
-          <div style={{ marginLeft: '1rem', display: 'inline' }}>
-            <Button onClick={props.reset}>Cancel</Button>
-          </div>
-        </ButtonWrapper>
-      </form>
+          <ButtonWrapper>
+            <Button color="orange" type="submit">
+              Submit Request
+            </Button>
+            <div className={styles.CancelButtonContainer}>
+              <Button onClick={props.reset}>Cancel</Button>
+            </div>
+          </ButtonWrapper>
+        </form>
+      </div>
     </Panel.Section>
   );
 }

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.module.scss
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.module.scss
@@ -4,7 +4,7 @@
   margin-top: 1rem;
 }
 
-.CancelButtonContainer {
+.ClearButtonContainer {
   margin-left: 1rem;
   display: inline;
 }

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.module.scss
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.module.scss
@@ -1,0 +1,10 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.FormContainer {
+  margin-top: 1rem;
+}
+
+.CancelButtonContainer {
+  margin-left: 1rem;
+  display: inline;
+}

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.module.scss
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.module.scss
@@ -8,3 +8,7 @@
   margin-left: 1rem;
   display: inline;
 }
+
+.ScreenReaderOnly {
+  @include visually-hidden();
+}

--- a/src/pages/dataPrivacy/components/tests/SingleRecipientTab.test.js
+++ b/src/pages/dataPrivacy/components/tests/SingleRecipientTab.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { RadioGroup, TextFieldWrapper } from 'src/components';
+import { SingleRecipientTab } from '../SingleRecipientTab';
+describe('Page: Single Recipient Tab', () => {
+  const defaultProps = {
+    handleSubmit: jest.fn(),
+  };
+  const subject = () => {
+    return shallow(<SingleRecipientTab {...defaultProps} />);
+  };
+
+  it('renders correctly', () => {
+    const wrapper = subject();
+    expect(wrapper.find({ component: RadioGroup, name: 'requestType' })).toExist();
+    expect(wrapper.find({ component: TextFieldWrapper, name: 'address' })).toExist();
+    expect(wrapper.find('SubaccountSection')).toExist();
+  });
+});

--- a/src/pages/dataPrivacy/components/tests/SingleRecipientTab.test.js
+++ b/src/pages/dataPrivacy/components/tests/SingleRecipientTab.test.js
@@ -13,7 +13,7 @@ describe('Page: Single Recipient Tab', () => {
   it('renders correctly', () => {
     const wrapper = subject();
     expect(wrapper.find({ component: RadioGroup, name: 'requestType' })).toExist();
-    expect(wrapper.find({ component: TextFieldWrapper, name: 'address' })).toExist();
+    expect(wrapper.find({ component: TextFieldWrapper, name: 'email' })).toExist();
     expect(wrapper.find('SubaccountSection')).toExist();
   });
 });

--- a/src/pages/dataPrivacy/tests/DataPrivacyPage.test.js
+++ b/src/pages/dataPrivacy/tests/DataPrivacyPage.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { DataPrivacyPage } from '../DataPrivacyPage';
 import ApiDetailsTab from '../components/ApiDetailsTab';
+import SingleRecipientTab from '../components/SingleRecipientTab';
 
 describe('Page: Recipient Email Verification', () => {
   const defaultProps = {
@@ -13,6 +14,16 @@ describe('Page: Recipient Email Verification', () => {
   const subject = props => {
     return shallow(<DataPrivacyPage {...defaultProps} {...props} />);
   };
+
+  it('renders Single Recipient tab correctly', () => {
+    const props = {
+      match: {
+        params: { category: 'single-recipient' },
+      },
+    };
+    const wrapper = subject(props);
+    expect(wrapper.find(SingleRecipientTab)).toExist();
+  });
 
   it('renders Api tab correctly', () => {
     const props = {

--- a/src/pages/snippets/CreatePage.js
+++ b/src/pages/snippets/CreatePage.js
@@ -24,17 +24,11 @@ export default class CreatePage extends React.Component {
     this.props.clearSnippet(); // loaded for duplicate
   }
 
-  fillIdField = (event) => {
+  fillIdField = event => {
     this.props.change('id', slugify(event.target.value));
-  }
+  };
 
-  submitSnippet = ({
-    assignTo,
-    content: { html, text, amp_html } = {},
-    id,
-    name,
-    subaccount
-  }) => {
+  submitSnippet = ({ assignTo, content: { html, text, amp_html } = {}, id, name, subaccount }) => {
     // must handle when subaccount is set to null by SubaccountSection
     const subaccountId = subaccount ? subaccount.id : undefined;
     const { createSnippet, history } = this.props;
@@ -46,11 +40,11 @@ export default class CreatePage extends React.Component {
       sharedWithSubaccounts: assignTo === 'shared',
       subaccountId,
       text,
-      amp_html
+      amp_html,
     }).then(() => {
       history.push(`/snippets/edit/${id}${setSubaccountQuery(subaccountId)}`);
     });
-  }
+  };
 
   render() {
     const { snippetToDuplicate, handleSubmit, hasSubaccounts, loading, submitting } = this.props;
@@ -66,7 +60,7 @@ export default class CreatePage extends React.Component {
         primaryAction={{
           Component: Button,
           content: 'Create Snippet',
-          onClick: handleSubmit(this.submitSnippet)
+          onClick: handleSubmit(this.submitSnippet),
         }}
       >
         <Form onSubmit={this.submitSnippet}>
@@ -91,7 +85,11 @@ export default class CreatePage extends React.Component {
                     validate={[required, slug, maxLength(64)]}
                   />
                 </Panel.Section>
-                {hasSubaccounts && <SubaccountSection newTemplate={true} disabled={submitting} />}
+                {hasSubaccounts && (
+                  <Panel.Section>
+                    <SubaccountSection newTemplate={true} disabled={submitting} />
+                  </Panel.Section>
+                )}
               </Panel>
             </Grid.Column>
             <Grid.Column xs={12} lg={8}>

--- a/src/pages/snippets/EditPage.js
+++ b/src/pages/snippets/EditPage.js
@@ -127,7 +127,6 @@ export default class EditPage extends React.Component {
                 </Panel.Section>
                 {canViewSubaccountSection && (
                   <Panel.Section>
-                    {' '}
                     <SubaccountSection newTemplate={false} disabled={disabled} />
                   </Panel.Section>
                 )}

--- a/src/pages/snippets/EditPage.js
+++ b/src/pages/snippets/EditPage.js
@@ -24,12 +24,12 @@ export default class EditPage extends React.Component {
 
   secondaryActions = [
     {
-      Component: (props) => (
+      Component: props => (
         <DeleteSnippetLink {...props} id={this.props.id} subaccountId={this.props.subaccountId} />
       ),
       content: 'Delete',
       to: '/', // needed to render Component
-      visible: () => this.props.canModify
+      visible: () => this.props.canModify,
     },
     {
       Component: PageLink,
@@ -38,19 +38,19 @@ export default class EditPage extends React.Component {
         pathname: '/snippets/create',
         state: {
           id: this.props.id,
-          subaccountId: this.props.subaccountId
-        }
+          subaccountId: this.props.subaccountId,
+        },
       },
-      visible: () => this.props.canModify
-    }
-  ]
+      visible: () => this.props.canModify,
+    },
+  ];
 
   submitSnippet = ({
     content: { html, text, amp_html } = {},
     id,
     name,
     subaccount,
-    shared_with_subaccounts: sharedWithSubaccounts
+    shared_with_subaccounts: sharedWithSubaccounts,
   }) => {
     // must handle when subaccount is set to null by SubaccountSection
     const subaccountId = subaccount ? subaccount.id : undefined;
@@ -63,9 +63,9 @@ export default class EditPage extends React.Component {
       sharedWithSubaccounts,
       subaccountId,
       text,
-      amp_html
+      amp_html,
     }).then(() => showAlert({ type: 'success', message: 'Snippet saved' }));
-  }
+  };
 
   render() {
     const {
@@ -76,7 +76,7 @@ export default class EditPage extends React.Component {
       canViewSubaccount,
       id,
       loading,
-      submitting
+      submitting,
     } = this.props;
     const disabled = !canModify || submitting;
     const canViewSubaccountSection = hasSubaccounts && canViewSubaccount;
@@ -101,11 +101,9 @@ export default class EditPage extends React.Component {
           Component: Button,
           content: 'Save Snippet',
           disabled,
-          onClick: handleSubmit(this.submitSnippet)
+          onClick: handleSubmit(this.submitSnippet),
         }}
-        secondaryActions={
-          this.secondaryActions.filter(({ visible = () => true }) => visible())
-        }
+        secondaryActions={this.secondaryActions.filter(({ visible = () => true }) => visible())}
       >
         <Form onSubmit={this.submitSnippet}>
           <Grid>
@@ -128,7 +126,10 @@ export default class EditPage extends React.Component {
                   />
                 </Panel.Section>
                 {canViewSubaccountSection && (
-                  <SubaccountSection newTemplate={false} disabled={disabled} />
+                  <Panel.Section>
+                    {' '}
+                    <SubaccountSection newTemplate={false} disabled={disabled} />
+                  </Panel.Section>
                 )}
               </Panel>
               <Panel sectioned>

--- a/src/pages/snippets/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/snippets/tests/__snapshots__/EditPage.test.js.snap
@@ -84,10 +84,13 @@ exports[`EditPage renders disabled form when submitting 1`] = `
               name="id"
             />
           </Panel.Section>
-          <SubaccountSection
-            disabled={true}
-            newTemplate={false}
-          />
+          <Panel.Section>
+             
+            <SubaccountSection
+              disabled={true}
+              newTemplate={false}
+            />
+          </Panel.Section>
         </Panel>
         <Panel
           sectioned={true}
@@ -165,10 +168,13 @@ exports[`EditPage renders disabled form when user does not have authorization to
               name="id"
             />
           </Panel.Section>
-          <SubaccountSection
-            disabled={true}
-            newTemplate={false}
-          />
+          <Panel.Section>
+             
+            <SubaccountSection
+              disabled={true}
+              newTemplate={false}
+            />
+          </Panel.Section>
         </Panel>
         <Panel
           sectioned={true}
@@ -266,9 +272,12 @@ exports[`EditPage renders edit form 1`] = `
               name="id"
             />
           </Panel.Section>
-          <SubaccountSection
-            newTemplate={false}
-          />
+          <Panel.Section>
+             
+            <SubaccountSection
+              newTemplate={false}
+            />
+          </Panel.Section>
         </Panel>
         <Panel
           sectioned={true}

--- a/src/pages/snippets/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/snippets/tests/__snapshots__/EditPage.test.js.snap
@@ -85,7 +85,6 @@ exports[`EditPage renders disabled form when submitting 1`] = `
             />
           </Panel.Section>
           <Panel.Section>
-             
             <SubaccountSection
               disabled={true}
               newTemplate={false}
@@ -169,7 +168,6 @@ exports[`EditPage renders disabled form when user does not have authorization to
             />
           </Panel.Section>
           <Panel.Section>
-             
             <SubaccountSection
               disabled={true}
               newTemplate={false}
@@ -273,7 +271,6 @@ exports[`EditPage renders edit form 1`] = `
             />
           </Panel.Section>
           <Panel.Section>
-             
             <SubaccountSection
               newTemplate={false}
             />

--- a/src/pages/templates/components/create/CreateForm.js
+++ b/src/pages/templates/components/create/CreateForm.js
@@ -19,7 +19,7 @@ import { selectDomainsBySubaccountWithDefault } from 'src/selectors/templates';
 
 export class CreateForm extends Component {
   // Fills in ID based on Name
-  handleIdFill = (e) => {
+  handleIdFill = e => {
     const { autofill, formName } = this.props;
     autofill(formName, 'id', slugify(e.target.value));
   };
@@ -53,32 +53,32 @@ export class CreateForm extends Component {
         <Grid.Column xs={12} lg={7}>
           <Panel.Section>
             <Field
-              name='name'
+              name="name"
               component={TextFieldWrapper}
-              label='Template Name'
+              label="Template Name"
               onChange={this.handleIdFill}
               validate={required}
             />
 
             <Field
-              name='id'
+              name="id"
               component={TextFieldWrapper}
-              label='Template ID'
-              helpText={'A Unique ID for your template, we\'ll fill this in for you.'}
+              label="Template ID"
+              helpText={"A Unique ID for your template, we'll fill this in for you."}
               validate={[required, slug]}
             />
             <Field
-              name='content.subject'
+              name="content.subject"
               component={TextFieldWrapper}
-              label='Subject'
+              label="Subject"
               validate={required}
             />
 
             <Field
-              name='content.from.email'
+              name="content.from.email"
               component={FromEmailWrapper}
-              placeholder='example@email.com'
-              label='From Email'
+              placeholder="example@email.com"
+              label="From Email"
               validate={[required, emailOrSubstitution]}
               domains={domains}
               helpText={this.fromEmailHelpText()}
@@ -86,18 +86,20 @@ export class CreateForm extends Component {
           </Panel.Section>
         </Grid.Column>
         <Grid.Column xs={12} lg={5}>
-          {canViewSubaccountSection && <SubaccountSection newTemplate={true}/>}
+          {canViewSubaccountSection && (
+            <Panel.Section>
+              <SubaccountSection newTemplate={true} />
+            </Panel.Section>
+          )}
         </Grid.Column>
-
       </Grid>
     );
   }
 }
 
 CreateForm.defaultProps = {
-  domains: []
+  domains: [],
 };
-
 
 const mapStateToProps = (state, props) => {
   const selector = formValueSelector(props.formName);
@@ -107,11 +109,10 @@ const mapStateToProps = (state, props) => {
     fromEmail: selector(state, 'content.from.email'),
     domainsLoading: state.sendingDomains.listLoading,
     hasSubaccounts: hasSubaccounts(state),
-    canViewSubaccount: selectCondition(not(isSubaccountUser))(state)
+    canViewSubaccount: selectCondition(not(isSubaccountUser))(state),
   };
 };
 
 const connectedForm = connect(mapStateToProps, { autofill })(CreateForm);
 connectedForm.displayName = 'TemplateCreateForm';
 export default connectedForm;
-

--- a/src/pages/templates/components/settings/SettingsForm.js
+++ b/src/pages/templates/components/settings/SettingsForm.js
@@ -101,7 +101,9 @@ export default class SettingsForm extends React.Component {
             />
           </Panel.Section>
           {canViewSubaccountSection && (
-            <SubaccountSection newTemplate={false} disabled={submitting || isPublishedMode} />
+            <Panel.Section>
+              <SubaccountSection newTemplate={false} disabled={submitting || isPublishedMode} />
+            </Panel.Section>
           )}
           <Panel.Section>
             <Field

--- a/src/reducers/dataPrivacy.js
+++ b/src/reducers/dataPrivacy.js
@@ -1,0 +1,24 @@
+const initialState = {
+  dataPrivacyRequestSuccess: null,
+  dataPrivacyRequestPending: null,
+  dataPrivacyRequestError: null,
+};
+
+export default (state = initialState, { type }) => {
+  switch (type) {
+    case 'POST_RTBF_REQUEST_PENDING':
+      return { ...state, dataPrivacyRequestPending: true, dataPrivacyRequestError: null };
+    case 'POST_RTBF_REQUEST_FAIL':
+      return { ...state, dataPrivacyRequestPending: false, dataPrivacyRequestError: true };
+    case 'POST_RTBF_REQUEST_SUCCESS':
+      return {
+        ...state,
+        dataPrivacyRequestSuccess: true,
+        dataPrivacyRequestPending: false,
+        dataPrivacyRequestError: null,
+      };
+
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -16,6 +16,7 @@ import blacklist from './blacklist';
 import brightback from './brightback';
 import cookieConsent from './cookieConsent';
 import delayReport from './delayReport';
+import dataPrivacy from './dataPrivacy';
 import engagementReport from './engagementReport';
 import rejectionReport from './rejectionReport';
 import currentUser from './currentUser';
@@ -65,6 +66,7 @@ const appReducer = combineReducers({
   brightback,
   cookieConsent,
   currentUser,
+  dataPrivacy,
   delayReport,
   engagementReport,
   globalAlert,


### PR DESCRIPTION
AC-1264 - (UI) Single address tab

### What Changed
- Tab 1 for the single address form is created
- The form changes endpoints based on Right to Be forgotten or opting out
- Subaccount is assigned to header
- Cypress tests are added for Single Recipient Page

### How To Test
 - Enable 'data_privacy' flag.
 - Navigate to /account/data-privacy/single-recipient.
 - Check if it matched mocks https://sparkpost.invisionapp.com/share/BCVKAJRH4E9#/screens/400849700
 - Submit request for rtbf and Opt out check if requests are sent as doucmented - https://github.com/SparkPost/sparkpost-admin-api-documentation/pull/452/files

### To Do
- [ ] Address Feedback
