### PR TITLE
AC-1474: (UI) Add the Delete SCIM token flow

### DIFF
--- a/cypress/fixtures/api-keys/401.delete.scim-token.json
+++ b/cypress/fixtures/api-keys/401.delete.scim-token.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "Resource could not be found"
+    }
+  ]
+}

--- a/cypress/tests/integration/accounts/account-settings/accountSettingsPage.js
+++ b/cypress/tests/integration/accounts/account-settings/accountSettingsPage.js
@@ -125,6 +125,7 @@ describe('Account Settings Page', () => {
             cy.wait('@scimTokenDelete');
             cy.wait('@scimTokenGet');
           });
+          cy.findByText('SCIM token deleted').should('be.visible');
           cy.findByText('No token generated').should('be.visible');
           cy.findByText('Delete token').should('not.be.visible');
         });

--- a/cypress/tests/integration/accounts/account-settings/accountSettingsPage.js
+++ b/cypress/tests/integration/accounts/account-settings/accountSettingsPage.js
@@ -94,6 +94,41 @@ describe('Account Settings Page', () => {
           cy.findByText('123f••••••••').should('be.visible');
         });
       });
+      describe('Delete token flow: ', () => {
+        beforeEach(() => {
+          cy.stubRequest({
+            url: 'api/v1/api-keys?grant=scim/manage',
+            fixture: 'api-keys/200.get.scim-token.json',
+            requestAlias: 'scimTokenGet',
+          });
+          cy.visit(PAGE_URL);
+        });
+        it('Delete Token flow for scim token', () => {
+          cy.findByText('old1••••••••').should('be.visible');
+          cy.findByText('Delete Token').click();
+          cy.withinModal(() => {
+            cy.findAllByText('Delete SCIM Token').should('be.visible');
+            cy.stubRequest({
+              url: 'api/v1/api-keys/oldid',
+              method: 'DELETE',
+              fixture: 'api-keys/200.get.scim-token-notoken.json',
+              requestAlias: 'scimTokenDelete',
+            });
+            cy.stubRequest({
+              url: 'api/v1/api-keys?grant=scim/manage',
+              fixture: 'api-keys/200.get.scim-token-notoken.json',
+              requestAlias: 'scimTokenGet',
+            });
+            cy.get('button')
+              .contains('Delete SCIM Token')
+              .click();
+            cy.wait('@scimTokenDelete');
+            cy.wait('@scimTokenGet');
+          });
+          cy.findByText('No token generated').should('be.visible');
+          cy.findByText('Delete token').should('not.be.visible');
+        });
+      });
     });
   });
 });

--- a/cypress/tests/integration/accounts/account-settings/accountSettingsPage.js
+++ b/cypress/tests/integration/accounts/account-settings/accountSettingsPage.js
@@ -94,41 +94,37 @@ describe('Account Settings Page', () => {
           cy.findByText('123f••••••••').should('be.visible');
         });
       });
-      describe('Delete token flow: ', () => {
-        beforeEach(() => {
+
+      it('Delete Token flow for scim token', () => {
+        cy.stubRequest({
+          url: 'api/v1/api-keys?grant=scim/manage',
+          fixture: 'api-keys/200.get.scim-token.json',
+          requestAlias: 'scimTokenGet',
+        });
+        cy.visit(PAGE_URL);
+        cy.findByText('old1••••••••').should('be.visible');
+        cy.findByText('Delete Token').click();
+        cy.withinModal(() => {
+          cy.findAllByText('Delete SCIM Token').should('be.visible');
+          cy.stubRequest({
+            url: 'api/v1/api-keys/oldid',
+            method: 'DELETE',
+            fixture: 'api-keys/200.get.scim-token-notoken.json',
+            requestAlias: 'scimTokenDelete',
+          });
           cy.stubRequest({
             url: 'api/v1/api-keys?grant=scim/manage',
-            fixture: 'api-keys/200.get.scim-token.json',
+            fixture: 'api-keys/200.get.scim-token-notoken.json',
             requestAlias: 'scimTokenGet',
           });
-          cy.visit(PAGE_URL);
+          cy.get('button')
+            .contains('Delete SCIM Token')
+            .click();
+          cy.wait(['@scimTokenDelete', '@scimTokenGet']);
         });
-        it('Delete Token flow for scim token', () => {
-          cy.findByText('old1••••••••').should('be.visible');
-          cy.findByText('Delete Token').click();
-          cy.withinModal(() => {
-            cy.findAllByText('Delete SCIM Token').should('be.visible');
-            cy.stubRequest({
-              url: 'api/v1/api-keys/oldid',
-              method: 'DELETE',
-              fixture: 'api-keys/200.get.scim-token-notoken.json',
-              requestAlias: 'scimTokenDelete',
-            });
-            cy.stubRequest({
-              url: 'api/v1/api-keys?grant=scim/manage',
-              fixture: 'api-keys/200.get.scim-token-notoken.json',
-              requestAlias: 'scimTokenGet',
-            });
-            cy.get('button')
-              .contains('Delete SCIM Token')
-              .click();
-            cy.wait('@scimTokenDelete');
-            cy.wait('@scimTokenGet');
-          });
-          cy.findByText('SCIM token deleted').should('be.visible');
-          cy.findByText('No token generated').should('be.visible');
-          cy.findByText('Delete token').should('not.be.visible');
-        });
+        cy.findByText('SCIM token deleted').should('be.visible');
+        cy.findByText('No token generated').should('be.visible');
+        cy.findByText('Delete token').should('not.be.visible');
       });
     });
   });

