### PR TITLE
FE-951 - Alert Create page breaks in Hibana theme

### DIFF
--- a/src/pages/alerts/components/AlertForm.container.js
+++ b/src/pages/alerts/components/AlertForm.container.js
@@ -27,6 +27,7 @@ export default function withAlertForm(WrappedComponent) {
   const formOptions = {
     form: FORM_NAME,
     enableReinitialize: true,
+    destroyOnUnmount: false, //prevents the initial values and values disappearing when hibana is enabled
     validate: validateForm,
   };
 


### PR DESCRIPTION
FE-951 - Alert Create page breaks in Hibana theme

### What Changed
 - Added `destroyOnUnmount: false` to AlertForm

### How To Test
 - To replicate issues :
     - Open /alerts/create
     - Click "Take a Look" Hibana button
     - Select "Health Score" metric
 - Also Check out the following cases - https://msys.slack.com/archives/GKXTKHDSP/p1585325093014300

### To Do
- [ ] Address feedback
