### PR TITLE
[FE-968-2] Fix for Banner pending plan change

### DIFF
--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -36,13 +36,13 @@ export const PendingPlanBanner = ({ account, subscription }) => {
 
   return (
     <Banner status="warning" title="Pending Plan Change" my="300">
-      <p>
-        <Box maxWidth={tokens.sizing_1200}>
+      <Box maxWidth={tokens.sizing_1200}>
+        <p>
           You're scheduled to switch to the {account.pending_subscription.name} plan on{' '}
           {dateFormat(account.pending_subscription.effective_date)}, and can't update your plan
           until that switch happens.
-        </Box>
-      </p>
+        </p>
+      </Box>
     </Banner>
   );
 };

--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -8,6 +8,7 @@ import * as conversions from 'src/helpers/conversionTracking';
 import { Abbreviation } from 'src/components';
 import { ANALYTICS_PREMIUM_SUPPORT, ANALYTICS_ENTERPRISE_SUPPORT } from 'src/constants';
 import _ from 'lodash';
+import { tokens } from '@sparkpost/design-tokens-hibana';
 const dateFormat = date => format(date, 'MMM DD, YYYY');
 
 /**
@@ -23,12 +24,12 @@ export const PendingPlanBanner = ({ account, subscription }) => {
   if (pendingDowngrades.length > 0) {
     return (
       <Banner status="warning" title="Pending Plan Change" my="300">
-        <p>
-          <Box maxWidth={600}>
+        <Box maxWidth={tokens.sizing_1200}>
+          <p>
             You're scheduled for a pending downgrade and can't update your plan until that switch
             happens.
-          </Box>
-        </p>
+          </p>
+        </Box>
       </Banner>
     );
   }
@@ -36,7 +37,7 @@ export const PendingPlanBanner = ({ account, subscription }) => {
   return (
     <Banner status="warning" title="Pending Plan Change" my="300">
       <p>
-        <Box maxWidth={600}>
+        <Box maxWidth={tokens.sizing_1200}>
           You're scheduled to switch to the {account.pending_subscription.name} plan on{' '}
           {dateFormat(account.pending_subscription.effective_date)}, and can't update your plan
           until that switch happens.

--- a/src/pages/billing/components/Banners.js
+++ b/src/pages/billing/components/Banners.js
@@ -8,7 +8,6 @@ import * as conversions from 'src/helpers/conversionTracking';
 import { Abbreviation } from 'src/components';
 import { ANALYTICS_PREMIUM_SUPPORT, ANALYTICS_ENTERPRISE_SUPPORT } from 'src/constants';
 import _ from 'lodash';
-import { tokens } from '@sparkpost/design-tokens-hibana';
 const dateFormat = date => format(date, 'MMM DD, YYYY');
 
 /**
@@ -24,7 +23,7 @@ export const PendingPlanBanner = ({ account, subscription }) => {
   if (pendingDowngrades.length > 0) {
     return (
       <Banner status="warning" title="Pending Plan Change" my="300">
-        <Box maxWidth={tokens.sizing_1200}>
+        <Box maxWidth="1200">
           <p>
             You're scheduled for a pending downgrade and can't update your plan until that switch
             happens.
@@ -36,7 +35,7 @@ export const PendingPlanBanner = ({ account, subscription }) => {
 
   return (
     <Banner status="warning" title="Pending Plan Change" my="300">
-      <Box maxWidth={tokens.sizing_1200}>
+      <Box maxWidth="1200">
         <p>
           You're scheduled to switch to the {account.pending_subscription.name} plan on{' '}
           {dateFormat(account.pending_subscription.effective_date)}, and can't update your plan

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -102,17 +102,17 @@ exports[`Billing Banners:  PendingPlanBanner should render with pending_subscrip
   status="warning"
   title="Pending Plan Change"
 >
-  <p>
-    <Box
-      maxWidth="45rem"
-    >
+  <Box
+    maxWidth="45rem"
+  >
+    <p>
       You're scheduled to switch to the 
        plan on
        
       Oct 05, 2020
       , and can't update your plan until that switch happens.
-    </Box>
-  </p>
+    </p>
+  </Box>
 </Banner>
 `;
 

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -104,7 +104,7 @@ exports[`Billing Banners:  PendingPlanBanner should render with pending_subscrip
 >
   <p>
     <Box
-      maxWidth={600}
+      maxWidth="45rem"
     >
       You're scheduled to switch to the 
        plan on

--- a/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/Banners.test.js.snap
@@ -103,7 +103,7 @@ exports[`Billing Banners:  PendingPlanBanner should render with pending_subscrip
   title="Pending Plan Change"
 >
   <Box
-    maxWidth="45rem"
+    maxWidth="1200"
   >
     <p>
       You're scheduled to switch to the 


### PR DESCRIPTION
[FE-968-2] Fix for Banner pending plan change

### What Changed
 - Fixed the maxWidth value for pending plan change banner

### How To Test
 - Check the Pending Plan Banner on billing page(after Downgrading plan)

### To Do
- [ ] Address feedback
