### PR TITLE
SD-1693: Update SparkPost UI to Reflect New IP Pool Options

### DIFF
--- a/src/pages/ipPools/EditPage.js
+++ b/src/pages/ipPools/EditPage.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { ApiErrorBanner, DeleteModal, Loading } from 'src/components';
-import { Box, Page, Panel } from 'src/components/matchbox';
+import { ExternalLink } from 'src/components/links';
+import { Banner, Box, Button, Page, Panel } from 'src/components/matchbox';
 import { OGOnlyWrapper } from 'src/components/hibana';
+import { LINKS } from 'src/constants';
 import PoolForm from './components/PoolForm';
 import IpList from './components/IpList';
 
@@ -177,6 +179,24 @@ export class EditPage extends Component {
           },
         ]}
       >
+        <Banner
+          status="warning"
+          title="New dedicated IP addresses need to be warmed up"
+          marginBottom="500"
+        >
+          <Box maxWidth="1200">
+            <p>
+              In order to establish a positive sending reputation, warm up new dedicated IP
+              addresses by gradually sending more emails.
+            </p>
+
+            <Banner.Actions>
+              <ExternalLink as={Button} to={LINKS.IP_WARM_UP}>
+                Read our IP Warm-up Overview
+              </ExternalLink>
+            </Banner.Actions>
+          </Box>
+        </Banner>
         {this.renderForm()}
         {this.renderIps()}
 

--- a/src/pages/ipPools/ListPage.js
+++ b/src/pages/ipPools/ListPage.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { listPools } from 'src/actions/ipPools';
 import { Loading, TableCollection, ApiErrorBanner } from 'src/components';
-import { PageLink } from 'src/components/links';
-import { Page } from 'src/components/matchbox';
+import { PageLink, SupportTicketLink } from 'src/components/links';
+import { Banner, Page, Stack } from 'src/components/matchbox';
 import { openSupportTicketForm } from 'src/actions/support';
 import { not } from 'src/helpers/conditions';
 import { selectCondition } from 'src/selectors/accessConditionState';
