### PR TITLE
AC-1505: (UI)Remove the usage report for new customers

### DIFF
--- a/src/components/usageReport/UsageReport.js
+++ b/src/components/usageReport/UsageReport.js
@@ -84,43 +84,46 @@ export class UsageReport extends Component {
     const hasDailyLimit = usage.day.limit > 0;
     const hasMonthlyLimit = usage.month.limit > 0;
 
-    return (
-      <Panel title="Your Usage Report" actions={actions}>
-        <Panel.Section>
-          <ProgressLabel
-            title="Today"
-            secondaryTitle={`Since ${formatDateTime(usage.day.start)}`}
-          />
-          {hasDailyLimit && (
-            <ProgressBar completed={getPercent(usage.day.used, usage.day.limit)} my="300" />
-          )}
-          <DisplayNumber label="Used" content={usage.day.used.toLocaleString()} primary />
-          {hasDailyLimit && (
-            <DisplayNumber label="Daily Limit" content={usage.day.limit.toLocaleString()} />
-          )}
-          <SendMoreCTA hasSendingLimits={hasDailyLimit || hasMonthlyLimit} />
-        </Panel.Section>
-        <Panel.Section>
-          <ProgressLabel
-            title="This Month"
-            secondaryTitle={`Billing cycle: ${formatDate(usage.month.start)} - ${formatDate(
-              usage.month.end,
-            )}`}
-          />
-          {hasMonthlyLimit && (
-            <ProgressBar completed={getPercent(usage.month.used, usage.month.limit)} my="300" />
-          )}
-          <DisplayNumber label="Used" content={usage.month.used.toLocaleString()} primary />
-          <DisplayNumber label="Included" content={subscription.plan_volume.toLocaleString()} />
-          {overage > 0 && (
-            <DisplayNumber label="Extra Emails Used" content={overage.toLocaleString()} />
-          )}
-          {hasMonthlyLimit && (
-            <DisplayNumber label="Monthly limit" content={usage.month.limit.toLocaleString()} />
-          )}
-        </Panel.Section>
-      </Panel>
-    );
+    if (usage.month.used > 0 || usage.day.used > 0)
+      return (
+        <Panel title="Your Usage Report" actions={actions}>
+          <Panel.Section>
+            <ProgressLabel
+              title="Today"
+              secondaryTitle={`Since ${formatDateTime(usage.day.start)}`}
+            />
+            {hasDailyLimit && (
+              <ProgressBar completed={getPercent(usage.day.used, usage.day.limit)} my="300" />
+            )}
+            <DisplayNumber label="Used" content={usage.day.used.toLocaleString()} primary />
+            {hasDailyLimit && (
+              <DisplayNumber label="Daily Limit" content={usage.day.limit.toLocaleString()} />
+            )}
+            <SendMoreCTA hasSendingLimits={hasDailyLimit || hasMonthlyLimit} />
+          </Panel.Section>
+          <Panel.Section>
+            <ProgressLabel
+              title="This Month"
+              secondaryTitle={`Billing cycle: ${formatDate(usage.month.start)} - ${formatDate(
+                usage.month.end,
+              )}`}
+            />
+            {hasMonthlyLimit && (
+              <ProgressBar completed={getPercent(usage.month.used, usage.month.limit)} my="300" />
+            )}
+            <DisplayNumber label="Used" content={usage.month.used.toLocaleString()} primary />
+            <DisplayNumber label="Included" content={subscription.plan_volume.toLocaleString()} />
+            {overage > 0 && (
+              <DisplayNumber label="Extra Emails Used" content={overage.toLocaleString()} />
+            )}
+            {hasMonthlyLimit && (
+              <DisplayNumber label="Monthly limit" content={usage.month.limit.toLocaleString()} />
+            )}
+          </Panel.Section>
+        </Panel>
+      );
+
+    return null;
   }
 }
 

--- a/src/components/usageReport/tests/UsageReport.test.js
+++ b/src/components/usageReport/tests/UsageReport.test.js
@@ -42,6 +42,30 @@ describe('UsageReport Component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render null when usage is zero', () => {
+    const props = {
+      getAccount: getAccount,
+      subscription: {
+        plan_volume: 10000,
+      },
+      usage: {
+        month: {
+          used: 0,
+          limit: 50000,
+          start: '2017-08-01T08:00:00.000Z',
+          end: '2017-08-31T08:00:00.000Z',
+        },
+        day: {
+          used: 0,
+          limit: 2000,
+          start: '2017-08-30T00:00:00.000Z',
+        },
+      },
+    };
+    const wrapper = shallow(<UsageReport {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should render with regular usage', () => {
     const wrapper = shallow(<UsageReport {...props} />);
     expect(wrapper).toMatchSnapshot();

--- a/src/components/usageReport/tests/__snapshots__/UsageReport.test.js.snap
+++ b/src/components/usageReport/tests/__snapshots__/UsageReport.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UsageReport Component should render null when usage is zero 1`] = `""`;
+
 exports[`UsageReport Component should render null without props 1`] = `
 <PanelLoading
   accent={false}


### PR DESCRIPTION
AC-1505: (UI)Remove the usage report for new customers

### What Changed
 - UsageReport will not show up if there is no usage.

### How To Test
 - Sign up for a new account, dashboard should not have a Usage Report.

### To Do
- [ ] Address feedback
