### PR TITLE
AC-1398: Removed summary condition for RV

### DIFF
--- a/src/pages/billing/SummaryPage.js
+++ b/src/pages/billing/SummaryPage.js
@@ -7,7 +7,7 @@ import { selectBillingInfo, selectAccountBilling } from 'src/selectors/accountBi
 import { selectAccountAgeInDays } from 'src/selectors/accountAge';
 import ConditionSwitch, { defaultCase } from 'src/components/auth/ConditionSwitch';
 import { getSubscription } from 'src/actions/billing';
-import { isSuspendedForBilling, hasAccountOptionEnabled } from 'src/helpers/conditions/account';
+import { isSuspendedForBilling } from 'src/helpers/conditions/account';
 import { Loading } from 'src/components';
 import BillingSummary from './components/BillingSummary';
 import ManuallyBilledOrAwsBanner from './components/ManuallyBilledOrAwsBanner';
@@ -46,7 +46,6 @@ export class BillingSummaryPage extends Component {
       sendingIps,
       invoices,
       accountAgeInDays,
-      hasRecipientValidation,
       subscription,
     } = this.props;
     const suspendedBilling = (
@@ -67,7 +66,6 @@ export class BillingSummaryPage extends Component {
     const billingSummary = (
       <BillingSummary
         condition={defaultCase}
-        hasRecipientValidation={hasRecipientValidation}
         account={account}
         subscription={subscription}
         {...billingInfo}
@@ -101,7 +99,6 @@ const mapStateToProps = state => {
     billingInfo: selectBillingInfo(state),
     sendingIps: state.sendingIps.list,
     invoices: state.invoices.list,
-    hasRecipientValidation: hasAccountOptionEnabled('recipient_validation')(state),
   };
 };
 export default connect(mapStateToProps, {

--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -110,7 +110,6 @@ export default class BillingSummary extends Component {
       canPurchaseIps,
       invoices,
       accountAgeInDays,
-      hasRecipientValidation,
     } = this.props;
     const { rvUsage, pending_cancellation, subscription, billing = {} } = account;
     const { show } = this.state;
@@ -119,7 +118,6 @@ export default class BillingSummary extends Component {
       billing !== null && !billing.credit_card && subscription.type === 'default';
 
     const volumeUsed = _.get(rvUsage, 'recipient_validation.month.used', 0);
-    const showRecipientValidation = hasRecipientValidation && rvUsage;
 
     const changePlanActions = [];
     if (!pending_cancellation && canChangePlan && !isTransitioningToSelfServe) {
@@ -143,7 +141,7 @@ export default class BillingSummary extends Component {
             </LabelledValue>
           </Panel.Section>
           {canPurchaseIps && this.renderDedicatedIpSummarySection(isTransitioningToSelfServe)}
-          {showRecipientValidation && this.renderRecipientValidationSection({ rvUsage })}
+          {rvUsage && this.renderRecipientValidationSection({ rvUsage })}
         </Panel>
 
         {canUpdateBillingInfo && this.renderSummary()}

--- a/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
@@ -79,6 +79,26 @@ exports[`Component: Billing Summary should render correctly for a paid plan 1`] 
         }
       }
     />
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <Panel
     data-id="billing-panel"
@@ -198,6 +218,26 @@ exports[`Component: Billing Summary should render correctly for a standard free 
         />
       </LabelledValue>
     </Panel.Section>
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <PremiumBanner />
   <EnterpriseBanner />
@@ -275,6 +315,26 @@ exports[`Component: Billing Summary should render correctly if you can't buy IPs
             }
           }
         />
+      </LabelledValue>
+    </Panel.Section>
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
       </LabelledValue>
     </Panel.Section>
   </Panel>
@@ -397,6 +457,26 @@ exports[`Component: Billing Summary should render correctly if you can't change 
         }
       }
     />
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <Panel
     data-id="billing-panel"
@@ -526,6 +606,26 @@ exports[`Component: Billing Summary should render correctly if you can't update 
         }
       }
     />
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <PremiumBanner />
   <EnterpriseBanner />
@@ -615,6 +715,26 @@ exports[`Component: Billing Summary should render with IP modal open 1`] = `
         }
       }
     />
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <Panel
     data-id="billing-panel"
@@ -748,6 +868,26 @@ exports[`Component: Billing Summary should render with the billing contact modal
         }
       }
     />
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <Panel
     data-id="billing-panel"
@@ -881,6 +1021,26 @@ exports[`Component: Billing Summary should render with the payment info modal op
         }
       }
     />
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <Panel
     data-id="billing-panel"
@@ -1014,6 +1174,26 @@ exports[`Component: Billing Summary should show the invoice history if there are
         }
       }
     />
+    <Panel.Section>
+      <LabelledValue
+        label="Recipient Validation"
+      >
+        <h6>
+          123,123
+           emails validated for 
+          $599.37
+          <small>
+             as of 
+            Jun 9 2019, 8:00pm
+          </small>
+        </h6>
+        <UnstyledLink
+          onClick={[Function]}
+        >
+          How was this calculated?
+        </UnstyledLink>
+      </LabelledValue>
+    </Panel.Section>
   </Panel>
   <Panel
     data-id="billing-panel"


### PR DESCRIPTION
### What Changed
 - RV usage was not showing up in billing summary, removed condition check for old account option

### How To Test
 - Create account, and go `/account/billing`, no usage for RV should show up.
 - Add RV, validate a few addresses, and then go back to billing. RV should show up (might be slightly delayed on updating usage).