@@ -79,6 +79,19 @@ export class IpPoolsList extends Component {
 
     return (
       <Page primaryAction={createAction} secondaryActions={purchaseActions} title="IP Pools">
+        <Banner
+          status="info"
+          title="SparkPost now supports Strict TLS and Custom Messaging Expiration"
+          marginBottom="500"
+        >
+          <Stack>
+            <p>
+              To adjust these settings, please{' '}
+              <SupportTicketLink>submit a support ticket</SupportTicketLink> or contact your TAM.
+            </p>
+            <p>Following implementation, changes may take up to 2 weeks to propagate.</p>
+          </Stack>
+        </Banner>
         {error ? this.renderError() : this.renderCollection()}
       </Page>
     );

--- a/src/pages/ipPools/ListPage.js
+++ b/src/pages/ipPools/ListPage.js
@@ -2,9 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { listPools } from 'src/actions/ipPools';
 import { Loading, TableCollection, ApiErrorBanner } from 'src/components';
-import { ExternalLink, PageLink } from 'src/components/links';
-import { Banner, Box, Button, Page } from 'src/components/matchbox';
-import { LINKS } from 'src/constants';
+import { PageLink } from 'src/components/links';
+import { Page } from 'src/components/matchbox';
 import { openSupportTicketForm } from 'src/actions/support';
 import { not } from 'src/helpers/conditions';
 import { selectCondition } from 'src/selectors/accessConditionState';
@@ -57,6 +56,7 @@ export class IpPoolsList extends Component {
 
   render() {
     const { loading, error, showPurchaseCTA, isManuallyBilled, openSupportTicketForm } = this.props;
+
     if (loading) {
       return <Loading />;
     }
@@ -79,33 +79,11 @@ export class IpPoolsList extends Component {
 
     return (
       <Page primaryAction={createAction} secondaryActions={purchaseActions} title="IP Pools">
-        <IPWarmupReminderBanner />
         {error ? this.renderError() : this.renderCollection()}
       </Page>
     );
   }
 }
-
-export const IPWarmupReminderBanner = () => (
-  <Banner
-    status="warning"
-    title="New dedicated IP addresses need to be warmed up"
-    marginBottom="500"
-  >
-    <Box maxWidth="1200">
-      <p>
-        In order to establish a positive sending reputation, warm up new dedicated IP addresses by
-        gradually sending more emails.
-      </p>
-
-      <Banner.Actions>
-        <ExternalLink as={Button} to={LINKS.IP_WARM_UP}>
-          Read our IP Warm-up Overview
-        </ExternalLink>
-      </Banner.Actions>
-    </Box>
-  </Banner>
-);
 
 function mapStateToProps(state) {
   const { ipPools } = state;

--- a/src/pages/ipPools/tests/ListPage.test.js
+++ b/src/pages/ipPools/tests/ListPage.test.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { IpPoolsList, getRowData, IPWarmupReminderBanner } from '../ListPage';
+import { IpPoolsList, getRowData } from '../ListPage';
 
 describe('IP Pools List Page', () => {
   let props;
@@ -11,13 +11,13 @@ describe('IP Pools List Page', () => {
     props = {
       loading: false,
       ipPools: [
-        { name: 'Test Pool 1', id: 101, ips: [{ external_ip: 1111 }, { external_ip: 2222 }]},
-        { name: 'Test Pool 2', id: 102, ips: []}
+        { name: 'Test Pool 1', id: 101, ips: [{ external_ip: 1111 }, { external_ip: 2222 }] },
+        { name: 'Test Pool 2', id: 102, ips: [] },
       ],
       listPools: jest.fn(() => []),
       showPurchaseCTA: true,
       isManuallyBilled: false,
-      isAdmin: true
+      isAdmin: true,
     };
 
     wrapper = shallow(<IpPoolsList {...props} />);
@@ -28,7 +28,7 @@ describe('IP Pools List Page', () => {
   });
 
   it('should show alert upon error', () => {
-    wrapper.setProps({ ipPools: [], error: { message: 'Uh oh! It broke.' }});
+    wrapper.setProps({ ipPools: [], error: { message: 'Uh oh! It broke.' } });
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -41,38 +41,31 @@ describe('IP Pools List Page', () => {
     const rows = getRowData({
       id: 'my-pool',
       name: 'My Pool',
-      ips: [1,2,3]
+      ips: [1, 2, 3],
     });
 
     expect(rows).toMatchSnapshot();
   });
 
   it('does not render purchase action if showPurchaseCTA is false', () => {
-    wrapper.setProps({ ipPools: [{ name: 'Default', ips: []}], showPurchaseCTA: false });
+    wrapper.setProps({ ipPools: [{ name: 'Default', ips: [] }], showPurchaseCTA: false });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('does not render purchase action if showPurchaseCTA is false2', () => {
-    wrapper.setProps({ ipPools: [{ name: 'Default', ips: []}], showPurchaseCTA: false });
+    wrapper.setProps({ ipPools: [{ name: 'Default', ips: [] }], showPurchaseCTA: false });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders request IP action if showPurchaseCTA is true and isManuallyBilled is true', () => {
     wrapper.setProps({ isManuallyBilled: true });
     expect(wrapper.prop('secondaryActions')).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ content: 'Request IPs' })
-      ])
+      expect.arrayContaining([expect.objectContaining({ content: 'Request IPs' })]),
     );
   });
 
   it('does not render purchase action if isAdmin is false', () => {
-    wrapper.setProps({ ipPools: [{ name: 'Default', ips: []}], isAdmin: false });
+    wrapper.setProps({ ipPools: [{ name: 'Default', ips: [] }], isAdmin: false });
     expect(wrapper).toMatchSnapshot();
   });
-
-  it('should render the IP warm-up banner correctly', () => {
-    expect(shallow(<IPWarmupReminderBanner />)).toMatchSnapshot();
-  });
-
 });

--- a/src/pages/ipPools/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/EditPage.test.js.snap
@@ -31,6 +31,27 @@ exports[`IP Pools Edit Page render tests should not show purchase action if show
   }
   title="My Pool (my-pool)"
 >
+  <Banner
+    marginBottom="500"
+    status="warning"
+    title="New dedicated IP addresses need to be warmed up"
+  >
+    <Box
+      maxWidth="1200"
+    >
+      <p>
+        In order to establish a positive sending reputation, warm up new dedicated IP addresses by gradually sending more emails.
+      </p>
+      <Banner.Actions>
+        <ExternalLink
+          as={[Function]}
+          to="https://support.sparkpost.com/customer/portal/articles/1972209-ip-warm-up-overview"
+        >
+          Read our IP Warm-up Overview
+        </ExternalLink>
+      </Banner.Actions>
+    </Box>
+  </Banner>
   <withRouter(Connect(ReduxForm))
     isNew={false}
     onSubmit={[Function]}
@@ -104,6 +125,27 @@ exports[`IP Pools Edit Page render tests should render the edit page correctly 1
   }
   title="My Pool (my-pool)"
 >
+  <Banner
+    marginBottom="500"
+    status="warning"
+    title="New dedicated IP addresses need to be warmed up"
+  >
+    <Box
+      maxWidth="1200"
+    >
+      <p>
+        In order to establish a positive sending reputation, warm up new dedicated IP addresses by gradually sending more emails.
+      </p>
+      <Banner.Actions>
+        <ExternalLink
+          as={[Function]}
+          to="https://support.sparkpost.com/customer/portal/articles/1972209-ip-warm-up-overview"
+        >
+          Read our IP Warm-up Overview
+        </ExternalLink>
+      </Banner.Actions>
+    </Box>
+  </Banner>
   <withRouter(Connect(ReduxForm))
     isNew={false}
     onSubmit={[Function]}

--- a/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
@@ -20,6 +20,25 @@ exports[`IP Pools List Page does not render purchase action if isAdmin is false 
   }
   title="IP Pools"
 >
+  <Banner
+    marginBottom="500"
+    status="info"
+    title="SparkPost now supports Strict TLS and Custom Messaging Expiration"
+  >
+    <Stack>
+      <p>
+        To adjust these settings, please
+         
+        <Connect(SupportTicketLink)>
+          submit a support ticket
+        </Connect(SupportTicketLink)>
+         or contact your TAM.
+      </p>
+      <p>
+        Following implementation, changes may take up to 2 weeks to propagate.
+      </p>
+    </Stack>
+  </Banner>
   <TableCollection
     columns={
       Array [
@@ -81,6 +100,25 @@ exports[`IP Pools List Page does not render purchase action if showPurchaseCTA i
   secondaryActions={null}
   title="IP Pools"
 >
+  <Banner
+    marginBottom="500"
+    status="info"
+    title="SparkPost now supports Strict TLS and Custom Messaging Expiration"
+  >
+    <Stack>
+      <p>
+        To adjust these settings, please
+         
+        <Connect(SupportTicketLink)>
+          submit a support ticket
+        </Connect(SupportTicketLink)>
+         or contact your TAM.
+      </p>
+      <p>
+        Following implementation, changes may take up to 2 weeks to propagate.
+      </p>
+    </Stack>
+  </Banner>
   <TableCollection
     columns={
       Array [
@@ -142,6 +180,25 @@ exports[`IP Pools List Page does not render purchase action if showPurchaseCTA i
   secondaryActions={null}
   title="IP Pools"
 >
+  <Banner
+    marginBottom="500"
+    status="info"
+    title="SparkPost now supports Strict TLS and Custom Messaging Expiration"
+  >
+    <Stack>
+      <p>
+        To adjust these settings, please
+         
+        <Connect(SupportTicketLink)>
+          submit a support ticket
+        </Connect(SupportTicketLink)>
+         or contact your TAM.
+      </p>
+      <p>
+        Following implementation, changes may take up to 2 weeks to propagate.
+      </p>
+    </Stack>
+  </Banner>
   <TableCollection
     columns={
       Array [
@@ -225,6 +282,25 @@ exports[`IP Pools List Page should render the list page correctly 1`] = `
   }
   title="IP Pools"
 >
+  <Banner
+    marginBottom="500"
+    status="info"
+    title="SparkPost now supports Strict TLS and Custom Messaging Expiration"
+  >
+    <Stack>
+      <p>
+        To adjust these settings, please
+         
+        <Connect(SupportTicketLink)>
+          submit a support ticket
+        </Connect(SupportTicketLink)>
+         or contact your TAM.
+      </p>
+      <p>
+        Following implementation, changes may take up to 2 weeks to propagate.
+      </p>
+    </Stack>
+  </Banner>
   <TableCollection
     columns={
       Array [
@@ -307,6 +383,25 @@ exports[`IP Pools List Page should show alert upon error 1`] = `
   }
   title="IP Pools"
 >
+  <Banner
+    marginBottom="500"
+    status="info"
+    title="SparkPost now supports Strict TLS and Custom Messaging Expiration"
+  >
+    <Stack>
+      <p>
+        To adjust these settings, please
+         
+        <Connect(SupportTicketLink)>
+          submit a support ticket
+        </Connect(SupportTicketLink)>
+         or contact your TAM.
+      </p>
+      <p>
+        Following implementation, changes may take up to 2 weeks to propagate.
+      </p>
+    </Stack>
+  </Banner>
   <ApiErrorBanner
     errorDetails="Uh oh! It broke."
     message="Sorry, we seem to have had some trouble loading your ip pools."

--- a/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/ipPools/tests/__snapshots__/ListPage.test.js.snap
@@ -20,7 +20,6 @@ exports[`IP Pools List Page does not render purchase action if isAdmin is false 
   }
   title="IP Pools"
 >
-  <IPWarmupReminderBanner />
   <TableCollection
     columns={
       Array [
@@ -82,7 +81,6 @@ exports[`IP Pools List Page does not render purchase action if showPurchaseCTA i
   secondaryActions={null}
   title="IP Pools"
 >
-  <IPWarmupReminderBanner />
   <TableCollection
     columns={
       Array [
@@ -144,7 +142,6 @@ exports[`IP Pools List Page does not render purchase action if showPurchaseCTA i
   secondaryActions={null}
   title="IP Pools"
 >
-  <IPWarmupReminderBanner />
   <TableCollection
     columns={
       Array [
@@ -208,30 +205,6 @@ Array [
 ]
 `;
 
-exports[`IP Pools List Page should render the IP warm-up banner correctly 1`] = `
-<Banner
-  marginBottom="500"
-  status="warning"
-  title="New dedicated IP addresses need to be warmed up"
->
-  <Box
-    maxWidth="1200"
-  >
-    <p>
-      In order to establish a positive sending reputation, warm up new dedicated IP addresses by gradually sending more emails.
-    </p>
-    <Banner.Actions>
-      <ExternalLink
-        as={[Function]}
-        to="https://support.sparkpost.com/customer/portal/articles/1972209-ip-warm-up-overview"
-      >
-        Read our IP Warm-up Overview
-      </ExternalLink>
-    </Banner.Actions>
-  </Box>
-</Banner>
-`;
-
 exports[`IP Pools List Page should render the list page correctly 1`] = `
 <Page
   primaryAction={
@@ -252,7 +225,6 @@ exports[`IP Pools List Page should render the list page correctly 1`] = `
   }
   title="IP Pools"
 >
-  <IPWarmupReminderBanner />
   <TableCollection
     columns={
       Array [
@@ -335,7 +307,6 @@ exports[`IP Pools List Page should show alert upon error 1`] = `
   }
   title="IP Pools"
 >
-  <IPWarmupReminderBanner />
   <ApiErrorBanner
     errorDetails="Uh oh! It broke."
     message="Sorry, we seem to have had some trouble loading your ip pools."


### PR DESCRIPTION
### What Changed
 - Moved IP warm-up banner to edit IP pool page (maybe should add it to edit ip page?)
 - Added Strict TLS and Custom Messaging Expiration banner to IP pool list page

### How To Test
 - Navigate to /account/ip-pools and confirm Strict TLS ... banner is visible
 - Click submit a support ticket to confirm support modal opens
 - Navigate to /account/ip-pools/edit/default and confirm warm-up banner is visible
