### PR TITLE
Setting Account Icon to 650

### DIFF
--- a/src/components/hibana/AccountPopover.module.scss
+++ b/src/components/hibana/AccountPopover.module.scss
@@ -11,8 +11,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: spacing(700);
-  height: spacing(700);
+  width: spacing(650);
+  height: spacing(650);
   border-radius: border-radius(circle);
   background-color: color(brand, orange);
   color: color(white);


### PR DESCRIPTION
Switches account popover button dimensions to the 650 spacing token instead of 700

Note: Give your PR a short title. Something like "_TICKET NUMBER: feature description_" is good.

### What Changed
 - What changes did you make to satisfy the AC?
     > Outline changes to user flows, any surprising architectural decisions 
     > Alignment between PR commits and this section helps your reviewers.

### How To Test
 - Describe any special dev environment setup required.
     > Anything outside basic hamurai-managed stuff counts as "special".
 - Describe any special accounts that need to be tested.
     > Include any specific user roles and necessary feature flags.

### To Do
- [ ] Any outstanding tasks go here
    > Manage reviewers' expectations on missing features, tests, bugs, late design changes, ...)
- [ ] Tag new routes in Pendo
