### PR TITLE
AC-1289: Added company name field and show password on join page

### DIFF
--- a/src/__func__/signup/helpers.js
+++ b/src/__func__/signup/helpers.js
@@ -29,7 +29,7 @@ class SignupFlow {
       { name: 'tou_accepted', value: true, type: 'checkbox' },
       { name: 'email_opt_in', value: optIn, type: 'checkbox' },
     ]);
-    await this.page.simulate('button', 'click');
+    await this.page.simulate('button[id="submit"]', 'click');
   }
 
   async choosePlan({ planFilter = freePlanPredicate, submit = true } = {}) {

--- a/src/components/pendo/Pendo.js
+++ b/src/components/pendo/Pendo.js
@@ -15,6 +15,7 @@ export class Pendo extends React.Component {
       accountId,
       accountSvcLevel,
       accountPlanCode,
+      companyName,
       username,
       userAccessLevel,
       status,
@@ -42,6 +43,7 @@ export class Pendo extends React.Component {
       account: {
         id: `${tenantId}_${accountId}`,
         tenant: tenantId,
+        companyName,
         plan: accountPlanCode,
         serviceLevel: accountSvcLevel,
         accountCreatedAt,
@@ -66,13 +68,14 @@ export class Pendo extends React.Component {
 const mapStateToProps = state => ({
   accessControlReady: state.accessControlReady,
   accountCreatedAt: state.account.created,
-  status: state.account.status,
-  statusReasonCategory: state.account.status_reason_category,
   accountId: state.account.customer_id,
   accountPlanCode: currentPlanCodeSelector(state),
   accountSvcLevel: state.account.service_level,
-  username: usernameSelector(state),
+  companyName: state.account.company_name,
+  status: state.account.status,
+  statusReasonCategory: state.account.status_reason_category,
   userAccessLevel: state.currentUser.access_level,
+  username: usernameSelector(state),
 });
 
 export default connect(mapStateToProps)(Pendo);

--- a/src/components/pendo/tests/Pendo.test.js
+++ b/src/components/pendo/tests/Pendo.test.js
@@ -20,6 +20,7 @@ describe('Component: Pendo', () => {
         username="fredo-mcgurk"
         userAccessLevel="admin"
         status="active"
+        companyName="Company Inc."
         {...props}
       />,
     );

--- a/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
+++ b/src/components/pendo/tests/__snapshots__/Pendo.test.js.snap
@@ -5,6 +5,7 @@ Array [
   Object {
     "account": Object {
       "accountCreatedAt": "2014-12-30T17:43:18.954Z",
+      "companyName": "Company Inc.",
       "id": "test_999999",
       "plan": "1meellion",
       "serviceLevel": "enterprise",

--- a/src/pages/join/components/JoinForm.js
+++ b/src/pages/join/components/JoinForm.js
@@ -35,6 +35,7 @@ export class JoinForm extends Component {
     reCaptchaReady: false,
     reCaptchaInstance: null,
     recaptcha_response: null,
+    showPassword: false,
   };
 
   reCaptchaLoaded = () => {
@@ -65,7 +66,7 @@ export class JoinForm extends Component {
   render() {
     const { loading, pristine, invalid, submitting } = this.props;
 
-    const { reCaptchaReady } = this.state;
+    const { reCaptchaReady, showPassword } = this.state;
 
     const pending = loading || submitting || !reCaptchaReady;
 
@@ -96,6 +97,14 @@ export class JoinForm extends Component {
           </Grid.Column>
         </Grid>
         <Field
+          name="company"
+          component={TextFieldWrapper}
+          label="Company"
+          disabled={pending}
+          autoComplete="organization"
+          placeholder="Knope Industries LLC"
+        />
+        <Field
           name="email"
           component={TextFieldWrapper}
           label="Email"
@@ -110,9 +119,14 @@ export class JoinForm extends Component {
           label="Password"
           validate={[required, minLength(12), endsWithWhitespace]}
           disabled={!reCaptchaReady || loading}
-          type="password"
+          type={showPassword ? 'text' : 'password'}
           autoComplete="new-password"
           placeholder="••••••••••••"
+          connectRight={
+            <Button onClick={() => this.setState({ showPassword: !showPassword })}>
+              {showPassword ? 'hide' : 'show'}
+            </Button>
+          }
         />
 
         <Checkbox.Group>
@@ -140,7 +154,12 @@ export class JoinForm extends Component {
           />
         </Checkbox.Group>
 
-        <Button primary disabled={pending || pristine || invalid} onClick={this.executeRecaptcha}>
+        <Button
+          id="submit"
+          primary
+          disabled={pending || pristine || invalid}
+          onClick={this.executeRecaptcha}
+        >
           {loading ? 'Loading' : 'Create Account'}
         </Button>
 

--- a/src/pages/join/components/JoinForm.js
+++ b/src/pages/join/components/JoinForm.js
@@ -97,7 +97,7 @@ export class JoinForm extends Component {
           </Grid.Column>
         </Grid>
         <Field
-          name="company"
+          name="company_name"
           component={TextFieldWrapper}
           label="Company"
           disabled={pending}

--- a/src/pages/join/components/JoinForm.js
+++ b/src/pages/join/components/JoinForm.js
@@ -10,6 +10,7 @@ import { Grid } from '@sparkpost/matchbox';
 import { ExternalLink } from 'src/components/links';
 import { Button, Checkbox } from 'src/components/matchbox';
 import { required, minLength, email, endsWithWhitespace } from 'src/helpers/validation';
+import useHibanaToggle from 'src/hooks/useHibanaToggle';
 import styles from './JoinForm.module.scss';
 const { recaptcha } = config;
 
@@ -123,9 +124,9 @@ export class JoinForm extends Component {
           autoComplete="new-password"
           placeholder="••••••••••••"
           connectRight={
-            <Button onClick={() => this.setState({ showPassword: !showPassword })}>
-              {showPassword ? 'hide' : 'show'}
-            </Button>
+            <ShowPasswordButton onClick={() => this.setState({ showPassword: !showPassword })}>
+              {showPassword ? 'Hide' : 'Show'}
+            </ShowPasswordButton>
           }
         />
 
@@ -176,6 +177,25 @@ export class JoinForm extends Component {
   }
 }
 
+function OGShowPasswordButton({ children, onClick }) {
+  return (
+    <Button onClick={onClick} data-id="show-password-button">
+      {children}
+    </Button>
+  );
+}
+
+function HibanaShowPasswordButton({ children, onClick }) {
+  return (
+    <Button primary outline onClick={onClick} data-id="show-password-button">
+      {children}
+    </Button>
+  );
+}
+
+function ShowPasswordButton(props) {
+  return useHibanaToggle(OGShowPasswordButton, HibanaShowPasswordButton)(props);
+}
 const mapStateToProps = state => ({
   initialValues: {
     tou_accepted: false,

--- a/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
+++ b/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
@@ -62,11 +62,11 @@ exports[`JoinForm render disables form when loading 1`] = `
     autoComplete="new-password"
     component={[Function]}
     connectRight={
-      <Button
+      <ShowPasswordButton
         onClick={[Function]}
       >
-        show
-      </Button>
+        Show
+      </ShowPasswordButton>
     }
     disabled={true}
     label="Password"
@@ -202,11 +202,11 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
     autoComplete="new-password"
     component={[Function]}
     connectRight={
-      <Button
+      <ShowPasswordButton
         onClick={[Function]}
       >
-        show
-      </Button>
+        Show
+      </ShowPasswordButton>
     }
     disabled={true}
     label="Password"
@@ -342,11 +342,11 @@ exports[`JoinForm render enables form correctly 1`] = `
     autoComplete="new-password"
     component={[Function]}
     connectRight={
-      <Button
+      <ShowPasswordButton
         onClick={[Function]}
       >
-        show
-      </Button>
+        Show
+      </ShowPasswordButton>
     }
     disabled={false}
     label="Password"

--- a/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
+++ b/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
@@ -37,6 +37,14 @@ exports[`JoinForm render disables form when loading 1`] = `
     </Grid.Column>
   </Grid>
   <Field
+    autoComplete="organization"
+    component={[Function]}
+    disabled={true}
+    label="Company"
+    name="company"
+    placeholder="Knope Industries LLC"
+  />
+  <Field
     autoComplete="username email"
     component={[Function]}
     disabled={true}
@@ -53,6 +61,13 @@ exports[`JoinForm render disables form when loading 1`] = `
   <Field
     autoComplete="new-password"
     component={[Function]}
+    connectRight={
+      <Button
+        onClick={[Function]}
+      >
+        show
+      </Button>
+    }
     disabled={true}
     label="Password"
     name="password"
@@ -100,6 +115,7 @@ exports[`JoinForm render disables form when loading 1`] = `
   </Checkbox.Group>
   <Button
     disabled={true}
+    id="submit"
     onClick={[Function]}
     primary={true}
   >
@@ -161,6 +177,14 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
     </Grid.Column>
   </Grid>
   <Field
+    autoComplete="organization"
+    component={[Function]}
+    disabled={true}
+    label="Company"
+    name="company"
+    placeholder="Knope Industries LLC"
+  />
+  <Field
     autoComplete="username email"
     component={[Function]}
     disabled={true}
@@ -177,6 +201,13 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
   <Field
     autoComplete="new-password"
     component={[Function]}
+    connectRight={
+      <Button
+        onClick={[Function]}
+      >
+        show
+      </Button>
+    }
     disabled={true}
     label="Password"
     name="password"
@@ -224,6 +255,7 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
   </Checkbox.Group>
   <Button
     disabled={true}
+    id="submit"
     onClick={[Function]}
     primary={true}
   >
@@ -285,6 +317,14 @@ exports[`JoinForm render enables form correctly 1`] = `
     </Grid.Column>
   </Grid>
   <Field
+    autoComplete="organization"
+    component={[Function]}
+    disabled={false}
+    label="Company"
+    name="company"
+    placeholder="Knope Industries LLC"
+  />
+  <Field
     autoComplete="username email"
     component={[Function]}
     disabled={false}
@@ -301,6 +341,13 @@ exports[`JoinForm render enables form correctly 1`] = `
   <Field
     autoComplete="new-password"
     component={[Function]}
+    connectRight={
+      <Button
+        onClick={[Function]}
+      >
+        show
+      </Button>
+    }
     disabled={false}
     label="Password"
     name="password"
@@ -348,6 +395,7 @@ exports[`JoinForm render enables form correctly 1`] = `
   </Checkbox.Group>
   <Button
     disabled={false}
+    id="submit"
     onClick={[Function]}
     primary={true}
   >

--- a/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
+++ b/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
@@ -41,7 +41,7 @@ exports[`JoinForm render disables form when loading 1`] = `
     component={[Function]}
     disabled={true}
     label="Company"
-    name="company"
+    name="company_name"
     placeholder="Knope Industries LLC"
   />
   <Field
@@ -181,7 +181,7 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
     component={[Function]}
     disabled={true}
     label="Company"
-    name="company"
+    name="company_name"
     placeholder="Knope Industries LLC"
   />
   <Field
@@ -321,7 +321,7 @@ exports[`JoinForm render enables form correctly 1`] = `
     component={[Function]}
     disabled={false}
     label="Company"
-    name="company"
+    name="company_name"
     placeholder="Knope Industries LLC"
   />
   <Field


### PR DESCRIPTION
### What Changed
 - Added company name field
 - Added field view password field

### How To Test
 - Create account
 - Verify that show password works correctly
 -Add company name
 - Verify company name exists on the account information on logging in the app (network request)
