### PR TITLE
FE-1015: Error: useHibanaState must be used within a HibanaProvide

### DIFF
--- a/src/Providers.js
+++ b/src/Providers.js
@@ -14,13 +14,13 @@ const reloadApp = () => {
 
 const Providers = ({ store = {}, children }) => (
   <Provider store={store}>
-    <ErrorBoundary onCtaClick={reloadApp} ctaLabel="Reload Page">
-      <HibanaProvider>
-        <HibanaTheme>
+    <HibanaProvider>
+      <HibanaTheme>
+        <ErrorBoundary onCtaClick={reloadApp} ctaLabel="Reload Page">
           <Poll>{children}</Poll>
-        </HibanaTheme>
-      </HibanaProvider>
-    </ErrorBoundary>
+        </ErrorBoundary>
+      </HibanaTheme>
+    </HibanaProvider>
   </Provider>
 );
 

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -898,6 +898,20 @@ const routes = [
     category: 'Account',
   },
   {
+    path: '/error-boundary',
+    public: true,
+    component: () => {
+      throw new Error('Oops');
+    },
+  },
+  {
+    path: '/private-error-boundary',
+    layout: App,
+    component: () => {
+      throw new Error('Oops');
+    },
+  },
+  {
     path: '/logout',
     component: LogoutPage,
     title: 'Logging out...',


### PR DESCRIPTION
### What Changed
 - Moved HibanaProvider and HibanaTheme above ErrorBoundary
 - Added two new routes /error-boundary and /private-error-boundary for testing ErrorBoundary's

### How To Test
 - Open /error-boundary to confirm app error boundary renders EmptyState without error
