### PR TITLE
FE-897 - Component Wrapper for Matchbox Tooltip

### DIFF
--- a/src/components/CopyToClipboard/CopyToClipboard.js
+++ b/src/components/CopyToClipboard/CopyToClipboard.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import copy from 'copy-to-clipboard';
 
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { Button } from 'src/components/matchbox';
 import { ContentCopy } from '@sparkpost/matchbox-icons';
 

--- a/src/components/CopyToClipboard/tests/__snapshots__/CopyToClipboard.test.js.snap
+++ b/src/components/CopyToClipboard/tests/__snapshots__/CopyToClipboard.test.js.snap
@@ -2,20 +2,8 @@
 
 exports[`CopyToClipboard Component renders with default props 1`] = `
 <Tooltip
-  bottom={true}
   content="Copy to Clipboard"
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Button
     name="copy-field-button"

--- a/src/components/charts/Legend.js
+++ b/src/components/charts/Legend.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import styles from './Legend.module.scss';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import cx from 'classnames';
 
 const Item = ({ label, fill = 'whitesmoke', tooltipContent, hasBorder }) => {
   const content = (
     <div className={styles.Item}>
-      <span className={cx(styles.Fill, hasBorder && styles.Border)} style={{ background: fill }}/>
+      <span className={cx(styles.Fill, hasBorder && styles.Border)} style={{ background: fill }} />
       <span className={styles.Label}>{label}</span>
     </div>
   );
@@ -24,7 +24,9 @@ const Item = ({ label, fill = 'whitesmoke', tooltipContent, hasBorder }) => {
 
 const Legend = ({ items, tooltipContent }) => (
   <div className={styles.Legend}>
-    {items.map((item, i) => <Item key={i} tooltipContent={tooltipContent} {...item} />)}
+    {items.map((item, i) => (
+      <Item key={i} tooltipContent={tooltipContent} {...item} />
+    ))}
   </div>
 );
 

--- a/src/components/copyField/CopyField.js
+++ b/src/components/copyField/CopyField.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import copy from 'copy-to-clipboard';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { ContentCopy } from '@sparkpost/matchbox-icons';
 import { Button, TextField } from 'src/components/matchbox';
 

--- a/src/components/copyField/tests/__snapshots__/CopyField.test.js.snap
+++ b/src/components/copyField/tests/__snapshots__/CopyField.test.js.snap
@@ -2,21 +2,9 @@
 
 exports[`CopyField Component should handle copy click 1`] = `
 <Tooltip
-  bottom={true}
   content="Copied to clipboard!"
   dark={true}
   disabled={false}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Button
     name="copy-field-button"
