### PR TITLE
AC-1413: (UI) Report all Zuora API errors with error code

### DIFF
--- a/cypress/fixtures/zuora/payment-method/credit-cards/200.post.with-error.json
+++ b/cypress/fixtures/zuora/payment-method/credit-cards/200.post.with-error.json
@@ -1,0 +1,13 @@
+{
+  "success": false,
+  "reasons":  [
+  {
+    "code": 53100320,
+    "message": "'termType' value should be one of: TERMED, EVERGREEN"
+  },
+  {
+    "code": 53100321,
+    "message": "some other zuora error"
+  }
+]
+}

--- a/cypress/fixtures/zuora/payment-method/credit-cards/400.post.json
+++ b/cypress/fixtures/zuora/payment-method/credit-cards/400.post.json
@@ -1,0 +1,3 @@
+{
+  "errors": [{ "message": "This is an error" }]
+}

--- a/cypress/tests/integration/accounts/billing/billingPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/billingPage.spec.js
@@ -376,6 +376,86 @@ describe('Billing Page', () => {
         cy.findByText('View Details').click();
         cy.findByText('This is an error').should('be.visible');
       });
+      describe('reports error to sentry', () => {
+        it('sends zuora error codes to sentry when zuora errors with 200', () => {
+          cy.stubRequest({
+            method: 'POST',
+            url: `${BILLING_API_BASE_URL}/cors-data*`,
+            fixture: 'billing/cors-data/200.post.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            url: '/v1/payment-methods/credit-cards',
+            fixture: 'zuora/payment-method/credit-cards/200.post.with-error.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            url: `${ACCOUNT_API_BASE_URL}/subscription/check`,
+            fixture: 'account/subscription/check/200.post.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            url: `${BILLING_API_BASE_URL}/subscription/check`,
+            fixture: 'billing/subscription/check/200.post.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            statusCode: 400,
+            url: `${BILLING_API_BASE_URL}/collect`,
+            fixture: 'billing/collect/400.post.json',
+          });
+
+          fillOutForm();
+          cy.findAllByText(/Update Payment Information */i)
+            .last()
+            .click();
+          cy.findByText('Something went wrong.').should('be.visible');
+        });
+
+        it('reports error to sentry when zuora errors with 4xx or 5xx', () => {
+          cy.stubRequest({
+            method: 'POST',
+            url: `${BILLING_API_BASE_URL}/cors-data*`,
+            fixture: 'billing/cors-data/200.post.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            statusCode: 400,
+            url: '/v1/payment-methods/credit-cards',
+            fixture: 'zuora/payment-method/credit-cards/400.post.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            url: `${ACCOUNT_API_BASE_URL}/subscription/check`,
+            fixture: 'account/subscription/check/200.post.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            url: `${BILLING_API_BASE_URL}/subscription/check`,
+            fixture: 'billing/subscription/check/200.post.json',
+          });
+
+          cy.stubRequest({
+            method: 'POST',
+            statusCode: 400,
+            url: `${BILLING_API_BASE_URL}/collect`,
+            fixture: 'billing/collect/400.post.json',
+          });
+
+          fillOutForm();
+          cy.findAllByText(/Update Payment Information */i)
+            .last()
+            .click();
+          cy.findByText('An error occurred while contacting zuora').should('be.visible');
+        });
+      });
     });
 
     describe('the update billing contact form', () => {

--- a/cypress/tests/integration/accounts/billing/billingPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/billingPage.spec.js
@@ -413,7 +413,9 @@ describe('Billing Page', () => {
           cy.findAllByText(/Update Payment Information */i)
             .last()
             .click();
-          cy.findByText('Something went wrong.').should('be.visible');
+          cy.findByText("'termType' value should be one of: TERMED, EVERGREEN").should(
+            'be.visible',
+          );
         });
 
         it('reports error to sentry when zuora errors with 4xx or 5xx', () => {
@@ -453,7 +455,9 @@ describe('Billing Page', () => {
           cy.findAllByText(/Update Payment Information */i)
             .last()
             .click();
-          cy.findByText('An error occurred while contacting zuora').should('be.visible');
+          cy.findByText('An error occurred while contacting the billing service').should(
+            'be.visible',
+          );
         });
       });
     });

