### PR TITLE
SA-1306 Disable the Timezone picker when datepicker changes local precision to day, week, month

### DIFF
--- a/src/components/typeahead/TimezoneTypeahead.js
+++ b/src/components/typeahead/TimezoneTypeahead.js
@@ -33,7 +33,13 @@ const options = moment.tz
 options.unshift(UTC_OPTION);
 
 export const TimezoneTypeahead = props => {
-  const { initialValue, onChange: parentOnChange, isForcedUTC, ...rest } = props;
+  const {
+    initialValue,
+    onChange: parentOnChange,
+    isForcedUTC,
+    disabledAndUTCOnly,
+    ...rest
+  } = props;
   const [selected, setSelected] = useState(options[0]);
 
   const findOptionInList = useCallback(value => options.find(option => option.value === value), []);
@@ -59,20 +65,24 @@ export const TimezoneTypeahead = props => {
     }
   };
 
-  return (
-    <Typeahead
-      renderItem={item => <Item label={item.label} />}
-      itemToString={item => (item ? item.label : '')}
-      placeholder="Select a Timezone"
-      label="Time Zone"
-      errorInLabel={false}
-      error={false}
-      name="timezone-typeahead"
-      results={options}
-      selectedItem={selected}
-      onChange={onChange}
-      maxNumberOfResults={options.length}
-      {...rest}
-    />
-  );
+  const typeaheadProps = {
+    renderItem: item => <Item label={item.label} />,
+    itemToString: item => (item ? item.label : ''),
+    placeholder: 'Select a Timezone',
+    label: 'Time Zone',
+    errorInLabel: false,
+    error: false,
+    name: 'timezone-typeahead',
+    results: options,
+    selectedItem: selected,
+    onChange: onChange,
+    maxNumberOfResults: options.length,
+    ...rest,
+  };
+
+  if (disabledAndUTCOnly) {
+    return <Typeahead {...typeaheadProps} selectedItem={UTC_OPTION} disabled />;
+  }
+
+  return <Typeahead {...typeaheadProps} />;
 };

