### PR TITLE
SA-1417 -  Inbox Placement list page crashes when user's session expires and logs in again

### DIFF
--- a/src/reducers/inboxPlacement.js
+++ b/src/reducers/inboxPlacement.js
@@ -54,7 +54,11 @@ export default (state = initialState, { type, payload, meta }) => {
       };
     }
     case 'GET_INBOX_PLACEMENT_TRENDS_FILTER_VALUES_FAIL':
-      return { ...state, getTrendsFilterValuesPending: false, getTrendsFilterValuesError: payload };
+      return {
+        ...state,
+        getTrendsFilterValuesPending: false,
+        getTrendsFilterValuesError: payload.message,
+      };
 
     case 'GET_INBOX_PLACEMENT_TESTS_BY_MAILBOX_PROVIDER_PENDING':
       return { ...state, getByProviderPending: true, getByProviderError: null };

--- a/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
+++ b/src/reducers/tests/__snapshots__/inboxPlacement.test.js.snap
@@ -90,13 +90,7 @@ exports[`Inbox Placement Reducer get inbox placement trends filter values fail 1
 Object {
   "allMessages": Array [],
   "currentTestDetails": Object {},
-  "getTrendsFilterValuesError": Object {
-    "errors": Array [
-      Object {
-        "message": "Some error occurred",
-      },
-    ],
-  },
+  "getTrendsFilterValuesError": undefined,
   "getTrendsFilterValuesPending": false,
   "messagesById": Object {},
   "placementsByProvider": Array [],


### PR DESCRIPTION
SA-1417 -  Inbox Placement list page crashes when user's session expires and logs in again

### What Changed
 - getTrendsFilterValuesError should be a string; TypeAhead expects a string

### How To Test
 - Login and open the network tab to get the token sent by authenticate. Copy that token.
 - Navigate to inbox-placement page
 - Use postman and using POST /authenticate/logout invalidate the token
 - Now on inbox-placement page, change the date range filter to something else; this should trigger a logout. Watchout for two error alerts meaning message-filter api and inbox-placement api must have thrown 401.
- Now login again, you should have landed on inbox-placement page without it crashing.

### To Do
- [ ] Address feedback
