### PR TITLE
FE-929: Re-style global chart component

### DIFF
--- a/src/components/callout/Callout.js
+++ b/src/components/callout/Callout.js
@@ -4,7 +4,7 @@ import styles from './Callout.module.scss';
 import useHibanaToggle from 'src/hooks/useHibanaToggle';
 import { Box, Text } from 'src/components/matchbox';
 
-const HibanaCallout = ({ children, height = '220px', title }) => (
+const HibanaCallout = ({ children, height = '220px', title = '' }) => (
   <Box height={height} display="flex" justifyContent="center" alignItems="center">
     <Box>
       <Text as="h3" mb="200" color="gray.800">

--- a/src/components/charts/Legend.js
+++ b/src/components/charts/Legend.js
@@ -33,10 +33,9 @@ const HibanaItem = props => {
         as="span"
         display="inline-block"
         verticalAlign="middle"
-        marginRight="10"
-        marginTop={-10}
+        marginRight={10}
+        marginTop={-4}
         size={12}
-        borderRadius={6}
         borderStyle={hasBorder ? 'solid' : undefined}
         borderColor={hasBorder ? '#00000' : undefined}
         borderWidth={hasBorder ? '100' : undefined}

--- a/src/components/charts/Legend.js
+++ b/src/components/charts/Legend.js
@@ -4,16 +4,30 @@ import { Box, Text, Tooltip } from 'src/components/matchbox';
 import cx from 'classnames';
 import useHibanaToggle from 'src/hooks/useHibanaToggle';
 
-const Item = props => {
+const OGItem = props => {
   const { label, fill = 'whitesmoke', tooltipContent, hasBorder } = props;
-  const OGContent = (
+  const content = (
     <div className={styles.Item}>
       <span className={cx(styles.Fill, hasBorder && styles.Border)} style={{ background: fill }} />
       <span className={styles.Label}>{label}</span>
     </div>
   );
 
-  const HibanaContent = (
+  if (tooltipContent) {
+    return (
+      <Tooltip content={tooltipContent(label)} dark>
+        {content}
+      </Tooltip>
+    );
+  }
+
+  return content;
+};
+
+const HibanaItem = props => {
+  const { label, fill = 'whitesmoke', tooltipContent, hasBorder } = props;
+
+  const content = (
     <Box display="inline-block" whiteSpace="nowrap">
       <Box
         as="span"
@@ -26,6 +40,7 @@ const Item = props => {
         borderStyle={hasBorder ? 'solid' : undefined}
         borderColor={hasBorder ? '#00000' : undefined}
         borderWidth={hasBorder ? '100' : undefined}
+        bg={fill}
       />
       <Text
         as="span"
@@ -39,8 +54,6 @@ const Item = props => {
     </Box>
   );
 
-  const content = useHibanaToggle(OGContent, HibanaContent)(props);
-
   if (tooltipContent) {
     return (
       <Tooltip content={tooltipContent(label)} dark>
@@ -52,12 +65,21 @@ const Item = props => {
   return content;
 };
 
-const Legend = ({ items, tooltipContent }) => (
+export const OGLegend = ({ items, tooltipContent }) => (
   <div className={styles.Legend}>
     {items.map((item, i) => (
-      <Item key={i} tooltipContent={tooltipContent} {...item} />
+      <OGItem key={i} tooltipContent={tooltipContent} {...item} />
     ))}
   </div>
 );
 
+const HibanaLegend = ({ items, tooltipContent }) => (
+  <Box marginTop="100" marginLeft="300">
+    {items.map((item, i) => (
+      <HibanaItem key={i} tooltipContent={tooltipContent} {...item} />
+    ))}
+  </Box>
+);
+
+const Legend = props => useHibanaToggle(OGLegend, HibanaLegend)(props);
 export default Legend;

--- a/src/components/charts/Legend.js
+++ b/src/components/charts/Legend.js
@@ -1,15 +1,45 @@
 import React from 'react';
 import styles from './Legend.module.scss';
-import { Tooltip } from 'src/components/matchbox';
+import { Box, Text, Tooltip } from 'src/components/matchbox';
 import cx from 'classnames';
+import useHibanaToggle from 'src/hooks/useHibanaToggle';
 
-const Item = ({ label, fill = 'whitesmoke', tooltipContent, hasBorder }) => {
-  const content = (
+const Item = props => {
+  const { label, fill = 'whitesmoke', tooltipContent, hasBorder } = props;
+  const OGContent = (
     <div className={styles.Item}>
       <span className={cx(styles.Fill, hasBorder && styles.Border)} style={{ background: fill }} />
       <span className={styles.Label}>{label}</span>
     </div>
   );
+
+  const HibanaContent = (
+    <Box display="inline-block" whiteSpace="nowrap">
+      <Box
+        as="span"
+        display="inline-block"
+        verticalAlign="middle"
+        marginRight="10"
+        marginTop={-10}
+        size={12}
+        borderRadius={6}
+        borderStyle={hasBorder ? 'solid' : undefined}
+        borderColor={hasBorder ? '#00000' : undefined}
+        borderWidth={hasBorder ? '100' : undefined}
+      />
+      <Text
+        as="span"
+        display="inline-block"
+        verticalAlign="middle"
+        marginRight="300"
+        fontWeight="400"
+      >
+        {label}
+      </Text>
+    </Box>
+  );
+
+  const content = useHibanaToggle(OGContent, HibanaContent)(props);
 
   if (tooltipContent) {
     return (

--- a/src/components/charts/Tooltip.js
+++ b/src/components/charts/Tooltip.js
@@ -2,7 +2,9 @@ import React, { useLayoutEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { formatDate } from 'src/helpers/date';
 import { getBoundingClientRect } from 'src/helpers/geometry';
-import styles from './Tooltip.module.scss';
+import useHibanaOverride from 'src/hooks/useHibanaOverride';
+import OGStyles from './Tooltip.module.scss';
+import HibanaStyles from './TooltipHibana.module.scss';
 import _ from 'lodash';
 import './Tooltip.scss';
 
@@ -11,7 +13,7 @@ function Tooltip(props) {
   const content = _.get(props, 'payload[0]', {});
   const date = _.get(content, 'payload.date');
   const wrapper = useRef(null);
-
+  const styles = useHibanaOverride(OGStyles, HibanaStyles);
   const [positionedOnRight, setPositionedOnRight] = useState(true);
   const [position, setPosition] = useState({ left: 0, top: 0 });
 
@@ -24,8 +26,8 @@ function Tooltip(props) {
     const newPositionedOnRight = xTarget + rect.width + offset < window.innerWidth;
 
     const coords = {
-      top: coordinate.y - (rect.height / 2),
-      left: newPositionedOnRight ? coordinate.x + offset : (coordinate.x - offset) - rect.width
+      top: coordinate.y - rect.height / 2,
+      left: newPositionedOnRight ? coordinate.x + offset : coordinate.x - offset - rect.width,
     };
 
     setPosition(coords);
@@ -33,36 +35,25 @@ function Tooltip(props) {
   }, [coordinate.x, coordinate.y, offset, positionedOnRight, wrapper]);
 
   return (
-    <div
-      className={styles.TooltipWrapper}
-      ref={wrapper}
-      style={{ width, ...position }}
-    >
-      {date && (
-        <div className={styles.TooltipDate}>
-          {formatDate(date)}
-        </div>
-      )}
-      <div className={styles.TooltipContent}>
-        {children(content)}
-      </div>
+    <div className={styles.TooltipWrapper} ref={wrapper} style={{ width, ...position }}>
+      {date && <div className={styles.TooltipDate}>{formatDate(date)}</div>}
+      <div className={styles.TooltipContent}>{children(content)}</div>
     </div>
   );
 }
-
 
 const defaultChildren = ({ value }) => value;
 
 Tooltip.propTypes = {
   children: PropTypes.func,
   width: PropTypes.string,
-  offset: PropTypes.number
+  offset: PropTypes.number,
 };
 
 Tooltip.defaultProps = {
   children: defaultChildren,
   width: '200px',
-  offset: 25
+  offset: 25,
 };
 
 export default Tooltip;

--- a/src/components/charts/TooltipHibana.module.scss
+++ b/src/components/charts/TooltipHibana.module.scss
@@ -1,0 +1,25 @@
+@import '~@sparkpost/matchbox/src/styles/config.scss';
+
+.TooltipWrapper {
+  position: absolute;
+  background: #2c353d;
+  box-shadow: shadow(deep), shadow(deeper);
+  user-select: none;
+  border-radius: 0;
+  min-width: 200px;
+}
+
+.TooltipDate {
+  padding: rem(9) rem(13);
+  color: #97a0a8;
+}
+
+.TooltipContent {
+  padding: rem(9) rem(13);
+  color: color(gray, 10);
+}
+
+.TooltipDate {
+  font-size: rem(18);
+  border-bottom: 1px solid darken(color(gray, 1), 5);
+}

--- a/src/components/charts/TooltipMetric.js
+++ b/src/components/charts/TooltipMetric.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import styles from './TooltipMetric.module.scss';
 import { Box, Text } from 'src/components/matchbox';
-import { useHibanaToggle } from 'src/hooks/useHibanaToggle';
+import useHibanaToggle from 'src/hooks/useHibanaToggle';
 
 export const OGTooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
   <div className={styles.Wrapper}>
@@ -16,29 +16,23 @@ export const OGTooltipMetric = ({ color = '#6e6e73', description, label, value }
     </div>
   </div>
 );
-const HibanaTooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
-  <Box position="relative" display="inline-block" width="100" height="100">
-    <Box display="flex" justifyContent="flex-start">
-      <Box background={color || 'red'} flex="0 0 0" height="100" minWidth={4} marginRight="100" />
-      <Box
-        flex="1 0 0"
-        display="flex"
-        height="100"
-        flexDirection="column"
-        justifyContent={description ? 'space-around' : 'space-between'}
-      >
-        <Text as="p" fontSize="300" fontWeight="400" lineHeight="100">
+export const HibanaTooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
+  <Box position="relative" display="inline-block" width={1} height="200">
+    <Box display="flex" justifyContent="space-between">
+      <Box bg={color} marginRight="100" borderRadius={8} size={16} marginTop="100" />
+      <Box display="flex" height="100" flexDirection="column">
+        <Text as="span" fontSize="100" fontWeight="300">
           {label}
         </Text>
         {description && (
-          <Text as="p" fontSize="100" fontWeight="300" lineHeight="100">
+          <Text as="span" fontSize="100" fontWeight="300">
             {description}
           </Text>
         )}
-        <Text className={styles.Value} as="p" fontSize="800" fontWeight="300" lineHeight="100">
-          {value}
-        </Text>
       </Box>
+      <Text as="span" fontSize="100" fontWeight="600">
+        {value}
+      </Text>
     </Box>
   </Box>
 );

--- a/src/components/charts/TooltipMetric.js
+++ b/src/components/charts/TooltipMetric.js
@@ -21,7 +21,7 @@ export const HibanaTooltipMetric = ({ color = '#6e6e73', description, label, val
     <Box display="flex" justifyContent="space-between">
       <Box bg={color} marginRight="100" borderRadius={8} size={16} marginTop="100" />
       <Box display="flex" height="100" flexDirection="column" flex="1 0 0">
-        <Text as="span" fontSize="100" fontWeight="300">
+        <Text as="span" fontSize="200" fontWeight="300">
           {label}
         </Text>
         {description && (
@@ -30,7 +30,7 @@ export const HibanaTooltipMetric = ({ color = '#6e6e73', description, label, val
           </Text>
         )}
       </Box>
-      <Text as="span" fontSize="100" fontWeight="600">
+      <Text as="span" fontSize="200" fontWeight="600">
         {value}
       </Text>
     </Box>

--- a/src/components/charts/TooltipMetric.js
+++ b/src/components/charts/TooltipMetric.js
@@ -20,7 +20,7 @@ export const HibanaTooltipMetric = ({ color = '#6e6e73', description, label, val
   <Box position="relative" display="inline-block" width={1} height="200">
     <Box display="flex" justifyContent="space-between">
       <Box bg={color} marginRight="100" borderRadius={8} size={16} marginTop="100" />
-      <Box display="flex" height="100" flexDirection="column">
+      <Box display="flex" height="100" flexDirection="column" flex="1 0 0">
         <Text as="span" fontSize="100" fontWeight="300">
           {label}
         </Text>

--- a/src/components/charts/TooltipMetric.js
+++ b/src/components/charts/TooltipMetric.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import classnames from 'classnames';
 import styles from './TooltipMetric.module.scss';
+import { Box, Text } from 'src/components/matchbox';
+import { useHibanaToggle } from 'src/hooks/useHibanaToggle';
 
-const TooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
+export const OGTooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
   <div className={styles.Wrapper}>
     <div className={styles.TooltipMetric}>
       <div style={{ background: color }} className={styles.Color} />
@@ -14,5 +16,31 @@ const TooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
     </div>
   </div>
 );
-
+const HibanaTooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
+  <Box position="relative" display="inline-block" width="100" height="100">
+    <Box display="flex" justifyContent="flex-start">
+      <Box background={color || 'red'} flex="0 0 0" height="100" minWidth={4} marginRight="100" />
+      <Box
+        flex="1 0 0"
+        display="flex"
+        height="100"
+        flexDirection="column"
+        justifyContent={description ? 'space-around' : 'space-between'}
+      >
+        <Text as="p" fontSize="300" fontWeight="400" lineHeight="100">
+          {label}
+        </Text>
+        {description && (
+          <Text as="p" fontSize="100" fontWeight="300" lineHeight="100">
+            {description}
+          </Text>
+        )}
+        <Text className={styles.Value} as="p" fontSize="800" fontWeight="300" lineHeight="100">
+          {value}
+        </Text>
+      </Box>
+    </Box>
+  </Box>
+);
+const TooltipMetric = props => useHibanaToggle(OGTooltipMetric, HibanaTooltipMetric)(props);
 export default TooltipMetric;

--- a/src/components/charts/TooltipMetric.js
+++ b/src/components/charts/TooltipMetric.js
@@ -16,7 +16,12 @@ export const OGTooltipMetric = ({ color = '#6e6e73', description, label, value }
     </div>
   </div>
 );
-export const HibanaTooltipMetric = ({ color = '#6e6e73', description, label, value }) => (
+export const HibanaTooltipMetric = ({
+  color = '#6e6e73',
+  description = '',
+  label = '',
+  value = '',
+}) => (
   <Box position="relative" display="inline-block" width={1} height="200">
     <Box display="flex" justifyContent="space-between">
       <Box bg={color} marginRight="100" borderRadius={8} size={16} marginTop="100" />

--- a/src/components/charts/tests/Legend.test.js
+++ b/src/components/charts/tests/Legend.test.js
@@ -1,6 +1,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import Legend from '../Legend';
+import { OGLegend } from '../Legend';
+import { useHibana } from 'src/context/HibanaContext';
+jest.mock('src/context/HibanaContext');
 
 describe('Legend Component', () => {
   let wrapper;
@@ -11,22 +13,23 @@ describe('Legend Component', () => {
       items: [
         { fill: 'blue', label: 'label 1' },
         { label: 'label 2' },
-        { label: 'label 2', fill: 'white', hasBorder: true }
-      ]
+        { label: 'label 2', fill: 'white', hasBorder: true },
+      ],
     };
-    wrapper = shallow(<Legend {...props}/>);
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+    wrapper = shallow(<OGLegend {...props} />);
   });
 
   it('renders correctly', () => {
     expect(wrapper).toMatchSnapshot();
-    wrapper.find('Item').forEach((item) => {
+    wrapper.find('Item').forEach(item => {
       expect(item.dive()).toMatchSnapshot();
     });
   });
 
   it('renders correctly with tooltip content', () => {
-    wrapper.setProps({ tooltipContent: (label) => label });
-    wrapper.find('Item').forEach((item) => {
+    wrapper.setProps({ tooltipContent: label => label });
+    wrapper.find('OGItem').forEach(item => {
       expect(item.dive().find('Tooltip')).toExist();
     });
   });

--- a/src/components/charts/tests/Tooltip.test.js
+++ b/src/components/charts/tests/Tooltip.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Tooltip from '../Tooltip';
 import * as geometry from 'src/helpers/geometry';
 import useHibanaOverride from 'src/hooks/useHibanaOverride';
-import styles from './TooltipHibana.module.scss';
+import styles from './Tooltip.module.scss';
 
 jest.mock('src/hooks/useHibanaOverride');
 jest.mock('src/helpers/geometry');

--- a/src/components/charts/tests/Tooltip.test.js
+++ b/src/components/charts/tests/Tooltip.test.js
@@ -2,44 +2,50 @@ import { mount } from 'enzyme';
 import React from 'react';
 import Tooltip from '../Tooltip';
 import * as geometry from 'src/helpers/geometry';
+import useHibanaOverride from 'src/hooks/useHibanaOverride';
+import styles from './TooltipHibana.module.scss';
 
+jest.mock('src/hooks/useHibanaOverride');
 jest.mock('src/helpers/geometry');
 
 describe('Signals Tooltip Component', () => {
-  let wrapper;
-  let props;
-
-  beforeEach(() => {
-    props = {
-      coordinate: { x: 0, y: 0 },
-      payload: [{
+  let defaultProps = {
+    coordinate: { x: 0, y: 0 },
+    width: '200px',
+    offset: 25,
+    payload: [
+      {
         value: 1,
         payload: {
           value: 1,
-          date: new Date('2010-01-01T12:00:00.000Z')
-        }
-      }]
-    };
+          date: new Date('2010-01-01T12:00:00.000Z'),
+        },
+      },
+    ],
+  };
+  beforeEach(() => {
     geometry.getBoundingClientRect.mockImplementation(() => ({ left: 0, width: 0, height: 0 }));
-    wrapper = mount(<Tooltip {...props}/>);
+    useHibanaOverride.mockReturnValue(styles);
   });
 
+  const subject = props => mount(<Tooltip {...defaultProps} {...props} />);
+
   it('renders correctly with default children', () => {
-    expect(wrapper).toMatchSnapshot();
+    expect(subject()).toMatchSnapshot();
   });
 
   it('renders correctly without date', () => {
-    wrapper.setProps({ payload: [{ payload: { value: 1 }}]});
+    const wrapper = subject({ payload: [{ payload: { value: 1 } }] });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders children correctly', () => {
-    wrapper.setProps({ children: () => 'test' });
+    const wrapper = subject({ children: () => 'test' });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders with a custom width correctly', () => {
-    wrapper.setProps({ width: '1200px' });
+    const wrapper = subject({ width: '1200px' });
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -47,7 +53,7 @@ describe('Signals Tooltip Component', () => {
     let setRect;
 
     beforeEach(() => {
-      setRect = (options) => {
+      setRect = options => {
         geometry.getBoundingClientRect.mockImplementation(() => options);
       };
       global.innerWidth = 1000;
@@ -55,25 +61,24 @@ describe('Signals Tooltip Component', () => {
 
     it('should calculate position when x coordinates change', () => {
       setRect({ left: 100, width: 200, height: 100 });
-      wrapper.setProps({ coordinate: { x: 100, y: 0 }});
+      const wrapper = subject({ coordinate: { x: 100, y: 0 } });
       wrapper.update();
-
       expect(wrapper.find('.TooltipWrapper').prop('style')).toEqual({
         left: 125, // Equal to coordinate.x + offset
         top: -50,
-        width: '200px'
+        width: '200px',
       });
     });
 
     it('should calculate position when y coordinates change and tooltip overflows past right edge of viewport', () => {
       setRect({ left: 900, width: 200, height: 100 });
-      wrapper.setProps({ coordinate: { x: 0, y: 100 }});
+      const wrapper = subject({ coordinate: { x: 0, y: 100 } });
       wrapper.update();
 
       expect(wrapper.find('.TooltipWrapper').prop('style')).toEqual({
         left: -225, // Equal to coordinate.x - width - offset
         top: 50,
-        width: '200px'
+        width: '200px',
       });
     });
   });

--- a/src/components/charts/tests/TooltipMetric.test.js
+++ b/src/components/charts/tests/TooltipMetric.test.js
@@ -1,6 +1,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import TooltipMetric from '../TooltipMetric';
+import { OGTooltipMetric } from '../TooltipMetric';
+import { useHibana } from 'src/context/HibanaContext';
+jest.mock('src/context/HibanaContext');
 
 describe('Signals TooltipMetric Component', () => {
   let wrapper;
@@ -9,9 +11,10 @@ describe('Signals TooltipMetric Component', () => {
   beforeEach(() => {
     props = {
       label: 'Foo',
-      value: 101
+      value: 101,
     };
-    wrapper = shallow(<TooltipMetric {...props}/>);
+    useHibana.mockImplementationOnce(() => [{ isHibanaEnabled: false }]);
+    wrapper = shallow(<OGTooltipMetric {...props} />);
   });
 
   it('renders correctly', () => {

--- a/src/components/charts/tests/__snapshots__/Legend.test.js.snap
+++ b/src/components/charts/tests/__snapshots__/Legend.test.js.snap
@@ -4,80 +4,20 @@ exports[`Legend Component renders correctly 1`] = `
 <div
   className="Legend"
 >
-  <Item
+  <OGItem
     fill="blue"
     key="0"
     label="label 1"
   />
-  <Item
+  <OGItem
     key="1"
     label="label 2"
   />
-  <Item
+  <OGItem
     fill="white"
     hasBorder={true}
     key="2"
     label="label 2"
   />
-</div>
-`;
-
-exports[`Legend Component renders correctly 2`] = `
-<div
-  className="Item"
->
-  <span
-    className="Fill"
-    style={
-      Object {
-        "background": "blue",
-      }
-    }
-  />
-  <span
-    className="Label"
-  >
-    label 1
-  </span>
-</div>
-`;
-
-exports[`Legend Component renders correctly 3`] = `
-<div
-  className="Item"
->
-  <span
-    className="Fill"
-    style={
-      Object {
-        "background": "whitesmoke",
-      }
-    }
-  />
-  <span
-    className="Label"
-  >
-    label 2
-  </span>
-</div>
-`;
-
-exports[`Legend Component renders correctly 4`] = `
-<div
-  className="Item"
->
-  <span
-    className="Fill Border"
-    style={
-      Object {
-        "background": "white",
-      }
-    }
-  />
-  <span
-    className="Label"
-  >
-    label 2
-  </span>
 </div>
 `;

--- a/src/pages/inboxPlacement/components/TrendsChart.js
+++ b/src/pages/inboxPlacement/components/TrendsChart.js
@@ -13,6 +13,7 @@ import { selectTrends } from 'src/selectors/inboxPlacement';
 import Callout from 'src/components/callout';
 import { PanelLoading } from 'src/components';
 import { formatApiDate } from 'src/helpers/date';
+import { Stack } from 'src/components/matchbox';
 
 const yKeys = [
   {
@@ -46,19 +47,21 @@ const yAxisProps = {
 };
 
 const getTooltipContent = ({ payload = {} }) => (
-  <>
+  <Stack>
     <TooltipMetric label={'Total Messages'} value={payload.totalMessages} />
-    {yKeys
-      .map(({ fill, label, key }) => (
-        <TooltipMetric
-          key={key}
-          color={fill}
-          label={label}
-          value={`${(payload[key] * 100).toFixed(0)}%`}
-        />
-      ))
-      .reverse()}
-  </>
+    <Stack>
+      {yKeys
+        .map(({ fill, label, key }) => (
+          <TooltipMetric
+            key={key}
+            color={fill}
+            label={label}
+            value={`${(payload[key] * 100).toFixed(0)}%`}
+          />
+        ))
+        .reverse()}
+    </Stack>
+  </Stack>
 );
 
 export const TrendsChart = props => {

--- a/src/pages/signals/ComplaintsByCohortPage.js
+++ b/src/pages/signals/ComplaintsByCohortPage.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { getComplaintsByCohort, getEngagementRecency } from 'src/actions/signals';
 import { selectComplaintsByCohortDetails } from 'src/selectors/signals';
 import { PageLink } from 'src/components/links';
-import { Grid, Panel } from 'src/components/matchbox';
+import { Grid, Panel, Stack } from 'src/components/matchbox';
 import LineChart from './components/charts/linechart/LineChart';
 import Legend from './components/charts/legend/Legend';
 import Callout from 'src/components/callout';
@@ -61,7 +61,7 @@ export class ComplaintsByCohortPage extends Component {
     );
 
     return (
-      <>
+      <Stack>
         {_.orderBy(metrics, 'value', 'desc').map(metric => (
           <TooltipMetric
             key={metric.key}
@@ -71,7 +71,7 @@ export class ComplaintsByCohortPage extends Component {
             value={`${roundToPlaces(metric.value * 100, 3)}%`}
           />
         ))}
-      </>
+      </Stack>
     );
   };
 

--- a/src/pages/signals/EngagementRateByCohortPage.js
+++ b/src/pages/signals/EngagementRateByCohortPage.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { getEngagementRateByCohort, getEngagementRecency } from 'src/actions/signals';
 import { selectEngagementRateByCohortDetails } from 'src/selectors/signals';
 import { PageLink } from 'src/components/links';
-import { Grid, Panel } from 'src/components/matchbox';
+import { Grid, Panel, Stack } from 'src/components/matchbox';
 import LineChart from './components/charts/linechart/LineChart';
 import Legend from './components/charts/legend/Legend';
 import Callout from 'src/components/callout';
@@ -61,7 +61,7 @@ export class EngagementRateByCohortPage extends Component {
     );
 
     return (
-      <>
+      <Stack>
         {_.orderBy(metrics, 'value', 'desc').map(metric => (
           <TooltipMetric
             key={metric.key}
@@ -71,7 +71,7 @@ export class EngagementRateByCohortPage extends Component {
             value={`${roundToPlaces(metric.value * 100, 1)}%`}
           />
         ))}
-      </>
+      </Stack>
     );
   };
 

--- a/src/pages/signals/EngagementRecencyPage.js
+++ b/src/pages/signals/EngagementRecencyPage.js
@@ -1,9 +1,9 @@
 /* eslint-disable max-lines */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { getEngagementRecency } from 'src/actions/signals';
 import { selectEngagementRecencyDetails } from 'src/selectors/signals';
 import { PageLink } from 'src/components/links';
-import { Grid, Panel } from 'src/components/matchbox';
+import { Grid, Panel, Stack } from 'src/components/matchbox';
 import BarChart from './components/charts/barchart/BarChart';
 import Callout from 'src/components/callout';
 import DateFilter from './components/filters/DateFilter';
@@ -43,7 +43,7 @@ export class EngagementRecencyPage extends Component {
   };
 
   getTooltipContent = ({ payload = {} }) => (
-    <Fragment>
+    <Stack>
       {_.keys(cohorts).map(key => (
         <TooltipMetric
           key={key}
@@ -53,7 +53,7 @@ export class EngagementRecencyPage extends Component {
           value={`${roundToPlaces(payload[`c_${key}`] * 100, 1)}%`}
         />
       ))}
-    </Fragment>
+    </Stack>
   );
 
   renderContent = () => {

--- a/src/pages/signals/SpamTrapPage.js
+++ b/src/pages/signals/SpamTrapPage.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { getSpamHits } from 'src/actions/signals';
 import { selectSpamHitsDetails } from 'src/selectors/signals';
 import { PageLink } from 'src/components/links';
-import { Grid, Panel } from 'src/components/matchbox';
+import { Grid, Panel, Stack } from 'src/components/matchbox';
 import Page from './components/SignalsPage';
 import BarChart from './components/charts/barchart/BarChart';
 import SpamTrapActions from './components/actionContent/SpamTrapActions';
@@ -61,7 +61,7 @@ export class SpamTrapPage extends Component {
   };
 
   getTooltipContent = ({ payload = {} }) => (
-    <>
+    <Stack>
       {this.state.calculation === 'absolute' ? (
         <TooltipMetric label="Spam Trap Hits" value={formatFullNumber(payload.trap_hits)} />
       ) : (
@@ -70,20 +70,22 @@ export class SpamTrapPage extends Component {
           value={`${roundToPlaces(payload.relative_trap_hits * 100, 4)}%`}
         />
       )}
-      {spamTrapHitTypesCollection.map(({ fill, key, label }) => (
-        <TooltipMetric
-          color={fill}
-          key={key}
-          label={label}
-          value={
-            this.state.calculation === 'absolute'
-              ? `${formatFullNumber(payload[key])}`
-              : `${roundToPlaces(payload[`relative_${key}`] * 100, 4)}%`
-          }
-        />
-      ))}
+      <Stack>
+        {spamTrapHitTypesCollection.map(({ fill, key, label }) => (
+          <TooltipMetric
+            color={fill}
+            key={key}
+            label={label}
+            value={
+              this.state.calculation === 'absolute'
+                ? `${formatFullNumber(payload[key])}`
+                : `${roundToPlaces(payload[`relative_${key}`] * 100, 4)}%`
+            }
+          />
+        ))}
+      </Stack>
       <TooltipMetric label="Injections" value={formatFullNumber(payload.injections)} />
-    </>
+    </Stack>
   );
 
   renderContent = () => {

--- a/src/pages/signals/tests/__snapshots__/ComplaintsByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/ComplaintsByCohortPage.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Signals Complaints Page bar chart props renders tooltip content 1`] = `
-<Fragment>
+<Stack>
   <TooltipMetric
     color="#88E2E7"
     description="Never engaged, first email in last 7 days"
@@ -37,7 +37,7 @@ exports[`Signals Complaints Page bar chart props renders tooltip content 1`] = `
     label="Never Engaged"
     value="11.111%"
   />
-</Fragment>
+</Stack>
 `;
 
 exports[`Signals Complaints Page renders correctly 1`] = `

--- a/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRateByCohortPage.test.js.snap
@@ -11,7 +11,7 @@ Object {
 `;
 
 exports[`Signals Engagement Rate By Cohort Page bar chart props renders tooltip content 1`] = `
-<Fragment>
+<Stack>
   <TooltipMetric
     color="#88E2E7"
     description="Never engaged, first email in last 7 days"
@@ -47,7 +47,7 @@ exports[`Signals Engagement Rate By Cohort Page bar chart props renders tooltip 
     label="Never Engaged"
     value="11.1%"
   />
-</Fragment>
+</Stack>
 `;
 
 exports[`Signals Engagement Rate By Cohort Page renders correctly 1`] = `

--- a/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/EngagementRecencyPage.test.js.snap
@@ -11,7 +11,7 @@ Object {
 `;
 
 exports[`Signals Engagement Recency Page bar chart props renders tooltip content 1`] = `
-<Fragment>
+<Stack>
   <TooltipMetric
     color="#88E2E7"
     description="Never engaged, first email in last 7 days"
@@ -47,7 +47,7 @@ exports[`Signals Engagement Recency Page bar chart props renders tooltip content
     label="Recently Engaged"
     value="40%"
   />
-</Fragment>
+</Stack>
 `;
 
 exports[`Signals Engagement Recency Page renders correctly 1`] = `

--- a/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
+++ b/src/pages/signals/tests/__snapshots__/SpamTrapPage.test.js.snap
@@ -8,34 +8,36 @@ Object {
 `;
 
 exports[`Signals Spam Trap Page bar chart props renders tooltip content 1`] = `
-<Fragment>
+<Stack>
   <TooltipMetric
     label="Spam Trap Rate"
     value="10%"
   />
-  <TooltipMetric
-    color="#50CFDA"
-    key="trap_hits_parked"
-    label="Parked"
-    value="2.5%"
-  />
-  <TooltipMetric
-    color="#29B9C7"
-    key="trap_hits_recycled"
-    label="Recycled"
-    value="2.5%"
-  />
-  <TooltipMetric
-    color="#1A838B"
-    key="trap_hits_typo"
-    label="Typo"
-    value="5%"
-  />
+  <Stack>
+    <TooltipMetric
+      color="#50CFDA"
+      key="trap_hits_parked"
+      label="Parked"
+      value="2.5%"
+    />
+    <TooltipMetric
+      color="#29B9C7"
+      key="trap_hits_recycled"
+      label="Recycled"
+      value="2.5%"
+    />
+    <TooltipMetric
+      color="#1A838B"
+      key="trap_hits_typo"
+      label="Typo"
+      value="5%"
+    />
+  </Stack>
   <TooltipMetric
     label="Injections"
     value="1,240"
   />
-</Fragment>
+</Stack>
 `;
 
 exports[`Signals Spam Trap Page renders correctly 1`] = `


### PR DESCRIPTION
FE-929: Re-style global chart component

### What Changed
 - Added Hibana style for TooltipMetric
 - Added Hibana style for Tooltip
 - Update `<Legend/>`

 **Note**  - `BarChart` doesn't seem to need any update

### How To Test

 - point to prd and Check the charts in 108 account.
 - Check Bar Chart, Tooltip, Legend 
        - /signals/engagement/cohorts/sid/0
        - /inbox-placement

### To Do
- [ ] Address Feedback
