### PR TITLE
FE-964: Updated API keys and tracking domains pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,11 +4026,11 @@
       }
     },
     "@sparkpost/matchbox-hibana": {
-      "version": "npm:@sparkpost/matchbox@4.0.0-hibana.17",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-4.0.0-hibana.17.tgz",
-      "integrity": "sha512-UErJNwb0lUnacq0SxwCvBONjmCUiOqTUradUYvKoD/xgUDz6m67AoSC2WKO9E+3g5VUNRM8VseUdcaKNj4Smbw==",
+      "version": "npm:@sparkpost/matchbox@4.0.0-hibana.18",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-4.0.0-hibana.18.tgz",
+      "integrity": "sha512-Yj9wRkaeXdWboJ3Nx9dBxWv8nzVjJzydBpbubr4LGSKlFNp1U/RW4HYyd8uTb2MlbL3UJqzgPHKpS3P7fKCNYQ==",
       "requires": {
-        "@sparkpost/design-tokens": "^1.0.0-beta.17",
+        "@sparkpost/design-tokens": "^1.0.0-beta.19",
         "@sparkpost/matchbox-icons": "^1.2.1",
         "@styled-system/prop-types": "^5.1.2",
         "@styled-system/props": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@sparkpost/boomerang": "^1.0.6",
     "@sparkpost/design-tokens-hibana": "npm:@sparkpost/design-tokens@^1.0.0-beta.19",
     "@sparkpost/matchbox": "^3.9.1",
-    "@sparkpost/matchbox-hibana": "npm:@sparkpost/matchbox@4.0.0-hibana.17",
+    "@sparkpost/matchbox-hibana": "npm:@sparkpost/matchbox@4.0.0-hibana.18",
     "@sparkpost/matchbox-icons": "^1.2.1",
     "@styled-system/props": "^5.1.5",
     "axios": "^0.18.0",

--- a/src/components/grantBoxes/GrantsCheckboxes.js
+++ b/src/components/grantBoxes/GrantsCheckboxes.js
@@ -1,4 +1,3 @@
-import classnames from 'classnames/bind';
 import React from 'react';
 import _ from 'lodash';
 import { Field } from 'redux-form';
@@ -10,7 +9,10 @@ import hibanaStyles from './GrantsCheckboxesHibana.module.scss';
 
 const GrantsCheckboxes = ({ grants, show, disabled }) => {
   const styles = useHibanaOverride(OGStyles, hibanaStyles);
-  const cx = classnames.bind(styles);
+
+  if (!show) {
+    return null;
+  }
 
   const grantFields = _.map(grants, grant => (
     <div className={styles.Grant} key={grant.key}>
@@ -36,9 +38,7 @@ const GrantsCheckboxes = ({ grants, show, disabled }) => {
     </Grid.Column>
   ));
 
-  const gridClasses = cx('Grants', { show });
-
-  return <Grid className={gridClasses}>{grantCols}</Grid>;
+  return <Grid className={styles.Grants}>{grantCols}</Grid>;
 };
 
 export default GrantsCheckboxes;

--- a/src/components/grantBoxes/GrantsCheckboxes.module.scss
+++ b/src/components/grantBoxes/GrantsCheckboxes.module.scss
@@ -1,12 +1,8 @@
 @import '~@sparkpost/matchbox/src/styles/config.scss';
 
 .Grants {
-  display: none;
   margin-bottom: 1rem;
-
-  &.show {
-    display: flex;
-  }
+  display: flex;
 }
 
 .Grant {

--- a/src/components/grantBoxes/tests/__snapshots__/GrantsCheckboxes.test.js.snap
+++ b/src/components/grantBoxes/tests/__snapshots__/GrantsCheckboxes.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`GrantsCheckboxes should render 1`] = `
 <Grid
-  className="Grants show"
+  className="Grants"
 >
   <Grid.Column
     key="0"

--- a/src/components/matchbox/Button.js
+++ b/src/components/matchbox/Button.js
@@ -62,11 +62,6 @@ function getVariantProps({ variant, isHibanaEnabled }) {
           color: 'red',
           outlineBorder: true,
         };
-      case 'destructive-secondary':
-        return {
-          color: 'red',
-          outlineBorder: true,
-        };
       // use when connecting a button to a TextField
       case 'connected':
         return {

--- a/src/pages/api-keys/components/ApiKeyForm.js
+++ b/src/pages/api-keys/components/ApiKeyForm.js
@@ -23,7 +23,6 @@ import { required } from 'src/helpers/validation';
 import GrantsCheckboxes from 'src/components/grantBoxes/GrantsCheckboxes';
 
 const formName = 'apiKeyForm';
-const maxWidth = '860px'; //TODO: Remove once Hibana tokens are available
 
 export class ApiKeyForm extends Component {
   get availableGrants() {
@@ -67,7 +66,7 @@ export class ApiKeyForm extends Component {
       <form onSubmit={handleSubmit(this.onSubmit)}>
         <Panel.Section>
           <Stack>
-            <Box maxWidth={maxWidth}>
+            <Box maxWidth="1200">
               <Field
                 name="label"
                 component={TextFieldWrapper}
@@ -76,7 +75,7 @@ export class ApiKeyForm extends Component {
                 disabled={isReadOnly}
               />
             </Box>
-            <Box maxWidth={maxWidth}>
+            <Box maxWidth="1200">
               <Field
                 name="subaccount"
                 helpText={

--- a/src/pages/api-keys/components/ApiKeyForm.js
+++ b/src/pages/api-keys/components/ApiKeyForm.js
@@ -102,19 +102,21 @@ export class ApiKeyForm extends Component {
               show={showGrants}
               disabled={isReadOnly}
             />
-            <Field
-              name="validIps"
-              component={TextFieldWrapper}
-              label="Allowed IPs"
-              helpText={
-                isReadOnly
-                  ? ''
-                  : 'Leaving the field blank will allow access by valid API keys from any IP address.'
-              }
-              placeholder={isReadOnly ? '' : '10.20.30.40, 10.20.30.0/24'}
-              validate={validIpList}
-              disabled={isReadOnly}
-            />
+            <Box maxWidth="1200">
+              <Field
+                name="validIps"
+                component={TextFieldWrapper}
+                label="Allowed IPs"
+                helpText={
+                  isReadOnly
+                    ? ''
+                    : 'Leaving the field blank will allow access by valid API keys from any IP address.'
+                }
+                placeholder={isReadOnly ? '' : '10.20.30.40, 10.20.30.0/24'}
+                validate={validIpList}
+                disabled={isReadOnly}
+              />
+            </Box>
           </Stack>
         </Panel.Section>
         {!isReadOnly && (

--- a/src/pages/api-keys/components/ApiKeyForm.js
+++ b/src/pages/api-keys/components/ApiKeyForm.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { Field, reduxForm, formValueSelector } from 'redux-form';
-import { Button, Panel } from 'src/components/matchbox';
+import { Box, Button, Panel, Stack } from 'src/components/matchbox';
 
 import {
   RadioGroup,
@@ -23,6 +23,7 @@ import { required } from 'src/helpers/validation';
 import GrantsCheckboxes from 'src/components/grantBoxes/GrantsCheckboxes';
 
 const formName = 'apiKeyForm';
+const maxWidth = '860px'; //TODO: Remove once Hibana tokens are available
 
 export class ApiKeyForm extends Component {
   get availableGrants() {
@@ -65,49 +66,61 @@ export class ApiKeyForm extends Component {
     return (
       <form onSubmit={handleSubmit(this.onSubmit)}>
         <Panel.Section>
-          <Field
-            name="label"
-            component={TextFieldWrapper}
-            validate={required}
-            label="API Key Name"
-            disabled={isReadOnly}
-          />
-          <Field
-            name="subaccount"
-            helpText={
-              isReadOnly
-                ? ''
-                : 'This assignment is permanent. Leave blank to assign to master account.'
-            }
-            component={SubaccountTypeaheadWrapper}
-            disabled={!isNew}
-          />
+          <Stack>
+            <Box maxWidth={maxWidth}>
+              <Field
+                name="label"
+                component={TextFieldWrapper}
+                validate={required}
+                label="API Key Name"
+                disabled={isReadOnly}
+              />
+            </Box>
+            <Box maxWidth={maxWidth}>
+              <Field
+                name="subaccount"
+                helpText={
+                  isReadOnly
+                    ? ''
+                    : 'This assignment is permanent. Leave blank to assign to master account.'
+                }
+                component={SubaccountTypeaheadWrapper}
+                disabled={!isNew}
+              />
+            </Box>
+          </Stack>
         </Panel.Section>
         <Panel.Section>
-          <Field
-            name="grantsRadio"
-            component={RadioGroup}
-            label="API Permissions"
-            options={this.getGrantOptions()}
-          />
-          <GrantsCheckboxes grants={this.availableGrants} show={showGrants} disabled={isReadOnly} />
-          <Field
-            name="validIps"
-            component={TextFieldWrapper}
-            label="Allowed IPs"
-            helpText={
-              isReadOnly
-                ? ''
-                : 'Leaving the field blank will allow access by valid API keys from any IP address.'
-            }
-            placeholder={isReadOnly ? '' : '10.20.30.40, 10.20.30.0/24'}
-            validate={validIpList}
-            disabled={isReadOnly}
-          />
+          <Stack>
+            <Field
+              name="grantsRadio"
+              component={RadioGroup}
+              label="API Permissions"
+              options={this.getGrantOptions()}
+            />
+            <GrantsCheckboxes
+              grants={this.availableGrants}
+              show={showGrants}
+              disabled={isReadOnly}
+            />
+            <Field
+              name="validIps"
+              component={TextFieldWrapper}
+              label="Allowed IPs"
+              helpText={
+                isReadOnly
+                  ? ''
+                  : 'Leaving the field blank will allow access by valid API keys from any IP address.'
+              }
+              placeholder={isReadOnly ? '' : '10.20.30.40, 10.20.30.0/24'}
+              validate={validIpList}
+              disabled={isReadOnly}
+            />
+          </Stack>
         </Panel.Section>
         {!isReadOnly && (
           <Panel.Section>
-            <Button submit primary disabled={submitting || pristine}>
+            <Button submit variant="primary" disabled={submitting || pristine}>
               {submitting ? 'Loading...' : submitText}
             </Button>
           </Panel.Section>

--- a/src/pages/api-keys/components/tests/__snapshots__/ApiKeyForm.test.js.snap
+++ b/src/pages/api-keys/components/tests/__snapshots__/ApiKeyForm.test.js.snap
@@ -3,73 +3,85 @@
 exports[`renders correctly - new and no subaccounts 1`] = `
 <form>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      disabled={false}
-      label="API Key Name"
-      name="label"
-      validate={[Function]}
-    />
-    <Field
-      component={[Function]}
-      disabled={false}
-      helpText="This assignment is permanent. Leave blank to assign to master account."
-      name="subaccount"
-    />
+    <Stack>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          label="API Key Name"
+          name="label"
+          validate={[Function]}
+        />
+      </Box>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          helpText="This assignment is permanent. Leave blank to assign to master account."
+          name="subaccount"
+        />
+      </Box>
+    </Stack>
   </Panel.Section>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      label="API Permissions"
-      name="grantsRadio"
-      options={
-        Array [
-          Object {
-            "disabled": false,
-            "label": "All",
-            "value": "all",
-          },
-          Object {
-            "disabled": false,
-            "label": "Select",
-            "value": "select",
-          },
-        ]
-      }
-    />
-    <GrantsCheckboxes
-      disabled={false}
-      grants={
-        Object {
-          "grant1": Object {
-            "key": "value",
-          },
-          "grant2": Object {
-            "key": "value",
-          },
-          "grant3": Object {
-            "key": "value",
-          },
-          "grant4": Object {
-            "key": "value",
-          },
+    <Stack>
+      <Field
+        component={[Function]}
+        label="API Permissions"
+        name="grantsRadio"
+        options={
+          Array [
+            Object {
+              "disabled": false,
+              "label": "All",
+              "value": "all",
+            },
+            Object {
+              "disabled": false,
+              "label": "Select",
+              "value": "select",
+            },
+          ]
         }
-      }
-    />
-    <Field
-      component={[Function]}
-      disabled={false}
-      helpText="Leaving the field blank will allow access by valid API keys from any IP address."
-      label="Allowed IPs"
-      name="validIps"
-      placeholder="10.20.30.40, 10.20.30.0/24"
-      validate={[Function]}
-    />
+      />
+      <GrantsCheckboxes
+        disabled={false}
+        grants={
+          Object {
+            "grant1": Object {
+              "key": "value",
+            },
+            "grant2": Object {
+              "key": "value",
+            },
+            "grant3": Object {
+              "key": "value",
+            },
+            "grant4": Object {
+              "key": "value",
+            },
+          }
+        }
+      />
+      <Field
+        component={[Function]}
+        disabled={false}
+        helpText="Leaving the field blank will allow access by valid API keys from any IP address."
+        label="Allowed IPs"
+        name="validIps"
+        placeholder="10.20.30.40, 10.20.30.0/24"
+        validate={[Function]}
+      />
+    </Stack>
   </Panel.Section>
   <Panel.Section>
     <Button
-      primary={true}
       submit={true}
+      variant="primary"
     >
       Create API Key
     </Button>
@@ -80,68 +92,80 @@ exports[`renders correctly - new and no subaccounts 1`] = `
 exports[`renders correctly - readonly mode 1`] = `
 <form>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      disabled={true}
-      label="API Key Name"
-      name="label"
-      validate={[Function]}
-    />
-    <Field
-      component={[Function]}
-      disabled={false}
-      helpText=""
-      name="subaccount"
-    />
+    <Stack>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          label="API Key Name"
+          name="label"
+          validate={[Function]}
+        />
+      </Box>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          helpText=""
+          name="subaccount"
+        />
+      </Box>
+    </Stack>
   </Panel.Section>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      label="API Permissions"
-      name="grantsRadio"
-      options={
-        Array [
-          Object {
-            "disabled": true,
-            "label": "All",
-            "value": "all",
-          },
-          Object {
-            "disabled": true,
-            "label": "Select",
-            "value": "select",
-          },
-        ]
-      }
-    />
-    <GrantsCheckboxes
-      disabled={true}
-      grants={
-        Object {
-          "grant1": Object {
-            "key": "value",
-          },
-          "grant2": Object {
-            "key": "value",
-          },
-          "grant3": Object {
-            "key": "value",
-          },
-          "grant4": Object {
-            "key": "value",
-          },
+    <Stack>
+      <Field
+        component={[Function]}
+        label="API Permissions"
+        name="grantsRadio"
+        options={
+          Array [
+            Object {
+              "disabled": true,
+              "label": "All",
+              "value": "all",
+            },
+            Object {
+              "disabled": true,
+              "label": "Select",
+              "value": "select",
+            },
+          ]
         }
-      }
-    />
-    <Field
-      component={[Function]}
-      disabled={true}
-      helpText=""
-      label="Allowed IPs"
-      name="validIps"
-      placeholder=""
-      validate={[Function]}
-    />
+      />
+      <GrantsCheckboxes
+        disabled={true}
+        grants={
+          Object {
+            "grant1": Object {
+              "key": "value",
+            },
+            "grant2": Object {
+              "key": "value",
+            },
+            "grant3": Object {
+              "key": "value",
+            },
+            "grant4": Object {
+              "key": "value",
+            },
+          }
+        }
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        helpText=""
+        label="Allowed IPs"
+        name="validIps"
+        placeholder=""
+        validate={[Function]}
+      />
+    </Stack>
   </Panel.Section>
 </form>
 `;
@@ -149,67 +173,79 @@ exports[`renders correctly - readonly mode 1`] = `
 exports[`renders correctly - update and subaccounts 1`] = `
 <form>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      disabled={false}
-      label="API Key Name"
-      name="label"
-      validate={[Function]}
-    />
-    <Field
-      component={[Function]}
-      disabled={true}
-      helpText="This assignment is permanent. Leave blank to assign to master account."
-      name="subaccount"
-    />
+    <Stack>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          label="API Key Name"
+          name="label"
+          validate={[Function]}
+        />
+      </Box>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          helpText="This assignment is permanent. Leave blank to assign to master account."
+          name="subaccount"
+        />
+      </Box>
+    </Stack>
   </Panel.Section>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      label="API Permissions"
-      name="grantsRadio"
-      options={
-        Array [
-          Object {
-            "disabled": false,
-            "label": "All",
-            "value": "all",
-          },
-          Object {
-            "disabled": false,
-            "label": "Select",
-            "value": "select",
-          },
-        ]
-      }
-    />
-    <GrantsCheckboxes
-      disabled={false}
-      grants={
-        Object {
-          "grant1": Object {
-            "key": "value",
-          },
-          "grant2": Object {
-            "key": "value",
-          },
+    <Stack>
+      <Field
+        component={[Function]}
+        label="API Permissions"
+        name="grantsRadio"
+        options={
+          Array [
+            Object {
+              "disabled": false,
+              "label": "All",
+              "value": "all",
+            },
+            Object {
+              "disabled": false,
+              "label": "Select",
+              "value": "select",
+            },
+          ]
         }
-      }
-    />
-    <Field
-      component={[Function]}
-      disabled={false}
-      helpText="Leaving the field blank will allow access by valid API keys from any IP address."
-      label="Allowed IPs"
-      name="validIps"
-      placeholder="10.20.30.40, 10.20.30.0/24"
-      validate={[Function]}
-    />
+      />
+      <GrantsCheckboxes
+        disabled={false}
+        grants={
+          Object {
+            "grant1": Object {
+              "key": "value",
+            },
+            "grant2": Object {
+              "key": "value",
+            },
+          }
+        }
+      />
+      <Field
+        component={[Function]}
+        disabled={false}
+        helpText="Leaving the field blank will allow access by valid API keys from any IP address."
+        label="Allowed IPs"
+        name="validIps"
+        placeholder="10.20.30.40, 10.20.30.0/24"
+        validate={[Function]}
+      />
+    </Stack>
   </Panel.Section>
   <Panel.Section>
     <Button
-      primary={true}
       submit={true}
+      variant="primary"
     >
       Update API Key
     </Button>
@@ -220,74 +256,86 @@ exports[`renders correctly - update and subaccounts 1`] = `
 exports[`submits correctly 1`] = `
 <form>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      disabled={false}
-      label="API Key Name"
-      name="label"
-      validate={[Function]}
-    />
-    <Field
-      component={[Function]}
-      disabled={false}
-      helpText="This assignment is permanent. Leave blank to assign to master account."
-      name="subaccount"
-    />
+    <Stack>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          label="API Key Name"
+          name="label"
+          validate={[Function]}
+        />
+      </Box>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          helpText="This assignment is permanent. Leave blank to assign to master account."
+          name="subaccount"
+        />
+      </Box>
+    </Stack>
   </Panel.Section>
   <Panel.Section>
-    <Field
-      component={[Function]}
-      label="API Permissions"
-      name="grantsRadio"
-      options={
-        Array [
-          Object {
-            "disabled": false,
-            "label": "All",
-            "value": "all",
-          },
-          Object {
-            "disabled": false,
-            "label": "Select",
-            "value": "select",
-          },
-        ]
-      }
-    />
-    <GrantsCheckboxes
-      disabled={false}
-      grants={
-        Object {
-          "grant1": Object {
-            "key": "value",
-          },
-          "grant2": Object {
-            "key": "value",
-          },
-          "grant3": Object {
-            "key": "value",
-          },
-          "grant4": Object {
-            "key": "value",
-          },
+    <Stack>
+      <Field
+        component={[Function]}
+        label="API Permissions"
+        name="grantsRadio"
+        options={
+          Array [
+            Object {
+              "disabled": false,
+              "label": "All",
+              "value": "all",
+            },
+            Object {
+              "disabled": false,
+              "label": "Select",
+              "value": "select",
+            },
+          ]
         }
-      }
-    />
-    <Field
-      component={[Function]}
-      disabled={false}
-      helpText="Leaving the field blank will allow access by valid API keys from any IP address."
-      label="Allowed IPs"
-      name="validIps"
-      placeholder="10.20.30.40, 10.20.30.0/24"
-      validate={[Function]}
-    />
+      />
+      <GrantsCheckboxes
+        disabled={false}
+        grants={
+          Object {
+            "grant1": Object {
+              "key": "value",
+            },
+            "grant2": Object {
+              "key": "value",
+            },
+            "grant3": Object {
+              "key": "value",
+            },
+            "grant4": Object {
+              "key": "value",
+            },
+          }
+        }
+      />
+      <Field
+        component={[Function]}
+        disabled={false}
+        helpText="Leaving the field blank will allow access by valid API keys from any IP address."
+        label="Allowed IPs"
+        name="validIps"
+        placeholder="10.20.30.40, 10.20.30.0/24"
+        validate={[Function]}
+      />
+    </Stack>
   </Panel.Section>
   <Panel.Section>
     <Button
       disabled={true}
-      primary={true}
       submit={true}
+      variant="primary"
     >
       Loading...
     </Button>

--- a/src/pages/api-keys/components/tests/__snapshots__/ApiKeyForm.test.js.snap
+++ b/src/pages/api-keys/components/tests/__snapshots__/ApiKeyForm.test.js.snap
@@ -67,15 +67,19 @@ exports[`renders correctly - new and no subaccounts 1`] = `
           }
         }
       />
-      <Field
-        component={[Function]}
-        disabled={false}
-        helpText="Leaving the field blank will allow access by valid API keys from any IP address."
-        label="Allowed IPs"
-        name="validIps"
-        placeholder="10.20.30.40, 10.20.30.0/24"
-        validate={[Function]}
-      />
+      <Box
+        maxWidth="1200"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          helpText="Leaving the field blank will allow access by valid API keys from any IP address."
+          label="Allowed IPs"
+          name="validIps"
+          placeholder="10.20.30.40, 10.20.30.0/24"
+          validate={[Function]}
+        />
+      </Box>
     </Stack>
   </Panel.Section>
   <Panel.Section>
@@ -156,15 +160,19 @@ exports[`renders correctly - readonly mode 1`] = `
           }
         }
       />
-      <Field
-        component={[Function]}
-        disabled={true}
-        helpText=""
-        label="Allowed IPs"
-        name="validIps"
-        placeholder=""
-        validate={[Function]}
-      />
+      <Box
+        maxWidth="1200"
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          helpText=""
+          label="Allowed IPs"
+          name="validIps"
+          placeholder=""
+          validate={[Function]}
+        />
+      </Box>
     </Stack>
   </Panel.Section>
 </form>
@@ -231,15 +239,19 @@ exports[`renders correctly - update and subaccounts 1`] = `
           }
         }
       />
-      <Field
-        component={[Function]}
-        disabled={false}
-        helpText="Leaving the field blank will allow access by valid API keys from any IP address."
-        label="Allowed IPs"
-        name="validIps"
-        placeholder="10.20.30.40, 10.20.30.0/24"
-        validate={[Function]}
-      />
+      <Box
+        maxWidth="1200"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          helpText="Leaving the field blank will allow access by valid API keys from any IP address."
+          label="Allowed IPs"
+          name="validIps"
+          placeholder="10.20.30.40, 10.20.30.0/24"
+          validate={[Function]}
+        />
+      </Box>
     </Stack>
   </Panel.Section>
   <Panel.Section>
@@ -320,15 +332,19 @@ exports[`submits correctly 1`] = `
           }
         }
       />
-      <Field
-        component={[Function]}
-        disabled={false}
-        helpText="Leaving the field blank will allow access by valid API keys from any IP address."
-        label="Allowed IPs"
-        name="validIps"
-        placeholder="10.20.30.40, 10.20.30.0/24"
-        validate={[Function]}
-      />
+      <Box
+        maxWidth="1200"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          helpText="Leaving the field blank will allow access by valid API keys from any IP address."
+          label="Allowed IPs"
+          name="validIps"
+          placeholder="10.20.30.40, 10.20.30.0/24"
+          validate={[Function]}
+        />
+      </Box>
     </Stack>
   </Panel.Section>
   <Panel.Section>

--- a/src/pages/api-keys/components/tests/__snapshots__/ApiKeyForm.test.js.snap
+++ b/src/pages/api-keys/components/tests/__snapshots__/ApiKeyForm.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders correctly - new and no subaccounts 1`] = `
   <Panel.Section>
     <Stack>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}
@@ -16,7 +16,7 @@ exports[`renders correctly - new and no subaccounts 1`] = `
         />
       </Box>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}