@@ -34,21 +22,9 @@ exports[`CopyField Component should pass rest of attrs to TextField 1`] = `
 <TextField
   connectRight={
     <Tooltip
-      bottom={true}
       content="Copied to clipboard!"
       dark={true}
       disabled={true}
-      forcePosition={false}
-      horizontalOffset="0px"
-      preferredDirection={
-        Object {
-          "bottom": true,
-          "left": false,
-          "right": true,
-          "top": false,
-        }
-      }
-      right={true}
     >
       <Button
         name="copy-field-button"
@@ -73,21 +49,9 @@ exports[`CopyField Component should render - no props 1`] = `
 <TextField
   connectRight={
     <Tooltip
-      bottom={true}
       content="Copied to clipboard!"
       dark={true}
       disabled={true}
-      forcePosition={false}
-      horizontalOffset="0px"
-      preferredDirection={
-        Object {
-          "bottom": true,
-          "left": false,
-          "right": true,
-          "top": false,
-        }
-      }
-      right={true}
     >
       <Button
         name="copy-field-button"

--- a/src/components/domainStatus/StatusTooltipHeader.js
+++ b/src/components/domainStatus/StatusTooltipHeader.js
@@ -1,10 +1,15 @@
 import React from 'react';
 
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { Help } from '@sparkpost/matchbox-icons';
 
-const tooltipContent = 'Domains can be ready for sending (From), sending with DKIM signing, and bounce (Return Path) usage.';
+const tooltipContent =
+  'Domains can be ready for sending (From), sending with DKIM signing, and bounce (Return Path) usage.';
 
-const StatusTooltipHeader = () => <Tooltip dark content={tooltipContent}>Status <Help size={14}/></Tooltip>;
+const StatusTooltipHeader = () => (
+  <Tooltip dark content={tooltipContent}>
+    Status <Help size={14} />
+  </Tooltip>
+);
 
 export default StatusTooltipHeader;

--- a/src/components/domainStatus/tests/__snapshots__/StatusTooltip.test.js.snap
+++ b/src/components/domainStatus/tests/__snapshots__/StatusTooltip.test.js.snap
@@ -2,20 +2,8 @@
 
 exports[`StatusTooltipHeader component renders 1`] = `
 <Tooltip
-  bottom={true}
   content="Domains can be ready for sending (From), sending with DKIM signing, and bounce (Return Path) usage."
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   Status 
   <Help

--- a/src/components/grantBoxes/GrantsCheckboxes.js
+++ b/src/components/grantBoxes/GrantsCheckboxes.js
@@ -2,15 +2,15 @@ import classnames from 'classnames/bind';
 import React from 'react';
 import _ from 'lodash';
 import { Field } from 'redux-form';
-import { Grid, Tooltip } from '@sparkpost/matchbox';
-
+import { Grid } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { CheckboxWrapper } from 'src/components/reduxFormWrappers';
 import styles from './GrantsCheckboxes.module.scss';
 
 const cx = classnames.bind(styles);
 
 const GrantsCheckboxes = ({ grants, show, disabled }) => {
-  const grantFields = _.map(grants, (grant) => (
+  const grantFields = _.map(grants, grant => (
     <div className={styles.Grant} key={grant.key}>
       <Tooltip dark content={grant.description}>
         <Field
@@ -23,7 +23,6 @@ const GrantsCheckboxes = ({ grants, show, disabled }) => {
       </Tooltip>
     </div>
   ));
-
 
   const grantFieldChunks = _.chunk(grantFields, Math.ceil(_.size(grants) / 3));
 

--- a/src/components/grantBoxes/tests/__snapshots__/GrantsCheckboxes.test.js.snap
+++ b/src/components/grantBoxes/tests/__snapshots__/GrantsCheckboxes.test.js.snap
@@ -14,20 +14,8 @@ exports[`GrantsCheckboxes should render 1`] = `
       key="grant1"
     >
       <Tooltip
-        bottom={true}
         content="desc for grant 1"
         dark={true}
-        forcePosition={false}
-        horizontalOffset="0px"
-        preferredDirection={
-          Object {
-            "bottom": true,
-            "left": false,
-            "right": true,
-            "top": false,
-          }
-        }
-        right={true}
       >
         <Field
           component={[Function]}
@@ -48,20 +36,8 @@ exports[`GrantsCheckboxes should render 1`] = `
       key="grant2"
     >
       <Tooltip
-        bottom={true}
         content="desc for grant 2"
         dark={true}
-        forcePosition={false}
-        horizontalOffset="0px"
-        preferredDirection={
-          Object {
-            "bottom": true,
-            "left": false,
-            "right": true,
-            "top": false,
-          }
-        }
-        right={true}
       >
         <Field
           component={[Function]}

--- a/src/components/matchbox/Tooltip.js
+++ b/src/components/matchbox/Tooltip.js
@@ -2,16 +2,16 @@ import React from 'react';
 import { Tooltip as OGTooltip } from '@sparkpost/matchbox';
 import { Tooltip as HibanaTooltip } from '@sparkpost/matchbox-hibana';
 import { useHibana } from 'src/context/HibanaContext';
-import { omitSystemProps } from 'src/helpers/hibana';
+import { omitSystemProps, omitDeprecatedProps } from 'src/helpers/hibana';
 
 export default function Tooltip(props) {
   const [state] = useHibana();
   const { isHibanaEnabled } = state;
 
   if (!isHibanaEnabled) {
-    return <OGTooltip {...omitSystemProps(props, ['color', 'width'])} />;
+    return <OGTooltip {...omitSystemProps(props, ['width'])} />;
   }
-  return <HibanaTooltip {...props} />;
+  return <HibanaTooltip {...omitDeprecatedProps(props, ['dark'])} />;
 }
 
 OGTooltip.displayName = 'OGTooltip';

--- a/src/components/matchbox/Tooltip.js
+++ b/src/components/matchbox/Tooltip.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Tooltip as OGTooltip } from '@sparkpost/matchbox';
+import { Tooltip as HibanaTooltip } from '@sparkpost/matchbox-hibana';
+import { useHibana } from 'src/context/HibanaContext';
+import { omitSystemProps } from 'src/helpers/hibana';
+
+export default function Tooltip(props) {
+  const [state] = useHibana();
+  const { isHibanaEnabled } = state;
+
+  if (!isHibanaEnabled) {
+    return <OGTooltip {...omitSystemProps(props, ['color'])} />;
+  }
+  return <HibanaTooltip {...props} />;
+}
+
+OGTooltip.displayName = 'OGTooltip';
+HibanaTooltip.displayName = 'HibanaTooltip';

--- a/src/components/matchbox/Tooltip.js
+++ b/src/components/matchbox/Tooltip.js
@@ -9,7 +9,7 @@ export default function Tooltip(props) {
   const { isHibanaEnabled } = state;
 
   if (!isHibanaEnabled) {
-    return <OGTooltip {...omitSystemProps(props, ['color'])} />;
+    return <OGTooltip {...omitSystemProps(props, ['color', 'width'])} />;
   }
   return <HibanaTooltip {...props} />;
 }

--- a/src/components/matchbox/index.js
+++ b/src/components/matchbox/index.js
@@ -23,3 +23,4 @@ export { default as TextField } from './TextField';
 export { default as ThemeProvider } from './ThemeProvider';
 export { default as UnstyledLink } from './UnstyledLink';
 export { default as WindowEvent } from './WindowEvent';
+export { default as Tooltip } from './Tooltip';

--- a/src/components/matchbox/tests/Tooltip.test.js
+++ b/src/components/matchbox/tests/Tooltip.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { useHibana } from 'src/context/HibanaContext';
+import Tooltip from '../Tooltip';
+
+jest.mock('src/context/HibanaContext');
+
+describe('Tooltip Matchbox component wrapper', () => {
+  const subject = props => {
+    return shallow(<Tooltip {...props}>Children...</Tooltip>);
+  };
+
+  it('renders the Hibana version of the Tooltip component correctly when hibana is enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
+
+    const wrapper = subject();
+
+    expect(wrapper).toHaveDisplayName('HibanaTooltip');
+  });
+
+  it('only renders passed in children when hibana is not enabled', () => {
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+
+    const wrapper = subject();
+
+    expect(wrapper).toHaveDisplayName('OGTooltip');
+  });
+});

--- a/src/components/matchbox/tests/Tooltip.test.js
+++ b/src/components/matchbox/tests/Tooltip.test.js
@@ -7,13 +7,20 @@ jest.mock('src/context/HibanaContext');
 
 describe('Tooltip Matchbox component wrapper', () => {
   const subject = props => {
-    return shallow(<Tooltip {...props}>Children...</Tooltip>);
+    const defaultProps = { width: '50px' };
+    return shallow(
+      <Tooltip {...defaultProps} {...props}>
+        Children...
+      </Tooltip>,
+    );
   };
 
   it('renders the Hibana version of the Tooltip component correctly when hibana is enabled', () => {
     useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: true }]);
 
     const wrapper = subject();
+
+    expect(wrapper).toHaveProp('width', '50px');
 
     expect(wrapper).toHaveDisplayName('HibanaTooltip');
   });

--- a/src/components/tags/DomainStatusTag.js
+++ b/src/components/tags/DomainStatusTag.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { ErrorOutline, Schedule } from '@sparkpost/matchbox-icons';
 import { Tag } from 'src/components/matchbox';
 

--- a/src/components/tags/tests/__snapshots__/DomainStatusTag.test.js.snap
+++ b/src/components/tags/tests/__snapshots__/DomainStatusTag.test.js.snap
@@ -2,20 +2,8 @@
 
 exports[`Component: DomainStatusTag should render for blocked status 1`] = `
 <Tooltip
-  bottom={true}
   content="This domain is not available for use. For more information, please contact support."
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Tag
     color="red"
@@ -32,20 +20,8 @@ exports[`Component: DomainStatusTag should render for blocked status 1`] = `
 
 exports[`Component: DomainStatusTag should render for pending status 1`] = `
 <Tooltip
-  bottom={true}
   content="This domain is pending review, please check back again soon."
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Tag>
     <Schedule
@@ -60,20 +36,8 @@ exports[`Component: DomainStatusTag should render for pending status 1`] = `
 
 exports[`Component: DomainStatusTag should render for unverified status 1`] = `
 <Tooltip
-  bottom={true}
   content="This domain must be verified before use."
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Tag
     color="yellow"

--- a/src/helpers/hibana.js
+++ b/src/helpers/hibana.js
@@ -1,5 +1,5 @@
 import { omit } from '@styled-system/props';
-
+import _ from 'lodash';
 export const omitSystemProps = (props, whitelistedProps = []) => {
   const newProps = omit(props);
 
@@ -12,4 +12,8 @@ export const omitSystemProps = (props, whitelistedProps = []) => {
   }
 
   return newProps;
+};
+
+export const omitDeprecatedProps = (props, deprecatedProps = []) => {
+  return _.omit(props, deprecatedProps);
 };

--- a/src/pages/abTesting/components/view/VariantsView.js
+++ b/src/pages/abTesting/components/view/VariantsView.js
@@ -1,7 +1,6 @@
 import React, { Fragment } from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
 import { PageLink } from 'src/components/links';
-import { Panel } from 'src/components/matchbox';
+import { Panel, Tooltip } from 'src/components/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
 import { LabelledValue, Unit } from 'src/components';
 import { hasTestDelivered } from 'src/helpers/abTesting';

--- a/src/pages/abTesting/components/view/tests/__snapshots__/VariantsView.test.js.snap
+++ b/src/pages/abTesting/components/view/tests/__snapshots__/VariantsView.test.js.snap
@@ -7,7 +7,6 @@ exports[`Variants View Component: Engagement Component: should render clicks cor
   >
     <h6>
       <Tooltip
-        bottom={true}
         content={
           <span>
             10
@@ -18,17 +17,6 @@ exports[`Variants View Component: Engagement Component: should render clicks cor
           </span>
         }
         dark={true}
-        forcePosition={false}
-        horizontalOffset="0px"
-        preferredDirection={
-          Object {
-            "bottom": true,
-            "left": false,
-            "right": true,
-            "top": false,
-          }
-        }
-        right={true}
       >
         <Unit
           unit="percent"
@@ -53,7 +41,6 @@ exports[`Variants View Component: Engagement Component: should render opens corr
   >
     <h6>
       <Tooltip
-        bottom={true}
         content={
           <span>
             0
@@ -64,17 +51,6 @@ exports[`Variants View Component: Engagement Component: should render opens corr
           </span>
         }
         dark={true}
-        forcePosition={false}
-        horizontalOffset="0px"
-        preferredDirection={
-          Object {
-            "bottom": true,
-            "left": false,
-            "right": true,
-            "top": false,
-          }
-        }
-        right={true}
       >
         <Unit
           unit="percent"

--- a/src/pages/alerts/components/AlertCollection.js
+++ b/src/pages/alerts/components/AlertCollection.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
 import { Delete } from '@sparkpost/matchbox-icons';
+import { Table, Button, Tag, ScreenReaderOnly, Tooltip } from 'src/components/matchbox';
 import { TableCollection, DisplayDate } from 'src/components';
 import { NewCollectionBody } from 'src/components/collection';
 import { PageLink } from 'src/components/links';
-import { Button, ScreenReaderOnly, Table, Tag } from 'src/components/matchbox';
 import AlertToggle from './AlertToggle';
 import { METRICS } from '../constants/formConstants';
 import styles from './AlertCollection.module.scss';

--- a/src/pages/alerts/components/tests/__snapshots__/AlertCollection.test.js.snap
+++ b/src/pages/alerts/components/tests/__snapshots__/AlertCollection.test.js.snap
@@ -98,20 +98,9 @@ Array [
     muted={true}
   />,
   <Tooltip
-    bottom={true}
     content="Delete"
     dark={true}
-    forcePosition={false}
     horizontalOffset="-8px"
-    preferredDirection={
-      Object {
-        "bottom": true,
-        "left": false,
-        "right": true,
-        "top": false,
-      }
-    }
-    right={true}
     width="auto"
   >
     <Button
@@ -149,20 +138,9 @@ Array [
     muted={false}
   />,
   <Tooltip
-    bottom={true}
     content="Delete"
     dark={true}
-    forcePosition={false}
     horizontalOffset="-8px"
-    preferredDirection={
-      Object {
-        "bottom": true,
-        "left": false,
-        "right": true,
-        "top": false,
-      }
-    }
-    right={true}
     width="auto"
   >
     <Button
@@ -200,20 +178,9 @@ Array [
     muted={true}
   />,
   <Tooltip
-    bottom={true}
     content="Delete"
     dark={true}
-    forcePosition={false}
     horizontalOffset="-8px"
-    preferredDirection={
-      Object {
-        "bottom": true,
-        "left": false,
-        "right": true,
-        "top": false,
-      }
-    }
-    right={true}
     width="auto"
   >
     <Button

--- a/src/pages/inboxPlacement/TestListPage.js
+++ b/src/pages/inboxPlacement/TestListPage.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import moment from 'moment';
-import { Tooltip } from '@sparkpost/matchbox';
-import { Page, Panel, Table } from 'src/components/matchbox';
+import { Page, Panel, Table, Tooltip } from 'src/components/matchbox';
 import { Schedule } from '@sparkpost/matchbox-icons';
 import { ApiErrorBanner, Loading } from 'src/components';
 import { PageLink } from 'src/components/links';

--- a/src/pages/profile/components/CopyCodes.js
+++ b/src/pages/profile/components/CopyCodes.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
-import { Button } from 'src/components/matchbox';
+import { Button, Tooltip } from 'src/components/matchbox';
 import { ContentCopy } from '@sparkpost/matchbox-icons';
 import copy from 'copy-to-clipboard';
 

--- a/src/pages/profile/components/tests/__snapshots__/CopyCodes.test.js.snap
+++ b/src/pages/profile/components/tests/__snapshots__/CopyCodes.test.js.snap
@@ -2,21 +2,9 @@
 
 exports[`CopyCodes Component should render 1`] = `
 <Tooltip
-  bottom={true}
   content="Copied to clipboard!"
   dark={true}
   disabled={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Button
     onClick={[Function]}
@@ -31,21 +19,9 @@ exports[`CopyCodes Component should render 1`] = `
 
 exports[`CopyCodes Component should show tooltip when copied state is true 1`] = `
 <Tooltip
-  bottom={true}
   content="Copied to clipboard!"
   dark={true}
   disabled={false}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Button
     onClick={[Function]}

--- a/src/pages/recipientValidation/components/Tooltip.js
+++ b/src/pages/recipientValidation/components/Tooltip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import styles from './Tooltip.module.scss';
 
 const InfoTooltip = ({ content }) => (

--- a/src/pages/recipientValidation/components/Tooltip.js
+++ b/src/pages/recipientValidation/components/Tooltip.js
@@ -5,7 +5,6 @@ import styles from './Tooltip.module.scss';
 
 const InfoTooltip = ({ content }) => (
   <Tooltip
-    color
     children={<InfoOutline className={styles.TooltipIcon} size={16} />}
     content={<div className={styles.content}>{content}</div>}
     dark

--- a/src/pages/recipientValidation/components/tests/__snapshots__/Tooltip.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/Tooltip.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`renders tooltip correctly renders correctly icon 1`] = `
 <Tooltip
-  color={true}
   content={
     <div
       className="content"

--- a/src/pages/recipientValidation/components/tests/__snapshots__/Tooltip.test.js.snap
+++ b/src/pages/recipientValidation/components/tests/__snapshots__/Tooltip.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`renders tooltip correctly renders correctly icon 1`] = `
 <Tooltip
-  bottom={true}
   color={true}
   content={
     <div
@@ -12,17 +11,7 @@ exports[`renders tooltip correctly renders correctly icon 1`] = `
     </div>
   }
   dark={true}
-  forcePosition={false}
   horizontalOffset="-.8rem"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <InfoOutline
     className="TooltipIcon"

--- a/src/pages/reports/components/MetricCard.js
+++ b/src/pages/reports/components/MetricCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { Panel } from 'src/components/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
 

--- a/src/pages/reports/components/tests/__snapshots__/MetricCard.test.js.snap
+++ b/src/pages/reports/components/tests/__snapshots__/MetricCard.test.js.snap
@@ -21,20 +21,9 @@ exports[`MetricCard Component:  should render correctly with all props 1`] = `
         Card Label
          
         <Tooltip
-          bottom={true}
           content="Tooltip Content"
           dark={true}
-          forcePosition={false}
           horizontalOffset="-1.1rem"
-          preferredDirection={
-            Object {
-              "bottom": true,
-              "left": false,
-              "right": true,
-              "top": false,
-            }
-          }
-          right={true}
         >
           <InfoOutline />
         </Tooltip>

--- a/src/pages/reports/engagement/components/EngagementTable.js
+++ b/src/pages/reports/engagement/components/EngagementTable.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
 
 import { Empty, PanelLoading, TableCollection } from 'src/components';
@@ -13,7 +13,7 @@ const COLUMNS = [
     key: 'link_name',
     label: 'Link',
     sortKey: 'link_name',
-    width: '40%'
+    width: '40%',
   },
   {
     key: 'count_raw_clicked_approx',
@@ -26,7 +26,7 @@ const COLUMNS = [
       </span>
     ),
     sortKey: 'count_raw_clicked_approx',
-    width: '20%'
+    width: '20%',
   },
   {
     key: 'count_clicked',
@@ -39,21 +39,21 @@ const COLUMNS = [
       </span>
     ),
     sortKey: 'count_clicked',
-    width: '20%'
+    width: '20%',
   },
   {
     key: 'percentage_clicked',
     label: 'Percent of Total',
     sortKey: 'percentage_clicked',
-    width: '20%'
-  }
+    width: '20%',
+  },
 ];
 
-const DataRow = (row) => [
+const DataRow = row => [
   row.link_name,
   formatNumber(row.count_raw_clicked_approx),
   formatNumber(row.count_clicked),
-  formatPercent(row.percentage_clicked)
+  formatPercent(row.percentage_clicked),
 ];
 
 export default function EngagementTable({ data, loading }) {
@@ -70,9 +70,9 @@ export default function EngagementTable({ data, loading }) {
   const totalClicks = _.sumBy(data, 'count_clicked');
 
   // Must include percentage in data for sorting
-  const dataWithPercentage = data.map((row) => ({
+  const dataWithPercentage = data.map(row => ({
     ...row,
-    percentage_clicked: safeRate(row.count_clicked, totalClicks)
+    percentage_clicked: safeRate(row.count_clicked, totalClicks),
   }));
 
   return (

--- a/src/pages/reports/engagement/components/tests/__snapshots__/EngagementTable.test.js.snap
+++ b/src/pages/reports/engagement/components/tests/__snapshots__/EngagementTable.test.js.snap
@@ -28,20 +28,8 @@ exports[`EngagementTable when renders table 1`] = `
         "label": <span>
           Unique Clicks
           <Tooltip
-            bottom={true}
             content="Total number of messages which had at least one link selected one or more times."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
             top={true}
           >
             <InfoOutline
@@ -61,20 +49,8 @@ exports[`EngagementTable when renders table 1`] = `
         "label": <span>
           Clicks
           <Tooltip
-            bottom={true}
             content="Total number of times that links were selected across all messages."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
             top={true}
           >
             <InfoOutline

--- a/src/pages/reports/messageEvents/components/EventDetails.js
+++ b/src/pages/reports/messageEvents/components/EventDetails.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { Panel } from 'src/components/matchbox';
 import { LabelledValue, CopyField } from 'src/components';
 
@@ -8,8 +8,8 @@ import _ from 'lodash';
 
 class EventDetails extends Component {
   static defaultProps = {
-    details: {}
-  }
+    details: {},
+  };
 
   renderRow = ({ value, label, key }) => {
     // Renders value in a read only textfield
@@ -22,39 +22,42 @@ class EventDetails extends Component {
     }
 
     return <LabelledValue key={key} label={label} value={value} />;
-  }
+  };
 
   // Renders key-value rows
-  renderDetails = (detailsToRender) => {
+  renderDetails = detailsToRender => {
     const { documentation } = this.props;
 
-    return _.keys(detailsToRender).map((key) => {
-
+    return _.keys(detailsToRender).map(key => {
       // Gets tooltip content from documentation store
       const tooltipContent = _.get(documentation, [detailsToRender.type, key]);
 
       const row = {
         key,
-        label: tooltipContent ? <Tooltip dark content={tooltipContent}>{key}</Tooltip> : key,
-        value: detailsToRender[key]
+        label: tooltipContent ? (
+          <Tooltip dark content={tooltipContent}>
+            {key}
+          </Tooltip>
+        ) : (
+          key
+        ),
+        value: detailsToRender[key],
       };
 
       return this.renderRow(row);
     });
-  }
+  };
 
   render() {
     // Remove formattedDate as its only used for the history table
     const detailsToRender = _.omit(this.props.details, 'formattedDate');
 
     return (
-      <Panel title='Event Details'>
+      <Panel title="Event Details">
+        <Panel.Section>{this.renderDetails(detailsToRender)}</Panel.Section>
         <Panel.Section>
-          { this.renderDetails(detailsToRender) }
-        </Panel.Section>
-        <Panel.Section>
-          <LabelledValue label='Raw Json'>
-            <CopyField value={JSON.stringify(detailsToRender)}/>
+          <LabelledValue label="Raw Json">
+            <CopyField value={JSON.stringify(detailsToRender)} />
           </LabelledValue>
         </Panel.Section>
       </Panel>

--- a/src/pages/reports/messageEvents/components/EventTypeFilters.js
+++ b/src/pages/reports/messageEvents/components/EventTypeFilters.js
@@ -1,22 +1,29 @@
 import React from 'react';
-import { Checkbox, Tooltip } from '@sparkpost/matchbox';
+import { Checkbox } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { Field } from 'redux-form';
 import { CheckboxWrapper } from 'src/components/reduxFormWrappers';
 
 import styles from './SearchForm.module.scss';
 
-const EventTypeFilters = ({ eventTypeDocs }) => <Checkbox.Group label='Event Type'>
-  <div className={styles.CheckBoxGrid}>
-    {eventTypeDocs.map((evtDoc) =>
-      <Field
-        name={evtDoc.type}
-        component={CheckboxWrapper}
-        key={evtDoc.type}
-        label={<Tooltip dark content={evtDoc.description}>{evtDoc.displayName}</Tooltip>}
-        type="checkbox"
-      />
-    )}
-  </div>
-</Checkbox.Group>;
+const EventTypeFilters = ({ eventTypeDocs }) => (
+  <Checkbox.Group label="Event Type">
+    <div className={styles.CheckBoxGrid}>
+      {eventTypeDocs.map(evtDoc => (
+        <Field
+          name={evtDoc.type}
+          component={CheckboxWrapper}
+          key={evtDoc.type}
+          label={
+            <Tooltip dark content={evtDoc.description}>
+              {evtDoc.displayName}
+            </Tooltip>
+          }
+          type="checkbox"
+        />
+      ))}
+    </div>
+  </Checkbox.Group>
+);
 
 export default EventTypeFilters;

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/EventDetails.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/EventDetails.test.js.snap
@@ -9,20 +9,8 @@ exports[`EventDetails Component should render with all props 1`] = `
       key="key1"
       label={
         <Tooltip
-          bottom={true}
           content="description for key1"
           dark={true}
-          forcePosition={false}
-          horizontalOffset="0px"
-          preferredDirection={
-            Object {
-              "bottom": true,
-              "left": false,
-              "right": true,
-              "top": false,
-            }
-          }
-          right={true}
         >
           key1
         </Tooltip>

--- a/src/pages/reports/messageEvents/components/tests/__snapshots__/EventTypeFilters.test.js.snap
+++ b/src/pages/reports/messageEvents/components/tests/__snapshots__/EventTypeFilters.test.js.snap
@@ -12,20 +12,8 @@ exports[`EventTypeFilters should render from a list of event types 1`] = `
       key="amp_open"
       label={
         <Tooltip
-          bottom={true}
           content="AMP open desc"
           dark={true}
-          forcePosition={false}
-          horizontalOffset="0px"
-          preferredDirection={
-            Object {
-              "bottom": true,
-              "left": false,
-              "right": true,
-              "top": false,
-            }
-          }
-          right={true}
         >
           AMP Open
         </Tooltip>
@@ -38,20 +26,8 @@ exports[`EventTypeFilters should render from a list of event types 1`] = `
       key="bounce"
       label={
         <Tooltip
-          bottom={true}
           content="Bounce desc"
           dark={true}
-          forcePosition={false}
-          horizontalOffset="0px"
-          preferredDirection={
-            Object {
-              "bottom": true,
-              "left": false,
-              "right": true,
-              "top": false,
-            }
-          }
-          right={true}
         >
           Bounce
         </Tooltip>

--- a/src/pages/reports/summary/components/MetricsModal.js
+++ b/src/pages/reports/summary/components/MetricsModal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Checkbox, Tooltip } from '@sparkpost/matchbox';
-import { Button, Panel, WindowEvent } from 'src/components/matchbox';
+import { Button, Panel, WindowEvent, Tooltip } from 'src/components/matchbox';
+import { Checkbox } from '@sparkpost/matchbox';
 import { Modal } from 'src/components';
 import { list } from 'src/config/metrics';
 import _ from 'lodash';

--- a/src/pages/reports/summary/components/tests/__snapshots__/MetricsModal.test.js.snap
+++ b/src/pages/reports/summary/components/tests/__snapshots__/MetricsModal.test.js.snap
@@ -20,20 +20,8 @@ exports[`Component: Summary Chart Metrics Modal should disable checkboxes when m
           key="count_accepted"
         >
           <Tooltip
-            bottom={true}
             content="Messages an ISP or other remote domain accepted (less Out-of-Band Bounces)."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -49,20 +37,8 @@ exports[`Component: Summary Chart Metrics Modal should disable checkboxes when m
           key="count_injected"
         >
           <Tooltip
-            bottom={true}
             content="Messages either injected to or received by SparkPost."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={true}
@@ -78,20 +54,8 @@ exports[`Component: Summary Chart Metrics Modal should disable checkboxes when m
           key="count_sent"
         >
           <Tooltip
-            bottom={true}
             content="Messages that SparkPost attempted to deliver, which includes both Deliveries and In-Band Bounces."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -107,20 +71,8 @@ exports[`Component: Summary Chart Metrics Modal should disable checkboxes when m
           key="count_targeted"
         >
           <Tooltip
-            bottom={true}
             content="Messages successfully injected into SparkPost as well as rejected by it."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={true}
@@ -173,20 +125,8 @@ exports[`Component: Summary Chart Metrics Modal should render 1`] = `
           key="count_accepted"
         >
           <Tooltip
-            bottom={true}
             content="Messages an ISP or other remote domain accepted (less Out-of-Band Bounces)."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -202,20 +142,8 @@ exports[`Component: Summary Chart Metrics Modal should render 1`] = `
           key="count_injected"
         >
           <Tooltip
-            bottom={true}
             content="Messages either injected to or received by SparkPost."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -231,20 +159,8 @@ exports[`Component: Summary Chart Metrics Modal should render 1`] = `
           key="count_sent"
         >
           <Tooltip
-            bottom={true}
             content="Messages that SparkPost attempted to deliver, which includes both Deliveries and In-Band Bounces."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -260,20 +176,8 @@ exports[`Component: Summary Chart Metrics Modal should render 1`] = `
           key="count_targeted"
         >
           <Tooltip
-            bottom={true}
             content="Messages successfully injected into SparkPost as well as rejected by it."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -326,20 +230,8 @@ exports[`Component: Summary Chart Metrics Modal should select metrics 1`] = `
           key="count_accepted"
         >
           <Tooltip
-            bottom={true}
             content="Messages an ISP or other remote domain accepted (less Out-of-Band Bounces)."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -355,20 +247,8 @@ exports[`Component: Summary Chart Metrics Modal should select metrics 1`] = `
           key="count_injected"
         >
           <Tooltip
-            bottom={true}
             content="Messages either injected to or received by SparkPost."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={true}
@@ -384,20 +264,8 @@ exports[`Component: Summary Chart Metrics Modal should select metrics 1`] = `
           key="count_sent"
         >
           <Tooltip
-            bottom={true}
             content="Messages that SparkPost attempted to deliver, which includes both Deliveries and In-Band Bounces."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={false}
@@ -413,20 +281,8 @@ exports[`Component: Summary Chart Metrics Modal should select metrics 1`] = `
           key="count_targeted"
         >
           <Tooltip
-            bottom={true}
             content="Messages successfully injected into SparkPost as well as rejected by it."
             dark={true}
-            forcePosition={false}
-            horizontalOffset="0px"
-            preferredDirection={
-              Object {
-                "bottom": true,
-                "left": false,
-                "right": true,
-                "top": false,
-              }
-            }
-            right={true}
           >
             <Checkbox
               checked={true}

--- a/src/pages/sendingDomains/components/EditBounce.js
+++ b/src/pages/sendingDomains/components/EditBounce.js
@@ -1,11 +1,11 @@
 import React, { Component, Fragment } from 'react';
 import { Field, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
-import { Tooltip } from '@sparkpost/matchbox';
-import { Help } from '@sparkpost/matchbox-icons';
 import { update } from 'src/actions/sendingDomains';
+
+import { Help } from '@sparkpost/matchbox-icons';
 import { PageLink } from 'src/components/links';
-import { Banner, Panel } from 'src/components/matchbox';
+import { Banner, Panel, Tooltip } from 'src/components/matchbox';
 import ToggleBlock from 'src/components/toggleBlock/ToggleBlock';
 import { SendingDomainSection } from './SendingDomainSection';
 import { resolveReadyFor } from 'src/helpers/domains';

--- a/src/pages/sendingDomains/components/tests/__snapshots__/EditBounce.test.js.snap
+++ b/src/pages/sendingDomains/components/tests/__snapshots__/EditBounce.test.js.snap
@@ -5,20 +5,8 @@ exports[`Component: EditBounce default bounce toggle renders correctly if assign
   component={[Function]}
   label={
     <Tooltip
-      bottom={true}
       content="When this is set to \\"ON\\", all future transmissions for this subaccount will use xyz.com as their bounce domain (unless otherwise specified)."
       dark={true}
-      forcePosition={false}
-      horizontalOffset="0px"
-      preferredDirection={
-        Object {
-          "bottom": true,
-          "left": false,
-          "right": true,
-          "top": false,
-        }
-      }
-      right={true}
     >
       Default bounce domain 
        for Subaccount 101
@@ -39,20 +27,8 @@ exports[`Component: EditBounce default bounce toggle renders correctly toggle wh
   component={[Function]}
   label={
     <Tooltip
-      bottom={true}
       content="When this is set to \\"ON\\", all future transmissions will use xyz.com as their bounce domain (unless otherwise specified)."
       dark={true}
-      forcePosition={false}
-      horizontalOffset="0px"
-      preferredDirection={
-        Object {
-          "bottom": true,
-          "left": false,
-          "right": true,
-          "top": false,
-        }
-      }
-      right={true}
     >
       Default bounce domain 
       <Help
@@ -72,20 +48,8 @@ exports[`Component: EditBounce default bounce toggle renders correctly toggle wh
   component={[Function]}
   label={
     <Tooltip
-      bottom={true}
       content="When this is set to \\"ON\\", all future transmissions will use xyz.com as their bounce domain (unless otherwise specified)."
       dark={true}
-      forcePosition={false}
-      horizontalOffset="0px"
-      preferredDirection={
-        Object {
-          "bottom": true,
-          "left": false,
-          "right": true,
-          "top": false,
-        }
-      }
-      right={true}
     >
       Default bounce domain 
       <Help

--- a/src/pages/signals/components/InfoTooltip.js
+++ b/src/pages/signals/components/InfoTooltip.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
 import styles from './InfoTooltip.module.scss';
 

--- a/src/pages/signals/components/charts/legend/Legend.js
+++ b/src/pages/signals/components/charts/legend/Legend.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import styles from './Legend.module.scss';
 
 const Item = ({ label, fill = 'whitesmoke', tooltipContent }) => {
   const content = (
     <div className={styles.Item}>
-      <span className={styles.Fill} style={{ background: fill }}/>
+      <span className={styles.Fill} style={{ background: fill }} />
       <span className={styles.Label}>{label}</span>
     </div>
   );
@@ -23,7 +23,9 @@ const Item = ({ label, fill = 'whitesmoke', tooltipContent }) => {
 
 const Legend = ({ items, tooltipContent }) => (
   <div>
-    {items.map((item, i) => <Item key={i} tooltipContent={tooltipContent} {...item} />)}
+    {items.map((item, i) => (
+      <Item key={i} tooltipContent={tooltipContent} {...item} />
+    ))}
   </div>
 );
 

--- a/src/pages/signals/components/charts/legend/tests/__snapshots__/Legend.test.js.snap
+++ b/src/pages/signals/components/charts/legend/tests/__snapshots__/Legend.test.js.snap
@@ -72,20 +72,8 @@ exports[`Legend Component renders correctly with tooltip content 1`] = `
 
 exports[`Legend Component renders correctly with tooltip content 2`] = `
 <Tooltip
-  bottom={true}
   content="label 1"
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <div
     className="Item"
@@ -109,20 +97,8 @@ exports[`Legend Component renders correctly with tooltip content 2`] = `
 
 exports[`Legend Component renders correctly with tooltip content 3`] = `
 <Tooltip
-  bottom={true}
   content="label 2"
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <div
     className="Item"

--- a/src/pages/signals/components/dataCells/WoWHeaderCell.js
+++ b/src/pages/signals/components/dataCells/WoWHeaderCell.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
+import { Tooltip } from 'src/components/matchbox';
 import { InfoOutline } from '@sparkpost/matchbox-icons';
 import styles from './DataCell.module.scss';
 
 const WoWHeaderCell = () => (
-  <Tooltip content='Week Over Week Change' dark>
-    WoW <InfoOutline size={15} className={styles.InfoIcon}/>
+  <Tooltip content="Week Over Week Change" dark>
+    WoW <InfoOutline size={15} className={styles.InfoIcon} />
   </Tooltip>
 );
 

--- a/src/pages/signals/components/dataCells/tests/__snapshots__/WoWHeaderCell.test.js.snap
+++ b/src/pages/signals/components/dataCells/tests/__snapshots__/WoWHeaderCell.test.js.snap
@@ -2,20 +2,8 @@
 
 exports[`WoWHeaderCell renders 1`] = `
 <Tooltip
-  bottom={true}
   content="Week Over Week Change"
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   WoW 
   <InfoOutline

--- a/src/pages/signals/components/tests/__snapshots__/InfoTooltip.test.js.snap
+++ b/src/pages/signals/components/tests/__snapshots__/InfoTooltip.test.js.snap
@@ -2,19 +2,9 @@
 
 exports[`Signals InfoTooltip Component renders correctly 1`] = `
 <Tooltip
-  bottom={true}
   content="Foo"
   dark={true}
-  forcePosition={false}
   horizontalOffset="-0.15rem"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
   right={true}
 >
   <InfoOutline

--- a/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
+++ b/src/pages/signals/dashboards/tests/HealthScoreDashboard.test.js
@@ -2,7 +2,6 @@ import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { HealthScoreDashboard } from '../HealthScoreDashboard';
 import TestApp from 'src/__testHelpers__/TestApp';
-
 // Child components are mocked because
 // 1. useEffect requires enzyme mount to test
 // 2. child components are connected to redux
@@ -15,20 +14,33 @@ jest.mock('../../components/filters/DateFilter');
 jest.mock('../../components/filters/SubaccountFilter');
 
 describe('Signals Health Score Dashboard', () => {
-  const subject = (props = {}, render = shallow) =>
-    render(
-      <TestApp>
-        <HealthScoreDashboard
-          getCurrentHealthScore={() => {}}
-          getSubaccounts={() => {}}
-          relativeRange="90days"
-          from="2015-01-01"
-          to="2015-01-05"
-          subaccounts={['sub1', 'sub2']}
-          {...props}
-        />
-      </TestApp>,
-    );
+  const subject = (props = {}, render = shallow) => {
+    return render === mount
+      ? render(
+          <TestApp>
+            <HealthScoreDashboard
+              getCurrentHealthScore={() => {}}
+              getSubaccounts={() => {}}
+              relativeRange="90days"
+              from="2015-01-01"
+              to="2015-01-05"
+              subaccounts={['sub1', 'sub2']}
+              {...props}
+            />
+          </TestApp>,
+        )
+      : render(
+          <HealthScoreDashboard
+            getCurrentHealthScore={() => {}}
+            getSubaccounts={() => {}}
+            relativeRange="90days"
+            from="2015-01-01"
+            to="2015-01-05"
+            subaccounts={['sub1', 'sub2']}
+            {...props}
+          />,
+        );
+  };
 
   it('renders page', () => {
     expect(subject()).toMatchSnapshot();

--- a/src/pages/signals/dashboards/tests/__snapshots__/HealthScoreDashboard.test.js.snap
+++ b/src/pages/signals/dashboards/tests/__snapshots__/HealthScoreDashboard.test.js.snap
@@ -1,31 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Signals Health Score Dashboard renders page 1`] = `
-<Providers
-  store={
-    Object {
-      "dispatch": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-      Symbol(observable): [Function],
-    }
+<SignalsPage
+  primaryArea={
+    <Connect(DateFilter)
+      left={true}
+    />
+  }
+  title={
+    <React.Fragment>
+      Health Score
+      <InfoTooltip
+        content="
+  This is a predictive score that monitors your email health to identify problems before
+  they negatively impact email delivery. This score is informed by message events,
+  including bounces, spam trap hits, and engagement across our entire network.
+"
+      />
+    </React.Fragment>
   }
 >
-  <MemoryRouter>
-    <HealthScoreDashboard
-      from="2015-01-01"
-      getCurrentHealthScore={[Function]}
-      getSubaccounts={[Function]}
-      relativeRange="90days"
-      subaccounts={
-        Array [
-          "sub1",
-          "sub2",
-        ]
+  <Grid>
+    <Grid.Column
+      lg={5}
+      xl={4}
+      xs={12}
+    >
+      <Connect(CurrentHealthGauge) />
+    </Grid.Column>
+    <Grid.Column
+      lg={7}
+      xl={8}
+      xs={12}
+    >
+      <Connect(HealthScoreChart) />
+    </Grid.Column>
+  </Grid>
+  <Connect(withRouter(Connect(HealthScoreOverview)))
+    defaults={
+      Object {
+        "perPage": 25,
       }
-      to="2015-01-05"
-    />
-  </MemoryRouter>
-</Providers>
+    }
+    header={
+      <Grid>
+        <Connect(Connect(SubaccountFilter)) />
+        <Connect(FacetFilter)
+          facets={
+            Array [
+              Object {
+                "key": "campaign_id",
+                "label": "Campaign",
+              },
+              Object {
+                "key": "ip_pool",
+                "label": "IP Pool",
+              },
+              Object {
+                "key": "mb_provider",
+                "label": "Mailbox Provider",
+              },
+              Object {
+                "key": "sending_domain",
+                "label": "Sending Domain",
+              },
+            ]
+          }
+        />
+      </Grid>
+    }
+    hideTitle={true}
+    subaccounts={
+      Array [
+        "sub1",
+        "sub2",
+      ]
+    }
+  />
+</SignalsPage>
 `;

--- a/src/pages/templates/components/ListComponents.js
+++ b/src/pages/templates/components/ListComponents.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Tooltip } from '@sparkpost/matchbox';
 import { CheckCircle, Delete, Edit, ContentCopy } from '@sparkpost/matchbox-icons';
 import { formatDateTime } from 'src/helpers/date';
 import { setSubaccountQuery } from 'src/helpers/subaccounts';
 import { PageLink } from 'src/components/links';
-import { Button, ScreenReaderOnly, Tag } from 'src/components/matchbox';
+import { Button, ScreenReaderOnly, Tag, Tooltip } from 'src/components/matchbox';
+
 import styles from './ListComponents.module.scss';
 
 import { routeNamespace } from '../constants/routes';

--- a/src/pages/templates/components/tests/__snapshots__/ListComponents.test.js.snap
+++ b/src/pages/templates/components/tests/__snapshots__/ListComponents.test.js.snap
@@ -80,20 +80,8 @@ exports[`Template List Components Status should render published 1`] = `
 
 exports[`Template List Components Status should render unpublished changes 1`] = `
 <Tooltip
-  bottom={true}
   content="Contains unpublished changes"
   dark={true}
-  forcePosition={false}
-  horizontalOffset="0px"
-  preferredDirection={
-    Object {
-      "bottom": true,
-      "left": false,
-      "right": true,
-      "top": false,
-    }
-  }
-  right={true}
 >
   <Tag
     className="PublishedWithChanges"


### PR DESCRIPTION
FE-897 - Component Wrapper for Matchbox Tooltip

### What Changed
 - Added Component Wrapper for Tooltip
 - Replaced all instances of Tooltip

### How To Test
[**Bug with tooltip** -[FE-981](https://jira.int.messagesystems.com/browse/FE-981) ]
-  Check the Tooltip on /templates
<img width="375" alt="Screen Shot 2020-03-25 at 11 55 55 AM" src="https://user-images.githubusercontent.com/4179337/77557036-a4a6e080-6e8f-11ea-8a73-8207b82908ec.png">
- Check the /account/sending-domains. `<StatusTooltipHeader/>` 
<img width="388" alt="Screen Shot 2020-03-25 at 3 23 36 PM" src="https://user-images.githubusercontent.com/4179337/77577211-bfd41900-6eac-11ea-96a8-64e88a8d23dd.png">
- Check /account/sending-domains/edit/staging-test.spappteam.com  
<img width="336" alt="Screen Shot 2020-03-25 at 3 27 01 PM" src="https://user-images.githubusercontent.com/4179337/77577444-31ac6280-6ead-11ea-98d2-437729acc2f1.png">

### To Do
- [ ] Address Feedback