--- a/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
+++ b/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
@@ -7,25 +7,29 @@ Array [
     "type": "ZUORA_REQUEST_PENDING",
   },
   Object {
+    "meta": Object {},
+    "payload": Object {
+      "error": [ZuoraApiError: The credit card is bad and wrong],
+      "message": "The credit card is bad and wrong",
+      "response": Object {
+        "data": Object {
+          "reasons": Array [
+            Object {
+              "message": "The credit card is bad and wrong",
+            },
+          ],
+          "success": false,
+        },
+      },
+    },
+    "type": "ZUORA_REQUEST_FAIL",
+  },
+  Object {
     "payload": Object {
       "message": "The credit card is bad and wrong",
       "type": "error",
     },
     "type": "SHOW_GLOBAL_ALERT",
-  },
-  Object {
-    "meta": Object {},
-    "payload": Object {
-      "data": Object {
-        "reasons": Array [
-          Object {
-            "message": "The credit card is bad and wrong",
-          },
-        ],
-        "success": false,
-      },
-    },
-    "type": "ZUORA_REQUEST_SUCCESS",
   },
 ]
 `;

--- a/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
+++ b/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
@@ -31,6 +31,20 @@ Array [
     },
     "type": "SHOW_GLOBAL_ALERT",
   },
+  Object {
+    "meta": Object {},
+    "payload": Object {
+      "data": Object {
+        "reasons": Array [
+          Object {
+            "message": "The credit card is bad and wrong",
+          },
+        ],
+        "success": false,
+      },
+    },
+    "type": "ZUORA_REQUEST_SUCCESS",
+  },
 ]
 `;
 