@@ -94,7 +94,7 @@ exports[`renders correctly - readonly mode 1`] = `
   <Panel.Section>
     <Stack>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}
@@ -105,7 +105,7 @@ exports[`renders correctly - readonly mode 1`] = `
         />
       </Box>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}
@@ -175,7 +175,7 @@ exports[`renders correctly - update and subaccounts 1`] = `
   <Panel.Section>
     <Stack>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}
@@ -186,7 +186,7 @@ exports[`renders correctly - update and subaccounts 1`] = `
         />
       </Box>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}
@@ -258,7 +258,7 @@ exports[`submits correctly 1`] = `
   <Panel.Section>
     <Stack>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}
@@ -269,7 +269,7 @@ exports[`submits correctly 1`] = `
         />
       </Box>
       <Box
-        maxWidth="860px"
+        maxWidth="1200"
       >
         <Field
           component={[Function]}

--- a/src/pages/trackingDomains/components/CreateForm.js
+++ b/src/pages/trackingDomains/components/CreateForm.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import { reduxForm, Field } from 'redux-form';
-import { Button, Panel } from 'src/components/matchbox';
-import { TextFieldWrapper } from 'src/components';
+import { Box, Button, Panel, Stack } from 'src/components/matchbox';
+import { ButtonWrapper, TextFieldWrapper } from 'src/components';
 import { required, domain } from 'src/helpers/validation';
 import { SubaccountTypeaheadWrapper } from 'src/components/reduxFormWrappers';
 
