### PR TITLE
TR-2344: Links in template editor need noreferrer attribute

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/cypress/fixtures/utils/content-previewer/200.post.json
+++ b/cypress/fixtures/utils/content-previewer/200.post.json
@@ -3,7 +3,7 @@
     "subject": "Test Template",
     "from": { "email": "fake-user@bounce.uat.sparkspam.com" },
     "text": "This is some text content.",
-    "html": "<h1>This is some HTML content</h1>",
+    "html": "<div><h1>This is some HTML content</h1><a href='https://example.com'>Click Here</a></div>",
     "amp_html": "<h1>This is some AMP HTML content</h1>"
   }
 }

--- a/cypress/tests/integration/templates/editDraftPage.spec.js
+++ b/cypress/tests/integration/templates/editDraftPage.spec.js
@@ -543,7 +543,7 @@ describe('The templates edit draft page', () => {
         .find('a')
         .should('contain', 'Click Here')
         .should('have.attr', 'rel', 'noopener noreferrer')
-        .should('have.attr', 'target', '_blank');
+        .should('have.attr', 'target', '_parent');
 
       cy.findByText('AMP HTML').click();
 

--- a/cypress/tests/integration/templates/editDraftPage.spec.js
+++ b/cypress/tests/integration/templates/editDraftPage.spec.js
@@ -21,6 +21,15 @@ function testPreviewContent({ selector, content }) {
   });
 }
 
+// see, https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
+// todo, maybe replace testPreviewContent
+const getIframeBody = () =>
+  cy
+    .get('iframe')
+    .its('0.contentDocument.body')
+    .should('not.be.empty')
+    .then(cy.wrap);
+
 describe('The templates edit draft page', () => {
   beforeEach(() => {
     cy.stubAuth();
@@ -85,6 +94,7 @@ describe('The templates edit draft page', () => {
 
     cy.visit(PAGE_URL);
 
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(300); // The duration of the debounce function that triggers AMP validation
 
     // NOTE: No assertion necessary.
@@ -528,6 +538,12 @@ describe('The templates edit draft page', () => {
         selector: 'h1',
         content: 'This is some HTML content',
       });
+
+      getIframeBody()
+        .find('a')
+        .should('contain', 'Click Here')
+        .should('have.attr', 'rel', 'noopener noreferrer')
+        .should('have.attr', 'target', '_blank');
 
       cy.findByText('AMP HTML').click();
 

--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -62,8 +62,10 @@ export default class PreviewFrame extends Component {
     // ...because DOM collections only array-like
     const anchors = [...anchorHTMLCollection];
     anchors.forEach(a => {
+      // must overwrite "rel" value to avoid a security vulnerability
       a.setAttribute('rel', 'noopener noreferrer');
-      a.setAttribute('target', '_blank');
+      // must use _parent because Firefox and other browsers do not support _blank from an iframe
+      a.setAttribute('target', '_parent');
     });
 
     this.setState({ height: `${height + PADDING}px` });

--- a/src/pages/templates/components/PreviewFrame.js
+++ b/src/pages/templates/components/PreviewFrame.js
@@ -12,28 +12,25 @@ const FLEXIBLE_POLICY = [
   'allow-presentation',
   'allow-same-origin',
   'allow-scripts',
-  'allow-top-navigation'
+  'allow-top-navigation',
 ];
 
-const STRICT_POLICY = [
-  'allow-same-origin',
-  'allow-top-navigation'
-];
+const STRICT_POLICY = ['allow-same-origin', 'allow-top-navigation'];
 
 // @note This is a port of the previous fd.templates.preview.directive
 // @see https://github.com/SparkPost/webui/blob/master/src/app/templates/preview-directive.js
 export default class PreviewFrame extends Component {
   static defaultProps = {
-    strict: true
-  }
+    strict: true,
+  };
 
   static propTypes = {
-    content: PropTypes.string.isRequired
-  }
+    content: PropTypes.string.isRequired,
+  };
 
   state = {
-    height: undefined
-  }
+    height: undefined,
+  };
 
   componentDidMount() {
     // Must wait to write content until this.iframe is set after render()
@@ -56,7 +53,7 @@ export default class PreviewFrame extends Component {
       body.scrollHeight,
       html.clientHeight,
       html.offsetHeight,
-      html.scrollHeight
+      html.scrollHeight,
     );
 
     // Avoid loading links in iframe
@@ -64,12 +61,17 @@ export default class PreviewFrame extends Component {
 
     // ...because DOM collections only array-like
     const anchors = [...anchorHTMLCollection];
-    anchors.forEach((a) => a.setAttribute('target', '_parent'));
+    anchors.forEach(a => {
+      a.setAttribute('rel', 'noopener noreferrer');
+      a.setAttribute('target', '_blank');
+    });
 
     this.setState({ height: `${height + PADDING}px` });
-  }
+  };
 
-  setRef = (iframe) => { this.iframe = iframe; }
+  setRef = iframe => {
+    this.iframe = iframe;
+  };
 
   writeContent() {
     const { contentDocument } = this.iframe;


### PR DESCRIPTION
### What Changed
 - Set rel attribute on anchors in template preview

### How To Test
 - Create a new template
 - Set "HTML" content to `<a href="http://google.com">Click Here</a>`
 - Confirm link rendered in the preview has "rel" attribute set and when clicked it opens a new tab 