--- a/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
+++ b/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
@@ -7,24 +7,6 @@ Array [
     "type": "ZUORA_REQUEST_PENDING",
   },
   Object {
-    "meta": Object {},
-    "payload": Object {
-      "error": [ZuoraApiError: The credit card is bad and wrong],
-      "message": "The credit card is bad and wrong",
-      "response": Object {
-        "data": Object {
-          "reasons": Array [
-            Object {
-              "message": "The credit card is bad and wrong",
-            },
-          ],
-          "success": false,
-        },
-      },
-    },
-    "type": "ZUORA_REQUEST_FAIL",
-  },
-  Object {
     "payload": Object {
       "message": "The credit card is bad and wrong",
       "type": "error",

--- a/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
+++ b/src/actions/helpers/tests/__snapshots__/zuoraRequest.test.js.snap
@@ -9,15 +9,10 @@ Array [
   Object {
     "meta": Object {},
     "payload": Object {
-      "error": [ZuoraApiError: The credit card is bad and wrong],
-      "message": "The credit card is bad and wrong",
+      "error": [ZuoraApiError: An error occurred while contacting the billing service],
+      "message": "An error occurred while contacting the billing service",
       "response": Object {
         "data": Object {
-          "reasons": Array [
-            Object {
-              "message": "The credit card is bad and wrong",
-            },
-          ],
           "success": false,
         },
       },
@@ -26,7 +21,7 @@ Array [
   },
   Object {
     "payload": Object {
-      "message": "The credit card is bad and wrong",
+      "message": "An error occurred while contacting the billing service",
       "type": "error",
     },
     "type": "SHOW_GLOBAL_ALERT",

--- a/src/actions/helpers/tests/zuoraApiError.test.js
+++ b/src/actions/helpers/tests/zuoraApiError.test.js
@@ -1,0 +1,60 @@
+import ZuoraApiError from '../zuoraApiError';
+
+function createTestError(sugar = {}) {
+  const error = new Error('Oh No!');
+  return new ZuoraApiError(Object.assign(error, sugar));
+}
+
+describe('ZuoraApiError', () => {
+  it('instance of ZuoraApiError', () => {
+    const error = createTestError();
+    expect(error).toBeInstanceOf(ZuoraApiError);
+  });
+
+  it('instance of Error', () => {
+    const error = createTestError();
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('returns error name', () => {
+    const error = createTestError();
+    expect(error).toHaveProperty('name', 'ZuoraApiError');
+  });
+
+  it('returns error message', () => {
+    const error = createTestError({ response: { data: { success: false } } });
+    expect(error).toHaveProperty(
+      'message',
+      'An error occurred while contacting the billing service',
+    );
+  });
+
+  it('returns api error message', () => {
+    const error = createTestError({
+      response: {
+        data: {
+          success: false,
+          reasons: [
+            {
+              code: 53100320,
+              message: "'termType' value should be one of: TERMED, EVERGREEN",
+            },
+            {
+              code: 53100321,
+              message: 'some other zuora error',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(error).toHaveProperty('message', "'termType' value should be one of: TERMED, EVERGREEN");
+  });
+
+  it('returns extra properties', () => {
+    const error = createTestError({
+      extra: 'shh',
+    });
+    expect(error).toHaveProperty('extra');
+  });
+});

--- a/src/actions/helpers/tests/zuoraApiError.test.js
+++ b/src/actions/helpers/tests/zuoraApiError.test.js
@@ -51,6 +51,14 @@ describe('ZuoraApiError', () => {
     expect(error).toHaveProperty('message', "'termType' value should be one of: TERMED, EVERGREEN");
   });
 
+  it('returns a network error if no axios response', () => {
+    const error = createTestError();
+    expect(error).toHaveProperty(
+      'message',
+      'You may be having network issues or an adblocker may be blocking part of the app.',
+    );
+  });
+
   it('returns extra properties', () => {
     const error = createTestError({
       extra: 'shh',

--- a/src/actions/helpers/tests/zuoraRequest.test.js
+++ b/src/actions/helpers/tests/zuoraRequest.test.js
@@ -29,16 +29,9 @@ describe('Helper: Zuora API Request', () => {
   });
 
   it('should handle a zuora failure', async () => {
-    axiosMocks.zuora.mockImplementation(() =>
-      Promise.resolve({
-        data: {
-          success: false,
-          reasons: [{ message: 'The credit card is bad and wrong' }],
-        },
-      }),
-    );
-
-    await mockStore.dispatch(zuoraRequest(action));
+    expectedResponse = { data: { success: false } };
+    axiosMocks.zuora.mockImplementation(() => Promise.resolve(expectedResponse));
+    await expect(mockStore.dispatch(zuoraRequest(action))).rejects.toThrow();
     expect(mockStore.getActions()).toMatchSnapshot();
   });
 });

--- a/src/actions/helpers/tests/zuoraRequest.test.js
+++ b/src/actions/helpers/tests/zuoraRequest.test.js
@@ -18,11 +18,11 @@ describe('Helper: Zuora API Request', () => {
   beforeEach(() => {
     mockStore = createMockStore({});
     action = { type: 'ZUORA_REQUEST', meta: {} };
-    expectedResponse = { data: { success: true } };
-    axiosMocks.zuora.mockImplementation(() => Promise.resolve(expectedResponse));
   });
 
   it('should make a successful call', async () => {
+    expectedResponse = { data: { success: true } };
+    axiosMocks.zuora.mockImplementation(() => Promise.resolve(expectedResponse));
     const results = await mockStore.dispatch(zuoraRequest(action));
     expect(results).toBe(expectedResponse);
     expect(mockStore.getActions()).toMatchSnapshot();
@@ -38,7 +38,7 @@ describe('Helper: Zuora API Request', () => {
       }),
     );
 
-    await expect(mockStore.dispatch(zuoraRequest(action))).rejects.toThrow();
+    await mockStore.dispatch(zuoraRequest(action));
     expect(mockStore.getActions()).toMatchSnapshot();
   });
 });

--- a/src/actions/helpers/zuoraApiError.js
+++ b/src/actions/helpers/zuoraApiError.js
@@ -3,11 +3,13 @@ import { stripTags } from 'src/helpers/string';
 
 // TODO: Return an Error object as if we were to create it with class and extends Error
 function ZuoraApiError(error) {
-  const message = _.get(
-    error.response,
-    'data.reasons[0].message',
-    'An error occurred while contacting the billing service',
-  );
+  const message = error.response
+    ? _.get(
+        error.response,
+        'data.reasons[0].message',
+        'An error occurred while contacting the billing service',
+      )
+    : 'You may be having network issues or an adblocker may be blocking part of the app.';
 
   this.name = 'ZuoraApiError';
   this.stack = error.stack; // must manually assign prototype value

--- a/src/actions/helpers/zuoraApiError.js
+++ b/src/actions/helpers/zuoraApiError.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { stripTags } from 'src/helpers/string';
 
 // TODO: Return an Error object as if we were to create it with class and extends Error
 function ZuoraApiError(error) {

--- a/src/actions/helpers/zuoraApiError.js
+++ b/src/actions/helpers/zuoraApiError.js
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+
+// TODO: Return an Error object as if we were to create it with class and extends Error
+function ZuoraApiError(error) {
+  const message = _.get(
+    error.response,
+    'data.reasons[0].message',
+    'An error occurred while contacting the billing service',
+  );
+
+  this.name = 'ZuoraApiError';
+  this.stack = error.stack; // must manually assign prototype value
+  this.message = stripTags(message); // some messages include html tags
+
+  // Intentionally assigning additional properties
+  Object.assign(this, error);
+}
+
+ZuoraApiError.prototype = Object.create(Error.prototype);
+
+export default ZuoraApiError;

--- a/src/actions/helpers/zuoraRequest.js
+++ b/src/actions/helpers/zuoraRequest.js
@@ -20,27 +20,27 @@ export default requestHelperFactory({
         error.name = 'ZuoraApiError';
         error.response = response;
 
+        dispatch({
+          type: types.FAIL,
+          payload: { error, message: sanitizedMessage, response },
+          meta,
+        });
+
         // auto alert all errors
         dispatch(showAlert({ type: 'error', message: sanitizedMessage }));
 
         // TODO: 'return' err once we unchain all actions
         ErrorTracker.addRequestContextAndThrow(types.FAIL, response, error);
-
-        return dispatch({
-          type: types.FAIL,
-          payload: { error, message: sanitizedMessage, response },
-          meta,
-        });
       } catch (err) {
         ErrorTracker.report('zuora-request-error', err);
       }
+    } else {
+      dispatch({
+        type: types.SUCCESS,
+        payload: response,
+        meta,
+      });
     }
-
-    dispatch({
-      type: types.SUCCESS,
-      payload: response,
-      meta,
-    });
 
     return meta.onSuccess ? dispatch(meta.onSuccess({ results: response })) : response;
   },

--- a/src/actions/helpers/zuoraRequest.js
+++ b/src/actions/helpers/zuoraRequest.js
@@ -24,8 +24,8 @@ const onFail = ({ types, err, dispatch, meta }) => {
 
 const onSuccess = ({ types, response, dispatch, meta }) => {
   if (!response.data.success) {
-    // mocking axios err that would normally
-    const err = new Error('Oh no!');
+    // mocking axios err that would normally be thrown when an error occurs
+    const err = new Error('Something went wrong!');
     err.response = response;
     onFail({ dispatch, err, meta, types });
   }

--- a/src/actions/helpers/zuoraRequest.js
+++ b/src/actions/helpers/zuoraRequest.js
@@ -20,17 +20,17 @@ export default requestHelperFactory({
         error.name = 'ZuoraApiError';
         error.response = response;
 
-        dispatch({
-          type: types.FAIL,
-          payload: { error, message: sanitizedMessage, response },
-          meta,
-        });
-
         // auto alert all errors
         dispatch(showAlert({ type: 'error', message: sanitizedMessage }));
 
         // TODO: 'return' err once we unchain all actions
         ErrorTracker.addRequestContextAndThrow(types.FAIL, response, error);
+
+        return dispatch({
+          type: types.FAIL,
+          payload: { error, message: sanitizedMessage, response },
+          meta,
+        });
       } catch (err) {
         ErrorTracker.report('zuora-request-error', err);
       }

--- a/src/actions/helpers/zuoraRequest.js
+++ b/src/actions/helpers/zuoraRequest.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { zuora as zuoraAxios } from 'src/helpers/axiosInstances';
 import ErrorTracker from 'src/helpers/errorTracker';
 import { showAlert } from 'src/actions/globalAlert';
-import { stripTags } from 'src/helpers/string';
+import ZuoraApiError from './zuoraApiError';
 
 const onFail = ({ types, err, dispatch, meta }) => {
   const apiError = new ZuoraApiError(err);
@@ -11,7 +11,7 @@ const onFail = ({ types, err, dispatch, meta }) => {
 
   dispatch({
     type: types.FAIL,
-    payload: { error, message, response },
+    payload: { error: apiError, message, response },
     meta,
   });
 

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -222,7 +222,7 @@ class ErrorTracker {
     if (!Raven.isSetup()) {
       throw error;
     }
-    let zuoraErrorCodes = _.get(response, 'data.reasons', [])
+    const zuoraErrorCodes = _.get(response, 'data.reasons', [])
       .map(reason => reason.code)
       .join();
 

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -222,9 +222,22 @@ class ErrorTracker {
     if (!Raven.isSetup()) {
       throw error;
     }
-    Raven.context({ tags: { reduxActionType, httpResponseStatus: response.status || 0 } }, () => {
-      throw error;
-    });
+    let zuoraErrorCode = _.get(response, 'data.reasons', [])
+      .map(reason => reason.code)
+      .join();
+
+    Raven.context(
+      {
+        tags: {
+          reduxActionType,
+          httpResponseStatus: response.status || 0,
+          zuoraErrorCode: zuoraErrorCode,
+        },
+      },
+      () => {
+        throw error;
+      },
+    );
   }
 }
 

--- a/src/helpers/errorTracker.js
+++ b/src/helpers/errorTracker.js
@@ -222,7 +222,7 @@ class ErrorTracker {
     if (!Raven.isSetup()) {
       throw error;
     }
-    let zuoraErrorCode = _.get(response, 'data.reasons', [])
+    let zuoraErrorCodes = _.get(response, 'data.reasons', [])
       .map(reason => reason.code)
       .join();
 
@@ -231,7 +231,7 @@ class ErrorTracker {
         tags: {
           reduxActionType,
           httpResponseStatus: response.status || 0,
-          zuoraErrorCode: zuoraErrorCode,
+          zuoraErrorCodes: zuoraErrorCodes,
         },
       },
       () => {

--- a/src/helpers/tests/errorTracker.test.js
+++ b/src/helpers/tests/errorTracker.test.js
@@ -395,6 +395,7 @@ describe('.addRequestContextAndThrow', () => {
         tags: {
           reduxActionType: 'MOCK_REDUX_ACTION',
           httpResponseStatus: 404,
+          zuoraErrorCode: '',
         },
       },
       expect.any(Function),
@@ -410,6 +411,7 @@ describe('.addRequestContextAndThrow', () => {
         tags: {
           reduxActionType: 'MOCK_REDUX_ACTION',
           httpResponseStatus: 0,
+          zuoraErrorCode: '',
         },
       },
       expect.any(Function),

--- a/src/helpers/tests/errorTracker.test.js
+++ b/src/helpers/tests/errorTracker.test.js
@@ -395,7 +395,7 @@ describe('.addRequestContextAndThrow', () => {
         tags: {
           reduxActionType: 'MOCK_REDUX_ACTION',
           httpResponseStatus: 404,
-          zuoraErrorCode: '',
+          zuoraErrorCodes: '',
         },
       },
       expect.any(Function),
@@ -411,7 +411,7 @@ describe('.addRequestContextAndThrow', () => {
         tags: {
           reduxActionType: 'MOCK_REDUX_ACTION',
           httpResponseStatus: 0,
-          zuoraErrorCode: '',
+          zuoraErrorCodes: '',
         },
       },
       expect.any(Function),

--- a/src/pages/billing/forms/UpdatePaymentForm.js
+++ b/src/pages/billing/forms/UpdatePaymentForm.js
@@ -10,6 +10,7 @@ import { Button, Panel } from 'src/components/matchbox';
 import { ButtonWrapper } from 'src/components';
 import PaymentForm from 'src/components/billing/PaymentForm';
 import BillingAddressForm from 'src/components/billing/BillingAddressForm';
+import ErrorTracker from 'src/helpers/errorTracker';
 
 const FORMNAME = 'updatePayment';
 
@@ -23,9 +24,13 @@ export class UpdatePaymentForm extends Component {
 
     const newValues = values.card ? { ...values, card: prepareCardInfo(values.card) } : values;
 
-    return billingUpdate(newValues).then(() => {
-      showAlert({ type: 'success', message: 'Payment Information Updated' });
-    });
+    return billingUpdate(newValues)
+      .then(() => {
+        showAlert({ type: 'success', message: 'Payment Information Updated' });
+      })
+      .catch(error => {
+        ErrorTracker.report('update-payment-information-error', error);
+      });
   };
 
   render() {

--- a/src/pages/billing/forms/UpdatePaymentForm.js
+++ b/src/pages/billing/forms/UpdatePaymentForm.js
@@ -10,7 +10,6 @@ import { Button, Panel } from 'src/components/matchbox';
 import { ButtonWrapper } from 'src/components';
 import PaymentForm from 'src/components/billing/PaymentForm';
 import BillingAddressForm from 'src/components/billing/BillingAddressForm';
-import ErrorTracker from 'src/helpers/errorTracker';
 
 const FORMNAME = 'updatePayment';
 
@@ -28,9 +27,7 @@ export class UpdatePaymentForm extends Component {
       .then(() => {
         showAlert({ type: 'success', message: 'Payment Information Updated' });
       })
-      .catch(error => {
-        ErrorTracker.report('update-payment-information-error', error);
-      });
+      .catch(() => {});
   };
 
   render() {

--- a/src/pages/billing/forms/UpdatePaymentForm.js
+++ b/src/pages/billing/forms/UpdatePaymentForm.js
@@ -23,11 +23,9 @@ export class UpdatePaymentForm extends Component {
 
     const newValues = values.card ? { ...values, card: prepareCardInfo(values.card) } : values;
 
-    return billingUpdate(newValues)
-      .then(() => {
-        showAlert({ type: 'success', message: 'Payment Information Updated' });
-      })
-      .catch(() => {});
+    return billingUpdate(newValues).then(() => {
+      showAlert({ type: 'success', message: 'Payment Information Updated' });
+    });
   };
 
   render() {


### PR DESCRIPTION
AC-1413: (UI) Report all Zuora API errors with error code

### What Changed
 - Added ZuoraErrorCode in tags, when zuora request fails with response status 200
 - Added Error reporting to sentry when zuora errors out with 4xx or 5xx.
 - Added cypress tests to test the following

### How To Test
 - run the cypress tests that are added in this PR and open the network tab and check the sentry request (even though the sentry requests have failed, you should still be able to check Request Payload)

### To Do
- [ ] Address Feedback