--- a/src/actions/scimToken.js
+++ b/src/actions/scimToken.js
@@ -33,7 +33,7 @@ export function listScimToken() {
 export function deleteScimToken({ id, subaccount = null }) {
   const headers = setSubaccountHeader(subaccount);
   return sparkpostApiRequest({
-    type: 'DELETE_API_KEY',
+    type: 'DELETE_SCIM_TOKEN',
     meta: {
       method: 'DELETE',
       url: `/v1/api-keys/${id}`,

--- a/src/actions/scimToken.js
+++ b/src/actions/scimToken.js
@@ -1,4 +1,5 @@
 import sparkpostApiRequest from './helpers/sparkpostApiRequest';
+import setSubaccountHeader from './helpers/setSubaccountHeader';
 
 export function generateScimToken() {
   return sparkpostApiRequest({
@@ -25,6 +26,18 @@ export function listScimToken() {
         grant: 'scim/manage',
       },
       showErrorAlert: false,
+    },
+  });
+}
+
+export function deleteScimToken({ id, subaccount = null }) {
+  const headers = setSubaccountHeader(subaccount);
+  return sparkpostApiRequest({
+    type: 'DELETE_API_KEY',
+    meta: {
+      method: 'DELETE',
+      url: `/v1/api-keys/${id}`,
+      headers,
     },
   });
 }

--- a/src/actions/scimToken.js
+++ b/src/actions/scimToken.js
@@ -41,3 +41,7 @@ export function deleteScimToken({ id, subaccount = null }) {
     },
   });
 }
+
+export function resetScimTokenErrors() {
+  return { type: 'SCIM_TOKEN_ERROR_RESET' };
+}

--- a/src/actions/tests/__snapshots__/scimToken.test.js.snap
+++ b/src/actions/tests/__snapshots__/scimToken.test.js.snap
@@ -41,3 +41,9 @@ Object {
   "type": "LIST_SCIM_TOKEN",
 }
 `;
+
+exports[`Action Creator: scimToken resetScimTokenError should make the appropriate request 1`] = `
+Object {
+  "type": "SCIM_TOKEN_ERROR_RESET",
+}
+`;

--- a/src/actions/tests/__snapshots__/scimToken.test.js.snap
+++ b/src/actions/tests/__snapshots__/scimToken.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Action Creator: scimToken deleteScimToken should make the appropriate request 1`] = `
+Object {
+  "meta": Object {
+    "headers": Object {},
+    "method": "DELETE",
+    "url": "/v1/api-keys/fake-id",
+  },
+  "type": "DELETE_SCIM_TOKEN",
+}
+`;
+
 exports[`Action Creator: scimToken generateScimToken should make the appropriate request 1`] = `
 Object {
   "meta": Object {

--- a/src/actions/tests/scimToken.test.js
+++ b/src/actions/tests/scimToken.test.js
@@ -17,4 +17,9 @@ describe('Action Creator: scimToken', () => {
     const thunk = scimTokenRequests.deleteScimToken({ id: 'fake-id' });
     expect(thunk).toMatchSnapshot();
   });
+
+  it('resetScimTokenError should make the appropriate request', () => {
+    const thunk = scimTokenRequests.resetScimTokenErrors();
+    expect(thunk).toMatchSnapshot();
+  });
 });

--- a/src/actions/tests/scimToken.test.js
+++ b/src/actions/tests/scimToken.test.js
@@ -12,4 +12,9 @@ describe('Action Creator: scimToken', () => {
     const thunk = scimTokenRequests.listScimToken();
     expect(thunk).toMatchSnapshot();
   });
+
+  it('deleteScimToken should make the appropriate request', () => {
+    const thunk = scimTokenRequests.deleteScimToken({ id: 'fake-id' });
+    expect(thunk).toMatchSnapshot();
+  });
 });

--- a/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
+++ b/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Button, Modal, Panel, Stack, Text } from 'src/components/matchbox';
 import { ButtonWrapper, CopyField, LabelledValue, ShortKeyCode } from 'src/components';
 import useModal from 'src/hooks/useModal';
@@ -13,13 +13,16 @@ export default function SCIMTokenSection(props) {
     deleteScimToken,
     error,
     showAlert,
+    resetScimTokenErrors,
   } = props;
+  const { closeModal, isModalOpen, openModal, meta: { name } = {} } = useModal();
   const getActions =
     scimTokenList.length > 0
       ? [
           {
             content: 'Delete Token',
             onClick: () => {
+              resetScimTokenErrors();
               openModal({ name: 'Delete Token' });
             },
             color: 'orange',
@@ -27,6 +30,7 @@ export default function SCIMTokenSection(props) {
           {
             content: 'Generate SCIM Token',
             onClick: () => {
+              resetScimTokenErrors();
               openModal({ name: 'Override Token' });
             },
             color: 'orange',
@@ -36,12 +40,12 @@ export default function SCIMTokenSection(props) {
           {
             content: 'Generate SCIM Token',
             onClick: () => {
+              resetScimTokenErrors();
               handleGenerateToken();
             },
             color: 'orange',
           },
         ];
-  const { closeModal, isModalOpen, openModal, meta: { name } = {} } = useModal();
   const handleGenerateToken = () => {
     if (scimTokenList.length > 0) {
       deleteScimToken({ id: scimTokenList[0].id }).then(() => {
@@ -64,11 +68,7 @@ export default function SCIMTokenSection(props) {
       showAlert({ type: 'success', message: 'SCIM token deleted' });
     });
   };
-  useEffect(() => {
-    if (error) {
-      closeModal();
-    }
-  }, [error, closeModal]);
+
   const renderModalByName = name => {
     switch (name) {
       case 'Override Token':
@@ -173,9 +173,11 @@ export default function SCIMTokenSection(props) {
           )}
         </Heading>
       </LabelledValue>
-      <Modal open={isModalOpen} onClose={() => closeModal()} showCloseButton>
-        {isModalOpen && renderModalByName(name)}
-      </Modal>
+      {!error && (
+        <Modal open={isModalOpen} onClose={() => closeModal()} showCloseButton>
+          {isModalOpen && renderModalByName(name)}
+        </Modal>
+      )}
     </Panel.Section>
   );
 }

--- a/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
+++ b/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
@@ -129,7 +129,7 @@ export default function SCIMTokenSection(props) {
                 >
                   Delete SCIM Token
                 </Button>
-                <Button variant="secondary" onClick={() => closeModal()}>
+                <Button variant="monochrome-secondary" onClick={() => closeModal()}>
                   Cancel
                 </Button>
               </ButtonWrapper>

--- a/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
+++ b/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
@@ -43,10 +43,19 @@ export default function SCIMTokenSection(props) {
         ];
   const { closeModal, isModalOpen, openModal, meta: { name } = {} } = useModal();
   const handleGenerateToken = () => {
-    generateScimToken().then(() => {
-      openModal({ name: 'Generate SCIM Token' });
-      listScimToken();
-    });
+    if (scimTokenList.length > 0) {
+      deleteScimToken({ id: scimTokenList[0].id }).then(() => {
+        generateScimToken().then(() => {
+          openModal({ name: 'Generate SCIM Token' });
+          listScimToken();
+        });
+      });
+    } else {
+      generateScimToken().then(() => {
+        openModal({ name: 'Generate SCIM Token' });
+        listScimToken();
+      });
+    }
   };
   const handleDeleteToken = () => {
     deleteScimToken({ id: scimTokenList[0].id }).then(() => {

--- a/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
+++ b/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Button, Modal, Panel, Stack, Text } from 'src/components/matchbox';
 import { ButtonWrapper, CopyField, LabelledValue, ShortKeyCode } from 'src/components';
 import useModal from 'src/hooks/useModal';
 import Heading from 'src/components/text/Heading';
-import { showAlert } from 'src/actions/globalAlert';
+
 export default function SCIMTokenSection(props) {
-  const { scimTokenList, newScimToken, generateScimToken, listScimToken, deleteScimToken } = props;
+  const {
+    scimTokenList,
+    newScimToken,
+    generateScimToken,
+    listScimToken,
+    deleteScimToken,
+    error,
+    showAlert,
+  } = props;
   const getActions =
     scimTokenList.length > 0
       ? [
@@ -47,6 +55,11 @@ export default function SCIMTokenSection(props) {
       showAlert({ type: 'success', message: 'SCIM token deleted' });
     });
   };
+  useEffect(() => {
+    if (error) {
+      closeModal();
+    }
+  }, [error, closeModal]);
   const renderModalByName = name => {
     switch (name) {
       case 'Override Token':

--- a/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
+++ b/src/pages/account/components/SingleSignOnPanel/SCIMTokenSection.js
@@ -3,14 +3,17 @@ import { Button, Modal, Panel, Stack, Text } from 'src/components/matchbox';
 import { ButtonWrapper, CopyField, LabelledValue, ShortKeyCode } from 'src/components';
 import useModal from 'src/hooks/useModal';
 import Heading from 'src/components/text/Heading';
+import { showAlert } from 'src/actions/globalAlert';
 export default function SCIMTokenSection(props) {
-  const { scimTokenList, newScimToken, generateScimToken, listScimToken } = props;
+  const { scimTokenList, newScimToken, generateScimToken, listScimToken, deleteScimToken } = props;
   const getActions =
     scimTokenList.length > 0
       ? [
           {
             content: 'Delete Token',
-            onClick: () => {},
+            onClick: () => {
+              openModal({ name: 'Delete Token' });
+            },
             color: 'orange',
           },
           {
@@ -35,6 +38,13 @@ export default function SCIMTokenSection(props) {
     generateScimToken().then(() => {
       openModal({ name: 'Generate SCIM Token' });
       listScimToken();
+    });
+  };
+  const handleDeleteToken = () => {
+    deleteScimToken({ id: scimTokenList[0].id }).then(() => {
+      listScimToken();
+      closeModal();
+      showAlert({ type: 'success', message: 'SCIM token deleted' });
     });
   };
   const renderModalByName = name => {
@@ -67,6 +77,35 @@ export default function SCIMTokenSection(props) {
                   }}
                 >
                   Generate New Token
+                </Button>
+                <Button variant="secondary" onClick={() => closeModal()}>
+                  Cancel
+                </Button>
+              </ButtonWrapper>
+            </Panel.Section>
+          </Panel>
+        );
+      case 'Delete Token':
+        return (
+          <Panel title="Delete SCIM Token">
+            <Panel.Section>
+              <Stack>
+                <p>
+                  <Text as="span">
+                    The token will be immediately and permanently removed. This cannot be undone.
+                  </Text>
+                </p>
+              </Stack>
+            </Panel.Section>
+            <Panel.Section>
+              <ButtonWrapper>
+                <Button
+                  variant="destructive"
+                  onClick={() => {
+                    handleDeleteToken();
+                  }}
+                >
+                  Delete SCIM Token
                 </Button>
                 <Button variant="secondary" onClick={() => closeModal()}>
                   Cancel

--- a/src/pages/account/components/SingleSignOnPanel/SingleSignOnPanel.js
+++ b/src/pages/account/components/SingleSignOnPanel/SingleSignOnPanel.js
@@ -14,6 +14,7 @@ import SCIMTokenSection from './SCIMTokenSection';
 import { PANEL_LOADING_HEIGHT } from 'src/pages/account/constants';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import { generateScimToken, listScimToken, deleteScimToken } from 'src/actions/scimToken';
+import { showAlert } from 'src/actions/globalAlert';
 
 export function SingleSignOnPanel(props) {
   const {
@@ -27,6 +28,9 @@ export function SingleSignOnPanel(props) {
     deleteScimToken,
     scimTokenList,
     newScimToken,
+    deleteScimTokenError,
+    generateScimTokenError,
+    showAlert,
   } = props;
   useEffect(() => {
     getAccountSingleSignOnDetails();
@@ -50,11 +54,13 @@ export function SingleSignOnPanel(props) {
         <StatusSection readOnly={tfaRequired} {...props} />
         {isSsoScimUiEnabled && provider && (
           <SCIMTokenSection
+            showAlert={showAlert}
             scimTokenList={scimTokenList}
             newScimToken={newScimToken}
             generateScimToken={generateScimToken}
             listScimToken={listScimToken}
             deleteScimToken={deleteScimToken}
+            error={deleteScimTokenError || generateScimTokenError}
           />
         )}
       </React.Fragment>
@@ -88,6 +94,7 @@ const mapDispatchToProps = {
   listScimToken,
   generateScimToken,
   deleteScimToken,
+  showAlert,
 };
 
 const mapStateToProps = state => ({
@@ -96,6 +103,8 @@ const mapStateToProps = state => ({
   isSsoScimUiEnabled: isAccountUiOptionSet('sso_scim_section')(state),
   scimTokenList: state.scimToken.scimTokenList,
   newScimToken: state.scimToken.newScimToken,
+  deleteScimTokenError: state.scimToken.deleteScimTokenError,
+  generateScimTokenError: state.scimToken.generateScimTokenError,
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SingleSignOnPanel);

--- a/src/pages/account/components/SingleSignOnPanel/SingleSignOnPanel.js
+++ b/src/pages/account/components/SingleSignOnPanel/SingleSignOnPanel.js
@@ -13,7 +13,7 @@ import StatusSection from './StatusSection';
 import SCIMTokenSection from './SCIMTokenSection';
 import { PANEL_LOADING_HEIGHT } from 'src/pages/account/constants';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
-import { generateScimToken, listScimToken } from 'src/actions/scimToken';
+import { generateScimToken, listScimToken, deleteScimToken } from 'src/actions/scimToken';
 
 export function SingleSignOnPanel(props) {
   const {
@@ -24,6 +24,7 @@ export function SingleSignOnPanel(props) {
     loading,
     listScimToken,
     generateScimToken,
+    deleteScimToken,
     scimTokenList,
     newScimToken,
   } = props;
@@ -53,6 +54,7 @@ export function SingleSignOnPanel(props) {
             newScimToken={newScimToken}
             generateScimToken={generateScimToken}
             listScimToken={listScimToken}
+            deleteScimToken={deleteScimToken}
           />
         )}
       </React.Fragment>
@@ -85,6 +87,7 @@ const mapDispatchToProps = {
   updateAccountSingleSignOn,
   listScimToken,
   generateScimToken,
+  deleteScimToken,
 };
 
 const mapStateToProps = state => ({

--- a/src/pages/account/components/SingleSignOnPanel/SingleSignOnPanel.js
+++ b/src/pages/account/components/SingleSignOnPanel/SingleSignOnPanel.js
@@ -13,7 +13,12 @@ import StatusSection from './StatusSection';
 import SCIMTokenSection from './SCIMTokenSection';
 import { PANEL_LOADING_HEIGHT } from 'src/pages/account/constants';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
-import { generateScimToken, listScimToken, deleteScimToken } from 'src/actions/scimToken';
+import {
+  generateScimToken,
+  listScimToken,
+  deleteScimToken,
+  resetScimTokenErrors,
+} from 'src/actions/scimToken';
 import { showAlert } from 'src/actions/globalAlert';
 
 export function SingleSignOnPanel(props) {
@@ -30,6 +35,7 @@ export function SingleSignOnPanel(props) {
     newScimToken,
     deleteScimTokenError,
     generateScimTokenError,
+    resetScimTokenErrors,
     showAlert,
   } = props;
   useEffect(() => {
@@ -60,6 +66,7 @@ export function SingleSignOnPanel(props) {
             generateScimToken={generateScimToken}
             listScimToken={listScimToken}
             deleteScimToken={deleteScimToken}
+            resetScimTokenErrors={resetScimTokenErrors}
             error={deleteScimTokenError || generateScimTokenError}
           />
         )}
@@ -94,6 +101,7 @@ const mapDispatchToProps = {
   listScimToken,
   generateScimToken,
   deleteScimToken,
+  resetScimTokenErrors,
   showAlert,
 };
 

--- a/src/reducers/scimToken.js
+++ b/src/reducers/scimToken.js
@@ -63,6 +63,14 @@ export default (state = initialState, { type, payload }) => {
         deleteScimTokenPending: false,
       };
     }
+    case 'SCIM_TOKEN_ERROR_RESET': {
+      return {
+        ...state,
+        deleteScimTokenSuccess: null,
+        deleteScimTokenError: null,
+        deleteScimTokenPending: null,
+      };
+    }
     default:
       return state;
   }

--- a/src/reducers/scimToken.js
+++ b/src/reducers/scimToken.js
@@ -6,6 +6,9 @@ const initialState = {
   generateScimTokenSuccess: null,
   generateScimTokenPending: null,
   generateScimTokenError: null,
+  deleteScimTokenSuccess: null,
+  deleteScimTokenPending: null,
+  deleteScimTokenError: null,
 };
 
 export default (state = initialState, { type, payload }) => {
@@ -33,6 +36,32 @@ export default (state = initialState, { type, payload }) => {
 
     case 'LIST_SCIM_TOKEN_FAIL': {
       return { ...state, scimTokenListLoading: false, error: payload };
+    }
+    //DELETE_SCIM_TOKEN
+    case 'DELETE_SCIM_TOKEN_SUCCESS': {
+      return {
+        ...state,
+        deleteScimTokenSuccess: true,
+        deleteScimTokenError: false,
+        deleteScimTokenPending: false,
+      };
+    }
+
+    case 'DELETE_SCIM_TOKEN_PENDING': {
+      return {
+        ...state,
+        deleteScimTokenSuccess: false,
+        deleteScimTokenError: false,
+        deleteScimTokenPending: true,
+      };
+    }
+    case 'DELETE_SCIM_TOKEN_FAIL': {
+      return {
+        ...state,
+        deleteScimTokenSuccess: false,
+        deleteScimTokenError: true,
+        deleteScimTokenPending: false,
+      };
     }
     default:
       return state;

--- a/src/reducers/tests/__snapshots__/scimToken.test.js.snap
+++ b/src/reducers/tests/__snapshots__/scimToken.test.js.snap
@@ -90,6 +90,21 @@ Object {
 }
 `;
 
