### PR TITLE
FE-890 - Component Wrapper for Matchbox Table

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@sparkpost/boomerang": "^1.0.6",
     "@sparkpost/design-tokens-hibana": "npm:@sparkpost/design-tokens@^1.0.0-beta.16",
     "@sparkpost/matchbox": "^3.9.1",
-    "@sparkpost/matchbox-hibana": "npm:@sparkpost/matchbox@^4.0.0-hibana.8",
+    "@sparkpost/matchbox-hibana": "npm:@sparkpost/matchbox@^4.0.0-hibana.9",
     "@sparkpost/matchbox-icons": "^1.2.1",
     "@styled-system/props": "^5.1.5",
     "axios": "^0.18.0",

--- a/src/components/collection/FilterSortCollection.js
+++ b/src/components/collection/FilterSortCollection.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Table, Grid } from '@sparkpost/matchbox';
-import { Panel, Select } from 'src/components/matchbox';
+import { Grid } from '@sparkpost/matchbox';
+import { Select, Table, Panel } from 'src/components/matchbox';
 import { Collection } from 'src/components/index';
 import _ from 'lodash';
 import styles from './FilterSortCollection.module.scss';

--- a/src/components/collection/TableCollection.js
+++ b/src/components/collection/TableCollection.js
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
 import _ from 'lodash';
-import { Table } from '@sparkpost/matchbox';
-import { Panel } from 'src/components/matchbox';
+import { Panel, Table } from 'src/components/matchbox';
 import Collection from './Collection';
 import TableHeader from './TableHeader';
 import styles from './TableCollection.module.scss';
 
