### PR TITLE
FE-1100 - Incorporate UX feedback for the users feature

### DIFF
--- a/src/pages/users/CreatePage.js
+++ b/src/pages/users/CreatePage.js
@@ -45,14 +45,13 @@ export class CreatePage extends Component {
           <form onSubmit={handleSubmit(this.handleSubmit)}>
             <Panel.Section>
               <Stack>
-                <p>An invitation will be sent to the email address you supply</p>
-
                 <Field
                   name="email"
                   validate={[required, email]}
                   normalize={trimWhitespaces}
                   label="Email address"
                   component={TextFieldWrapper}
+                  helpText="An invitation will be sent to the email address you supply"
                 />
 
                 <Field

--- a/src/pages/users/ListPage.js
+++ b/src/pages/users/ListPage.js
@@ -77,7 +77,7 @@ export class ListPage extends Component {
     const data = [
       <User name={user.name} email={user.email} username={user.username} />,
       user.roleLabel,
-      user.tfa_enabled ? <Tag color="blue">Enabled</Tag> : <Tag>Disabled</Tag>,
+      user.tfa_enabled ? <Tag>Enabled</Tag> : <Tag>Disabled</Tag>,
       user.last_login ? <TimeAgo date={user.last_login} live={false} /> : 'Never',
       <Actions
         username={user.username}

--- a/src/pages/users/tests/__snapshots__/CreatePage.test.js.snap
+++ b/src/pages/users/tests/__snapshots__/CreatePage.test.js.snap
@@ -27,11 +27,9 @@ exports[`Page: User Create Page should render correctly by default 1`] = `
     >
       <Panel.Section>
         <Stack>
-          <p>
-            An invitation will be sent to the email address you supply
-          </p>
           <Field
             component={[Function]}
+            helpText="An invitation will be sent to the email address you supply"
             label="Email address"
             name="email"
             normalize={[Function]}


### PR DESCRIPTION
[FE-1100](https://jira.int.messagesystems.com/browse/FE-1100)

### What Changed
- Incorporated feedback tweaks outlined in the ticket

### How To Test
- Go to `/account/users` and verify the "Enabled" tag in the 2FA column does not render with a color
- Go to `/account/users/create` and verify that the paragraph help text is moved below the field via the `helpText` prop

### To Do
- [ ] Incorporate feedback