+exports[`Reducer: ScimToken when scim token error are reset 1`] = `
+Object {
+  "deleteScimTokenError": null,
+  "deleteScimTokenPending": null,
+  "deleteScimTokenSuccess": null,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": null,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
 exports[`Reducer: ScimToken when scim token list failed to load 1`] = `
 Object {
   "deleteScimTokenError": null,

--- a/src/reducers/tests/__snapshots__/scimToken.test.js.snap
+++ b/src/reducers/tests/__snapshots__/scimToken.test.js.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reducer: ScimToken when delete scim token fails 1`] = `
+Object {
+  "deleteScimTokenError": true,
+  "deleteScimTokenPending": false,
+  "deleteScimTokenSuccess": false,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": null,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
+exports[`Reducer: ScimToken when delete scim token is pending 1`] = `
+Object {
+  "deleteScimTokenError": false,
+  "deleteScimTokenPending": true,
+  "deleteScimTokenSuccess": false,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": null,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
+exports[`Reducer: ScimToken when delete scim token succeeds 1`] = `
+Object {
+  "deleteScimTokenError": false,
+  "deleteScimTokenPending": false,
+  "deleteScimTokenSuccess": true,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": null,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
+exports[`Reducer: ScimToken when generate scim token failed 1`] = `
+Object {
+  "deleteScimTokenError": null,
+  "deleteScimTokenPending": null,
+  "deleteScimTokenSuccess": null,
+  "error": null,
+  "generateScimTokenError": [Error: Oh no!],
+  "generateScimTokenPending": false,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
+exports[`Reducer: ScimToken when generate scim token is pending 1`] = `
+Object {
+  "deleteScimTokenError": null,
+  "deleteScimTokenPending": null,
+  "deleteScimTokenSuccess": null,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": true,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
+exports[`Reducer: ScimToken when generate scim token succeeds 1`] = `
+Object {
+  "deleteScimTokenError": null,
+  "deleteScimTokenPending": null,
+  "deleteScimTokenSuccess": null,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": false,
+  "generateScimTokenSuccess": true,
+  "newScimToken": "this-is-a-fake-api-key",
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
+exports[`Reducer: ScimToken when scim token list failed to load 1`] = `
+Object {
+  "deleteScimTokenError": null,
+  "deleteScimTokenPending": null,
+  "deleteScimTokenSuccess": null,
+  "error": [Error: Oh no!],
+  "generateScimTokenError": null,
+  "generateScimTokenPending": null,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": false,
+}
+`;
+
+exports[`Reducer: ScimToken when scim token list is pending 1`] = `
+Object {
+  "deleteScimTokenError": null,
+  "deleteScimTokenPending": null,
+  "deleteScimTokenSuccess": null,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": null,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [],
+  "scimTokenListLoading": true,
+}
+`;
+
+exports[`Reducer: ScimToken when scim token list loaded 1`] = `
+Object {
+  "deleteScimTokenError": null,
+  "deleteScimTokenPending": null,
+  "deleteScimTokenSuccess": null,
+  "error": null,
+  "generateScimTokenError": null,
+  "generateScimTokenPending": null,
+  "generateScimTokenSuccess": null,
+  "newScimToken": null,
+  "scimTokenList": Array [
+    Object {
+      "created_at": "2019-06-18T20:50:12.164Z",
+      "grants": Array [
+        "scim/manage",
+      ],
+      "id": "oldid",
+      "label": "SCIM Token",
+      "short_key": "old1",
+      "username": "someuser",
+    },
+  ],
+  "scimTokenListLoading": false,
+}
+`;

--- a/src/reducers/tests/scimToken.test.js
+++ b/src/reducers/tests/scimToken.test.js
@@ -1,0 +1,56 @@
+import scimTokenReducer from '../scimToken';
+import cases from 'jest-in-case';
+
+cases(
+  'Reducer: ScimToken',
+  ({ name, ...action }) => {
+    expect(scimTokenReducer(undefined, action)).toMatchSnapshot();
+  },
+  {
+    'when scim token list failed to load': {
+      type: 'LIST_SCIM_TOKEN_FAIL',
+      payload: new Error('Oh no!'),
+    },
+    'when scim token list loaded': {
+      type: 'LIST_SCIM_TOKEN_SUCCESS',
+      payload: [
+        {
+          id: 'oldid',
+          label: 'SCIM Token',
+          short_key: 'old1',
+          grants: ['scim/manage'],
+          created_at: '2019-06-18T20:50:12.164Z',
+          username: 'someuser',
+        },
+      ],
+    },
+    'when scim token list is pending': {
+      type: 'LIST_SCIM_TOKEN_PENDING',
+    },
+    'when generate scim token failed': {
+      type: 'GENERATE_SCIM_TOKEN_FAIL',
+      payload: new Error('Oh no!'),
+    },
+    'when generate scim token is pending': {
+      type: 'GENERATE_SCIM_TOKEN_PENDING',
+    },
+    'when generate scim token succeeds': {
+      type: 'GENERATE_SCIM_TOKEN_SUCCESS',
+      payload: {
+        key: 'this-is-a-fake-api-key',
+        short_key: '123f',
+        label: 'Send Email Key (auto-generated)',
+        link: { href: '/api/v1/api-keys/mock-url-to-api-key' },
+      },
+    },
+    'when delete scim token is pending': {
+      type: 'DELETE_SCIM_TOKEN_PENDING',
+    },
+    'when delete scim token succeeds': {
+      type: 'DELETE_SCIM_TOKEN_SUCCESS',
+    },
+    'when delete scim token fails': {
+      type: 'DELETE_SCIM_TOKEN_FAIL',
+    },
+  },
+);

--- a/src/reducers/tests/scimToken.test.js
+++ b/src/reducers/tests/scimToken.test.js
@@ -52,5 +52,8 @@ cases(
     'when delete scim token fails': {
       type: 'DELETE_SCIM_TOKEN_FAIL',
     },
+    'when scim token error are reset': {
+      type: 'SCIM_TOKEN_ERROR_RESET',
+    },
   },
 );


### PR DESCRIPTION
AC-1474: (UI) Add the Delete SCIM token flow

### What Changed
 - Clicking on the Delete token opens Delete scim token modal.  https://sparkpost.invisionapp.com/public/share/FR169HZ78E#/screens/478309246

### How To Test
 - Click on the Delete Token in SCIM token section, it opens the Delete SCIM token modal. 
 - Run the cypress test added. This should help in checking the flow.

### To Do
- [ ] Address Feedback
- [x] Need to call the Delete endpoint when user overrides a SCIM token