### PR TITLE
SE-620: Replace Alert Mailbox Provider tooltip in Pendo with code (UI)

### DIFF
--- a/src/components/typeahead/ComboBoxTypeahead.js
+++ b/src/components/typeahead/ComboBoxTypeahead.js
@@ -8,6 +8,7 @@ import sortMatch from 'src/helpers/sortMatch';
 export const ComboBoxTypeahead = ({
   disabled,
   error,
+  helpText,
   isExclusiveItem,
   itemToString,
   label,
@@ -101,6 +102,7 @@ export const ComboBoxTypeahead = ({
     const inputProps = getInputProps({
       disabled,
       error: error && !isMenuOpen ? error : undefined,
+      helpText,
       id: name,
       itemToString,
       label,

--- a/src/components/typeahead/tests/ComboBoxTypeahead.test.js
+++ b/src/components/typeahead/tests/ComboBoxTypeahead.test.js
@@ -197,4 +197,9 @@ describe('ComboBoxTypeahead', () => {
 
     expect(onChange).toHaveBeenCalledWith(['apple']);
   });
+
+  it('renders help text', () => {
+    const wrapper = subject({ helpText: 'Did you know?' });
+    expect(wrapper).toHaveTextContent('Did you know?');
+  });
 });

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -65,6 +65,7 @@ export const LINKS = {
     'https://www.sparkpost.com/docs/my-account-and-profile/enabling-two-factor-authentication/',
   RECIPIENT_VALIDATION_ACCESS: 'https://www.sparkpost.com/rv-access',
   AUTO_IP_WARMUP_SETUP: 'https://www.sparkpost.com/docs/user-guide/automated-ip-warmup/',
+  MAILBOX_PROVIDERS: 'https://www.sparkpost.com/docs/user-guide/alerts/#mailbox-providers',
 };
 
 export const ENTERPRISE_PLAN_CODES = ['ent1'];

--- a/src/pages/alerts/components/fields/FilterFields.js
+++ b/src/pages/alerts/components/fields/FilterFields.js
@@ -3,8 +3,9 @@ import { connect } from 'react-redux';
 import { Field, formValueSelector, change } from 'redux-form';
 import { SelectWrapper } from 'src/components/reduxFormWrappers';
 import { getFormSpec } from '../../helpers/alertForm';
-import { MAILBOX_PROVIDERS } from 'src/constants';
+import { LINKS, MAILBOX_PROVIDERS } from 'src/constants';
 import { ComboBoxTypeaheadWrapper } from 'src/components';
+import { ExternalLink } from 'src/components/links';
 import { Grid } from 'src/components/matchbox';
 import { getIpPools } from 'src/selectors/ipPools';
 import { selectVerifiedDomains } from 'src/selectors/sendingDomains';
@@ -74,6 +75,12 @@ export class FilterFields extends Component {
         disabled: disabled,
         itemToString: mbItemToString,
         placeholder: 'Type To Search',
+        helpText: (
+          <>
+            For a breadown of popular inbox providers, see our{' '}
+            <ExternalLink to={LINKS.MAILBOX_PROVIDERS}>alerts guide</ExternalLink>
+          </>
+        ),
       },
       sending_domain: {
         disabled: disabled || sendingDomainsLoading || sendingDomains.length === 0,


### PR DESCRIPTION
### What Changed
 - Disabled Pendo tooltip
 - Added help text to mailbox provider

<img width="1389" alt="Screen Shot 2020-04-24 at 10 16 08 PM" src="https://user-images.githubusercontent.com/1335605/80269273-3c107680-867c-11ea-9e80-d976c9264b7c.png">

### How To Test
 - Open create alert page, /alerts/create
 - Select "Block Bounce Rate" from "Alert Metric" dropdown
 - Confirm Pendo tooltip is gone and help text is present