### PR TITLE
AC-1299 -  (UI) Join page should submit email_opt_in flag in creation_params to POST /account

### DIFF
--- a/src/__func__/signup/__snapshots__/join.test.js.snap
+++ b/src/__func__/signup/__snapshots__/join.test.js.snap
@@ -5,7 +5,9 @@ Array [
   Array [
     Object {
       "data": Object {
-        "creation_params": Object {},
+        "creation_params": Object {
+          "email_opt_in": false,
+        },
         "email": "test-username@example.com",
         "first_name": "Firsty",
         "last_name": "Ferret",

--- a/src/__func__/signup/__snapshots__/joinEmailOptIn.test.js.snap
+++ b/src/__func__/signup/__snapshots__/joinEmailOptIn.test.js.snap
@@ -5,7 +5,9 @@ Array [
   Array [
     Object {
       "data": Object {
-        "creation_params": Object {},
+        "creation_params": Object {
+          "email_opt_in": true,
+        },
         "email": "test-username@example.com",
         "first_name": "Firsty",
         "last_name": "Ferret",

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -56,7 +56,7 @@ export class JoinPage extends Component {
       ...accountFields,
       sfdcid,
       salesforce_data: { ...attributionData, email_opt_out: !values.email_opt_in },
-      creation_params: creationParams,
+      creation_params: { ...creationParams, email_opt_out: !values.email_opt_in },
     };
 
     return register(signupData)

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -56,7 +56,7 @@ export class JoinPage extends Component {
       ...accountFields,
       sfdcid,
       salesforce_data: { ...attributionData, email_opt_out: !values.email_opt_in },
-      creation_params: { ...creationParams, email_opt_out: !values.email_opt_in },
+      creation_params: { ...creationParams, email_opt_in: values.email_opt_in },
     };
 
     return register(signupData)

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -56,7 +56,7 @@ export class JoinPage extends Component {
       ...accountFields,
       sfdcid,
       salesforce_data: { ...attributionData, email_opt_out: !values.email_opt_in },
-      creation_params: { ...creationParams, email_opt_in: !!values.email_opt_in },
+      creation_params: { ...creationParams, email_opt_in: Boolean(values.email_opt_in) },
     };
 
     return register(signupData)

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -56,7 +56,7 @@ export class JoinPage extends Component {
       ...accountFields,
       sfdcid,
       salesforce_data: { ...attributionData, email_opt_out: !values.email_opt_in },
-      creation_params: { ...creationParams, email_opt_in: values.email_opt_in },
+      creation_params: { ...creationParams, email_opt_in: !!values.email_opt_in },
     };
 
     return register(signupData)

--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -41,7 +41,7 @@ Array [
   Array [
     Object {
       "creation_params": Object {
-        "email_opt_out": true,
+        "email_opt_in": false,
         "extra1": "bar1",
         "extra2": "bar2",
         "sfdcid": "abcd",

--- a/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
+++ b/src/pages/join/tests/__snapshots__/JoinPage.test.js.snap
@@ -41,6 +41,7 @@ Array [
   Array [
     Object {
       "creation_params": Object {
+        "email_opt_out": true,
         "extra1": "bar1",
         "extra2": "bar2",
         "sfdcid": "abcd",


### PR DESCRIPTION
AC-1299 -  (UI) Join page should submit email_opt_in flag in creation_params to POST /account

### What Changed
 - Added email_opt_in flag in creation_params to POST /account

### How To Test
 - Create a account and check if email_out_in flag is sent in the body for POST /account

### To Do
- [ ] Address feedback