--- a/src/components/typeahead/tests/TimezoneTypeahead.test.js
+++ b/src/components/typeahead/tests/TimezoneTypeahead.test.js
@@ -5,26 +5,24 @@ import { TimezoneTypeahead } from '../TimezoneTypeahead';
 import TestApp from 'src/__testHelpers__/TestApp';
 
 describe('Timezone Typeahead Item', () => {
+  const subject = props =>
+    mount(
+      <TestApp>
+        <TimezoneTypeahead {...props} />
+      </TestApp>,
+    );
   beforeEach(() => {
     moment.tz.setDefault('America/New_York');
   });
   // This includes a long list of options, but it's actually helpful to see a difference
   // when/if we update moment/moment-timezone which options might change
   it('should render the timezone list properly', () => {
-    const wrapper = mount(
-      <TestApp>
-        <TimezoneTypeahead />
-      </TestApp>,
-    );
+    const wrapper = subject();
     expect(wrapper.find('Typeahead').prop('results')).toMatchSnapshot();
   });
 
   it('should should select the first timezone (UTC) as the default', () => {
-    const wrapper = mount(
-      <TestApp>
-        <TimezoneTypeahead />
-      </TestApp>,
-    );
+    const wrapper = subject();
     expect(wrapper.find('Typeahead').prop('selectedItem')).toEqual({
       value: 'UTC',
       label: 'UTC',
@@ -32,11 +30,7 @@ describe('Timezone Typeahead Item', () => {
   });
 
   it('if initialValue is set, it should select that as the default', () => {
-    const wrapper = mount(
-      <TestApp>
-        <TimezoneTypeahead initialValue="Pacific/Chatham" />
-      </TestApp>,
-    );
+    const wrapper = subject({ initialValue: 'Pacific/Chatham' });
 
     expect(wrapper.find('Typeahead').prop('selectedItem')).toEqual({
       label: '(UTC+12:45) Pacific/Chatham',
@@ -46,11 +40,7 @@ describe('Timezone Typeahead Item', () => {
 
   it('if isForcedUTC is set, it should set timezone to UTC in onChange ', () => {
     const onChange = jest.fn();
-    mount(
-      <TestApp>
-        <TimezoneTypeahead initialValue="Pacific/Chatham" onChange={onChange} isForcedUTC={true} />
-      </TestApp>,
-    );
+    subject({ initialValue: 'Pacific/Chatham', onChange, isForcedUTC: true });
 
     expect(onChange).toBeCalledWith({
       label: 'UTC',
@@ -60,12 +50,22 @@ describe('Timezone Typeahead Item', () => {
 
   it('if isForcedUTC is not set, it should not call the onChange', () => {
     const onChange = jest.fn();
-    mount(
-      <TestApp>
-        <TimezoneTypeahead initialValue="Pacific/Chatham" onChange={onChange} isForcedUTC={false} />
-      </TestApp>,
-    );
+
+    subject({ initialValue: 'Pacific/Chatham', onChange, isForcedUTC: false });
 
     expect(onChange).not.toBeCalled();
+  });
+
+  it('if disabledAndUTCOnly is set, it should be disabled and have UTC value', () => {
+    const wrapper = subject({ initialValue: 'Pacific/Chatham', disabledAndUTCOnly: true });
+
+    const typeahead = wrapper.find('Typeahead');
+
+    expect(typeahead.prop('selectedItem')).toEqual({
+      label: 'UTC',
+      value: 'UTC',
+    });
+
+    expect(typeahead.prop('disabled')).toBe(true);
   });
 });

--- a/src/pages/reports/components/ReportOptions.js
+++ b/src/pages/reports/components/ReportOptions.js
@@ -93,14 +93,21 @@ export class ReportOptions extends Component {
       const isForcedUTC =
         reportOptions.precision && isForcedUTCRollupPrecision(reportOptions.precision);
 
+      const isShownForcedUTC =
+        this.state.shownPrecision && isForcedUTCRollupPrecision(this.state.shownPrecision);
+
+      const timezoneDisabled = reportLoading || (isForcedUTC && this.state.shownPrecision === '');
+
       const timezoneTypeahead = (
         <TimezoneTypeahead
           initialValue={reportOptions.timezone}
           onChange={this.handleTimezoneSelect}
-          disabled={reportLoading || isForcedUTC}
           isForcedUTC={isForcedUTC}
+          disabledAndUTCOnly={!!isShownForcedUTC}
+          disabled={timezoneDisabled}
         />
       );
+
       return (
         <>
           <Panel.Section>
@@ -136,15 +143,14 @@ export class ReportOptions extends Component {
                 </div>
               </Grid.Column>
               <Grid.Column xs={6} md={4}>
-                {isForcedUTC ? (
-                  <div className={styles.TimezoneTooltipWrapper}>
-                    <Tooltip content="Day, week, and month precision only support UTC.">
-                      {timezoneTypeahead}
-                    </Tooltip>
-                  </div>
-                ) : (
-                  timezoneTypeahead
-                )}
+                <div className={styles.TimezoneTooltipWrapper}>
+                  <Tooltip
+                    disabled={!isShownForcedUTC && !timezoneDisabled}
+                    content="Day, week, and month precision only support UTC."
+                  >
+                    {timezoneTypeahead}
+                  </Tooltip>
+                </div>
               </Grid.Column>
               <Grid.Column xs={6} md={2}>
                 {//We will show a fake selector that shows the temporary precision when the user

--- a/src/pages/reports/components/tests/ReportOptions.test.js
+++ b/src/pages/reports/components/tests/ReportOptions.test.js
@@ -116,4 +116,24 @@ describe('Component: Report Options', () => {
     expect(wrapper.find('Select')).toExist();
     expect(wrapper.find('Select')).toHaveValue('hour');
   });
+
+  it('should set the disabledAndUTCOnly prop when shownPrecision is day, month, or week', () => {
+    wrapper.setProps({ featureFlaggedMetrics: { useMetricsRollup: true } });
+    wrapper.setState({ shownPrecision: 'day' });
+    wrapper.update();
+
+    expect(wrapper.find('TimezoneTypeahead')).toHaveProp('disabledAndUTCOnly', true);
+
+    wrapper.setState({ shownPrecision: 'week' });
+    wrapper.update();
+    expect(wrapper.find('TimezoneTypeahead')).toHaveProp('disabledAndUTCOnly', true);
+
+    wrapper.setState({ shownPrecision: 'month' });
+    wrapper.update();
+    expect(wrapper.find('TimezoneTypeahead')).toHaveProp('disabledAndUTCOnly', true);
+
+    wrapper.setState({ shownPrecision: '' });
+    wrapper.update();
+    expect(wrapper.find('TimezoneTypeahead')).toHaveProp('disabledAndUTCOnly', false);
+  });
 });


### PR DESCRIPTION

### What Changed
 - Disabled datepicker when day, week, month precision is locally set in state to show that the date range choice will change their timezone.

### How To Test
 - Set Hour precision and timezone to something other than UTC. Then choose a date range out of the window of hourly precision (15 days, etc.). Before clicking apply, see the timezone picker is disabled and set to UTC. If you choose another within the window of hourly precision, the timezone will revert back and be enabled.
- The reverse is a little harder to test/see, but if you have a day precision set, open date picker and click on a day. Then hover over the same day (precision will change to 15 mins), and the timezone picker will re-enable itself (but with UTC still chosen, because that's the last timezone that was picked).
