### PR TITLE
FE-1097 - Custom dropdown components should render full width relative to their paired fields

### DIFF
--- a/src/components/filterDropdown/FilterDropdown.js
+++ b/src/components/filterDropdown/FilterDropdown.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { ArrowDropDown, ChevronRight } from '@sparkpost/matchbox-icons';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import { Field, change, formValueSelector } from 'redux-form';
-
-import { ArrowDropDown } from '@sparkpost/matchbox-icons';
-import { ActionList, Popover, TextField } from 'src/components/matchbox';
-
+import { useHibana } from 'src/context/HibanaContext';
+import { ActionList, Box, Popover, TextField } from 'src/components/matchbox';
 import styles from './FilterDropdown.module.scss';
 
 export class FilterDropdown extends Component {
@@ -74,7 +74,7 @@ export class FilterDropdown extends Component {
         <Popover
           as="div"
           id={`filter-dropdown-popover-${id}`}
-          className={popoverClassName}
+          className={classNames(styles.Popover, popoverClassName)}
           trigger={
             <>
               <label className={styles.hidden} htmlFor={`filter-dropdown-${id}`}>
@@ -86,7 +86,7 @@ export class FilterDropdown extends Component {
                 prefix={prefix}
                 value={displayValue}
                 readOnly
-                suffix={<ArrowDropDown />}
+                suffix={<FieldSuffix />}
               />
             </>
           }
@@ -98,6 +98,20 @@ export class FilterDropdown extends Component {
       </div>
     );
   }
+}
+
+function FieldSuffix() {
+  const [{ isHibanaEnabled }] = useHibana();
+
+  if (isHibanaEnabled) {
+    return (
+      <Box as="span" color="blue.700">
+        <ChevronRight size={24} style={{ transform: 'rotate(90deg)' }} />
+      </Box>
+    );
+  }
+
+  return <ArrowDropDown />;
 }
 
 FilterDropdown.propTypes = {
@@ -119,5 +133,6 @@ const mapStateToProps = (state, { formName, namespace }) => {
   const selector = formValueSelector(formName);
   return { values: selector(state, namespace) };
 };
+
 const mapDispatchToProps = { change };
 export default connect(mapStateToProps, mapDispatchToProps)(FilterDropdown);

--- a/src/components/filterDropdown/FilterDropdown.module.scss
+++ b/src/components/filterDropdown/FilterDropdown.module.scss
@@ -4,9 +4,12 @@
   @include visually-hidden;
 }
 
-.filter-dropdown{
-  .Matchbox-ActionList{
+.filter-dropdown {
+  .Matchbox-ActionList {
     overflow: auto;
   }
 }
 
+.Popover {
+  width: 100%;
+}

--- a/src/components/filterDropdown/tests/__snapshots__/FilterDropdown.test.js.snap
+++ b/src/components/filterDropdown/tests/__snapshots__/FilterDropdown.test.js.snap
@@ -4,6 +4,7 @@ exports[`Component: FilterDropdown renders correctly 1`] = `
 <div>
   <Popover
     as="div"
+    className="Popover"
     id="filter-dropdown-popover-my-filter-dropdown"
     onClose={[Function]}
     trigger={
@@ -18,7 +19,7 @@ exports[`Component: FilterDropdown renders correctly 1`] = `
           id="filter-dropdown-my-filter-dropdown"
           prefix={null}
           readOnly={true}
-          suffix={<ArrowDropDown />}
+          suffix={<FieldSuffix />}
           value="Status"
         />
       </React.Fragment>
@@ -83,6 +84,7 @@ exports[`Component: FilterDropdown renders selected correctly 1`] = `
 <div>
   <Popover
     as="div"
+    className="Popover"
     id="filter-dropdown-popover-my-filter-dropdown"
     onClose={[Function]}
     trigger={
@@ -97,7 +99,7 @@ exports[`Component: FilterDropdown renders selected correctly 1`] = `
           id="filter-dropdown-my-filter-dropdown"
           prefix="(1)"
           readOnly={true}
-          suffix={<ArrowDropDown />}
+          suffix={<FieldSuffix />}
           value="Status"
         />
       </React.Fragment>

--- a/src/pages/signals/components/filters/SubaccountFilter.module.scss
+++ b/src/pages/signals/components/filters/SubaccountFilter.module.scss
@@ -37,7 +37,7 @@
 }
 
 .Popover {
-  width: 300px;
+  width: 100%;
 
   > span {
     display: none; // remove popover carrot

--- a/src/pages/suppressions/components/SuppressionSearch.js
+++ b/src/pages/suppressions/components/SuppressionSearch.js
@@ -7,7 +7,6 @@ import { FilterDropdown } from 'src/components';
 import * as suppressionActions from 'src/actions/suppressions';
 import DatePicker from 'src/components/datePicker/DatePicker';
 import { selectSearchInitialValues } from 'src/selectors/suppressions';
-import styles from './SuppressionSearch.module.scss';
 import { TYPES, SOURCES, RELATIVE_DATE_OPTIONS } from '../constants';
 
 export class SuppressionSearch extends Component {
@@ -54,7 +53,6 @@ export class SuppressionSearch extends Component {
           <FilterDropdown
             label="Type"
             id="types-filter-dropdown"
-            popoverClassName={styles.suppressionPopver}
             formName="filterForm"
             options={TYPES}
             namespace="types"
@@ -71,7 +69,6 @@ export class SuppressionSearch extends Component {
             options={SOURCES}
             namespace="sources"
             displayValue="Sources"
-            popoverClassName={styles.fatPopover}
             onClose={this.handleSourcesSelection}
           />
         </Grid.Column>

--- a/src/pages/suppressions/components/SuppressionSearch.module.scss
+++ b/src/pages/suppressions/components/SuppressionSearch.module.scss
@@ -1,5 +1,0 @@
-@import '~@sparkpost/matchbox/src/styles/config.scss';
-
-.suppressionPopver {
-  width: 207px;
-}

--- a/src/pages/suppressions/components/tests/__snapshots__/SuppressionSearch.test.js.snap
+++ b/src/pages/suppressions/components/tests/__snapshots__/SuppressionSearch.test.js.snap
@@ -70,7 +70,6 @@ exports[`SuppressionSearch renders correctly 1`] = `
           },
         ]
       }
-      popoverClassName="suppressionPopver"
     />
   </Grid.Column>
   <Grid.Column
@@ -112,7 +111,6 @@ exports[`SuppressionSearch renders correctly 1`] = `
           },
         ]
       }
-      popoverClassName="fatPopover"
     />
   </Grid.Column>
 </Grid>


### PR DESCRIPTION
[FE-1097](https://jira.int.messagesystems.com/browse/FE-1097)

### What Changed
- Updated `SubaccountFilter` and `FilterDropdown` components according to ticket requirements

### How To Test
- [ ] Verify all instances of the `SubaccountFilter` render with a full width popover in both the OG and Hibana themes
- [ ] Verify all instances of the `FilterDropdown` render with a full width popover in both the OG and Hibana themes - also verify that the icon is a blue chevron for Hibana only for this component

### To Do
- [ ] Incorporate feedback
