### PR TITLE
AC-1341: Subaccount_reporting UI option doesn't toggle off

### DIFF
--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -23,7 +23,6 @@ export const isManuallyBilled = ({ account }) => _.get(account, 'subscription.ty
 export const isCustomBilling = ({ account }) => _.get(account, 'subscription.custom', false);
 export const isSelfServeBilling = any(subscriptionSelfServeIsTrue, isAws);
 export const hasOnlineSupport = ({ account }) => _.get(account, 'support.online', false);
-export const hasUiOption = option => ({ account }) => _.has(account.options, `ui.${option}`);
 export const isAccountUiOptionSet = (option, defaultValue) => ({ account }) => {
   return Boolean(_.get(account.options, `ui.${option}`, defaultValue));
 };

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -10,7 +10,6 @@ import {
   isCustomBilling,
   isSelfServeBilling,
   hasOnlineSupport,
-  hasUiOption,
   isAccountUiOptionSet,
   hasAccountOptionEnabled,
   getAccountUiOptionValue,
@@ -167,65 +166,39 @@ describe('Condition: hasOnlineSupport', () => {
   });
 });
 
-describe('Condition: hasUiOption', () => {
-  it('should return true when option is set', () => {
-    const state = {
-      account: {
-        options: {
-          ui: { iceCream: 'vanilla' },
-        },
-      },
-    };
-    expect(hasUiOption('iceCream')(state)).toEqual(true);
-  });
-
-  it('should return false when option is missing', () => {
-    const state = {
-      account: {
-        options: {
-          ui: {},
-        },
-      },
-    };
-    expect(hasUiOption('iceCream')(state)).toEqual(false);
-  });
-});
-
-describe('Condition: isUiOptionSet', () => {
-  cases(
-    'isUiOptionSet',
-    opts => {
-      const state = { account: { options: { ui: opts.options } } };
-      expect(isAccountUiOptionSet('option', opts.defaultVal)(state)).toEqual(opts.result);
+cases(
+  'isAccountUiOptionSet',
+  opts => {
+    const state = { account: { options: { ui: opts.options } } };
+    expect(isAccountUiOptionSet('option', opts.defaultVal)(state)).toEqual(opts.result);
+  },
+  {
+    // Account option takes precedence
+    'Account option precedence: false/false=false': {
+      options: { option: false },
+      defaultVal: false,
+      result: false,
     },
-    {
-      // Account option takes precedence
-      'Account option precedence: false/false=false': {
-        options: { option: false },
-        defaultVal: false,
-        result: false,
-      },
-      'Account option precedence: true/false=true': {
-        options: { option: true },
-        defaultVal: false,
-        result: true,
-      },
-      'Account option precedence: false/true=false': {
-        options: { option: false },
-        defaultVal: true,
-        result: false,
-      },
-      'Account option precedence: true/true=true': {
-        options: { option: true },
-        defaultVal: true,
-        result: true,
-      },
-      // Default used iff option is missing
-      'Default: true=true': { options: {}, defaultVal: true, result: true },
-      'Default: false=false': { options: {}, defaultVal: false, result: false },
+    'Account option precedence: true/false=true': {
+      options: { option: true },
+      defaultVal: false,
+      result: true,
     },
-  );
-});
+    'Account option precedence: false/true=false': {
+      options: { option: false },
+      defaultVal: true,
+      result: false,
+    },
+    'Account option precedence: true/true=true': {
+      options: { option: true },
+      defaultVal: true,
+      result: true,
+    },
+    // Default used iff option is missing
+    'Default: true=true': { options: {}, defaultVal: true, result: true },
+    'Default: false=false': { options: {}, defaultVal: false, result: false },
+  },
+);
 
 describe('Condition: isCustomBilling', () => {
   it('should return false', () => {

--- a/src/pages/users/CreatePage.js
+++ b/src/pages/users/CreatePage.js
@@ -10,7 +10,7 @@ import { inviteUser } from 'src/actions/users';
 import { showAlert } from 'src/actions/globalAlert';
 import { trimWhitespaces } from 'src/helpers/string';
 import { FORMS, ROLES } from 'src/constants';
-import { hasUiOption } from 'src/helpers/conditions/account';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 
 import RoleRadioGroup from './components/RoleRadioGroup';
 
@@ -72,7 +72,7 @@ const mapStateToProps = state => ({
   initialValues: {
     access: ROLES.ADMIN, // Sadly redux-form does not reflect a select's initial value
   },
-  isSubaccountReportingLive: hasUiOption('subaccount_reporting')(state),
+  isSubaccountReportingLive: isAccountUiOptionSet('subaccount_reporting')(state),
 });
 
 const mapDispatchToProps = { inviteUser, showAlert };

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -6,7 +6,7 @@ import TimeAgo from 'react-timeago';
 import { Users } from 'src/components/images';
 import { PageLink } from 'src/components/links';
 import { Page, Tag } from 'src/components/matchbox';
-import { hasUiOption } from 'src/helpers/conditions/account';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 import * as usersActions from 'src/actions/users';
 import { selectUsers } from 'src/selectors/users';
@@ -211,7 +211,7 @@ const mapStateToProps = state => ({
   users: selectUsers(state),
   hasSubaccounts: hasSubaccounts(state),
   subaccounts: state.subaccounts.list,
-  isSubAccountReportingLive: hasUiOption('subaccount_reporting')(state),
+  isSubAccountReportingLive: isAccountUiOptionSet('subaccount_reporting')(state),
 });
 
 export default connect(mapStateToProps, { ...usersActions, listSubaccounts })(ListPage);


### PR DESCRIPTION
### What Changed
 - Switched feature toggle to use `isAccountUiOptionSet`

### How To Test

1. Create a new account
1. Click "Manage Users" link from account dropdown
1. Click "Invite User" button
1. _Confirm the "Assign to subaccount" checkbox is **not** displayed_
1. Enable "subaccount_reporting" UI feature flag
1. _Confirm the "Assign to subaccount" checkbox is **not** displayed_
1. Create a subaccount
1. _Confirm the "Assign to subaccount" checkbox is displayed_
1. Disable "subaccount_reporting" UI feature flag
1. _Confirm the "Assign to subaccount" checkbox is **not** displayed_

<img width="1392" alt="Screen Shot 2020-03-31 at 12 34 19 PM" src="https://user-images.githubusercontent.com/1335605/78051630-f6e27880-734b-11ea-9dbc-4bed53ea9a6f.png">





