### PR TITLE
AC-1265: Fix for error handling on data privacy

### DIFF
--- a/src/pages/dataPrivacy/DataPrivacyPage.js
+++ b/src/pages/dataPrivacy/DataPrivacyPage.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { withRouter } from 'react-router-dom';
 import { Page } from '@sparkpost/matchbox';
 import { Panel, Tabs } from 'src/components/matchbox';
+import { connect } from 'react-redux';
+import { resetDataPrivacy } from 'src/actions/dataPrivacy';
 import styles from './DataPrivacyPage.module.scss';
 import ApiDetailsTab from './components/ApiDetailsTab';
 import SingleRecipientTab from './components/SingleRecipientTab';
@@ -20,6 +22,7 @@ export const DataPrivacyPage = props => {
   }, [props.history, tabIndex]);
 
   const handleTabs = tabIdx => {
+    props.resetDataPrivacy();
     setTabIndex(tabIdx);
   };
 
@@ -57,4 +60,4 @@ export const DataPrivacyPage = props => {
   );
 };
 
-export default withRouter(DataPrivacyPage);
+export default connect(null, { resetDataPrivacy })(withRouter(DataPrivacyPage));

--- a/src/pages/dataPrivacy/tests/DataPrivacyPage.test.js
+++ b/src/pages/dataPrivacy/tests/DataPrivacyPage.test.js
@@ -9,6 +9,7 @@ describe('Page: Recipient Email Verification', () => {
     history: {
       replace: jest.fn(),
     },
+    resetDataPrivacy: jest.fn(),
   };
 
   const subject = props => {


### PR DESCRIPTION
### What Changed
 - Reset added for swapping tabs on data privacy

### How To Test
 - Go to /account/data-privacy
 - Single tab, add an invalid email address
 - Swap tabs
 - Verify that multi error modal is not there

### To Do
- [ ] Address feedback
