### PR TITLE
AC-1267 - Release UI for data privacy

### DIFF
--- a/cypress/fixtures/account/200.get.json
+++ b/cypress/fixtures/account/200.get.json
@@ -62,8 +62,7 @@
         "feature_alerts": true,
         "ip_auto_warmup": true,
         "brightback": true,
-        "allow_injection_alerts": true,
-        "data_privacy": true
+        "allow_injection_alerts": true
       },
       "initial_open_pixel_tracking": true,
       "smtp_tracking_default": true,

--- a/src/components/subaccountSection/SubaccountSection.js
+++ b/src/components/subaccountSection/SubaccountSection.js
@@ -50,7 +50,7 @@ export default class SubaccountSection extends Component {
         <Field
           component={RadioGroup}
           name="assignTo"
-          title="Subaccount Assignment"
+          label="Subaccount Assignment"
           options={this.props.createOptions ? this.props.createOptions : createOptions}
         />
         {typeahead}

--- a/src/components/subaccountSection/__snapshots__/SubaccountSection.test.js.snap
+++ b/src/components/subaccountSection/__snapshots__/SubaccountSection.test.js.snap
@@ -5,6 +5,7 @@ exports[`Templates SubaccountSection on create should render radio group 1`] = `
   <div>
     <Field
       component={[Function]}
+      label="Subaccount Assignment"
       name="assignTo"
       options={
         Array [
@@ -22,7 +23,6 @@ exports[`Templates SubaccountSection on create should render radio group 1`] = `
           },
         ]
       }
-      title="Subaccount Assignment"
     />
   </div>
 </Fragment>

--- a/src/config/navItems/account.js
+++ b/src/config/navItems/account.js
@@ -2,8 +2,8 @@ import { OpenInNew, ExitToApp } from '@sparkpost/matchbox-icons';
 import { LINKS } from 'src/constants';
 import { openSupportPanel } from 'src/actions/support';
 import { isHeroku } from 'src/helpers/conditions/user';
-import { all, hasGrants, not, any } from 'src/helpers/conditions';
-import { isAccountUiOptionSet, onPlan } from 'src/helpers/conditions/account';
+import { hasGrants, not, any } from 'src/helpers/conditions';
+import { onPlan } from 'src/helpers/conditions/account';
 
 /***
  * These values are pulled in through the accountNavItems selector, which will map
@@ -81,7 +81,7 @@ const dataAndPrivacy = {
   label: 'Data and Privacy',
   to: '/account/data-privacy',
   section: 1,
-  condition: all(hasGrants('users/manage'), isAccountUiOptionSet('data_privacy')),
+  condition: hasGrants('users/manage'),
 };
 
 const getHelp = {
@@ -131,6 +131,7 @@ export const hibanaAccountNavItems = [
   // usage,  // In the mock, but doesn't exist yet?
   ...billingLinks,
   users,
+  dataAndPrivacy,
   subaccounts,
   alerts,
   help,

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -627,7 +627,7 @@ const routes = [
   {
     path: '/account/data-privacy/:category',
     component: DataPrivacyPage,
-    condition: all(hasGrants('users/manage'), isAccountUiOptionSet('data_privacy')), //TODO: Remove account UI option
+    condition: hasGrants('users/manage'),
     layout: App,
     title: 'Data and Privacy',
     category: 'Account',

--- a/src/pages/dataPrivacy/components/MultipleRecipientsTab.js
+++ b/src/pages/dataPrivacy/components/MultipleRecipientsTab.js
@@ -102,7 +102,7 @@ export function MultipleRecipientsTab({
           <Field
             component={RadioGroup}
             name="requestType"
-            title="Select Compliance Type"
+            label="Select Compliance Type"
             options={REQUEST_TYPES}
             disabled={submitting}
             validate={[required]}

--- a/src/pages/dataPrivacy/components/MultipleRecipientsTab.js
+++ b/src/pages/dataPrivacy/components/MultipleRecipientsTab.js
@@ -29,6 +29,7 @@ export function MultipleRecipientsTab({
   submitting,
   dataPrivacyRequestError,
   resetDataPrivacy,
+  pristine,
 }) {
   // Adapted minimally from parseRecipientList() in webui/src/app/recipients/recipients-controller.js
 
@@ -140,7 +141,9 @@ export function MultipleRecipientsTab({
             <Button className={styles.submit} color="orange" type="submit">
               Submit Request
             </Button>
-            <Button onClick={reset}>Clear</Button>
+            <Button onClick={reset} disabled={pristine || submitting}>
+              Clear
+            </Button>
           </ButtonWrapper>
         </form>
       </div>

--- a/src/pages/dataPrivacy/components/MultipleRecipientsTab.js
+++ b/src/pages/dataPrivacy/components/MultipleRecipientsTab.js
@@ -157,6 +157,9 @@ const mapStateToProps = ({ dataPrivacy }) => {
   const { dataPrivacyRequestError } = dataPrivacy;
   return {
     dataPrivacyRequestError,
+    initialValues: {
+      assignTo: 'master',
+    },
   };
 };
 

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -71,7 +71,9 @@ export function SingleRecipientTab(props) {
             >
               Submit Request
             </Button>
-            <Button onClick={props.reset}>Clear</Button>
+            <Button onClick={props.reset} disabled={props.pristine || props.submitting}>
+              Clear
+            </Button>
           </ButtonWrapper>
         </form>
       </div>

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -86,6 +86,9 @@ const formOptions = {
 const mapStateToProps = state => {
   return {
     dataPrivacyRequestPending: state.dataPrivacy.dataPrivacyRequestPending,
+    initialValues: {
+      assignTo: 'master',
+    },
   };
 };
 export default connect(mapStateToProps, { submitRTBFRequest, submitOptOutRequest, showAlert })(

--- a/src/pages/dataPrivacy/components/SingleRecipientTab.js
+++ b/src/pages/dataPrivacy/components/SingleRecipientTab.js
@@ -40,7 +40,7 @@ export function SingleRecipientTab(props) {
           <Field
             component={RadioGroup}
             name="requestType"
-            title="Select Compliance Type"
+            label="Select Compliance Type"
             options={REQUEST_TYPES}
             disabled={props.dataPrivacyRequestPending}
             validate={[required]}


### PR DESCRIPTION
AC-1267 - Release UI for data privacy

### What Changed
 - Removed ui flag data_privacy
 - Added Data and Privacy Page to hibana nav
 - Replaced title with label in SubaccountSection, MultipleRecipientsTab, SingleRecipientsTab

### How To Test
 - Check if Data and Privacy page is visible without enabling feature flag.(only to admin users)
 - Check if SubaccountSection used in templates, snippets and Data Privacy page looks the same after the replacement of title with label.
 - Check if the Data and Privacy Page is visible under Hibana Nav.

### To Do
- [ ] Address Feedback
