### PR TITLE
AC-1446 - Show the Subaccounts Section while changing plans

### DIFF
--- a/cypress/fixtures/billing/bundles/200.get.json
+++ b/cypress/fixtures/billing/bundles/200.get.json
@@ -7,7 +7,7 @@
       "products": [
         {
           "product": "subaccounts",
-          "plan": "subaccounts-free"
+          "plan": "subaccounts-unlimited"
         },
         {
           "product": "sso",
@@ -37,6 +37,10 @@
           "plan": "online-support"
         },
         {
+          "product": "subaccounts",
+          "plan": "subaccounts-starter"
+        },
+        {
           "product": "messaging",
           "plan": "50K-starter-0519"
         }
@@ -54,6 +58,10 @@
         {
           "product": "messaging",
           "plan": "100K-starter-0519"
+        },
+        {
+          "product": "subaccounts",
+          "plan": "subaccounts-starter"
         }
       ]
     },

--- a/cypress/fixtures/billing/plans/200.get.json
+++ b/cypress/fixtures/billing/plans/200.get.json
@@ -3,7 +3,8 @@
     {
       "plan": "subaccounts-unlimited",
       "product": "subaccounts",
-      "price": 0
+      "price": 0,
+      "limit": 5000
     },
     {
       "billing_id": "2c92c0f9488dbcd001488f4835d52bc4",
@@ -21,12 +22,14 @@
     {
       "plan": "subaccounts-premier",
       "product": "subaccounts",
-      "price": 0
+      "price": 0,
+      "limit": 15
     },
     {
-      "plan": "subaccounts-free",
+      "plan": "subaccounts-starter",
       "product": "subaccounts",
-      "price": 0
+      "price": 0, 
+      "limit": 0
     },
     {
       "plan": "sso",

--- a/cypress/fixtures/billing/subscription/200.get.starter-plan-higher-subaccounts-limitoverride.json
+++ b/cypress/fixtures/billing/subscription/200.get.starter-plan-higher-subaccounts-limitoverride.json
@@ -1,0 +1,30 @@
+{
+  "results": {
+  "bill_cycle_day": 14,
+  "pending_downgrades": [],
+  "products": [
+    {
+      "plan": "50K-starter-0519",
+      "product": "messaging",
+      "price": 20,
+      "overage": 0.001,
+      "volume": 50000,
+      "billing_period": "month"
+    },
+    {
+      "plan": "subaccounts-starter",
+      "product": "subaccounts",
+      "quantity": 19,
+      "price": 0,
+      "limit": 0,
+      "limit_override": 20
+    },
+    {
+      "plan": "online-support",
+      "product": "online_support",
+      "price": 0
+    }
+  ],
+  "type": "active"
+}
+}

--- a/cypress/fixtures/billing/subscription/200.get.test-plan-with-subaccounts.json
+++ b/cypress/fixtures/billing/subscription/200.get.test-plan-with-subaccounts.json
@@ -10,7 +10,7 @@
       {
         "plan": "subaccounts-free",
         "product": "subaccounts",
-        "quantity": 20,
+        "quantity": 14,
         "limit": 5000
       },
       {

--- a/cypress/fixtures/billing/subscription/200.get.test-plan-with-subaccounts.json
+++ b/cypress/fixtures/billing/subscription/200.get.test-plan-with-subaccounts.json
@@ -10,7 +10,7 @@
       {
         "plan": "subaccounts-free",
         "product": "subaccounts",
-        "quantity": 0,
+        "quantity": 20,
         "limit": 5000
       },
       {

--- a/cypress/fixtures/billing/subscription/bundle/200.put.json
+++ b/cypress/fixtures/billing/subscription/bundle/200.put.json
@@ -1,0 +1,4 @@
+{ "results": {
+  "message": "Subscribed to 100K-premier-0519 bundle"
+}
+}

--- a/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
@@ -218,6 +218,7 @@ describe('Change Billing Plan Page', () => {
     cy.findByText('Update Status')
       .should('have.prop', 'href')
       .and('include', 'account/subaccounts');
+    cy.findByText('Change Plan').should('be.disabled');
   });
   it('Upgrades free account to starter 50K with query parameter', () => {
     cy.stubRequest({
@@ -436,7 +437,7 @@ describe('Change Billing Plan Page', () => {
     cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
   });
 
-  it("Upgrades free account to premier 1M with previous active subaccounts, current quatity of subaccounts doesn't exceed new limit", () => {
+  it("Upgrades free account to premier 1M with previous active subaccounts, current quantity of subaccounts doesn't exceed new limit", () => {
     // user is on the test plan
     cy.stubRequest({
       url: '/api/v1/account',

--- a/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
@@ -189,7 +189,7 @@ describe('Change Billing Plan Page', () => {
     cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
   });
 
-  it('Upgrades free account to starter 100K with previous active subaccounts', () => {
+  it('Upgrades free account to starter 100K with previous active subaccounts, current quantity of subaccounts exceeds new limit', () => {
     // user is on the test plan
     cy.stubRequest({
       url: '/api/v1/account',
@@ -218,32 +218,6 @@ describe('Change Billing Plan Page', () => {
     cy.findByText('Update Status')
       .should('have.prop', 'href')
       .and('include', 'account/subaccounts');
-    //calls to update the subscription with 0 active subaccounts
-    cy.stubRequest({
-      url: '/api/v1/billing/subscription',
-      fixture: 'billing/subscription/200.get.test-plan.json',
-    });
-    //confirms that active subaccounts now is less than limit
-    cy.findByText('Update Status').should('not.be.visible');
-
-    fillOutCreditCardForm();
-
-    mockCommonHttpCalls();
-
-    // Then server returns the new plan info that was saved...
-    cy.stubRequest({
-      url: '/api/v1/account',
-      fixture: 'account/200.get.100k-starter-plan.json',
-    });
-
-    cy.findByText('Change Plan').click();
-    cy.withinSnackbar(() => {
-      cy.findByText('Subscription Updated').should('be.visible');
-    });
-    cy.findByText('Plan Overview').should('be.visible');
-    cy.findByText('Your Plan').should('be.visible');
-    cy.findByText('100,000 emails for $30 per month').should('be.visible');
-    cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
   });
   it('Upgrades free account to starter 50K with query parameter', () => {
     cy.stubRequest({
@@ -462,7 +436,7 @@ describe('Change Billing Plan Page', () => {
     cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
   });
 
-  it('Upgrades free account to premier 1M with previous active subaccounts', () => {
+  it("Upgrades free account to premier 1M with previous active subaccounts, current quatity of subaccounts doesn't exceed new limit", () => {
     // user is on the test plan
     cy.stubRequest({
       url: '/api/v1/account',
@@ -483,21 +457,6 @@ describe('Change Billing Plan Page', () => {
     cy.get('[data-id=select-plan-1M-premier-0519]').click();
 
     cy.findByText('Your new plan only allows for 15 active subaccounts.').should('be.visible');
-    cy.findByText('Update Status').should('be.visible');
-    cy.findByText('Update Status')
-      .should('have.prop', 'href')
-      .and('include', 'account/subaccounts');
-    //calls to update the subscription with 0 active subaccounts
-    cy.stubRequest({
-      url: '/api/v1/billing/subscription',
-      fixture: 'billing/subscription/200.get.test-plan.json',
-    });
-    //confirms that active subaccounts now is less than limit
-    cy.findByText('Update Status').should('not.be.visible');
-
-    fillOutCreditCardForm();
-
-    mockCommonHttpCalls();
 
     fillOutCreditCardForm();
     mockCommonHttpCalls();

--- a/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
@@ -189,6 +189,62 @@ describe('Change Billing Plan Page', () => {
     cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
   });
 
+  it('Upgrades free account to starter 100K with previous active subaccounts', () => {
+    // user is on the test plan
+    cy.stubRequest({
+      url: '/api/v1/account',
+      fixture: 'account/200.get.test-plan.json',
+    });
+    cy.stubRequest({
+      url: '/api/v1/billing',
+      fixture: 'billing/200.get.has-no-credit-card.json',
+      fixtureAlias: 'billingGet',
+    });
+    cy.stubRequest({
+      url: '/api/v1/billing/subscription',
+      fixture: 'billing/subscription/200.get.test-plan-with-subaccounts.json',
+    });
+
+    cy.visit('/account/billing/plan');
+
+    cy.findAllByText('100,000').should('be.visible');
+    cy.findAllByText('emails/month').should('be.visible');
+    cy.findAllByText('$20').should('be.visible');
+
+    cy.get('[data-id=select-plan-100K-starter-0519]').click();
+
+    cy.findByText("Your new plan doesn't include subaccounts.").should('be.visible');
+    cy.findByText('Update Status').should('be.visible');
+    cy.findByText('Update Status')
+      .should('have.prop', 'href')
+      .and('include', 'account/subaccounts');
+    //calls to update the subscription with 0 active subaccounts
+    cy.stubRequest({
+      url: '/api/v1/billing/subscription',
+      fixture: 'billing/subscription/200.get.test-plan.json',
+    });
+    //confirms that active subaccounts now is less than limit
+    cy.findByText('Update Status').should('not.be.visible');
+
+    fillOutCreditCardForm();
+
+    mockCommonHttpCalls();
+
+    // Then server returns the new plan info that was saved...
+    cy.stubRequest({
+      url: '/api/v1/account',
+      fixture: 'account/200.get.100k-starter-plan.json',
+    });
+
+    cy.findByText('Change Plan').click();
+    cy.withinSnackbar(() => {
+      cy.findByText('Subscription Updated').should('be.visible');
+    });
+    cy.findByText('Plan Overview').should('be.visible');
+    cy.findByText('Your Plan').should('be.visible');
+    cy.findByText('100,000 emails for $30 per month').should('be.visible');
+    cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
+  });
   it('Upgrades free account to starter 50K with query parameter', () => {
     cy.stubRequest({
       url: '/api/v1/account',
@@ -403,6 +459,62 @@ describe('Change Billing Plan Page', () => {
     cy.findByText('Plan Overview').should('be.visible');
     cy.findByText('Your Plan').should('be.visible');
     cy.findByText('500,000 emails for $290 per month').should('be.visible');
+    cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
+  });
+
+  it('Upgrades free account to premier 1M with previous active subaccounts', () => {
+    // user is on the test plan
+    cy.stubRequest({
+      url: '/api/v1/account',
+      fixture: 'account/200.get.test-plan.json',
+    });
+    cy.stubRequest({
+      url: '/api/v1/billing',
+      fixture: 'billing/200.get.has-no-credit-card.json',
+      fixtureAlias: 'billingGet',
+    });
+    cy.stubRequest({
+      url: '/api/v1/billing/subscription',
+      fixture: 'billing/subscription/200.get.test-plan-with-subaccounts.json',
+    });
+
+    cy.visit('/account/billing/plan');
+
+    cy.get('[data-id=select-plan-1M-premier-0519]').click();
+
+    cy.findByText('Your new plan only allows for 15 active subaccounts.').should('be.visible');
+    cy.findByText('Update Status').should('be.visible');
+    cy.findByText('Update Status')
+      .should('have.prop', 'href')
+      .and('include', 'account/subaccounts');
+    //calls to update the subscription with 0 active subaccounts
+    cy.stubRequest({
+      url: '/api/v1/billing/subscription',
+      fixture: 'billing/subscription/200.get.test-plan.json',
+    });
+    //confirms that active subaccounts now is less than limit
+    cy.findByText('Update Status').should('not.be.visible');
+
+    fillOutCreditCardForm();
+
+    mockCommonHttpCalls();
+
+    fillOutCreditCardForm();
+    mockCommonHttpCalls();
+
+    // Then server returns the new plan info that was saved...
+    cy.stubRequest({
+      url: '/api/v1/account',
+      fixture: 'account/200.get.1m-premier-plan.json',
+    });
+
+    cy.findByText('Change Plan').click();
+    cy.withinSnackbar(() => {
+      cy.findByText('Subscription Updated').should('be.visible');
+    });
+    cy.findByText('Plan Overview').should('be.visible');
+    cy.findByText('Your Plan').should('be.visible');
+    cy.findByText('1,000,000 emails for $525 per month').should('be.visible');
     cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
   });
 

--- a/src/pages/billing/components/FeatureChangeSection.js
+++ b/src/pages/billing/components/FeatureChangeSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Panel } from 'src/components/matchbox';
-import { CheckCircle } from '@sparkpost/matchbox-icons';
+import { CheckCircle, Warning } from '@sparkpost/matchbox-icons';
 
 import { Loading } from 'src/components/loading/Loading';
 import { useFeatureChangeContext } from '../context/FeatureChangeContext';
@@ -24,7 +24,7 @@ const Feature = ({ key, value, label, description, action }) => {
 };
 
 const FeatureChangeSection = () => {
-  const { features = [], loading } = useFeatureChangeContext();
+  const { features = [], loading, isReady } = useFeatureChangeContext();
   const styles = useHibanaOverride(OGStyles, HibanaStyles);
 
   if (!features.length) {
@@ -39,20 +39,31 @@ const FeatureChangeSection = () => {
     );
   }
 
-  const renderCTA = () => (
-    <Panel.Section name="feature-change-status">
-      <div className={styles.FeatureListStatus}>
-        <CheckCircle className={cx(styles.FeatureListIcon, styles.success)} />
-        <div name="status-description">
-          <strong>Your features have been updated</strong>
-          <span>, please continue with your plan change.</span>
+  const renderCTA = () =>
+    isReady ? (
+      <Panel.Section name="feature-change-status">
+        <div className={styles.FeatureListStatus}>
+          <CheckCircle className={cx(styles.FeatureListIcon, styles.success)} />
+          <div name="status-description">
+            <strong>Your features have been updated</strong>
+            <span>, please continue with your plan change.</span>
+          </div>
         </div>
-      </div>
-    </Panel.Section>
-  );
+      </Panel.Section>
+    ) : (
+      <>
+        <Warning className={cx(styles.FeatureListIcon, styles.danger)} />
+        <div name="status-description">
+          <span>
+            Your new plan has additional limits on features you currently use. See the list below to{' '}
+          </span>
+          <strong>make the necessary changes before you can change plans.</strong>
+        </div>
+      </>
+    );
 
   return (
-    <Panel accent="green" title="Changes to Features">
+    <Panel accent={isReady ? 'green' : 'red'} title="Changes to Features">
       {renderCTA()}
       {features.map(props => (
         <Feature {...props} />

--- a/src/pages/billing/components/FeatureChangeSection.js
+++ b/src/pages/billing/components/FeatureChangeSection.js
@@ -51,7 +51,7 @@ const FeatureChangeSection = () => {
         </div>
       </Panel.Section>
     ) : (
-      <>
+      <Panel.Section name="feature-change-status">
         <Warning className={cx(styles.FeatureListIcon, styles.danger)} />
         <div name="status-description">
           <span>
@@ -59,7 +59,7 @@ const FeatureChangeSection = () => {
           </span>
           <strong>make the necessary changes before you can change plans.</strong>
         </div>
-      </>
+      </Panel.Section>
     );
 
   return (

--- a/src/pages/billing/components/FeatureChangeSection.js
+++ b/src/pages/billing/components/FeatureChangeSection.js
@@ -52,12 +52,15 @@ const FeatureChangeSection = () => {
       </Panel.Section>
     ) : (
       <Panel.Section name="feature-change-status">
-        <Warning className={cx(styles.FeatureListIcon, styles.danger)} />
-        <div name="status-description">
-          <span>
-            Your new plan has additional limits on features you currently use. See the list below to{' '}
-          </span>
-          <strong>make the necessary changes before you can change plans.</strong>
+        <div className={styles.FeatureListStatus}>
+          <Warning className={cx(styles.FeatureListIcon, styles.danger)} />
+          <div name="status-description">
+            <span>
+              Your new plan has additional limits on features you currently use. See the list below
+              to{' '}
+            </span>
+            <strong>make the necessary changes before you can change plans.</strong>
+          </div>
         </div>
       </Panel.Section>
     );

--- a/src/pages/billing/components/SubmitSection.js
+++ b/src/pages/billing/components/SubmitSection.js
@@ -3,13 +3,13 @@ import { Button } from 'src/components/matchbox';
 import { useFeatureChangeContext } from '../context/FeatureChangeContext';
 
 const SubmitSection = ({ loading }) => {
-  const { loading: featureSectionLoading } = useFeatureChangeContext();
+  const { loading: featureSectionLoading, isReady } = useFeatureChangeContext();
   if (featureSectionLoading) {
     return null;
   }
 
   return (
-    <Button type="submit" disabled={loading} variant="primary">
+    <Button type="submit" disabled={loading || !isReady} variant="primary">
       Change Plan
     </Button>
   );

--- a/src/pages/billing/components/tests/FeatureChangeSection.test.js
+++ b/src/pages/billing/components/tests/FeatureChangeSection.test.js
@@ -11,6 +11,7 @@ useHibanaOverride.mockReturnValue(styles);
 const defaultContextState = {
   loading: false,
   features: [],
+  isReady: true,
 };
 
 const subject = (contextState = {}) => {

--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -43,7 +43,6 @@ export const FeatureChangeProvider = ({
     );
   }, [plans, selectedBundle]);
 
-  // console.log(selectedPlansByProduct);
   // Used for finding the features that need to have a proper function
   // Inserts into actions if it's got a conflicting issue
   // Updates if it was already in actions had conflicting issue

--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, useEffect, useMemo } from 'react';
+import React, { createContext, useState, useCallback, useContext, useEffect, useMemo } from 'react';
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import { Button } from 'src/components/matchbox';
@@ -20,6 +20,16 @@ export const FeatureChangeProvider = ({
   useEffect(() => {
     getSubscription();
   }, [getSubscription]);
+
+  const checkConditions = useCallback(() => {
+    getSubscription();
+  }, [getSubscription]);
+  useEffect(() => {
+    window.addEventListener('focus', checkConditions);
+    return () => {
+      window.removeEventListener('focus', checkConditions);
+    };
+  }, [checkConditions]);
 
   //Keys the selected plan by product to make for easier comparison
   const selectedPlansByProduct = useMemo(() => {
@@ -127,6 +137,17 @@ export const FeatureChangeProvider = ({
   );
 
   //Checks if all provided conditions are good
+  // const featuresWithActions = useMemo(
+  //   () =>
+  //     _.map(actions, ({ action, condition, ...rest }, key) => ({
+  //       ...rest,
+  //       key,
+  //       value: condition !== undefined ? condition : confirmations[key],
+  //       action:
+  //         condition !== undefined ? action : <Button onClick={() => onConfirm(key)}>Got it</Button>,
+  //     })),
+  //   [actions],
+  // );
   const value = {
     features: mappedFeatures,
     loading,

--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -43,6 +43,7 @@ export const FeatureChangeProvider = ({
     );
   }, [plans, selectedBundle]);
 
+  // console.log(selectedPlansByProduct);
   // Used for finding the features that need to have a proper function
   // Inserts into actions if it's got a conflicting issue
   // Updates if it was already in actions had conflicting issue
@@ -66,13 +67,14 @@ export const FeatureChangeProvider = ({
                   </span>
                 </div>
               ),
+              condition: true,
             };
           }
           return resObject;
-        case 'subaccounts': {
+        case 'subaccounts':
           const limit = _.get(comparedPlan, 'limit', 0);
           const qtyExceedsLimit = Boolean(quantity > limit);
-          if (actions.subaccounts || qtyExceedsLimit) {
+          if (actions.subaccounts || qtyExceedsLimit || limit === 0) {
             resObject.subaccounts = {
               label: 'Subaccounts',
               description: (
@@ -97,15 +99,16 @@ export const FeatureChangeProvider = ({
                 </div>
               ),
               condition: !qtyExceedsLimit,
-              action: (
+              action: qtyExceedsLimit ? (
                 <Button variant="destructive" external to="/account/subaccounts">
                   Update Status
                 </Button>
+              ) : (
+                undefined
               ),
             };
           }
           return resObject;
-        }
         case 'sso':
         case 'tfa_required':
           if (actions.auth || !comparedPlan) {
@@ -113,6 +116,7 @@ export const FeatureChangeProvider = ({
               label: 'Authentication and Security',
               description:
                 'Your new plan no longer allows for single sign-on and account-wide requirement of two-factor authentication.',
+              condition: true,
             };
           }
           return resObject;
@@ -125,8 +129,6 @@ export const FeatureChangeProvider = ({
   };
 
   useMemo(calculateDifferences, [subscription]);
-
-  //Evaluates condition and generates action if condition exists
   const mappedFeatures = useMemo(
     () =>
       _.map(actions, (action, key) => ({
@@ -136,19 +138,8 @@ export const FeatureChangeProvider = ({
     [actions],
   );
 
-  //Checks if all provided conditions are good
-  // const featuresWithActions = useMemo(
-  //   () =>
-  //     _.map(actions, ({ action, condition, ...rest }, key) => ({
-  //       ...rest,
-  //       key,
-  //       value: condition !== undefined ? condition : confirmations[key],
-  //       action:
-  //         condition !== undefined ? action : <Button onClick={() => onConfirm(key)}>Got it</Button>,
-  //     })),
-  //   [actions],
-  // );
   const value = {
+    isReady: _.every(mappedFeatures, 'condition'),
     features: mappedFeatures,
     loading,
   };

--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -72,7 +72,9 @@ export const FeatureChangeProvider = ({
           }
           return resObject;
         case 'subaccounts':
-          const limit = _.get(comparedPlan, 'limit', 0);
+          //there will always be a limit present for each plan,
+          //but till the api is released we need to default the higher limit to keep the current flow working
+          const limit = _.get(comparedPlan, 'limit', 5000);
           const qtyExceedsLimit = Boolean(quantity > limit);
           if (actions.subaccounts || qtyExceedsLimit || limit === 0) {
             resObject.subaccounts = {

--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -53,7 +53,7 @@ export const FeatureChangeProvider = ({
     }
     const { products: currentProducts } = subscription;
     const diffObject = currentProducts.reduce(
-      (resObject, { product, quantity, limit: currentLimit }) => {
+      (resObject, { product, quantity, limit: currentLimit, limit_override }) => {
         const comparedPlan = selectedPlansByProduct[product];
         switch (product) {
           case 'dedicated_ip':
@@ -78,7 +78,14 @@ export const FeatureChangeProvider = ({
             const limit = _.get(comparedPlan, 'limit', 5000);
             const qtyExceedsLimit = Boolean(quantity > limit);
             const isLimitDecreasing = currentLimit > limit;
-            if (actions.subaccounts || qtyExceedsLimit || isLimitDecreasing) {
+            //we let the user upgrade/downgrade without showing subaccount section if current limit_override
+            //is higher than current Limit and that of compared plan
+            const overrideCondition =
+              limit_override && limit_override > currentLimit && limit_override > limit;
+            if (
+              (actions.subaccounts || qtyExceedsLimit || isLimitDecreasing) &&
+              !overrideCondition
+            ) {
               resObject.subaccounts = {
                 label: 'Subaccounts',
                 description: (

--- a/src/pages/billing/context/tests/FeatureChangeContext.test.js
+++ b/src/pages/billing/context/tests/FeatureChangeContext.test.js
@@ -17,6 +17,11 @@ const defaultProps = {
       plan: 'subaccounts-0519',
       limit: 15,
     },
+    'subaccounts-starter': {
+      product: 'subaccounts',
+      plan: 'subaccounts-starter',
+      limit: 0,
+    },
     'tfa-required-0519': {
       product: 'tfa_required',
       plan: 'tfa-required-0519',
@@ -38,7 +43,7 @@ const defaultProps = {
         product: 'subaccounts',
         plan: 'subaccounts-0519',
         quantity: 10,
-        limit_override: 20,
+        limit: 15,
       },
       {
         product: 'sso',
@@ -101,6 +106,21 @@ describe('FeatureChangeContext', () => {
           { product: 'messaging', plan: '100K-premier-0519' },
           { product: 'subaccounts', plan: 'subaccounts-0519' },
           { product: 'dedicated_ip', plan: 'ip-0519' },
+        ],
+      },
+    });
+    expect(wrapper.prop('value')).toMatchSnapshot();
+  });
+
+  it('should render acknowledgement for a change in limit on subaccounts', () => {
+    const wrapper = subject({
+      selectedBundle: {
+        products: [
+          { product: 'messaging', plan: '100K-premier-0519' },
+          { product: 'subaccounts', plan: 'subaccounts-starter' },
+          { product: 'dedicated_ip', plan: 'ip-0519' },
+          { product: 'sso', plan: 'sso-0519' },
+          { product: 'tfa_required', plan: 'tfa-required-0519' },
         ],
       },
     });

--- a/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
+++ b/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
@@ -4,11 +4,13 @@ exports[`FeatureChangeContext should render acknowledgement for a change in auth
 Object {
   "features": Array [
     Object {
+      "condition": true,
       "description": "Your new plan no longer allows for single sign-on and account-wide requirement of two-factor authentication.",
       "key": "auth",
       "label": "Authentication and Security",
     },
   ],
+  "isReady": true,
   "loading": false,
 }
 `;
@@ -17,6 +19,7 @@ exports[`FeatureChangeContext should render acknowledgement for a change in dedi
 Object {
   "features": Array [
     Object {
+      "condition": true,
       "description": <div>
         <span>
           Your new plan doesn't include dedicated IPs. 
@@ -27,6 +30,44 @@ Object {
       "label": "Dedicated IPs",
     },
   ],
+  "isReady": true,
+  "loading": false,
+}
+`;
+
+exports[`FeatureChangeContext should render acknowledgement for a change in limit on subaccounts 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "action": <Button
+        external={true}
+        to="/account/subaccounts"
+        variant="destructive"
+      >
+        Update Status
+      </Button>,
+      "condition": false,
+      "description": <div>
+        Your new plan doesn't include subaccounts.
+        <React.Fragment>
+          <span>
+             Please 
+          </span>
+          <strong>
+            change the status to terminated for
+             
+            10 subaccounts
+          </strong>
+          <span>
+             to continue.
+          </span>
+        </React.Fragment>
+      </div>,
+      "key": "subaccounts",
+      "label": "Subaccounts",
+    },
+  ],
+  "isReady": false,
   "loading": false,
 }
 `;


### PR DESCRIPTION
AC-1446 - Show the Subaccounts Section while changing plans

**Note** We had implemented this functionality earlier but removed it as api did not support limits

### What Changed
 - Added the functionality to bring back the subaccounts section when a user changes plan
 - Shows a warning to user and prevents them from changing plan if the current quantity of subaccounts is over the limit of the plan that they have selected
- if the current Limit is more than the future limit than than shows up as plain text **without** "Update account" button

### How To Test
 - Run the following cypress tests to see how this functions as the api as still not returning limits
       - Upgrades free account to premier 1M with previous active subaccounts, current quantity of subaccounts doesn't exceed new limit
       - Upgrades free account to starter 100K with previous active subaccounts, current quantity of subaccounts exceeds new limit

- We should be able to get this ticket out without the need of limit implementation in api, check if it allows for upgrade and downgrade without any issue

- link to old mocks: https://sparkpost.invisionapp.com/public/share/DGTCT4JW6JN#/screens/380587108

### To Do
- [ ] Address feedback