+const maxWidth = '860px'; //TODO: Remove max width on adding Hibana tokens
 export class CreateForm extends Component {
   render() {
     const { submitting, handleSubmit } = this.props;
@@ -12,24 +13,30 @@ export class CreateForm extends Component {
     return (
       <Panel sectioned>
         <form onSubmit={handleSubmit}>
-          <Panel.Section>
-            <Field
-              component={TextFieldWrapper}
-              label="Domain Name"
-              name="domain"
-              validate={[required, domain]}
-              disabled={submitting}
-            />
-            <Field
-              component={SubaccountTypeaheadWrapper}
-              name="subaccount"
-              helpText="Leaving this field blank will permanently assign the tracking domain to the master account."
-              disabled={submitting}
-            />
-            <Button submit primary={true} disabled={submitting}>
+          <Stack>
+            <Box maxWidth={maxWidth}>
+              <Field
+                component={TextFieldWrapper}
+                label="Domain Name"
+                name="domain"
+                validate={[required, domain]}
+                disabled={submitting}
+              />
+            </Box>
+            <Box maxWidth={maxWidth}>
+              <Field
+                component={SubaccountTypeaheadWrapper}
+                name="subaccount"
+                helpText="Leaving this field blank will permanently assign the tracking domain to the master account."
+                disabled={submitting}
+              />
+            </Box>
+          </Stack>
+          <ButtonWrapper>
+            <Button submit variant="primary" disabled={submitting}>
               {submitting ? 'Submitting...' : 'Add Tracking Domain'}
             </Button>
-          </Panel.Section>
+          </ButtonWrapper>
         </form>
       </Panel>
     );

--- a/src/pages/trackingDomains/components/TrackingDomainRow.js
+++ b/src/pages/trackingDomains/components/TrackingDomainRow.js
@@ -1,7 +1,6 @@
 /* eslint max-lines: ["error", 200] */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Refresh } from '@sparkpost/matchbox-icons';
 import {
   listTrackingDomains,
   updateTrackingDomain,
@@ -9,7 +8,7 @@ import {
   verifyTrackingDomain,
 } from 'src/actions/trackingDomains';
 import { Subaccount } from 'src/components';
-import { Grid, Button, Panel, Tag } from 'src/components/matchbox';
+import { Button, Grid, Inline, Panel, Tag } from 'src/components/matchbox';
 import { DeleteModal, ConfirmationModal } from 'src/components/modals';
 import { DomainStatusTag } from 'src/components/tags';
 import styles from './TrackingDomainRow.module.scss';
@@ -83,7 +82,7 @@ export class TrackingDomainRow extends Component {
     const verifyText = verifying.indexOf(domain) >= 0 ? 'Verifying...' : 'Retry Verification';
     return (
       <Button size="small" onClick={this.retryVerification}>
-        <Refresh /> {verifyText}
+        {verifyText}
       </Button>
     );
   }
@@ -138,7 +137,7 @@ export class TrackingDomainRow extends Component {
     return (
       <Panel.Section>
         <Grid>
-          <Grid.Column xs={12} md={9}>
+          <Grid.Column xs={12} md={8}>
             <span className={styles.DomainHeading}>{domain}</span>
             <div className={styles.TagRow}>
               {status !== 'verified' && <DomainStatusTag className={styles.Tag} status={status} />}
@@ -152,14 +151,16 @@ export class TrackingDomainRow extends Component {
               )}
             </div>
           </Grid.Column>
-          <Grid.Column xs={12} md={3}>
+          <Grid.Column xs={12} md={4}>
             <Button.Group className={styles.ButtonColumn}>
-              {this.renderDefaultOrVerifyButton()}
-              {status !== 'pending' && status !== 'blocked' && (
-                <Button destructive size="small" onClick={this.toggleDeleteModal}>
-                  Delete
-                </Button>
-              )}
+              <Inline>
+                {this.renderDefaultOrVerifyButton()}
+                {status !== 'pending' && status !== 'blocked' && (
+                  <Button destructive size="small" onClick={this.toggleDeleteModal}>
+                    Delete
+                  </Button>
+                )}
+              </Inline>
             </Button.Group>
           </Grid.Column>
         </Grid>

--- a/src/pages/trackingDomains/components/TrackingDomainRow.js
+++ b/src/pages/trackingDomains/components/TrackingDomainRow.js
@@ -8,7 +8,7 @@ import {
   verifyTrackingDomain,
 } from 'src/actions/trackingDomains';
 import { Subaccount } from 'src/components';
-import { Button, Grid, Inline, Panel, Tag } from 'src/components/matchbox';
+import { Button, Grid, Panel, Tag } from 'src/components/matchbox';
 import { DeleteModal, ConfirmationModal } from 'src/components/modals';
 import { DomainStatusTag } from 'src/components/tags';
 import styles from './TrackingDomainRow.module.scss';
@@ -153,14 +153,12 @@ export class TrackingDomainRow extends Component {
           </Grid.Column>
           <Grid.Column xs={12} md={4}>
             <Button.Group className={styles.ButtonColumn}>
-              <Inline>
-                {this.renderDefaultOrVerifyButton()}
-                {status !== 'pending' && status !== 'blocked' && (
-                  <Button destructive size="small" onClick={this.toggleDeleteModal}>
-                    Delete
-                  </Button>
-                )}
-              </Inline>
+              {this.renderDefaultOrVerifyButton()}
+              {status !== 'pending' && status !== 'blocked' && (
+                <Button destructive size="small" onClick={this.toggleDeleteModal}>
+                  Delete
+                </Button>
+              )}
             </Button.Group>
           </Grid.Column>
         </Grid>

--- a/src/pages/trackingDomains/components/UnverifiedBanner.js
+++ b/src/pages/trackingDomains/components/UnverifiedBanner.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Banner, Button } from 'src/components/matchbox';
+import { Banner, Button, Stack } from 'src/components/matchbox';
+import { ButtonWrapper } from 'src/components';
 import { LINKS } from 'src/constants';
 
 const UnverifiedBanner = ({ unverifiedDomains, cname }) => {
@@ -16,13 +17,17 @@ const UnverifiedBanner = ({ unverifiedDomains, cname }) => {
 
   return (
     <Banner status="warning" title={title} my="300">
-      <p>
-        To verify a tracking domain, edit its DNS settings to <strong>add a CNAME record</strong>{' '}
-        with the value of <strong>{cname}</strong>.
-      </p>
-      <Button outline external to={LINKS.DOMAIN_VERIFICATION}>
-        Learn more
-      </Button>
+      <Stack>
+        <p>
+          To verify a tracking domain, edit its DNS settings to <strong>add a CNAME record</strong>{' '}
+          with the value of <strong>{cname}</strong>.
+        </p>
+        <ButtonWrapper>
+          <Button outline external to={LINKS.DOMAIN_VERIFICATION}>
+            Learn more
+          </Button>
+        </ButtonWrapper>
+      </Stack>
     </Banner>
   );
 };

--- a/src/pages/trackingDomains/components/tests/__snapshots__/CreateForm.test.js.snap
+++ b/src/pages/trackingDomains/components/tests/__snapshots__/CreateForm.test.js.snap
@@ -7,33 +7,43 @@ exports[`Component: Tracking Domains Create Form should render correctly when su
   <form
     onSubmit={[MockFunction]}
   >
-    <Panel.Section>
-      <Field
-        component={[Function]}
-        disabled={false}
-        label="Domain Name"
-        name="domain"
-        validate={
-          Array [
-            [Function],
-            [Function],
-          ]
-        }
-      />
-      <Field
-        component={[Function]}
-        disabled={false}
-        helpText="Leaving this field blank will permanently assign the tracking domain to the master account."
-        name="subaccount"
-      />
+    <Stack>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          label="Domain Name"
+          name="domain"
+          validate={
+            Array [
+              [Function],
+              [Function],
+            ]
+          }
+        />
+      </Box>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          helpText="Leaving this field blank will permanently assign the tracking domain to the master account."
+          name="subaccount"
+        />
+      </Box>
+    </Stack>
+    <ButtonWrapper>
       <Button
         disabled={false}
-        primary={true}
         submit={true}
+        variant="primary"
       >
         Add Tracking Domain
       </Button>
-    </Panel.Section>
+    </ButtonWrapper>
   </form>
 </Panel>
 `;
@@ -45,33 +55,43 @@ exports[`Component: Tracking Domains Create Form should render correctly when su
   <form
     onSubmit={[MockFunction]}
   >
-    <Panel.Section>
-      <Field
-        component={[Function]}
-        disabled={true}
-        label="Domain Name"
-        name="domain"
-        validate={
-          Array [
-            [Function],
-            [Function],
-          ]
-        }
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        helpText="Leaving this field blank will permanently assign the tracking domain to the master account."
-        name="subaccount"
-      />
+    <Stack>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          label="Domain Name"
+          name="domain"
+          validate={
+            Array [
+              [Function],
+              [Function],
+            ]
+          }
+        />
+      </Box>
+      <Box
+        maxWidth="860px"
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          helpText="Leaving this field blank will permanently assign the tracking domain to the master account."
+          name="subaccount"
+        />
+      </Box>
+    </Stack>
+    <ButtonWrapper>
       <Button
         disabled={true}
-        primary={true}
         submit={true}
+        variant="primary"
       >
         Submitting...
       </Button>
-    </Panel.Section>
+    </ButtonWrapper>
   </form>
 </Panel>
 `;

--- a/src/pages/trackingDomains/components/tests/__snapshots__/TrackingDomainRow.test.js.snap
+++ b/src/pages/trackingDomains/components/tests/__snapshots__/TrackingDomainRow.test.js.snap
@@ -37,21 +37,19 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Verifying...
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Verifying...
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -113,14 +111,12 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -183,21 +179,19 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -262,22 +256,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Remove Default
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Remove Default
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -345,21 +337,19 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -416,22 +406,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            destructive={false}
-            onClick={[Function]}
-            size="small"
-          >
-            Set as Default
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          destructive={false}
+          onClick={[Function]}
+          size="small"
+        >
+          Set as Default
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -493,14 +481,12 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -570,21 +556,19 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Verifying...
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Verifying...
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -654,14 +638,12 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -731,21 +713,19 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -817,22 +797,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Remove Default
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Remove Default
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -908,21 +886,19 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -988,22 +964,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            destructive={false}
-            onClick={[Function]}
-            size="small"
-          >
-            Set as Default
-          </Button>
-          <Button
-            destructive={true}
-            onClick={[Function]}
-            size="small"
-          >
-            Delete
-          </Button>
-        </Inline>
+        <Button
+          destructive={false}
+          onClick={[Function]}
+          size="small"
+        >
+          Set as Default
+        </Button>
+        <Button
+          destructive={true}
+          onClick={[Function]}
+          size="small"
+        >
+          Delete
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -1073,14 +1047,12 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       <Button.Group
         className="ButtonColumn"
       >
-        <Inline>
-          <Button
-            onClick={[Function]}
-            size="small"
-          >
-            Retry Verification
-          </Button>
-        </Inline>
+        <Button
+          onClick={[Function]}
+          size="small"
+        >
+          Retry Verification
+        </Button>
       </Button.Group>
     </Grid.Column>
   </Grid>

--- a/src/pages/trackingDomains/components/tests/__snapshots__/TrackingDomainRow.test.js.snap
+++ b/src/pages/trackingDomains/components/tests/__snapshots__/TrackingDomainRow.test.js.snap
@@ -13,7 +13,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -31,27 +31,27 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Verifying...
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Verifying...
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -89,7 +89,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -107,20 +107,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -158,7 +158,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -177,27 +177,27 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -241,7 +241,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -256,26 +256,28 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Remove Default
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Remove Default
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -319,7 +321,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -337,27 +339,27 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -395,7 +397,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -408,26 +410,28 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       />
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          destructive={false}
-          onClick={[Function]}
-          size="small"
-        >
-          Set as Default
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            destructive={false}
+            onClick={[Function]}
+            size="small"
+          >
+            Set as Default
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -465,7 +469,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -483,20 +487,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to master account 
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -534,7 +538,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -560,27 +564,27 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Verifying...
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Verifying...
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -618,7 +622,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -644,20 +648,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -695,7 +699,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -721,27 +725,27 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -785,7 +789,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -807,26 +811,28 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Remove Default
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Remove Default
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -870,7 +876,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -896,27 +902,27 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -954,7 +960,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -976,26 +982,28 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          destructive={false}
-          onClick={[Function]}
-          size="small"
-        >
-          Set as Default
-        </Button>
-        <Button
-          destructive={true}
-          onClick={[Function]}
-          size="small"
-        >
-          Delete
-        </Button>
+        <Inline>
+          <Button
+            destructive={false}
+            onClick={[Function]}
+            size="small"
+          >
+            Set as Default
+          </Button>
+          <Button
+            destructive={true}
+            onClick={[Function]}
+            size="small"
+          >
+            Delete
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>
@@ -1033,7 +1041,7 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
 <Panel.Section>
   <Grid>
     <Grid.Column
-      md={9}
+      md={8}
       xs={12}
     >
       <span
@@ -1059,20 +1067,20 @@ exports[`Component: TrackingDomainRow rendering when assigned to subaccount shou
       </div>
     </Grid.Column>
     <Grid.Column
-      md={3}
+      md={4}
       xs={12}
     >
       <Button.Group
         className="ButtonColumn"
       >
-        <Button
-          onClick={[Function]}
-          size="small"
-        >
-          <Refresh />
-           
-          Retry Verification
-        </Button>
+        <Inline>
+          <Button
+            onClick={[Function]}
+            size="small"
+          >
+            Retry Verification
+          </Button>
+        </Inline>
       </Button.Group>
     </Grid.Column>
   </Grid>

--- a/src/pages/trackingDomains/components/tests/__snapshots__/UnverifiedBanner.test.js.snap
+++ b/src/pages/trackingDomains/components/tests/__snapshots__/UnverifiedBanner.test.js.snap
@@ -6,25 +6,29 @@ exports[`Component: UnverifiedBanner should render correctly with 1 unverified d
   status="warning"
   title="You have an unverified tracking domain"
 >
-  <p>
-    To verify a tracking domain, edit its DNS settings to 
-    <strong>
-      add a CNAME record
-    </strong>
-     
-    with the value of 
-    <strong>
-      spgo.io
-    </strong>
-    .
-  </p>
-  <Button
-    external={true}
-    outline={true}
-    to="https://www.sparkpost.com/docs/tech-resources/enabling-multiple-custom-tracking-domains"
-  >
-    Learn more
-  </Button>
+  <Stack>
+    <p>
+      To verify a tracking domain, edit its DNS settings to 
+      <strong>
+        add a CNAME record
+      </strong>
+       
+      with the value of 
+      <strong>
+        spgo.io
+      </strong>
+      .
+    </p>
+    <ButtonWrapper>
+      <Button
+        external={true}
+        outline={true}
+        to="https://www.sparkpost.com/docs/tech-resources/enabling-multiple-custom-tracking-domains"
+      >
+        Learn more
+      </Button>
+    </ButtonWrapper>
+  </Stack>
 </Banner>
 `;
 
@@ -34,25 +38,29 @@ exports[`Component: UnverifiedBanner should render correctly with more than 1 un
   status="warning"
   title="You have 2 unverified tracking domains"
 >
-  <p>
-    To verify a tracking domain, edit its DNS settings to 
-    <strong>
-      add a CNAME record
-    </strong>
-     
-    with the value of 
-    <strong>
-      spgo.io
-    </strong>
-    .
-  </p>
-  <Button
-    external={true}
-    outline={true}
-    to="https://www.sparkpost.com/docs/tech-resources/enabling-multiple-custom-tracking-domains"
-  >
-    Learn more
-  </Button>
+  <Stack>
+    <p>
+      To verify a tracking domain, edit its DNS settings to 
+      <strong>
+        add a CNAME record
+      </strong>
+       
+      with the value of 
+      <strong>
+        spgo.io
+      </strong>
+      .
+    </p>
+    <ButtonWrapper>
+      <Button
+        external={true}
+        outline={true}
+        to="https://www.sparkpost.com/docs/tech-resources/enabling-multiple-custom-tracking-domains"
+      >
+        Learn more
+      </Button>
+    </ButtonWrapper>
+  </Stack>
 </Banner>
 `;
 


### PR DESCRIPTION
### What Changed
 - Tracking domains pages (List, create)
- API keys pages (LIst, create/edit, view)

### How To Test
- Navigate to all these routes:
   - /account/api-keys
   - /account/api-keys/create
   - /account/api-keys/edit/:id
   - /account/api-keys/view/:id
   - /account/tracking-domains
   - /account/tracking-domains/create
 - Check that all the pages visually look correct