-const TableWrapper = (props) => (
+const TableWrapper = props => (
   <Panel>
     <div className={styles.TableWrapper}>
       <Table>{props.children}</Table>
@@ -14,27 +13,27 @@ const TableWrapper = (props) => (
   </Panel>
 );
 
-const TableBody = (props) => <tbody>{props.children}</tbody>;
+const TableBody = props => <tbody>{props.children}</tbody>;
 
 class TableCollection extends Component {
   state = {
     sortColumn: null,
-    sortDirection: null
-  }
+    sortDirection: null,
+  };
 
   static defaultProps = {
     defaultSortColumn: null,
-    defaultSortDirection: 'asc'
-  }
+    defaultSortDirection: 'asc',
+  };
 
   componentDidMount() {
     const { defaultSortColumn, defaultSortDirection } = this.props;
-    this.setState({ sortColumn: defaultSortColumn , sortDirection: defaultSortDirection });
+    this.setState({ sortColumn: defaultSortColumn, sortDirection: defaultSortDirection });
   }
 
   handleSortChange = (column, direction) => {
     this.setState({ sortColumn: column, sortDirection: direction });
-  }
+  };
 
   render() {
     const {
@@ -44,17 +43,26 @@ class TableCollection extends Component {
       columns,
       getRowData,
       rows,
-      title
+      title,
     } = this.props;
     const { sortColumn, sortDirection } = this.state;
 
     const WrapperComponent = wrapperComponent ? wrapperComponent : TableWrapper;
-    const HeaderComponent = headerComponent ? headerComponent : () => <TableHeader columns={columns} onSort={this.handleSortChange} sortColumn={sortColumn} sortDirection={sortDirection}/>;
+    const HeaderComponent = headerComponent
+      ? headerComponent
+      : () => (
+          <TableHeader
+            columns={columns}
+            onSort={this.handleSortChange}
+            sortColumn={sortColumn}
+            sortDirection={sortDirection}
+          />
+        );
     const TableRow = rowComponent
       ? rowComponent
-      : (props) => <Table.Row rowData={getRowData(props)} />;
+      : props => <Table.Row rowData={getRowData(props)} />;
 
-    const sortedRows = sortColumn ? _.orderBy(rows, sortColumn, sortDirection) : rows ;
+    const sortedRows = sortColumn ? _.orderBy(rows, sortColumn, sortDirection) : rows;
 
     return (
       <Collection

--- a/src/components/collection/TableHeader.js
+++ b/src/components/collection/TableHeader.js
@@ -1,22 +1,23 @@
 import React, { Component } from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import SortLabel from './SortLabel';
 
 export default class TableHeader extends Component {
-  handleSorting = (column) => {
+  handleSorting = column => {
     const { sortColumn, sortDirection } = this.props;
     let direction;
 
-    if (column === sortColumn) { // change direction as same column is clicked again
+    if (column === sortColumn) {
+      // change direction as same column is clicked again
       direction = sortDirection === 'asc' ? 'desc' : 'asc';
     } else {
       direction = 'asc';
     }
 
     this.props.onSort(column, direction);
-  }
+  };
 
-  renderSortCell = (item) => {
+  renderSortCell = item => {
     const { label, sortKey } = item;
     const { sortColumn, sortDirection } = this.props;
 
@@ -25,12 +26,13 @@ export default class TableHeader extends Component {
         <SortLabel
           onClick={() => this.handleSorting(sortKey)}
           direction={sortKey === sortColumn && sortDirection}
-          label={label} />
+          label={label}
+        />
       );
     }
 
     return label;
-  }
+  };
 
   render() {
     const { columns } = this.props;
@@ -41,7 +43,11 @@ export default class TableHeader extends Component {
       }
       const { label, sortKey, ...rest } = item;
 
-      return <Table.HeaderCell key={label} {...rest}>{this.renderSortCell(item)}</Table.HeaderCell>;
+      return (
+        <Table.HeaderCell key={label} {...rest}>
+          {this.renderSortCell(item)}
+        </Table.HeaderCell>
+      );
     });
 
     return (

--- a/src/components/collection/tests/FilterSortCollection.test.js
+++ b/src/components/collection/tests/FilterSortCollection.test.js
@@ -2,7 +2,7 @@ import { shallow, mount } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import FilterSortCollection from '../FilterSortCollection';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import TestApp from 'src/__testHelpers__/TestApp';
 
 describe('FilterSortCollection Component', () => {

--- a/src/components/collection/tests/TableCollection.test.js
+++ b/src/components/collection/tests/TableCollection.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import { shallow } from 'enzyme';
 
 import TableCollection from '../TableCollection';
@@ -15,7 +15,9 @@ describe('TableCollection Component', () => {
     headerComponent = (
       <thead>
         <Table.Row>
-          {columns.map((title) => <Table.HeaderCell key={title}>{title}</Table.HeaderCell>)}
+          {columns.map(title => (
+            <Table.HeaderCell key={title}>{title}</Table.HeaderCell>
+          ))}
         </Table.Row>
       </thead>
     );
@@ -26,7 +28,7 @@ describe('TableCollection Component', () => {
       getRowData: () => {},
       extraProp: 'plsPassDown',
       rows: [],
-      title: 'Example Table'
+      title: 'Example Table',
     };
   });
 
@@ -37,7 +39,7 @@ describe('TableCollection Component', () => {
     });
 
     it('renders with props', () => {
-      const wrapper = shallow(<TableCollection {...props}/>);
+      const wrapper = shallow(<TableCollection {...props} />);
       expect(wrapper).toMatchSnapshot();
     });
   });
@@ -46,11 +48,11 @@ describe('TableCollection Component', () => {
     let wrapper;
 
     beforeEach(() => {
-      wrapper = shallow(<TableCollection {...props}/>);
+      wrapper = shallow(<TableCollection {...props} />);
     });
 
     it('uses default if defaultSortColumn and defaultSortDirection are not passed', () => {
-      wrapper = shallow(<TableCollection {...props}/>);
+      wrapper = shallow(<TableCollection {...props} />);
       expect(wrapper.state().sortColumn).toEqual(null);
       expect(wrapper.state().sortDirection).toEqual('asc');
     });
@@ -58,14 +60,14 @@ describe('TableCollection Component', () => {
     it('sets state with defaultSortColumn when passed', () => {
       expect(wrapper.state().sortColumn).toEqual(null);
       props.defaultSortColumn = 'col1';
-      wrapper = shallow(<TableCollection {...props}/>);
+      wrapper = shallow(<TableCollection {...props} />);
       expect(wrapper.state().sortColumn).toEqual('col1');
     });
 
     it('sets default with sortDirection when passed', () => {
       expect(wrapper.state().sortDirection).toEqual('asc');
       props.defaultSortDirection = 'desc';
-      wrapper = shallow(<TableCollection {...props}/>);
+      wrapper = shallow(<TableCollection {...props} />);
       expect(wrapper.state().sortDirection).toEqual('desc');
     });
   });
@@ -74,7 +76,7 @@ describe('TableCollection Component', () => {
     let wrapper;
 
     beforeEach(() => {
-      wrapper = shallow(<TableCollection {...props}/>);
+      wrapper = shallow(<TableCollection {...props} />);
     });
 
     it('updates state correctly', () => {

--- a/src/components/matchbox/Table.js
+++ b/src/components/matchbox/Table.js
@@ -4,7 +4,16 @@ import { Table as HibanaTable } from '@sparkpost/matchbox-hibana';
 import { useHibana } from 'src/context/HibanaContext';
 import { omitSystemProps } from 'src/helpers/hibana';
 
-export default function Table(props) {
+HibanaTable.displayName = 'HibanaTable';
+HibanaTable.Cell.displayName = 'HibanaTableCell';
+HibanaTable.HeaderCell.displayName = 'HibanaTableHeaderCell';
+HibanaTable.Row.displayName = 'HibanaTableRow';
+OGTable.displayName = 'OGTable';
+OGTable.Cell.displayName = 'OGTableCell';
+OGTable.HeaderCell.displayName = 'OGTableHeaderCell';
+OGTable.Row.displayName = 'OGTableRow';
+
+export function Table(props) {
   const [state] = useHibana();
   const { isHibanaEnabled } = state;
 
@@ -13,3 +22,43 @@ export default function Table(props) {
   }
   return <HibanaTable {...props} />;
 }
+
+export function Cell(props) {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  if (!isHibanaEnabled) {
+    return <OGTable.Cell {...omitSystemProps(props)} />;
+  }
+  return <HibanaTable.Cell {...props} />;
+}
+
+export function HeaderCell(props) {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  if (!isHibanaEnabled) {
+    return <OGTable.HeaderCell {...omitSystemProps(props)} />;
+  }
+  return <HibanaTable.HeaderCell {...props} />;
+}
+
+export function Row(props) {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  if (!isHibanaEnabled) {
+    return <OGTable.Row {...omitSystemProps(props)} />;
+  }
+  return <HibanaTable.Row {...props} />;
+}
+
+Cell.displayName = 'Table.Cell';
+HeaderCell.displayName = 'Table.HeaderCell';
+Row.displayName = 'Table.Row';
+
+Table.Cell = Cell;
+Table.HeaderCell = HeaderCell;
+Table.Row = Row;
+
+export default Table;

--- a/src/components/matchbox/Table.js
+++ b/src/components/matchbox/Table.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Table as OGTable } from '@sparkpost/matchbox';
+import { Table as HibanaTable } from '@sparkpost/matchbox-hibana';
+import { useHibana } from 'src/context/HibanaContext';
+import { omitSystemProps } from 'src/helpers/hibana';
+
+export default function Table(props) {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  if (!isHibanaEnabled) {
+    return <OGTable {...omitSystemProps(props)} />;
+  }
+  return <HibanaTable {...props} />;
+}

--- a/src/components/matchbox/index.js
+++ b/src/components/matchbox/index.js
@@ -12,6 +12,7 @@ export { default as Slider } from './Slider';
 export { default as Snackbar } from './Snackbar';
 export { default as Select } from './Select';
 export { default as Stack } from './Stack';
+export { default as Table } from './Table';
 export { default as Tag } from './Tag';
 export { default as TextField } from './TextField';
 export { default as ThemeProvider } from './ThemeProvider';

--- a/src/components/matchbox/tests/Table.test.js
+++ b/src/components/matchbox/tests/Table.test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { useHibana } from 'src/context/HibanaContext';
+import Table from '../Table';
+
+jest.mock('src/context/HibanaContext');
+
+describe('Table Matchbox component wrapper', () => {
+  const subject = () => {
+    return shallow(<Table>table content is here</Table>);
+  };
+
+  it('renders the Hibana version of the Table component correctly when hibana is enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
+
+    const wrapper = subject();
+
+    expect(wrapper).toHaveDisplayName('HibanaTable');
+  });
+
+  it('renders default(OG) version of the Table component correctly when hibana is not enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+
+    const wrapper = subject();
+
+    expect(wrapper).toHaveDisplayName('OGTable');
+  });
+
+  describe('Table.Cell', () => {
+    const subject = () => {
+      return shallow(<Table.Cell>table content is here</Table.Cell>);
+    };
+    it('renders the Hibana version of the Table.Cell component correctly when hibana is enabled', () => {
+      useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
+
+      const wrapper = subject();
+
+      expect(wrapper).toHaveDisplayName('HibanaTableCell');
+    });
+
+    it('renders default(OG) version of the Table.Cell component correctly when hibana is not enabled', () => {
+      useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+
+      const wrapper = subject();
+
+      expect(wrapper).toHaveDisplayName('OGTableCell');
+    });
+  });
+  describe('Table.HeaderCell', () => {
+    const subject = () => {
+      return shallow(<Table.HeaderCell>table content is here</Table.HeaderCell>);
+    };
+    it('renders the Hibana version of the Table.HeaderCell component correctly when hibana is enabled', () => {
+      useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
+
+      const wrapper = subject();
+
+      expect(wrapper).toHaveDisplayName('HibanaTableHeaderCell');
+    });
+
+    it('renders default(OG) version of the Table.HeaderCell component correctly when hibana is not enabled', () => {
+      useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+
+      const wrapper = subject();
+
+      expect(wrapper).toHaveDisplayName('OGTableHeaderCell');
+    });
+  });
+  describe('Table.Row', () => {
+    const subject = () => {
+      return shallow(<Table.Row>table content is here</Table.Row>);
+    };
+    it('renders the Hibana version of the Table.Row component correctly when hibana is enabled', () => {
+      useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
+
+      const wrapper = subject();
+
+      expect(wrapper).toHaveDisplayName('HibanaTableRow');
+    });
+
+    it('renders default(OG) version of the Table.Row component correctly when hibana is not enabled', () => {
+      useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+
+      const wrapper = subject();
+
+      expect(wrapper).toHaveDisplayName('OGTableRow');
+    });
+  });
+});

--- a/src/components/recipientValidation/RecipientValidationPriceTable.js
+++ b/src/components/recipientValidation/RecipientValidationPriceTable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import { RECIPIENT_VALIDATION_TIERS } from 'src/constants';
 import { formatFullNumber } from 'src/helpers/units';
 import styles from './RecipientValidationPriceTable.module.scss';

--- a/src/components/summaryTable/Billboard.js
+++ b/src/components/summaryTable/Billboard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import styles from './SummaryTable.module.scss';
 
 const Billboard = ({ children, colSpan }) => (

--- a/src/components/summaryTable/Body.js
+++ b/src/components/summaryTable/Body.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import Callout from 'src/components/callout';
 import Loading from 'src/components/loading'; // todo, move to src/components
 import Billboard from './Billboard';
@@ -42,7 +42,7 @@ const Body = ({ columns, data, empty, error, loading, perPage }) => {
               className={classnames(styles.Cell, {
                 [styles.DataCell]: !Component,
                 [styles.CenterAlign]: align === 'center',
-                [styles.RightAlign]: align === 'right'
+                [styles.RightAlign]: align === 'right',
               })}
               key={`cell-${dataKey}`}
             >

--- a/src/components/summaryTable/Head.js
+++ b/src/components/summaryTable/Head.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import HeaderLabel from './HeaderLabel';
 import styles from './SummaryTable.module.scss';
 
@@ -11,7 +11,7 @@ const Head = ({ columns, onSort, order }) => (
         <Table.HeaderCell
           className={classnames(styles.Header, {
             [styles.CenterAlign]: align === 'center',
-            [styles.RightAlign]: align === 'right'
+            [styles.RightAlign]: align === 'right',
           })}
           key={`header-${dataKey}`}
           width={width}

--- a/src/components/summaryTable/SummaryTable.js
+++ b/src/components/summaryTable/SummaryTable.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Pagination, Table } from '@sparkpost/matchbox';
+import { Pagination } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import Body from './Body';
 import Column from './Column';
 import Head from './Head';
@@ -15,8 +16,8 @@ class SummaryTable extends React.Component {
   static defaultProps = {
     // refer to reducer for other default prop values
     data: [],
-    onChange: () => {}
-  }
+    onChange: () => {},
+  };
 
   static propTypes = {
     children: PropTypes.arrayOf(Column).isRequired,
@@ -28,12 +29,12 @@ class SummaryTable extends React.Component {
     onChange: PropTypes.func,
     order: PropTypes.shape({
       ascending: PropTypes.bool.isRequired,
-      dataKey: PropTypes.string.isRequired
+      dataKey: PropTypes.string.isRequired,
     }),
     perPage: PropTypes.number.isRequired,
     tableName: PropTypes.string.isRequired,
-    totalCount: PropTypes.number.isRequired
-  }
+    totalCount: PropTypes.number.isRequired,
+  };
 
   componentDidMount() {
     const pageProps = pickPageProps(this.props);
@@ -49,7 +50,7 @@ class SummaryTable extends React.Component {
     }
   }
 
-  handlePagination = (pageIndex) => {
+  handlePagination = pageIndex => {
     const { changeSummaryTable, currentPage, tableName } = this.props;
     const nextPage = pageIndex + 1;
 
@@ -58,21 +59,29 @@ class SummaryTable extends React.Component {
     if (currentPage !== nextPage) {
       changeSummaryTable(tableName, { currentPage: nextPage });
     }
-  }
+  };
 
-  handlePerPageChange = (perPage) => {
+  handlePerPageChange = perPage => {
     const { changeSummaryTable, tableName } = this.props;
     changeSummaryTable(tableName, { currentPage: 1, perPage });
-  }
+  };
 
-  handleSort = (order) => {
+  handleSort = order => {
     const { changeSummaryTable, tableName } = this.props;
     changeSummaryTable(tableName, { currentPage: 1, order });
-  }
+  };
 
   render() {
     const {
-      children, currentPage, data, empty, error, loading, order, perPage, totalCount
+      children,
+      currentPage,
+      data,
+      empty,
+      error,
+      loading,
+      order,
+      perPage,
+      totalCount,
     } = this.props;
     const columnProps = getColumnProps(children);
     const pages = Math.ceil(totalCount / perPage);

--- a/src/pages/alerts/components/AlertCollection.js
+++ b/src/pages/alerts/components/AlertCollection.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import { Table, Tooltip, ScreenReaderOnly } from '@sparkpost/matchbox';
+import { Tooltip, ScreenReaderOnly } from '@sparkpost/matchbox';
+import { Table, Button, Tag } from 'src/components/matchbox';
 import { TableCollection, PageLink, DisplayDate } from 'src/components';
 import { NewCollectionBody } from 'src/components/collection';
-import { Button, Tag } from 'src/components/matchbox';
 import AlertToggle from './AlertToggle';
 import { Delete } from '@sparkpost/matchbox-icons';
 import { METRICS } from '../constants/formConstants';

--- a/src/pages/alerts/components/AlertIncidents.js
+++ b/src/pages/alerts/components/AlertIncidents.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import { TableCollection, Empty } from 'src/components';
 import { NewCollectionBody } from 'src/components/collection';
 import { Tag } from 'src/components/matchbox';

--- a/src/pages/billing/components/FeatureComparisonModal.js
+++ b/src/pages/billing/components/FeatureComparisonModal.js
@@ -1,73 +1,104 @@
 import React from 'react';
-import { Modal, Table } from '@sparkpost/matchbox';
-import { Panel } from 'src/components/matchbox';
+import { Modal } from '@sparkpost/matchbox';
+import { Panel, Table } from 'src/components/matchbox';
 import { FEATURE_COMPARISON, PLANS } from './../constants';
 import _ from 'lodash';
 import styles from './FeatureComparisonModal.module.scss';
 import classNames from 'classnames';
 import { Check, Close } from '@sparkpost/matchbox-icons';
 export function Row({ featureName, ...featureValues }) {
-  return <Table.Row>
-    <Table.Cell className={styles.FeatureCell}> {featureName} </Table.Cell>
-    {_.map(featureValues, (val, key) => <Table.Cell key={key} className={classNames(styles.FeatureComparisonCell,
-      key === 'Test Account' && styles.PlanOne,
-      key === 'Starter Plans' && styles.PlanTwo,
-      key === 'Premier Plans' && styles.PlanThree)}> {renderCell(val)} </Table.Cell>)}
-  </Table.Row>;
+  return (
+    <Table.Row>
+      <Table.Cell className={styles.FeatureCell}> {featureName} </Table.Cell>
+      {_.map(featureValues, (val, key) => (
+        <Table.Cell
+          key={key}
+          className={classNames(
+            styles.FeatureComparisonCell,
+            key === 'Test Account' && styles.PlanOne,
+            key === 'Starter Plans' && styles.PlanTwo,
+            key === 'Premier Plans' && styles.PlanThree,
+          )}
+        >
+          {' '}
+          {renderCell(val)}{' '}
+        </Table.Cell>
+      ))}
+    </Table.Row>
+  );
 }
 export function HeaderRow({ plans }) {
-  return <Table.Row>
-    <Table.Cell className={styles.FeatureCell}>  </Table.Cell>
-    {plans.map((plan) =>
-      <Table.Cell key={plan} className={classNames(styles.FeatureComparisonCell,
-        plan === 'Test Account' && styles.PlanOne,
-        plan === 'Starter Plans' && styles.PlanTwo,
-        plan === 'Premier Plans' && styles.PlanThree,
-        styles.PlanName)}> {plan} </Table.Cell>)}
-  </Table.Row>;
+  return (
+    <Table.Row>
+      <Table.Cell className={styles.FeatureCell}> </Table.Cell>
+      {plans.map(plan => (
+        <Table.Cell
+          key={plan}
+          className={classNames(
+            styles.FeatureComparisonCell,
+            plan === 'Test Account' && styles.PlanOne,
+            plan === 'Starter Plans' && styles.PlanTwo,
+            plan === 'Premier Plans' && styles.PlanThree,
+            styles.PlanName,
+          )}
+        >
+          {' '}
+          {plan}{' '}
+        </Table.Cell>
+      ))}
+    </Table.Row>
+  );
 }
 export function GroupHeading({ groupName, colSpan }) {
-  return <Table.Row>
-    <Table.HeaderCell colSpan={colSpan} className={styles.GroupHeading}>
-      {groupName}
-    </Table.HeaderCell>
-  </Table.Row>;
+  return (
+    <Table.Row>
+      <Table.HeaderCell colSpan={colSpan} className={styles.GroupHeading}>
+        {groupName}
+      </Table.HeaderCell>
+    </Table.Row>
+  );
 }
 
 export function renderCell(cellValue) {
-  if (typeof cellValue === 'boolean') { return cellValue ? <Check/> : <Close className={styles.NotAvailable}/>; }
+  if (typeof cellValue === 'boolean') {
+    return cellValue ? <Check /> : <Close className={styles.NotAvailable} />;
+  }
   if (typeof cellValue === 'string') {
-    return <div>
-      {cellValue.split('\n').map((item, index) =>
-        <div key={index} className={index > 0 ? styles.SmallerFont : ''}>
-          {item}
-        </div>)}
-    </div>
-    ;
+    return (
+      <div>
+        {cellValue.split('\n').map((item, index) => (
+          <div key={index} className={index > 0 ? styles.SmallerFont : ''}>
+            {item}
+          </div>
+        ))}
+      </div>
+    );
   }
   return cellValue;
 }
 function ComparisonModal({ open, handleClose }) {
-  return (<Modal open={open} showCloseButton={true} onClose={handleClose} >
-    <Panel>
-      <div className={styles.FeatureComparisonTable}>
-        <Table>
-          <tbody>
-            <HeaderRow plans={PLANS}/>
-          </tbody>
-        </Table>
-        {_.map(FEATURE_COMPARISON, (featureObj, groupName) =>
-          <Table key={groupName}>
+  return (
+    <Modal open={open} showCloseButton={true} onClose={handleClose}>
+      <Panel>
+        <div className={styles.FeatureComparisonTable}>
+          <Table>
             <tbody>
-              <GroupHeading groupName={groupName} colSpan={PLANS.length + 1} />
-              {_.map(featureObj, (featureValues, featureName) =>
-                <Row key={featureName} featureName={featureName} {...featureValues}/>
-              )}
+              <HeaderRow plans={PLANS} />
             </tbody>
           </Table>
-        )}
-      </div>
-    </Panel>
-  </Modal>);
+          {_.map(FEATURE_COMPARISON, (featureObj, groupName) => (
+            <Table key={groupName}>
+              <tbody>
+                <GroupHeading groupName={groupName} colSpan={PLANS.length + 1} />
+                {_.map(featureObj, (featureValues, featureName) => (
+                  <Row key={featureName} featureName={featureName} {...featureValues} />
+                ))}
+              </tbody>
+            </Table>
+          ))}
+        </div>
+      </Panel>
+    </Modal>
+  );
 }
 export default ComparisonModal;

--- a/src/pages/billing/components/tests/__snapshots__/FeatureComparisonModal.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/FeatureComparisonModal.test.js.snap
@@ -78,7 +78,7 @@ exports[`FeatureComparisonModal:  HeaderRow: should render correctly 1`] = `
   <Table.Cell
     className="FeatureCell"
   >
-      
+     
   </Table.Cell>
   <Table.Cell
     className="FeatureComparisonCell PlanName"

--- a/src/pages/blacklist/components/IncidentsCollection.js
+++ b/src/pages/blacklist/components/IncidentsCollection.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Table, Grid } from '@sparkpost/matchbox';
+import { Grid } from '@sparkpost/matchbox';
 import { Search } from '@sparkpost/matchbox-icons';
 
 import { FORMATS } from 'src/constants';
 import { TableCollection, PageLink, DisplayDate } from 'src/components';
-import { Panel, Tag, TextField } from 'src/components/matchbox';
+import { Panel, Tag, TextField, Table } from 'src/components/matchbox';
 import styles from './IncidentsCollection.module.scss';
 import DatePicker from 'src/components/datePicker/DatePicker';
 

--- a/src/pages/blacklist/components/RelatedIncidents.js
+++ b/src/pages/blacklist/components/RelatedIncidents.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import { AccessTime } from '@sparkpost/matchbox-icons';
 import { PageLink } from 'src/components';
 import { Tag } from 'src/components/matchbox';

--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
-import { Page, Table, Tooltip } from '@sparkpost/matchbox';
-import { Panel } from 'src/components/matchbox';
+import { Page, Tooltip } from '@sparkpost/matchbox';
+import { Panel, Table } from 'src/components/matchbox';
 import { Schedule } from '@sparkpost/matchbox-icons';
 import { ApiErrorBanner, Loading, PageLink } from 'src/components';
 import formatScheduleLine from './helpers/formatScheduleLine';
@@ -194,7 +194,7 @@ export const TestListPage = ({ tests, error, loading, listTests }) => {
           <TrendsChart filters={filters} />
           <Panel.Section />
         </Panel>
-          {renderCollection()}
+        {renderCollection()}
       </>
     ),
     [filters, renderCollection, updateFilters],

--- a/src/pages/inboxPlacement/components/AllMessagesCollection.js
+++ b/src/pages/inboxPlacement/components/AllMessagesCollection.js
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-
-import { CodeBlock, ScreenReaderOnly, Table } from '@sparkpost/matchbox';
-import { Button } from 'src/components/matchbox';
+import { CodeBlock, ScreenReaderOnly } from '@sparkpost/matchbox';
+import { Button, Table } from 'src/components/matchbox';
 import { TableCollection } from 'src/components/collection';
 import styles from './AllMessagesCollection.module.scss';
 import startCase from 'lodash/startCase';

--- a/src/pages/inboxPlacement/components/PlacementBreakdown.js
+++ b/src/pages/inboxPlacement/components/PlacementBreakdown.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import cx from 'classnames';
 import _ from 'lodash';
 import { TableCollection } from 'src/components/collection';

--- a/src/pages/reports/messageEvents/components/TableElements.js
+++ b/src/pages/reports/messageEvents/components/TableElements.js
@@ -2,7 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import { snakeToFriendly } from 'src/helpers/string';
 
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import DisplayDate from 'src/components/displayDate/DisplayDate';
 
 import styles from './HistoryTable.module.scss';
@@ -10,11 +10,11 @@ import styles from './HistoryTable.module.scss';
 const Header = () => (
   <thead>
     <Table.Row>
-      <th width='2px'/>
-      <Table.HeaderCell className={styles.HeaderCell} width='35%'>
+      <th width="2px" />
+      <Table.HeaderCell className={styles.HeaderCell} width="35%">
         Time
       </Table.HeaderCell>
-      <Table.HeaderCell className={styles.HeaderCell} width='auto'>
+      <Table.HeaderCell className={styles.HeaderCell} width="auto">
         Event
       </Table.HeaderCell>
     </Table.Row>
@@ -23,7 +23,7 @@ const Header = () => (
 
 const Row = ({ onClick, selected, type, timestamp, formattedDate }) => (
   <Table.Row onClick={onClick} className={cx(styles.Row, selected && styles.selected)}>
-    <td className={styles.Bar}/>
+    <td className={styles.Bar} />
     <Table.Cell>
       <DisplayDate timestamp={timestamp} formattedDate={formattedDate} />
     </Table.Cell>
@@ -33,8 +33,4 @@ const Row = ({ onClick, selected, type, timestamp, formattedDate }) => (
 
 const TableWrapper = ({ children }) => <Table>{children}</Table>;
 
-export {
-  Header,
-  TableWrapper,
-  Row
-};
+export { Header, TableWrapper, Row };

--- a/src/pages/sendingDomains/components/SimpleTable.js
+++ b/src/pages/sendingDomains/components/SimpleTable.js
@@ -1,27 +1,21 @@
 import React from 'react';
-import { Table } from '@sparkpost/matchbox';
+import { Table } from 'src/components/matchbox';
 import styles from './SimpleTable.module.scss';
 
-const HeaderCell = (label, idx) => (<Table.HeaderCell key={idx}>
-  {label}
-</Table.HeaderCell>);
+const HeaderCell = (label, idx) => <Table.HeaderCell key={idx}>{label}</Table.HeaderCell>;
 
-const DataCell = (data, idx) => (
-  <Table.Cell key={idx}>
-    {data}
-  </Table.Cell>
+const DataCell = (data, idx) => <Table.Cell key={idx}>{data}</Table.Cell>;
+
+const Row = (row, idx) => (
+  <Table.Row key={idx} className={styles.Row}>
+    {row.map(DataCell)}
+  </Table.Row>
 );
-
-const Row = (row, idx) => (<Table.Row key={idx} className={styles.Row}>
-  {row.map(DataCell)}
-</Table.Row>);
 
 export default ({ header, rows }) => (
   <Table>
     <tbody>
-      <Table.Row key='header'>
-        {header.map(HeaderCell)}
-      </Table.Row>
+      <Table.Row key="header">{header.map(HeaderCell)}</Table.Row>
       {rows.map(Row)}
     </tbody>
   </Table>


### PR DESCRIPTION
FE-890 - Component Wrapper for Matchbox Table

### What Changed
 - Created Table Wrapper component and added Cell, HeaderCell and Row to this export
 - Replaced all instances of Table with Table Wrapper
 - upgraded matchbox hibana version to 9

### How To Test
-  Check the table on /inbox-placement, /blacklist/incidents, all pages in content nav, events page, signal pages
<img width="1358" alt="Screen Shot 2020-03-19 at 9 34 56 AM" src="https://user-images.githubusercontent.com/4179337/77073077-0d401a00-69c5-11ea-8d62-511f1656cecc.png">

### To Do
- [ ] Address Feedback