### PR TITLE
SA-1272 Add timezone and precision to report URLs

### DIFF
--- a/src/actions/brightback.js
+++ b/src/actions/brightback.js
@@ -32,7 +32,13 @@ export function prepBrightback(accountDetails) {
 
 export function loadPrerequisiteMetrics() {
   const { from, to } = getRelativeDates('7days', { roundToPrecision: false });
-  const metricsRequest = getQueryFromOptions({ from, to, metrics: METRICS });
+  const metricsRequest = getQueryFromOptions({
+    from,
+    to,
+    precision: 'day',
+    timezone: 'UTC',
+    metrics: METRICS,
+  });
   return sparkpostApiRequest({
     type: 'BRIGHTBACK_METRICS',
     meta: {

--- a/src/actions/reportOptions.js
+++ b/src/actions/reportOptions.js
@@ -1,16 +1,18 @@
+import moment from 'moment';
+
 import {
   fetchMetricsDomains,
   fetchMetricsCampaigns,
   fetchMetricsSendingIps,
   fetchMetricsIpPools,
-  fetchMetricsTemplates
+  fetchMetricsTemplates,
 } from './metrics';
 
 import { list as listSubaccounts } from './subaccounts';
 import { list as listSendingDomains } from './sendingDomains';
 import { getRelativeDates } from 'src/helpers/date';
-import { getQueryFromOptions } from 'src/helpers/metrics';
-import { isSameDate } from 'src/helpers/date';
+import { getQueryFromOptions, getPrecision } from 'src/helpers/metrics';
+import { isSameDate, getLocalTimezone } from 'src/helpers/date';
 import _ from 'lodash';
 
 // array of all lists that need to be re-filtered when time changes
@@ -19,7 +21,7 @@ const metricLists = [
   fetchMetricsCampaigns,
   fetchMetricsSendingIps,
   fetchMetricsIpPools,
-  fetchMetricsTemplates
+  fetchMetricsTemplates,
 ];
 
 /**
@@ -61,46 +63,49 @@ export function refreshTypeaheadCache(options) {
     if (isSameDate(cachedFrom, currentFrom) && isSameDate(cachedTo, currentTo) && cache[match]) {
       dispatch({
         type: 'UPDATE_METRICS_FROM_CACHE',
-        payload: cache[match]
+        payload: cache[match],
       });
       return Promise.resolve();
     }
-    const requests = metricLists.map((list) => dispatch(list(params)));
-    return Promise.all(requests).then((arrayOfMetrics) => {
+    const requests = metricLists.map(list => dispatch(list(params)));
+    return Promise.all(requests).then(arrayOfMetrics => {
       // Flattens the array from array of metrics objects to an object with each metric as a key
-      const metricsList = _.reduce(arrayOfMetrics, (accumulator, metric) => _.assign(accumulator, metric), {});
+      const metricsList = _.reduce(
+        arrayOfMetrics,
+        (accumulator, metric) => _.assign(accumulator, metric),
+        {},
+      );
       const payload = {
         from: currentFrom,
         to: currentTo,
-        itemToCache: { [match]: metricsList }
+        itemToCache: { [match]: metricsList },
       };
 
       dispatch({
         type: 'UPDATE_TYPEAHEAD_METRICS_CACHE',
-        payload
+        payload,
       });
     });
-
   };
 }
 
 export function addFilters(payload) {
   return {
     type: 'ADD_FILTERS',
-    payload
+    payload,
   };
 }
 
 export function removeFilter(payload) {
   return {
     type: 'REMOVE_FILTER',
-    payload
+    payload,
   };
 }
 
 export function clearFilters() {
   return {
-    type: 'CLEAR_FILTERS'
+    type: 'CLEAR_FILTERS',
   };
 }
 
@@ -120,14 +125,24 @@ export function refreshReportOptions(update) {
     const { reportOptions } = getState();
     update = { ...reportOptions, ...update };
 
-    // calculate relative dates if range is not "custom"
-    if (update.relativeRange && update.relativeRange !== 'custom') {
-      update = { ...update, ...getRelativeDates(update.relativeRange) };
+    if (update.relativeRange) {
+      if (update.relativeRange !== 'custom') {
+        const { from, to } = getRelativeDates(update.relativeRange);
+        const precision = getPrecision(from, moment(to));
+        update = { ...update, from, to, precision };
+      } else {
+        const precision = getPrecision(update.from, moment(update.to));
+        update = { ...update, precision };
+      }
+    }
+
+    if (!update.timezone) {
+      update.timezone = getLocalTimezone();
     }
 
     return dispatch({
       type: 'REFRESH_REPORT_OPTIONS',
-      payload: update
+      payload: update,
     });
   };
 }

--- a/src/helpers/reports.js
+++ b/src/helpers/reports.js
@@ -18,11 +18,11 @@ export function dedupeFilters(filters) {
  */
 export function parseSearch(search) {
   if (!search) {
-    return { options: {}};
+    return { options: {} };
   }
 
-  const { from, to, range, metrics, filters = []} = qs.parse(search);
-  const filtersList = (typeof filters === 'string' ? [filters] : filters).map((filter) => {
+  const { from, to, range, metrics, timezone, precision, filters = [] } = qs.parse(search);
+  const filtersList = (typeof filters === 'string' ? [filters] : filters).map(filter => {
     const parts = filter.split(':');
     const type = parts.shift();
     let value;
@@ -40,11 +40,10 @@ export function parseSearch(search) {
     return { value, type, id };
   });
 
-
   let options = {};
 
   if (metrics) {
-    options.metrics = (typeof metrics === 'string') ? [metrics] : metrics;
+    options.metrics = typeof metrics === 'string' ? [metrics] : metrics;
   }
 
   const fromTime = new Date(from);
@@ -62,6 +61,14 @@ export function parseSearch(search) {
     const invalidRange = !_.find(relativeDateOptions, ['value', range]);
     const effectiveRange = invalidRange ? 'day' : range;
     options = { ...options, ...getRelativeDates(effectiveRange) };
+  }
+
+  if (precision) {
+    options.precision = precision;
+  }
+
+  if (timezone) {
+    options.timezone = timezone;
   }
 
   // filters are used in pages to dispatch updates to Redux store

--- a/src/helpers/tests/metrics.test.js
+++ b/src/helpers/tests/metrics.test.js
@@ -7,7 +7,6 @@ import _ from 'lodash';
 jest.mock('src/helpers/date');
 
 describe('metrics helpers', () => {
-
   beforeEach(() => {
     dateHelpers.getLocalTimezone = jest.fn(() => 'Mock/Timezone');
   });
@@ -16,14 +15,13 @@ describe('metrics helpers', () => {
     const actual = metricsHelpers.getQueryFromOptions({
       from: '2017-12-18T00:00Z',
       to: '2017-12-18T11:00Z',
-      metrics: [
-        { key: 'count_bounce' },
-        { key: 'foo_bar', computeKeys: 'test + last' }
-      ],
+      metrics: [{ key: 'count_bounce' }, { key: 'foo_bar', computeKeys: 'test + last' }],
       filters: [
         { value: 'gmail.com', type: 'Recipient Domain' },
-        { value: 'foobar', type: 'Subaccount', id: 100 }
-      ]
+        { value: 'foobar', type: 'Subaccount', id: 100 },
+      ],
+      timezone: 'Mock/Timezone',
+      precision: 'hour',
     });
 
     expect(actual).toMatchSnapshot();
@@ -33,11 +31,9 @@ describe('metrics helpers', () => {
     const actual = metricsHelpers.getQueryFromOptions({
       from: '2017-12-18T00:00Z',
       to: '2017-12-18T11:00Z',
-      metrics: [
-        { key: 'count_bounce' }
-      ],
+      metrics: [{ key: 'count_bounce' }],
       filters: [],
-      limit: 1000
+      limit: 1000,
     });
 
     expect(actual).toMatchObject({ limit: 1000 });
@@ -47,11 +43,9 @@ describe('metrics helpers', () => {
     const actual = metricsHelpers.getQueryFromOptions({
       from: '2017-12-18T00:00Z',
       to: '2017-12-18T11:00Z',
-      metrics: [
-        { key: 'count_bounce' }
-      ],
+      metrics: [{ key: 'count_bounce' }],
       filters: [],
-      match: 'foo'
+      match: 'foo',
     });
 
     expect(actual).toMatchObject({ match: 'foo' });
@@ -66,7 +60,7 @@ describe('metrics helpers', () => {
     const actual = metricsHelpers.getDelimiter([
       { value: 'test,me' },
       { value: 'foo;bar' },
-      { value: 'test:me' }
+      { value: 'test:me' },
     ]);
 
     expect(actual).toEqual('+');
@@ -98,7 +92,6 @@ describe('metrics helpers', () => {
 
     to.add(200, 'days');
     expect(metricsHelpers.getPrecision(from, to)).toEqual('month');
-
   });
 
   it('should return minute as moment precision type', () => {
@@ -133,75 +126,86 @@ describe('metrics helpers', () => {
         timeLabel: '1min',
         from: '2016-12-18T10:28',
         to: '2016-12-18T11:28',
-        expected: { from: '2016-12-18T10:28', to: '2016-12-18T11:28' }
+        expected: { from: '2016-12-18T10:28', to: '2016-12-18T11:28' },
       },
       {
         timeLabel: '5min',
         from: '2016-12-18T10:09',
         to: '2016-12-18T12:01',
-        expected: { from: '2016-12-18T10:05', to: '2016-12-18T12:05' }
+        expected: { from: '2016-12-18T10:05', to: '2016-12-18T12:05' },
       },
       {
         timeLabel: '15min',
         from: '2016-12-18T06:29',
         to: '2016-12-18T10:01',
-        expected: { from: '2016-12-18T06:15', to: '2016-12-18T10:15' }
+        expected: { from: '2016-12-18T06:15', to: '2016-12-18T10:15' },
       },
       {
         timeLabel: 'hour',
         from: '2016-12-16T10:59',
         to: '2016-12-18T09:01',
-        expected: { from: '2016-12-16T10:00', to: '2016-12-18T09:59' }
+        expected: { from: '2016-12-16T10:00', to: '2016-12-18T09:59' },
       },
       {
         timeLabel: 'day',
         from: '2016-11-15T10:59',
         to: '2016-12-18T10:01',
-        expected: { from: '2016-11-15T00:00', to: '2016-12-18T23:59' }
+        expected: { from: '2016-11-15T00:00', to: '2016-12-18T23:59' },
       },
       {
         timeLabel: 'week',
         from: '2016-06-21T10:59',
         to: '2016-12-18T10:02',
-        expected: { from: '2016-06-21T00:00', to: '2016-12-18T23:59' }
+        expected: { from: '2016-06-21T00:00', to: '2016-12-18T23:59' },
       },
       {
         timeLabel: 'month',
         from: '2016-02-18T10:59',
         to: '2016-12-18T10:02',
-        expected: { from: '2016-02-18T00:00', to: '2016-12-18T23:59' }
-      }
+        expected: { from: '2016-02-18T00:00', to: '2016-12-18T23:59' },
+      },
     ];
 
-    const allCases = _.flatMap(caseList, (caseObj) => {
+    const allCases = _.flatMap(caseList, caseObj => {
       const cases = [];
-      const expectedTo = caseObj.timeLabel === '1min' // we don't round at this precision
-        ? moment(caseObj.expected.to)
-        : moment(caseObj.expected.to).endOf('minutes');
+      const expectedTo =
+        caseObj.timeLabel === '1min' // we don't round at this precision
+          ? moment(caseObj.expected.to)
+          : moment(caseObj.expected.to).endOf('minutes');
 
       cases.push({
         name: `should round at ${caseObj.timeLabel}`,
         from: moment(caseObj.from),
         to: moment(caseObj.to),
-        expectedValue: { from: moment(caseObj.expected.from).toISOString(), to: expectedTo.toISOString() }
+        expectedValue: {
+          from: moment(caseObj.expected.from).toISOString(),
+          to: expectedTo.toISOString(),
+        },
       });
 
       cases.push({
         name: `should not round if already at nearest precision for ${caseObj.timeLabel}`,
         from: moment(caseObj.expected.from),
         to: expectedTo,
-        expectedValue: { from: moment(caseObj.expected.from).toISOString(), to: expectedTo.toISOString() }
+        expectedValue: {
+          from: moment(caseObj.expected.from).toISOString(),
+          to: expectedTo.toISOString(),
+        },
       });
 
       return cases;
     });
 
-    cases('should round from and to values', ({ from, to, expectedValue }) => {
-      const { from: resFrom, to: resTo } = metricsHelpers.roundBoundaries(from, to);
+    cases(
+      'should round from and to values',
+      ({ from, to, expectedValue }) => {
+        const { from: resFrom, to: resTo } = metricsHelpers.roundBoundaries(from, to);
 
-      expect(resFrom.toISOString()).toEqual(expectedValue.from);
-      expect(resTo.toISOString()).toEqual(expectedValue.to);
-    }, allCases);
+        expect(resFrom.toISOString()).toEqual(expectedValue.from);
+        expect(resTo.toISOString()).toEqual(expectedValue.to);
+      },
+      allCases,
+    );
 
     it('should not round to when in future', () => {
       const now = moment('2016-12-19T10:02');
@@ -212,7 +216,6 @@ describe('metrics helpers', () => {
     });
   });
 
-
   it('should get metrics from keys', () => {
     const actual = metricsHelpers.getMetricsFromKeys(['count_delayed', 'count_injected']);
     expect(actual).toMatchSnapshot();
@@ -221,12 +224,17 @@ describe('metrics helpers', () => {
   it('should compute keys during transform', () => {
     const data = [
       { count_rendered: 100, count_unique_confirmed_opened_approx: 1, count_targeted: 100 },
-      { count_rendered: 101 }
+      { count_rendered: 101 },
     ];
 
     const metrics = [
       { key: 'count_rendered' },
-      { key: 'open_rate_approx', computeKeys: ['count_unique_confirmed_opened_approx', 'count_targeted'], type: 'percentage', compute: (item, keys) => ((item[keys[0]] / item[keys[1]]) * 100) }
+      {
+        key: 'open_rate_approx',
+        computeKeys: ['count_unique_confirmed_opened_approx', 'count_targeted'],
+        type: 'percentage',
+        compute: (item, keys) => (item[keys[0]] / item[keys[1]]) * 100,
+      },
     ];
 
     const actual = metricsHelpers.transformData(data, metrics);
@@ -236,10 +244,12 @@ describe('metrics helpers', () => {
   it('should build common metric options', () => {
     dateHelpers.getRelativeDates = jest.fn(() => ({ from: 'foo', to: 'bar' }));
 
-    const actual = metricsHelpers.buildCommonOptions({ domain: 'gmail' }, { campaign: 'test', relativeRange: '7days' });
+    const actual = metricsHelpers.buildCommonOptions(
+      { domain: 'gmail' },
+      { campaign: 'test', relativeRange: '7days' },
+    );
 
     expect(actual).toMatchSnapshot();
-
   });
 
   it('should calculate average', () => {
@@ -254,65 +264,74 @@ describe('metrics helpers', () => {
     expect(metricsHelpers.rate(item, keys)).toEqual(90);
   });
 
-
   describe('getValidDateRange', () => {
-
     const invalidCases = [
       {
         name: 'with undefined to',
-        from: moment('2018-01-15')
+        from: moment('2018-01-15'),
       },
       {
         name: 'with undefined from',
-        to: moment('2017-12-15')
+        to: moment('2017-12-15'),
       },
       {
         name: 'with invalid to',
         to: 'garbage',
-        from: moment('2018-01-15')
+        from: moment('2018-01-15'),
       },
       {
         name: 'with invalid from',
         to: moment('2017-12-15'),
-        from: 'garbage'
+        from: 'garbage',
       },
       {
         name: 'with invalid now',
         from: moment('2018-01-15'),
         to: moment('2017-12-15'),
-        now: 'garbage'
+        now: 'garbage',
       },
       {
         name: 'when to is before from',
         from: moment('2018-01-15'),
-        to: moment('2017-12-15')
+        to: moment('2017-12-15'),
       },
       {
         name: 'when to is after now',
         from: moment('2018-01-15'),
         to: moment('2018-02-15'),
-        now: moment('2018-02-00')
+        now: moment('2018-02-00'),
       },
       {
         name: 'when to is after now (without rounding)',
         from: moment('2018-01-15'),
         to: moment('2018-02-15'),
         now: moment('2018-02-00'),
-        roundToPrecision: false
-      }
+        roundToPrecision: false,
+      },
     ];
 
-    cases('should throw error', ({ from, to, now, roundToPrecision = true, preventFuture = true }) => {
-      const getInvalidDateRange = () => metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision, preventFuture });
-      expect(getInvalidDateRange).toThrowErrorMatchingSnapshot();
-    }, invalidCases);
+    cases(
+      'should throw error',
+      ({ from, to, now, roundToPrecision = true, preventFuture = true }) => {
+        const getInvalidDateRange = () =>
+          metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision, preventFuture });
+        expect(getInvalidDateRange).toThrowErrorMatchingSnapshot();
+      },
+      invalidCases,
+    );
 
     it('should use input range if valid and rounded up to nearest precision', () => {
       const from = moment('2018-01-15T11:00Z');
       const to = moment('2018-01-16T11:59Z');
       const now = moment('2018-02-01T11:00Z');
 
-      const validRange = metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision: true, preventFuture: true });
+      const validRange = metricsHelpers.getValidDateRange({
+        from,
+        to,
+        now,
+        roundToPrecision: true,
+        preventFuture: true,
+      });
       expect(validRange).toEqual({ from, to: to.endOf('minute') });
     });
 
@@ -321,7 +340,13 @@ describe('metrics helpers', () => {
       const to = moment('2018-01-16T11:33Z');
       const now = moment('2018-02-01T11:33Z');
 
-      const validRange = metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision: false, preventFuture: true });
+      const validRange = metricsHelpers.getValidDateRange({
+        from,
+        to,
+        now,
+        roundToPrecision: false,
+        preventFuture: true,
+      });
       expect(validRange).toEqual({ from, to });
     });
 
@@ -329,7 +354,12 @@ describe('metrics helpers', () => {
       const from = moment('2018-01-15T11:00Z');
       const to = moment('2018-01-16T11:59Z');
 
-      const validRange = metricsHelpers.getValidDateRange({ from, to, roundToPrecision: true, preventFuture: true });
+      const validRange = metricsHelpers.getValidDateRange({
+        from,
+        to,
+        roundToPrecision: true,
+        preventFuture: true,
+      });
       expect(validRange).toEqual({ from, to: to.endOf('minute') });
     });
 
@@ -338,7 +368,13 @@ describe('metrics helpers', () => {
       const to = moment('2018-01-19T11:59Z'); // would use day precision if valid
       const now = moment('2018-01-15T11:23Z'); // will instead use minute precision
 
-      const validRange = metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision: true, preventFuture: true });
+      const validRange = metricsHelpers.getValidDateRange({
+        from,
+        to,
+        now,
+        roundToPrecision: true,
+        preventFuture: true,
+      });
       expect(validRange).toEqual({ from, to: now });
     });
 
@@ -347,9 +383,19 @@ describe('metrics helpers', () => {
       const to = moment('2018-01-17T10:59Z');
       const now = moment('2018-01-16T11:23Z');
 
-      const validRange = metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision: true, preventFuture: true });
+      const validRange = metricsHelpers.getValidDateRange({
+        from,
+        to,
+        now,
+        roundToPrecision: true,
+        preventFuture: true,
+      });
       expect(validRange.from).toEqual(from);
-      expect(validRange.to.toISOString()).toEqual(moment('2018-01-16T11:59Z').endOf('minute').toISOString());
+      expect(validRange.to.toISOString()).toEqual(
+        moment('2018-01-16T11:59Z')
+          .endOf('minute')
+          .toISOString(),
+      );
     });
 
     it('should use rounded input if equal to rounded now', () => {
@@ -357,9 +403,19 @@ describe('metrics helpers', () => {
       const to = moment('2018-01-19T11:27Z');
       const now = moment('2018-01-19T11:23Z');
 
-      const validRange = metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision: true, preventFuture: true });
+      const validRange = metricsHelpers.getValidDateRange({
+        from,
+        to,
+        now,
+        roundToPrecision: true,
+        preventFuture: true,
+      });
       expect(validRange.from).toEqual(from);
-      expect(validRange.to.toISOString()).toEqual(moment('2018-01-19T11:59Z').endOf('minute').toISOString());
+      expect(validRange.to.toISOString()).toEqual(
+        moment('2018-01-19T11:59Z')
+          .endOf('minute')
+          .toISOString(),
+      );
     });
 
     it('should allow past or future dates if preventFuture is false', () => {
@@ -367,7 +423,13 @@ describe('metrics helpers', () => {
       const now = moment('2018-01-20T12:00Z');
       const to = moment('2018-01-21T12:00Z');
 
-      const validRange = metricsHelpers.getValidDateRange({ from, to, now, roundToPrecision: false, preventFuture: false });
+      const validRange = metricsHelpers.getValidDateRange({
+        from,
+        to,
+        now,
+        roundToPrecision: false,
+        preventFuture: false,
+      });
       expect(validRange).toEqual({ from, to });
     });
   });

--- a/src/reducers/reportOptions.js
+++ b/src/reducers/reportOptions.js
@@ -5,19 +5,25 @@ import config from 'src/config';
 const initialState = {
   relativeRange: 'day',
   filters: [],
-  metrics: getMetricsFromKeys(config.summaryChart.defaultMetrics)
+  metrics: getMetricsFromKeys(config.summaryChart.defaultMetrics),
 };
 
 export default (state = initialState, action) => {
   switch (action.type) {
-
     case 'REFRESH_REPORT_OPTIONS': {
-      const { to = state.to, from = state.from, relativeRange = state.relativeRange, metrics = state.metrics } = action.payload;
-      return { ...state, to, from, relativeRange, metrics };
+      const {
+        to = state.to,
+        from = state.from,
+        relativeRange = state.relativeRange,
+        metrics = state.metrics,
+        precision = state.precision,
+        timezone = state.timezone,
+      } = action.payload;
+      return { ...state, to, from, precision, timezone, relativeRange, metrics };
     }
 
     case 'ADD_FILTERS': {
-      const mergedFilters = dedupeFilters([ ...state.filters, ...action.payload ]);
+      const mergedFilters = dedupeFilters([...state.filters, ...action.payload]);
       if (mergedFilters.length === state.filters.length) {
         return state;
       }
@@ -29,12 +35,12 @@ export default (state = initialState, action) => {
         ...state,
         filters: [
           ...state.filters.slice(0, action.payload),
-          ...state.filters.slice(action.payload + 1)
-        ]
+          ...state.filters.slice(action.payload + 1),
+        ],
       };
 
     case 'CLEAR_FILTERS':
-      return { ...state, filters: []};
+      return { ...state, filters: [] };
 
     default:
       return state;

--- a/src/reducers/tests/__snapshots__/reportOptions.test.js.snap
+++ b/src/reducers/tests/__snapshots__/reportOptions.test.js.snap
@@ -43,7 +43,9 @@ Object {
     2,
     3,
   ],
+  "precision": "hour",
   "relativeRange": "day",
+  "timezone": "America/New_York",
   "to": 2018-01-02T00:00:00.000Z,
 }
 `;

--- a/src/reducers/tests/reportOptions.test.js
+++ b/src/reducers/tests/reportOptions.test.js
@@ -11,40 +11,44 @@ describe('Reducer: Report Options', () => {
       from: time(),
       relativeRange: 'day',
       to: time({ day: 2 }),
-      metrics: []
+      metrics: [],
     };
   });
-  cases('General cases', (action) => {
-    expect(reportOptionsReducer(testState, action)).toMatchSnapshot();
-  }, {
-    'add a filter': {
-      payload: [{ type: 'Example Domain', value: 'sparkpost.com' }],
-      type: 'ADD_FILTERS'
+  cases(
+    'General cases',
+    action => {
+      expect(reportOptionsReducer(testState, action)).toMatchSnapshot();
     },
-    'add multiple filters': {
-      payload: [
-        { type: 'Example Domain', value: 'sparkpost.com' },
-        { type: 'Example Domain', value: 'another.sparkpost.com' }
-      ],
-      type: 'ADD_FILTERS'
-    },
-    'set report options': {
-      payload: {
-        from: time({ year: 2018, month: 1, day: 1 }),
-        relativeRange: 'day',
-        to: time({ year: 2018, month: 1, day: 2 }),
-        metrics: [1, 2, 3]
+    {
+      'add a filter': {
+        payload: [{ type: 'Example Domain', value: 'sparkpost.com' }],
+        type: 'ADD_FILTERS',
       },
-      type: 'REFRESH_REPORT_OPTIONS'
-    }
-  });
+      'add multiple filters': {
+        payload: [
+          { type: 'Example Domain', value: 'sparkpost.com' },
+          { type: 'Example Domain', value: 'another.sparkpost.com' },
+        ],
+        type: 'ADD_FILTERS',
+      },
+      'set report options': {
+        payload: {
+          from: time({ year: 2018, month: 1, day: 1 }),
+          relativeRange: 'day',
+          to: time({ year: 2018, month: 1, day: 2 }),
+          metrics: [1, 2, 3],
+          timezone: 'America/New_York',
+          precision: 'hour',
+        },
+        type: 'REFRESH_REPORT_OPTIONS',
+      },
+    },
+  );
 
   it('should dedupe and preserve the state reference if a duplicate filter is added', () => {
     const action = {
       type: 'ADD_FILTERS',
-      payload: [
-        { type: 'Duplicate Domain', value: 'sparkpost.com' }
-      ]
+      payload: [{ type: 'Duplicate Domain', value: 'sparkpost.com' }],
     };
 
     const modified = reportOptionsReducer(testState, action);
@@ -55,5 +59,4 @@ describe('Reducer: Report Options', () => {
     expect(modified.filters).toHaveLength(1);
     expect(unmodified).toBe(modified);
   });
-
 });

--- a/src/selectors/reportSearchOptions.js
+++ b/src/selectors/reportSearchOptions.js
@@ -3,18 +3,26 @@ import moment from 'moment';
 import { stringifyTypeaheadfilter } from 'src/helpers/string';
 import _ from 'lodash';
 
-const selectDateOptions = (state) => ({
-  from: moment(state.reportOptions.from).utc().format(),
-  to: moment(state.reportOptions.to).utc().format(),
-  range: state.reportOptions.relativeRange
+const selectDateOptions = state => ({
+  from: moment(state.reportOptions.from)
+    .utc()
+    .format(),
+  to: moment(state.reportOptions.to)
+    .utc()
+    .format(),
+  range: state.reportOptions.relativeRange,
+  timezone: state.reportOptions.timezone,
+  precision: state.reportOptions.precision,
 });
 
-const selectTypeaheadFilters = (state) => ({
-  filters: _.get(state, 'reportOptions.filters', []).map(stringifyTypeaheadfilter)
+const selectTypeaheadFilters = state => ({
+  filters: _.get(state, 'reportOptions.filters', []).map(stringifyTypeaheadfilter),
 });
 
-const selectSummaryMetrics = (state) => ({
-  metrics: _.get(state, 'reportOptions.metrics', []).map((metric) => typeof metric === 'string' ? metric : metric.key)
+const selectSummaryMetrics = state => ({
+  metrics: _.get(state, 'reportOptions.metrics', []).map(metric =>
+    typeof metric === 'string' ? metric : metric.key,
+  ),
 });
 
 /**
@@ -22,7 +30,7 @@ const selectSummaryMetrics = (state) => ({
  */
 export const selectReportSearchOptions = createSelector(
   [selectDateOptions, selectTypeaheadFilters],
-  (dates, filters) => ({ ...dates, ...filters })
+  (dates, filters) => ({ ...dates, ...filters }),
 );
 
 /**
@@ -30,5 +38,5 @@ export const selectReportSearchOptions = createSelector(
  */
 export const selectSummaryChartSearchOptions = createSelector(
   [selectDateOptions, selectTypeaheadFilters, selectSummaryMetrics],
-  (dates, filters, metrics) => ({ ...dates, ...filters, ...metrics })
+  (dates, filters, metrics) => ({ ...dates, ...filters, ...metrics }),
 );

--- a/src/selectors/tests/__snapshots__/reportSearchOptions.test.js.snap
+++ b/src/selectors/tests/__snapshots__/reportSearchOptions.test.js.snap
@@ -7,7 +7,9 @@ Object {
     102,
   ],
   "from": "2018-03-23T21:10:08Z",
+  "precision": "hour",
   "range": undefined,
+  "timezone": "America/New_York",
   "to": "2018-03-23T21:11:08Z",
 }
 `;
@@ -24,7 +26,9 @@ Object {
     "count_accepted",
     "metric_key",
   ],
+  "precision": "hour",
   "range": undefined,
+  "timezone": "America/New_York",
   "to": "2018-03-23T21:11:08Z",
 }
 `;

--- a/src/selectors/tests/reportSearchOptions.test.js
+++ b/src/selectors/tests/reportSearchOptions.test.js
@@ -1,7 +1,7 @@
 import { selectReportSearchOptions, selectSummaryChartSearchOptions } from '../reportSearchOptions';
 
 jest.mock('src/helpers/string', () => ({
-  stringifyTypeaheadfilter: jest.fn((filter) => filter.id)
+  stringifyTypeaheadfilter: jest.fn(filter => filter.id),
 }));
 
 describe('ReportSearchOptions Selectors', () => {
@@ -13,8 +13,10 @@ describe('ReportSearchOptions Selectors', () => {
         to: '2018-03-23T17:11:08-04:00',
         range: null,
         filters: [{ id: 101 }, { id: 102 }],
-        metrics: ['count_bounce', 'count_accepted', { key: 'metric_key' }]
-      }
+        metrics: ['count_bounce', 'count_accepted', { key: 'metric_key' }],
+        precision: 'hour',
+        timezone: 'America/New_York',
+      },
     };
   });
 
@@ -29,5 +31,4 @@ describe('ReportSearchOptions Selectors', () => {
       expect(selectSummaryChartSearchOptions(state)).toMatchSnapshot();
     });
   });
-
 });


### PR DESCRIPTION
### What Changed
 - Added timezone and precision URL params to the report URLs for sharing

### How To Test
 - Open a report (/reports/summary as example)
   - See that your local timezone (based on browser/system clock) is added to the query params
   - See that precision (based on the to and from dates) is added to the query params
   - See that metrics API requests send that timezone along with the request
- Change the timezone in the query params to UTC
  - See that metrics API requests send that timezone along with the request

