### PR TITLE
FE-1115 - For Hibana only, replace Health Score bar charts with report builder-style line charts

### DIFF
--- a/src/components/charts/LineChart.js
+++ b/src/components/charts/LineChart.js
@@ -34,7 +34,14 @@ function Cursor({ data, height, points: [{ x, y }], width: chartWidth }) {
   );
 }
 
-function CustomTooltip({ showTooltip, payload, label, labelFormatter, formatter }) {
+function CustomTooltip({
+  showTooltip,
+  payload,
+  label,
+  labelFormatter = noop,
+  nameFormatter = noop,
+  formatter = noop,
+}) {
   if (!showTooltip) {
     return null;
   }
@@ -56,7 +63,7 @@ function CustomTooltip({ showTooltip, payload, label, labelFormatter, formatter 
                 backgroundColor={entry.stroke}
               />
               <Text as="span" fontSize="100" color="white">
-                {entry.name}
+                {nameFormatter(entry.name)}
               </Text>
             </Box>
             <Box ml="800">
@@ -71,12 +78,30 @@ function CustomTooltip({ showTooltip, payload, label, labelFormatter, formatter 
   );
 }
 
+function noop(val) {
+  return val;
+}
+
 export const lineChartConfig = {
   barsBackground: {
     fill: tokens.color_gray_200,
   },
   tooltipStyles: {
     zIndex: tokens.zIndex_overlay,
+  },
+  lineProps: {
+    strokeWidth: 2,
+    animationDuration: 400,
+    activeDot: false,
+    dot: false,
+    type: 'linear',
+  },
+  referenceLineProps: {
+    strokeWidth: 1,
+    strokeDasharray: [5, 5],
+    style: {
+      stroke: tokens.color_gray_600,
+    },
   },
 };
 

--- a/src/components/charts/LineChart.js
+++ b/src/components/charts/LineChart.js
@@ -35,7 +35,7 @@ function Cursor({ data, height, points: [{ x, y }], width: chartWidth }) {
 }
 
 function CustomTooltip({
-  showTooltip,
+  showTooltip = true,
   payload,
   label,
   labelFormatter = noop,
@@ -78,8 +78,8 @@ function CustomTooltip({
   );
 }
 
-function noop(val) {
-  return val;
+function noop(arg) {
+  return arg;
 }
 
 export const lineChartConfig = {
@@ -98,7 +98,7 @@ export const lineChartConfig = {
   },
   referenceLineProps: {
     strokeWidth: 1,
-    strokeDasharray: [5, 5],
+    strokeDasharray: '5 5',
     style: {
       stroke: tokens.color_gray_600,
     },

--- a/src/components/charts/LineChart.js
+++ b/src/components/charts/LineChart.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { tokens } from '@sparkpost/design-tokens-hibana';
 import { ComposedChart, Rectangle, ResponsiveContainer } from 'recharts';
 import { Box, Text } from 'src/components/matchbox';
+import { formatDate } from 'src/helpers/date';
 import styles from './LineChart.module.scss';
 
 function LineChart({ children }) {
@@ -91,6 +92,13 @@ export const lineChartConfig = {
     isAnimationActive: false,
     background: tokens.color_gray_200,
   },
+  cartesianGridProps: {
+    strokeDasharray: '0',
+    vertical: false,
+    style: {
+      stroke: tokens.color_gray_500,
+    },
+  },
   xAxisProps: {
     axisLine: false,
     scale: 'auto',
@@ -114,6 +122,7 @@ export const lineChartConfig = {
     wrapperStyle: {
       zIndex: tokens.zIndex_overlay,
     },
+    labelFormatter: formatDate,
   },
   lineProps: {
     strokeWidth: 2,

--- a/src/components/charts/LineChart.js
+++ b/src/components/charts/LineChart.js
@@ -83,11 +83,37 @@ function noop(arg) {
 }
 
 export const lineChartConfig = {
-  barsBackground: {
-    fill: tokens.color_gray_200,
+  barProps: {
+    dataKey: 'noKey',
+    key: 'noKey',
+    cursor: 'pointer',
+    stackId: 'id',
+    isAnimationActive: false,
+    background: tokens.color_gray_200,
   },
-  tooltipStyles: {
-    zIndex: tokens.zIndex_overlay,
+  xAxisProps: {
+    axisLine: false,
+    scale: 'auto',
+    height: 30,
+    tickLine: false,
+    interval: 'preserveStartEnd',
+  },
+  yAxisProps: {
+    axisLine: false,
+    tickLine: false,
+    width: 30,
+    minTickGap: 2,
+    padding: { top: 8, bottom: 8 },
+    interval: 'preserveStartEnd',
+  },
+  tooltipProps: {
+    isAnimationActive: false,
+    styles: {
+      zIndex: tokens.zIndex_overlay,
+    },
+    wrapperStyle: {
+      zIndex: tokens.zIndex_overlay,
+    },
   },
   lineProps: {
     strokeWidth: 2,
@@ -95,6 +121,7 @@ export const lineChartConfig = {
     activeDot: false,
     dot: false,
     type: 'linear',
+    stroke: tokens.color_blue_700,
   },
   referenceLineProps: {
     strokeWidth: 1,
@@ -105,13 +132,14 @@ export const lineChartConfig = {
   },
 };
 
-CustomTooltip.displayName = 'LineChart.CustomTooltip';
 YAxisLabel.displayName = 'LineChart.YAxisLabel';
 Container.displayName = 'LineChart.Container';
 Cursor.displayName = 'LineChart.Cursor';
-LineChart.CustomTooltip = CustomTooltip;
-LineChart.YAxisLabel = YAxisLabel;
+CustomTooltip.displayName = 'LineChart.CustomTooltip';
+
 LineChart.Container = Container;
 LineChart.Cursor = Cursor;
+LineChart.CustomTooltip = CustomTooltip;
+LineChart.YAxisLabel = YAxisLabel;
 
 export default LineChart;

--- a/src/components/charts/LineChart.js
+++ b/src/components/charts/LineChart.js
@@ -11,9 +11,9 @@ function LineChart({ children }) {
   return <div className={styles.ChartWrapper}>{children}</div>;
 }
 
-function Container({ children, data, height, syncId }) {
+function Container({ children, data, height, width = '99%', syncId }) {
   return (
-    <ResponsiveContainer width="99%" height={height}>
+    <ResponsiveContainer width={width} height={height}>
       <ComposedChart syncId={syncId} barCategoryGap="3%" data={data}>
         {children}
       </ComposedChart>

--- a/src/components/charts/LineChart.js
+++ b/src/components/charts/LineChart.js
@@ -1,10 +1,37 @@
 // This component is for use in the Hibana theme only!
 
 import React from 'react';
+import { tokens } from '@sparkpost/design-tokens-hibana';
+import { ComposedChart, Rectangle, ResponsiveContainer } from 'recharts';
 import { Box, Text } from 'src/components/matchbox';
+import styles from './LineChart.module.scss';
 
-function LineChart() {
-  return <></>;
+function LineChart({ children }) {
+  return <div className={styles.ChartWrapper}>{children}</div>;
+}
+
+function Container({ children, data, height, syncId }) {
+  return (
+    <ResponsiveContainer width="99%" height={height}>
+      <ComposedChart syncId={syncId} barCategoryGap="3%" data={data}>
+        {children}
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}
+
+function YAxisLabel({ children }) {
+  return <span className="sp-linechart-yLabel">{children}</span>;
+}
+
+function Cursor({ data, height, points: [{ x, y }], width: chartWidth }) {
+  const sectionWidth = chartWidth / data.length;
+  const gap = sectionWidth * 0.03;
+  const width = sectionWidth - gap * 2;
+
+  return (
+    <Rectangle x={x - width / 2} y={y} height={height} width={width} fill={tokens.color_gray_400} />
+  );
 }
 
 function CustomTooltip({ showTooltip, payload, label, labelFormatter, formatter }) {
@@ -44,7 +71,22 @@ function CustomTooltip({ showTooltip, payload, label, labelFormatter, formatter 
   );
 }
 
+export const lineChartConfig = {
+  barsBackground: {
+    fill: tokens.color_gray_200,
+  },
+  tooltipStyles: {
+    zIndex: tokens.zIndex_overlay,
+  },
+};
+
 CustomTooltip.displayName = 'LineChart.CustomTooltip';
+YAxisLabel.displayName = 'LineChart.YAxisLabel';
+Container.displayName = 'LineChart.Container';
+Cursor.displayName = 'LineChart.Cursor';
 LineChart.CustomTooltip = CustomTooltip;
+LineChart.YAxisLabel = YAxisLabel;
+LineChart.Container = Container;
+LineChart.Cursor = Cursor;
 
 export default LineChart;

--- a/src/components/charts/LineChart.js
+++ b/src/components/charts/LineChart.js
@@ -1,0 +1,50 @@
+// This component is for use in the Hibana theme only!
+
+import React from 'react';
+import { Box, Text } from 'src/components/matchbox';
+
+function LineChart() {
+  return <></>;
+}
+
+function CustomTooltip({ showTooltip, payload, label, labelFormatter, formatter }) {
+  if (!showTooltip) {
+    return null;
+  }
+
+  return (
+    <Box borderRadius="200" padding="200" bg="gray.1000">
+      <Box fontSize="100" color="gray.200" mb="100">
+        {labelFormatter(label)}
+      </Box>
+      {payload.map(entry => (
+        <Box key={`report_chart_${entry.name}`} mb="100">
+          <Box justifyContent="space-between" alignItems="center" display="flex">
+            <Box display="inline-flex" alignItems="center">
+              <Box // The colored circle
+                height="14px"
+                width="14px"
+                borderRadius="circle"
+                mr="300"
+                backgroundColor={entry.stroke}
+              />
+              <Text as="span" fontSize="100" color="white">
+                {entry.name}
+              </Text>
+            </Box>
+            <Box ml="800">
+              <Text fontSize="100" textAlign="right" color="white">
+                {formatter(entry.value)}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+CustomTooltip.displayName = 'LineChart.CustomTooltip';
+LineChart.CustomTooltip = CustomTooltip;
+
+export default LineChart;

--- a/src/components/charts/LineChart.module.scss
+++ b/src/components/charts/LineChart.module.scss
@@ -1,0 +1,5 @@
+@import 'src/styles/hibana/charts';
+
+.ChartWrapper {
+  @include line-chart();
+}

--- a/src/components/charts/index.js
+++ b/src/components/charts/index.js
@@ -1,0 +1,5 @@
+export { default as BarChart } from './BarChart';
+export { default as LineChart } from './LineChart';
+export { default as Legend } from './Legend';
+export { default as Tooltip } from './Tooltip';
+export { default as TooltipMetric } from './TooltipMetric';

--- a/src/components/charts/index.js
+++ b/src/components/charts/index.js
@@ -1,5 +1,5 @@
 export { default as BarChart } from './BarChart';
-export { default as LineChart } from './LineChart';
+export { default as LineChart, lineChartConfig } from './LineChart';
 export { default as Legend } from './Legend';
 export { default as Tooltip } from './Tooltip';
 export { default as TooltipMetric } from './TooltipMetric';

--- a/src/components/charts/tests/LineChart.test.js
+++ b/src/components/charts/tests/LineChart.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useHibana } from 'src/context/HibanaContext';
+import LineChart from '../LineChart';
+jest.mock('src/context/HibanaContext');
+useHibana.mockImplementation(() => [{ isHibanaEnabled: true }]);
+
+describe('LineChart', () => {
+  describe('CustomTooltip', () => {
+    const defaultProps = {
+      showTooltip: true,
+      payload: [],
+      label: 'Example Label',
+      labelFormatter: str => str,
+      formatter: str => str,
+    };
+    const subject = props => render(<LineChart.CustomTooltip {...defaultProps} {...props} />);
+
+    it('renders nothing if the `showTooltip` prop is falsy', () => {
+      subject({ showTooltip: false });
+
+      expect(screen.queryByText('Example Label')).not.toBeInTheDocument();
+    });
+
+    it('renders if the `showTooltip` prop is truthy', () => {
+      subject({ showTooltip: true });
+
+      expect(screen.queryByText('Example Label')).toBeInTheDocument();
+    });
+
+    it('renders the passed in `label` prop using the passed in `labelFormatter` function', () => {
+      const uppercaseStr = str => str.toUpperCase();
+      subject({ label: 'I should be uppercased', labelFormatter: uppercaseStr });
+
+      expect(screen.getByText('I SHOULD BE UPPERCASED')).toBeInTheDocument();
+    });
+
+    it('renders with the passed in payload content using the passed in `formatter` function', () => {
+      const payload = [
+        {
+          stroke: '#000',
+          name: 'Name 1',
+          value: 'VALUE ONE',
+        },
+        {
+          stroke: '#FFF',
+          name: 'NAME 2',
+          value: 'VaLuE TwO',
+        },
+      ];
+      const formatter = str => str.toLowerCase();
+      subject({ payload, formatter });
+
+      expect(screen.getByText('Name 1')).toBeInTheDocument();
+      expect(screen.getByText('value one')).toBeInTheDocument();
+      expect(screen.getByText('NAME 2')).toBeInTheDocument();
+      expect(screen.getByText('value two')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/reportBuilder/components/async/LineChart.js
+++ b/src/pages/reportBuilder/components/async/LineChart.js
@@ -4,36 +4,15 @@
 */
 
 import React from 'react';
-import {
-  Bar,
-  ComposedChart,
-  Line,
-  Rectangle,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
-import { tokens } from '@sparkpost/design-tokens-hibana';
-import { LineChart } from 'src/components/charts';
+import { Bar, Line, Tooltip, XAxis, YAxis } from 'recharts';
+import { LineChart, lineChartConfig } from 'src/components/charts';
 import moment from 'moment';
-import styles from './LineChart.module.scss';
 
 const identity = a => a;
 
 function orderDesc(a, b) {
   return b.value - a.value;
 }
-
-const Cursor = ({ data, height, points: [{ x, y }], width: chartWidth }) => {
-  const sectionWidth = chartWidth / data.length;
-  const gap = sectionWidth * 0.03;
-  const width = sectionWidth - gap * 2;
-
-  return (
-    <Rectangle x={x - width / 2} y={y} height={height} width={width} fill={tokens.color_gray_400} />
-  );
-};
 
 export default function SpLineChart(props) {
   const renderLines = () => {
@@ -104,44 +83,47 @@ export default function SpLineChart(props) {
   } = props;
 
   return (
-    <div className={styles.ChartWrapper}>
-      <ResponsiveContainer width="99%" height={height}>
-        <ComposedChart syncId={syncId} barCategoryGap="3%" data={data}>
-          <Bar key="noKey" dataKey="noKey" background={{ fill: tokens.color_gray_200 }} />
-          <XAxis
-            axisLine={false}
-            dataKey="ts"
-            height={30}
-            hide={!showXAxis}
-            interval="preserveStartEnd"
-            scale="auto"
-            tickFormatter={xTickFormatter}
-            tickLine={false}
-            ticks={getXTicks()}
-          />
-          <YAxis
-            axisLine={false}
-            domain={['dataMin', 'dataMax']}
-            interval="preserveStartEnd"
-            padding={{ top: 8, bottom: 8 }}
-            scale={yScale}
-            tickFormatter={yTickFormatter}
-            tickLine={false}
-            width={60}
-          />
-          <Tooltip
-            cursor={<Cursor data={data} />}
-            content={<LineChart.CustomTooltip showTooltip={showTooltip} />}
-            wrapperStyle={{ zIndex: tokens.zIndex_overlay }}
-            isAnimationActive={false}
-            itemSorter={orderDesc}
-            labelFormatter={tooltipLabelFormatter}
-            formatter={tooltipValueFormatter}
-          />
-          {renderLines()}
-        </ComposedChart>
-      </ResponsiveContainer>
-      <span className="sp-linechart-yLabel">{yLabel}</span>
-    </div>
+    <LineChart>
+      <LineChart.Container syncId={syncId} height={height} data={data}>
+        <Bar key="noKey" dataKey="noKey" background={lineChartConfig.barsBackground} />
+
+        <XAxis
+          axisLine={false}
+          dataKey="ts"
+          height={30}
+          hide={!showXAxis}
+          interval="preserveStartEnd"
+          scale="auto"
+          tickFormatter={xTickFormatter}
+          tickLine={false}
+          ticks={getXTicks()}
+        />
+
+        <YAxis
+          axisLine={false}
+          domain={['dataMin', 'dataMax']}
+          interval="preserveStartEnd"
+          padding={{ top: 8, bottom: 8 }}
+          scale={yScale}
+          tickFormatter={yTickFormatter}
+          tickLine={false}
+          width={60}
+        />
+
+        <Tooltip
+          cursor={<LineChart.Cursor data={data} />}
+          content={<LineChart.CustomTooltip showTooltip={showTooltip} />}
+          wrapperStyle={lineChartConfig.tooltipStyles}
+          isAnimationActive={false}
+          itemSorter={orderDesc}
+          labelFormatter={tooltipLabelFormatter}
+          formatter={tooltipValueFormatter}
+        />
+
+        {renderLines()}
+      </LineChart.Container>
+
+      <LineChart.YAxisLabel>{yLabel}</LineChart.YAxisLabel>
+    </LineChart>
   );
 }

--- a/src/pages/reportBuilder/components/async/LineChart.js
+++ b/src/pages/reportBuilder/components/async/LineChart.js
@@ -81,36 +81,28 @@ export default function SpLineChart(props) {
   return (
     <LineChart>
       <LineChart.Container syncId={syncId} height={height} data={data}>
-        <Bar key="noKey" dataKey="noKey" background={lineChartConfig.barsBackground} />
+        <Bar {...lineChartConfig.barProps} />
 
         <XAxis
-          axisLine={false}
+          {...lineChartConfig.xAxisProps}
           dataKey="ts"
-          height={30}
           hide={!showXAxis}
-          interval="preserveStartEnd"
-          scale="auto"
           tickFormatter={xTickFormatter}
-          tickLine={false}
           ticks={getXTicks()}
         />
 
         <YAxis
-          axisLine={false}
+          {...lineChartConfig.yAxisProps}
           domain={['dataMin', 'dataMax']}
-          interval="preserveStartEnd"
-          padding={{ top: 8, bottom: 8 }}
           scale={yScale}
           tickFormatter={yTickFormatter}
-          tickLine={false}
           width={60}
         />
 
         <Tooltip
+          {...lineChartConfig.toolTipProps}
           cursor={<LineChart.Cursor data={data} />}
           content={<LineChart.CustomTooltip showTooltip={showTooltip} />}
-          wrapperStyle={lineChartConfig.tooltipStyles}
-          isAnimationActive={false}
           itemSorter={orderDesc}
           labelFormatter={tooltipLabelFormatter}
           formatter={tooltipValueFormatter}

--- a/src/pages/reportBuilder/components/async/LineChart.js
+++ b/src/pages/reportBuilder/components/async/LineChart.js
@@ -14,52 +14,16 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { tokens } from '@sparkpost/design-tokens-hibana';
+import { LineChart } from 'src/components/charts';
 import moment from 'moment';
 import styles from './LineChart.module.scss';
-import { tokens } from '@sparkpost/design-tokens-hibana';
-import { Box, Text } from 'src/components/matchbox';
 
 const identity = a => a;
 
 function orderDesc(a, b) {
   return b.value - a.value;
 }
-
-const CustomTooltip = ({ showTooltip, payload, label, labelFormatter, formatter }) => {
-  if (!showTooltip) {
-    return null;
-  }
-  return (
-    <Box borderRadius="200" padding="200" bg="gray.1000">
-      <Box fontSize="100" color="gray.200" mb="100">
-        {labelFormatter(label)}
-      </Box>
-      {payload.map(entry => (
-        <Box key={`report_chart_${entry.name}`} mb="100">
-          <Box justifyContent="space-between" alignItems="center" display="flex">
-            <Box display="inline-flex" alignItems="center">
-              <Box //The color circle
-                height="14px"
-                width="14px"
-                borderRadius="circle"
-                mr={tokens.spacing_300}
-                backgroundColor={entry.stroke}
-              />
-              <Text as="span" fontSize="100" color="white">
-                {entry.name}
-              </Text>
-            </Box>
-            <Box ml="800">
-              <Text fontSize="100" textAlign="right" color="white">
-                {formatter(entry.value)}
-              </Text>
-            </Box>
-          </Box>
-        </Box>
-      ))}
-    </Box>
-  );
-};
 
 const Cursor = ({ data, height, points: [{ x, y }], width: chartWidth }) => {
   const sectionWidth = chartWidth / data.length;
@@ -167,7 +131,7 @@ export default function SpLineChart(props) {
           />
           <Tooltip
             cursor={<Cursor data={data} />}
-            content={<CustomTooltip showTooltip={showTooltip} />}
+            content={<LineChart.CustomTooltip showTooltip={showTooltip} />}
             wrapperStyle={{ zIndex: tokens.zIndex_overlay }}
             isAnimationActive={false}
             itemSorter={orderDesc}

--- a/src/pages/reportBuilder/components/async/LineChart.js
+++ b/src/pages/reportBuilder/components/async/LineChart.js
@@ -19,11 +19,7 @@ export default function SpLineChart(props) {
     const { lines = [] } = props;
     return lines.map(line => {
       const lineProps = {
-        strokeWidth: 2,
-        animationDuration: 400,
-        activeDot: false,
-        dot: false,
-        type: 'linear',
+        ...lineChartConfig.lineProps,
         ...line,
       };
       return <Line {...lineProps} />;

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import React, { Component } from 'react';
 import { PageLink } from 'src/components/links';
 import { Box, Grid, Panel } from 'src/components/matchbox';
@@ -9,6 +8,7 @@ import Page from './components/SignalsPage';
 import BarChart from './components/charts/barchart/BarChart';
 import DivergingBar from './components/charts/divergingBar/DivergingBar';
 import HealthScoreActions from './components/actionContent/HealthScoreActions';
+import HealthScoreLineChart from './components/HealthScoreLineChart';
 import TooltipMetric from 'src/components/charts/TooltipMetric';
 import DateFilter from './components/filters/DateFilter';
 import {
@@ -62,6 +62,10 @@ export class HealthScorePage extends Component {
     };
   };
 
+  handleTooltipValueFormatting = healthScore => {
+    return roundToPlaces(healthScore * 100, 1);
+  };
+
   renderContent = () => {
     const {
       data = [],
@@ -108,6 +112,17 @@ export class HealthScorePage extends Component {
             <ChartHeader title="Health Score" tooltipContent={HEALTH_SCORE_INFO} />
             {panelContent || (
               <Panel.Section>
+                <HealthScoreLineChart
+                  data={data.map(dataPoint => {
+                    return {
+                      ...dataPoint,
+                      health_score: dataPoint.health_score * 100,
+                    };
+                  })}
+                  onBarMouseOver={handleDateHover}
+                  tooltipFormatter={this.handleTooltipValueFormatting}
+                />
+
                 <BarChart
                   margin={newModelMarginsHealthScore}
                   gap={gap}

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import { PageLink } from 'src/components/links';
+import { Bar, CartesianGrid, Line, Tooltip, XAxis, YAxis } from 'recharts';
 import { Box, Grid, Panel } from 'src/components/matchbox';
 import { useHibana } from 'src/context/HibanaContext';
 import { OGOnlyWrapper } from 'src/components/hibana';
+import { LineChart, lineChartConfig } from 'src/components/charts';
 import { selectHealthScoreDetails } from 'src/selectors/signals';
 import { getHealthScore, getSpamHits } from 'src/actions/signals';
 import Page from './components/SignalsPage';
@@ -163,29 +165,62 @@ export class HealthScorePageClassComponent extends Component {
 
                 <ChartHeader title="Injections" tooltipContent={INJECTIONS_INFO} />
 
-                <BarChart
-                  margin={newModelMarginsOther}
-                  gap={gap}
-                  height={190}
-                  onClick={handleDateSelect}
-                  onMouseOver={handleDateHover}
-                  selected={selectedDate}
-                  hovered={hoveredDate}
-                  shouldHighlightSelected={shouldHighlightSelected}
-                  onMouseOut={resetDateHover}
-                  timeSeries={data}
-                  tooltipContent={({ payload = {} }) => (
-                    <TooltipMetric
-                      label="Injections"
-                      value={formatFullNumber(payload.injections)}
-                    />
-                  )}
-                  yKey="injections"
-                  yAxisProps={{
-                    tickFormatter: tick => formatNumber(tick),
-                  }}
-                  xAxisProps={this.getXAxisProps()}
-                />
+                {isHibanaEnabled ? (
+                  <LineChart>
+                    <LineChart.Container height={250} data={data}>
+                      <Bar {...lineChartConfig.barProps} onMouseOver={handleDateHover} />
+
+                      <CartesianGrid stroke="pink" {...lineChartConfig.cartesianGridProps} />
+
+                      <XAxis
+                        {...lineChartConfig.xAxisProps}
+                        {...this.getXAxisProps()}
+                        dataKey="date"
+                      />
+
+                      <YAxis
+                        {...lineChartConfig.yAxisProps}
+                        dataKey="injections"
+                        tickFormatter={tick => formatNumber(tick)}
+                      />
+
+                      <Tooltip
+                        {...lineChartConfig.tooltipProps}
+                        formatter={formatFullNumber}
+                        cursor={<LineChart.Cursor data={data} />}
+                        content={({ payload, ...props }) => (
+                          <LineChart.CustomTooltip {...props} payload={payload} />
+                        )}
+                      />
+
+                      <Line {...lineChartConfig.lineProps} dataKey="injections" />
+                    </LineChart.Container>
+                  </LineChart>
+                ) : (
+                  <BarChart
+                    margin={newModelMarginsOther}
+                    gap={gap}
+                    height={190}
+                    onClick={handleDateSelect}
+                    onMouseOver={handleDateHover}
+                    selected={selectedDate}
+                    hovered={hoveredDate}
+                    shouldHighlightSelected={shouldHighlightSelected}
+                    onMouseOut={resetDateHover}
+                    timeSeries={data}
+                    tooltipContent={({ payload = {} }) => (
+                      <TooltipMetric
+                        label="Injections"
+                        value={formatFullNumber(payload.injections)}
+                      />
+                    )}
+                    yKey="injections"
+                    yAxisProps={{
+                      tickFormatter: tick => formatNumber(tick),
+                    }}
+                    xAxisProps={this.getXAxisProps()}
+                  />
+                )}
 
                 {selectedComponent && !selectedWeightsAreEmpty && (
                   <>

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -110,6 +110,7 @@ export class HealthScorePage extends Component {
         <OGOnlyWrapper as={Grid.Column} sm={12} md={7}>
           <Panel data-id="health-score-panel">
             <ChartHeader title="Health Score" tooltipContent={HEALTH_SCORE_INFO} />
+
             {panelContent || (
               <Panel.Section>
                 <HealthScoreLineChart
@@ -155,7 +156,9 @@ export class HealthScorePage extends Component {
                   }}
                   xAxisProps={this.getXAxisProps()}
                 />
+
                 <ChartHeader title="Injections" tooltipContent={INJECTIONS_INFO} />
+
                 <BarChart
                   margin={newModelMarginsOther}
                   gap={gap}
@@ -179,9 +182,11 @@ export class HealthScorePage extends Component {
                   }}
                   xAxisProps={this.getXAxisProps()}
                 />
+
                 {selectedComponent && !selectedWeightsAreEmpty && (
                   <>
                     <ChartHeader title={HEALTH_SCORE_COMPONENTS[selectedComponent].chartTitle} />
+
                     <BarChart
                       margin={newModelMarginsOther}
                       gap={gap}
@@ -212,6 +217,7 @@ export class HealthScorePage extends Component {
             )}
           </Panel>
         </OGOnlyWrapper>
+
         <OGOnlyWrapper as={Grid.Column} sm={12} md={5} mdOffset={0}>
           {!loading && (
             <div data-id="health-score-components">
@@ -224,9 +230,11 @@ export class HealthScorePage extends Component {
                       hideLine
                       tooltipContent={HEALTH_SCORE_COMPONENT_INFO}
                     />
+
                     {!loading && selectedWeightsAreEmpty && (
                       <Empty message="Insufficient data to populate this chart" />
                     )}
+
                     {!panelContent && !selectedWeightsAreEmpty && (
                       <Panel.Section>
                         <DivergingBar
@@ -245,6 +253,7 @@ export class HealthScorePage extends Component {
                     )}
                   </Box>
                 </Box>
+
                 <Box as={Grid.Column} xs={12} md={5}>
                   {!panelContent && (
                     <Box as={Panel}>

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { PageLink } from 'src/components/links';
-import { Bar, CartesianGrid, Line, Tooltip, XAxis, YAxis } from 'recharts';
+import { Bar, Line, Tooltip, XAxis, YAxis } from 'recharts';
 import { Box, Grid, Panel } from 'src/components/matchbox';
 import { useHibana } from 'src/context/HibanaContext';
 import { OGOnlyWrapper } from 'src/components/hibana';
@@ -34,6 +34,8 @@ import {
   newModelMarginsHealthScore,
   newModelMarginsOther,
 } from './constants/healthScoreV2';
+
+const CHART_HEIGHT = 250;
 
 export class HealthScorePageClassComponent extends Component {
   state = {
@@ -167,10 +169,8 @@ export class HealthScorePageClassComponent extends Component {
 
                 {isHibanaEnabled ? (
                   <LineChart>
-                    <LineChart.Container height={250} data={data}>
+                    <LineChart.Container height={CHART_HEIGHT} data={data}>
                       <Bar {...lineChartConfig.barProps} onMouseOver={handleDateHover} />
-
-                      <CartesianGrid stroke="pink" {...lineChartConfig.cartesianGridProps} />
 
                       <XAxis
                         {...lineChartConfig.xAxisProps}
@@ -226,30 +226,67 @@ export class HealthScorePageClassComponent extends Component {
                   <>
                     <ChartHeader title={HEALTH_SCORE_COMPONENTS[selectedComponent].chartTitle} />
 
-                    <BarChart
-                      margin={newModelMarginsOther}
-                      gap={gap}
-                      height={190}
-                      onClick={handleDateSelect}
-                      onMouseOver={handleDateHover}
-                      onMouseOut={resetDateHover}
-                      hovered={hoveredDate}
-                      selected={selectedDate}
-                      shouldHighlightSelected={shouldHighlightSelected}
-                      timeSeries={dataForSelectedWeight}
-                      tooltipContent={({ payload = {} }) => (
-                        <TooltipMetric
-                          label={HEALTH_SCORE_COMPONENTS[selectedComponent].label}
-                          value={`${roundToPlaces(payload.weight_value * 100, 4)}%`}
-                        />
-                      )}
-                      yKey="weight_value"
-                      yAxisProps={{
-                        tickFormatter: tick => `${roundToPlaces(tick * 100, 3)}%`,
-                      }}
-                      yDomain={selectedDataIsZero ? [0, 1] : [0, 'auto']}
-                      xAxisProps={this.getXAxisProps()}
-                    />
+                    {isHibanaEnabled ? (
+                      <LineChart>
+                        <LineChart.Container height={CHART_HEIGHT} data={dataForSelectedWeight}>
+                          <Bar {...lineChartConfig.barProps} onMouseOver={handleDateHover} />
+
+                          <XAxis
+                            {...lineChartConfig.xAxisProps}
+                            {...this.getXAxisProps()}
+                            dataKey="date"
+                          />
+
+                          <YAxis
+                            {...lineChartConfig.yAxisProps}
+                            domain={selectedDataIsZero ? [0, 1] : [0, 'auto']}
+                            dataKey="weight_value"
+                            width={35}
+                            tickFormatter={tick => `${roundToPlaces(tick * 100, 3)}%`}
+                          />
+
+                          <Tooltip
+                            {...lineChartConfig.tooltipProps}
+                            cursor={<LineChart.Cursor data={dataForSelectedWeight} />}
+                            content={({ payload, ...props }) => (
+                              <LineChart.CustomTooltip
+                                {...props}
+                                nameFormatter={() => 'Suppression Hits'}
+                                formatter={val => `${roundToPlaces(val * 100, 4)}%`}
+                                payload={payload}
+                              />
+                            )}
+                          />
+
+                          <Line {...lineChartConfig.lineProps} dataKey="weight_value" />
+                        </LineChart.Container>
+                      </LineChart>
+                    ) : (
+                      <BarChart
+                        margin={newModelMarginsOther}
+                        gap={gap}
+                        height={190}
+                        onClick={handleDateSelect}
+                        onMouseOver={handleDateHover}
+                        onMouseOut={resetDateHover}
+                        hovered={hoveredDate}
+                        selected={selectedDate}
+                        shouldHighlightSelected={shouldHighlightSelected}
+                        timeSeries={dataForSelectedWeight}
+                        tooltipContent={({ payload = {} }) => (
+                          <TooltipMetric
+                            label={HEALTH_SCORE_COMPONENTS[selectedComponent].label}
+                            value={`${roundToPlaces(payload.weight_value * 100, 4)}%`}
+                          />
+                        )}
+                        yKey="weight_value"
+                        yAxisProps={{
+                          tickFormatter: tick => `${roundToPlaces(tick * 100, 3)}%`,
+                        }}
+                        yDomain={selectedDataIsZero ? [0, 1] : [0, 'auto']}
+                        xAxisProps={this.getXAxisProps()}
+                      />
+                    )}
                   </>
                 )}
               </Panel.Section>

--- a/src/pages/signals/HealthScorePage.js
+++ b/src/pages/signals/HealthScorePage.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { PageLink } from 'src/components/links';
 import { Box, Grid, Panel } from 'src/components/matchbox';
+import { useHibana } from 'src/context/HibanaContext';
 import { OGOnlyWrapper } from 'src/components/hibana';
 import { selectHealthScoreDetails } from 'src/selectors/signals';
 import { getHealthScore, getSpamHits } from 'src/actions/signals';
@@ -32,7 +33,7 @@ import {
   newModelMarginsOther,
 } from './constants/healthScoreV2';
 
-export class HealthScorePage extends Component {
+export class HealthScorePageClassComponent extends Component {
   state = {
     selectedComponent: null,
   };
@@ -79,6 +80,7 @@ export class HealthScorePage extends Component {
       hoveredDate,
       shouldHighlightSelected,
       resetDateHover,
+      isHibanaEnabled,
     } = this.props;
     const { selectedComponent } = this.state;
 
@@ -113,49 +115,51 @@ export class HealthScorePage extends Component {
 
             {panelContent || (
               <Panel.Section>
-                <HealthScoreLineChart
-                  data={data.map(dataPoint => {
-                    return {
-                      ...dataPoint,
-                      health_score: dataPoint.health_score * 100,
-                    };
-                  })}
-                  onBarMouseOver={handleDateHover}
-                  tooltipFormatter={this.handleTooltipValueFormatting}
-                />
-
-                <BarChart
-                  margin={newModelMarginsHealthScore}
-                  gap={gap}
-                  onClick={handleDateSelect}
-                  onMouseOver={handleDateHover}
-                  onMouseOut={resetDateHover}
-                  disableHover={false}
-                  shouldHighlightSelected={shouldHighlightSelected}
-                  selected={selectedDate}
-                  hovered={hoveredDate}
-                  timeSeries={data}
-                  tooltipContent={({ payload = {} }) =>
-                    payload.ranking && (
-                      <TooltipMetric
-                        label="Health Score"
-                        color={thresholds[payload.ranking].color}
-                        value={`${roundToPlaces(payload.health_score * 100, 1)}`}
-                      />
-                    )
-                  }
-                  yAxisRefLines={[
-                    { y: 0.8, stroke: thresholds.good.color, strokeWidth: 1 },
-                    { y: 0.55, stroke: thresholds.danger.color, strokeWidth: 1 },
-                  ]}
-                  xAxisRefLines={newModelLine}
-                  yKey="health_score"
-                  yAxisProps={{
-                    ticks: [0, 0.55, 0.8, 1],
-                    tickFormatter: tick => parseInt(tick * 100),
-                  }}
-                  xAxisProps={this.getXAxisProps()}
-                />
+                {isHibanaEnabled ? (
+                  <HealthScoreLineChart
+                    data={data.map(dataPoint => {
+                      return {
+                        ...dataPoint,
+                        health_score: dataPoint.health_score * 100,
+                      };
+                    })}
+                    onBarMouseOver={handleDateHover}
+                    tooltipFormatter={this.handleTooltipValueFormatting}
+                  />
+                ) : (
+                  <BarChart
+                    margin={newModelMarginsHealthScore}
+                    gap={gap}
+                    onClick={handleDateSelect}
+                    onMouseOver={handleDateHover}
+                    onMouseOut={resetDateHover}
+                    disableHover={false}
+                    shouldHighlightSelected={shouldHighlightSelected}
+                    selected={selectedDate}
+                    hovered={hoveredDate}
+                    timeSeries={data}
+                    tooltipContent={({ payload = {} }) =>
+                      payload.ranking && (
+                        <TooltipMetric
+                          label="Health Score"
+                          color={thresholds[payload.ranking].color}
+                          value={`${roundToPlaces(payload.health_score * 100, 1)}`}
+                        />
+                      )
+                    }
+                    yAxisRefLines={[
+                      { y: 0.8, stroke: thresholds.good.color, strokeWidth: 1 },
+                      { y: 0.55, stroke: thresholds.danger.color, strokeWidth: 1 },
+                    ]}
+                    xAxisRefLines={newModelLine}
+                    yKey="health_score"
+                    yAxisProps={{
+                      ticks: [0, 0.55, 0.8, 1],
+                      tickFormatter: tick => parseInt(tick * 100),
+                    }}
+                    xAxisProps={this.getXAxisProps()}
+                  />
+                )}
 
                 <ChartHeader title="Injections" tooltipContent={INJECTIONS_INFO} />
 
@@ -297,6 +301,12 @@ export class HealthScorePage extends Component {
       </Page>
     );
   }
+}
+
+function HealthScorePage(props) {
+  const [{ isHibanaEnabled }] = useHibana();
+
+  return <HealthScorePageClassComponent isHibanaEnabled={isHibanaEnabled} {...props} />;
 }
 
 export default withDetails(

--- a/src/pages/signals/components/HealthScoreLineChart.js
+++ b/src/pages/signals/components/HealthScoreLineChart.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import moment from 'moment';
+import { Bar, Line, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts';
+import { tokens } from '@sparkpost/design-tokens-hibana';
+import { LineChart, lineChartConfig } from 'src/components/charts';
+import { formatDate, getDateTicks } from 'src/helpers/date';
+import thresholds from 'src/pages/signals/constants/healthScoreThresholds';
+
+export default function HealthScoreLineChart({ data, filters, onBarMouseOver }) {
+  return (
+    <LineChart>
+      <LineChart.Container height={300} data={data}>
+        <Bar
+          key="this-is-a-key"
+          dataKey="noKey"
+          stackId="stack"
+          cursor="pointer"
+          isAnimationActive={false}
+          background={lineChartConfig.barsBackground}
+          onMouseOver={onBarMouseOver}
+        />
+
+        <XAxis
+          dataKey="date"
+          axisLine={false}
+          scale="auto"
+          height={30}
+          tickLine={false}
+          {...getXAxisProps(filters)}
+        />
+
+        <YAxis
+          dataKey="health_score"
+          axisLine={false}
+          tickLine={false}
+          width={30}
+          minTickGap={2}
+          ticks={[0, 55, 80, 100]}
+        />
+
+        <Tooltip
+          cursor={<LineChart.Cursor data={data} />}
+          content={({ payload, ...props }) => {
+            return <LineChart.CustomTooltip {...props} payload={formatTooltipPayload(payload)} />;
+          }}
+          wrapperStyle={lineChartConfig.tooltipStyles}
+          isAnimationActive={false}
+          labelFormatter={formatDate}
+          nameFormatter={() => 'Health Score'}
+          formatter={val => val}
+        />
+
+        <ReferenceLine {...lineChartConfig.referenceLineProps} strokeDasharray="none" y={100} />
+
+        <ReferenceLine
+          {...lineChartConfig.referenceLineProps}
+          y={80}
+          style={{ stroke: tokens.color_green_700 }}
+        />
+
+        <ReferenceLine
+          {...lineChartConfig.referenceLineProps}
+          y={55}
+          style={{ stroke: tokens.color_red_700 }}
+        />
+
+        <Line
+          {...lineChartConfig.lineProps}
+          dataKey="health_score"
+          stroke={tokens.color_blue_700}
+        />
+      </LineChart.Container>
+    </LineChart>
+  );
+}
+
+function formatTooltipPayload(data) {
+  const firstItem = data[0];
+  const payload = firstItem ? firstItem.payload : {};
+
+  if (payload) {
+    return [
+      ...data.map(item => {
+        return {
+          ...item,
+          stroke: thresholds[payload.ranking].color,
+        };
+      }),
+    ];
+  }
+
+  return payload;
+}
+
+function getXAxisProps(filters) {
+  const xTicks = getDateTicks(filters);
+  return {
+    ticks: xTicks,
+    tickFormatter: tick => moment(tick).format('M/D'),
+  };
+}

--- a/src/pages/signals/components/HealthScoreLineChart.js
+++ b/src/pages/signals/components/HealthScoreLineChart.js
@@ -4,14 +4,19 @@ import { Bar, Line, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts';
 import { tokens } from '@sparkpost/design-tokens-hibana';
 import { LineChart, lineChartConfig } from 'src/components/charts';
 import { formatDate, getDateTicks } from 'src/helpers/date';
+
 import thresholds from 'src/pages/signals/constants/healthScoreThresholds';
 
-export default function HealthScoreLineChart({ data, filters, onBarMouseOver }) {
+export default function HealthScoreLineChart({
+  data,
+  filters = [],
+  onBarMouseOver,
+  tooltipFormatter,
+}) {
   return (
     <LineChart>
       <LineChart.Container height={300} data={data}>
         <Bar
-          key="this-is-a-key"
           dataKey="noKey"
           stackId="stack"
           cursor="pointer"
@@ -41,7 +46,13 @@ export default function HealthScoreLineChart({ data, filters, onBarMouseOver }) 
         <Tooltip
           cursor={<LineChart.Cursor data={data} />}
           content={({ payload, ...props }) => {
-            return <LineChart.CustomTooltip {...props} payload={formatTooltipPayload(payload)} />;
+            return (
+              <LineChart.CustomTooltip
+                {...props}
+                payload={formatTooltipPayload(payload)}
+                formatter={tooltipFormatter}
+              />
+            );
           }}
           wrapperStyle={lineChartConfig.tooltipStyles}
           isAnimationActive={false}

--- a/src/pages/signals/components/HealthScoreLineChart.js
+++ b/src/pages/signals/components/HealthScoreLineChart.js
@@ -16,34 +16,19 @@ export default function HealthScoreLineChart({
   return (
     <LineChart>
       <LineChart.Container height={300} data={data}>
-        <Bar
-          dataKey="noKey"
-          stackId="stack"
-          cursor="pointer"
-          isAnimationActive={false}
-          background={lineChartConfig.barsBackground}
-          onMouseOver={onBarMouseOver}
-        />
+        <Bar {...lineChartConfig.barProps} onMouseOver={onBarMouseOver} />
 
-        <XAxis
-          dataKey="date"
-          axisLine={false}
-          scale="auto"
-          height={30}
-          tickLine={false}
-          {...getXAxisProps(filters)}
-        />
+        <XAxis {...lineChartConfig.xAxisProps} {...getXAxisProps(filters)} />
 
         <YAxis
+          {...lineChartConfig.yAxisProps}
           dataKey="health_score"
-          axisLine={false}
-          tickLine={false}
-          width={30}
-          minTickGap={2}
+          padding={{ top: 0 }}
           ticks={[0, 55, 80, 100]}
         />
 
         <Tooltip
+          {...lineChartConfig.tooltipProps}
           cursor={<LineChart.Cursor data={data} />}
           content={({ payload, ...props }) => {
             return (
@@ -54,8 +39,6 @@ export default function HealthScoreLineChart({
               />
             );
           }}
-          wrapperStyle={lineChartConfig.tooltipStyles}
-          isAnimationActive={false}
           labelFormatter={formatDate}
           nameFormatter={() => 'Health Score'}
           formatter={val => val}
@@ -75,11 +58,7 @@ export default function HealthScoreLineChart({
           style={{ stroke: tokens.color_red_700 }}
         />
 
-        <Line
-          {...lineChartConfig.lineProps}
-          dataKey="health_score"
-          stroke={tokens.color_blue_700}
-        />
+        <Line {...lineChartConfig.lineProps} dataKey="health_score" />
       </LineChart.Container>
     </LineChart>
   );

--- a/src/pages/signals/components/HealthScoreLineChart.js
+++ b/src/pages/signals/components/HealthScoreLineChart.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { Bar, Line, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts';
 import { tokens } from '@sparkpost/design-tokens-hibana';
 import { LineChart, lineChartConfig } from 'src/components/charts';
-import { formatDate, getDateTicks } from 'src/helpers/date';
+import { getDateTicks } from 'src/helpers/date';
 
 import thresholds from 'src/pages/signals/constants/healthScoreThresholds';
 
@@ -30,16 +30,13 @@ export default function HealthScoreLineChart({
         <Tooltip
           {...lineChartConfig.tooltipProps}
           cursor={<LineChart.Cursor data={data} />}
-          content={({ payload, ...props }) => {
-            return (
-              <LineChart.CustomTooltip
-                {...props}
-                payload={formatTooltipPayload(payload)}
-                formatter={tooltipFormatter}
-              />
-            );
-          }}
-          labelFormatter={formatDate}
+          content={({ payload, ...props }) => (
+            <LineChart.CustomTooltip
+              {...props}
+              payload={formatTooltipPayload(payload)}
+              formatter={tooltipFormatter}
+            />
+          )}
           nameFormatter={() => 'Health Score'}
           formatter={val => val}
         />

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -105,17 +105,16 @@ export function HealthScoreChart(props) {
     return { value: _.isNil(max) ? 'n/a' : max };
   }
 
-  // TODO: This is fugly
-  function formatTooltipPayload(payload) {
-    const firstItem = payload[0];
-    const payloadPayload = firstItem ? firstItem.payload : {}; // Yes, there is a payload property within this payload object
+  function formatTooltipPayload(data) {
+    const firstItem = data[0];
+    const payload = firstItem ? firstItem.payload : {};
 
-    if (payloadPayload) {
+    if (payload) {
       return [
-        ...payload.map(item => {
+        ...data.map(item => {
           return {
             ...item,
-            stroke: thresholds[payloadPayload.ranking].color || undefined,
+            stroke: thresholds[payload.ranking].color,
           };
         }),
       ];

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -132,73 +132,82 @@ export function HealthScoreChart(props) {
         {!noData && (
           <>
             {isHibanaEnabled ? (
-              <LineChart>
-                <LineChart.Container height={300} data={history}>
-                  <Bar key="noKey" dataKey="noKey" background={lineChartConfig.barsBackground} />
+              <div className="LiftTooltip" style={{ position: 'relative' }}>
+                <LineChart>
+                  <LineChart.Container height={300} data={history}>
+                    <Bar
+                      key="this-is-a-key"
+                      dataKey="noKey"
+                      stackId="stack"
+                      cursor="pointer"
+                      isAnimationActive={false}
+                      background={lineChartConfig.barsBackground}
+                      onMouseOver={handleDateHover}
+                    />
 
-                  <XAxis
-                    axisLine={false}
-                    dataKey="date"
-                    height={30}
-                    interval="preserveStartEnd"
-                    scale="auto"
-                    tickLine={false}
-                    {...getXAxisProps()}
-                  />
+                    <XAxis
+                      dataKey="date"
+                      axisLine={false}
+                      scale="auto"
+                      height={30}
+                      tickLine={false}
+                      {...getXAxisProps()}
+                    />
 
-                  <YAxis
-                    axisLine={false}
-                    tickLine={false}
-                    width={30}
-                    minTickGap={2}
-                    dataKey="health_score"
-                    ticks={[0, 55, 80, 100]}
-                  />
+                    <YAxis
+                      dataKey="health_score"
+                      axisLine={false}
+                      tickLine={false}
+                      width={30}
+                      minTickGap={2}
+                      ticks={[0, 55, 80, 100]}
+                    />
 
-                  <Tooltip
-                    cursor={<LineChart.Cursor data={history} />}
-                    content={({ payload, ...props }) => {
-                      return (
-                        <LineChart.CustomTooltip
-                          {...props}
-                          payload={formatTooltipPayload(payload)}
-                        />
-                      );
-                    }}
-                    wrapperStyle={lineChartConfig.tooltipStyles}
-                    isAnimationActive={false}
-                    labelFormatter={formatDate}
-                    nameFormatter={() => 'Health Score'}
-                    formatter={val => val}
-                  />
+                    <Tooltip
+                      cursor={<LineChart.Cursor data={history} />}
+                      content={({ payload, ...props }) => {
+                        return (
+                          <LineChart.CustomTooltip
+                            {...props}
+                            payload={formatTooltipPayload(payload)}
+                          />
+                        );
+                      }}
+                      wrapperStyle={lineChartConfig.tooltipStyles}
+                      isAnimationActive={false}
+                      labelFormatter={formatDate}
+                      nameFormatter={() => 'Health Score'}
+                      formatter={val => val}
+                    />
 
-                  <ReferenceLine
-                    {...lineChartConfig.referenceLineProps}
-                    strokeDasharray="none"
-                    y={100}
-                  />
+                    <ReferenceLine
+                      {...lineChartConfig.referenceLineProps}
+                      strokeDasharray="none"
+                      y={100}
+                    />
 
-                  <ReferenceLine
-                    {...lineChartConfig.referenceLineProps}
-                    y={80}
-                    style={{ stroke: tokens.color_green_700 }}
-                  />
+                    <ReferenceLine
+                      {...lineChartConfig.referenceLineProps}
+                      y={80}
+                      style={{ stroke: tokens.color_green_700 }}
+                    />
 
-                  <ReferenceLine
-                    {...lineChartConfig.referenceLineProps}
-                    y={55}
-                    style={{ stroke: tokens.color_red_700 }}
-                  />
+                    <ReferenceLine
+                      {...lineChartConfig.referenceLineProps}
+                      y={55}
+                      style={{ stroke: tokens.color_red_700 }}
+                    />
 
-                  <Line
-                    {...lineChartConfig.lineProps}
-                    dataKey="health_score"
-                    stroke={tokens.color_blue_700}
-                  />
-                </LineChart.Container>
+                    <Line
+                      {...lineChartConfig.lineProps}
+                      dataKey="health_score"
+                      stroke={tokens.color_blue_700}
+                    />
+                  </LineChart.Container>
 
-                <LineChart.YAxisLabel></LineChart.YAxisLabel>
-              </LineChart>
+                  <LineChart.YAxisLabel></LineChart.YAxisLabel>
+                </LineChart>
+              </div>
             ) : (
               <BarChart
                 margin={newModelMarginsHealthScore}

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -17,7 +17,6 @@ import { useHibana } from 'src/context/HibanaContext';
 import useHibanaOverride from 'src/hooks/useHibanaOverride';
 import MetricDisplay from '../MetricDisplay/MetricDisplay';
 import { formatNumber, roundToPlaces } from 'src/helpers/units';
-import { getTooltipLabelFormatter } from 'src/helpers/chart';
 import thresholds from '../../../constants/healthScoreThresholds';
 import {
   newModelLine,
@@ -164,7 +163,7 @@ export function HealthScoreChart(props) {
                     scale="auto"
                     // tickFormatter={xTickFormatter}
                     tickLine={false}
-                    ticks={history}
+                    {...getXAxisProps()}
                   />
 
                   <YAxis
@@ -175,24 +174,13 @@ export function HealthScoreChart(props) {
                     dataKey="health_score"
                     ticks={[0, 55, 80, 100]}
                   />
-                  {/* <YAxis
-                    dataKey="health_score"
-                    axisLine={false}
-                    domain={['dataMin', 'dataMax']}
-                    interval="preserveStartEnd"
-                    padding={{ top: 8, bottom: 8 }}
-                    // scale={yScale}
-                    // tickFormatter={yTickFormatter}
-                    tickLine={false}
-                    width={60}
-                  /> */}
 
                   <Tooltip
                     cursor={<LineChart.Cursor data={history} />}
                     content={<LineChart.CustomTooltip showTooltip={true} />}
                     wrapperStyle={lineChartConfig.tooltipStyles}
                     isAnimationActive={false}
-                    labelFormatter={getTooltipLabelFormatter}
+                    labelFormatter={formatDate}
                     nameFormatter={() => 'Health Score'}
                     formatter={val => val}
                   />

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -140,10 +140,8 @@ export function HealthScoreChart(props) {
                     axisLine={false}
                     dataKey="date"
                     height={30}
-                    // hide={!showXAxis}
                     interval="preserveStartEnd"
                     scale="auto"
-                    // tickFormatter={xTickFormatter}
                     tickLine={false}
                     {...getXAxisProps()}
                   />

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -3,13 +3,11 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import _ from 'lodash';
-import { tokens } from '@sparkpost/design-tokens-hibana';
-import { Bar, Line, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts';
 import { getCaretProps, getDoD } from 'src/helpers/signals';
 import { selectCurrentHealthScoreDashboard } from 'src/selectors/signals';
 import { Panel } from 'src/components/matchbox';
 import BarChart from '../../../components/charts/barchart/BarChart';
-import { LineChart, lineChartConfig } from 'src/components/charts';
+import HealthScoreLineChart from '../../../components/HealthScoreLineChart';
 import TooltipMetric from 'src/components/charts/TooltipMetric';
 import { PanelLoading } from 'src/components';
 import Callout from 'src/components/callout';
@@ -105,24 +103,6 @@ export function HealthScoreChart(props) {
     return { value: _.isNil(max) ? 'n/a' : max };
   }
 
-  function formatTooltipPayload(data) {
-    const firstItem = data[0];
-    const payload = firstItem ? firstItem.payload : {};
-
-    if (payload) {
-      return [
-        ...data.map(item => {
-          return {
-            ...item,
-            stroke: thresholds[payload.ranking].color,
-          };
-        }),
-      ];
-    }
-
-    return payload;
-  }
-
   return (
     <Panel sectioned title={`${formatDate(filters.from)} – ${formatDate(filters.to)}`}>
       <div className={styles.Content}>
@@ -131,82 +111,11 @@ export function HealthScoreChart(props) {
         {!noData && (
           <>
             {isHibanaEnabled ? (
-              <div className="LiftTooltip" style={{ position: 'relative' }}>
-                <LineChart>
-                  <LineChart.Container height={300} data={history}>
-                    <Bar
-                      key="this-is-a-key"
-                      dataKey="noKey"
-                      stackId="stack"
-                      cursor="pointer"
-                      isAnimationActive={false}
-                      background={lineChartConfig.barsBackground}
-                      onMouseOver={handleDateHover}
-                    />
-
-                    <XAxis
-                      dataKey="date"
-                      axisLine={false}
-                      scale="auto"
-                      height={30}
-                      tickLine={false}
-                      {...getXAxisProps()}
-                    />
-
-                    <YAxis
-                      dataKey="health_score"
-                      axisLine={false}
-                      tickLine={false}
-                      width={30}
-                      minTickGap={2}
-                      ticks={[0, 55, 80, 100]}
-                    />
-
-                    <Tooltip
-                      cursor={<LineChart.Cursor data={history} />}
-                      content={({ payload, ...props }) => {
-                        return (
-                          <LineChart.CustomTooltip
-                            {...props}
-                            payload={formatTooltipPayload(payload)}
-                          />
-                        );
-                      }}
-                      wrapperStyle={lineChartConfig.tooltipStyles}
-                      isAnimationActive={false}
-                      labelFormatter={formatDate}
-                      nameFormatter={() => 'Health Score'}
-                      formatter={val => val}
-                    />
-
-                    <ReferenceLine
-                      {...lineChartConfig.referenceLineProps}
-                      strokeDasharray="none"
-                      y={100}
-                    />
-
-                    <ReferenceLine
-                      {...lineChartConfig.referenceLineProps}
-                      y={80}
-                      style={{ stroke: tokens.color_green_700 }}
-                    />
-
-                    <ReferenceLine
-                      {...lineChartConfig.referenceLineProps}
-                      y={55}
-                      style={{ stroke: tokens.color_red_700 }}
-                    />
-
-                    <Line
-                      {...lineChartConfig.lineProps}
-                      dataKey="health_score"
-                      stroke={tokens.color_blue_700}
-                    />
-                  </LineChart.Container>
-
-                  <LineChart.YAxisLabel></LineChart.YAxisLabel>
-                </LineChart>
-              </div>
+              <HealthScoreLineChart
+                data={history}
+                filters={filters}
+                onBarMouseOver={handleDateHover}
+              />
             ) : (
               <BarChart
                 margin={newModelMarginsHealthScore}

--- a/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
+++ b/src/pages/signals/dashboards/components/HealthScoreChart/HealthScoreChart.js
@@ -105,42 +105,24 @@ export function HealthScoreChart(props) {
     return { value: _.isNil(max) ? 'n/a' : max };
   }
 
-  // function getXTicks() {
-  //   const { history: data, precision } = props;
-  //   let ticks;
+  // TODO: This is fugly
+  function formatTooltipPayload(payload) {
+    const firstItem = payload[0];
+    const payloadPayload = firstItem ? firstItem.payload : {}; // Yes, there is a payload property within this payload object
 
-  //   // Shows ticks every Sunday
-  //   if (precision === 'day' && data.length > 15) {
-  //     ticks = data.reduce((acc, { ts }) => {
-  //       if (moment(ts).isoWeekday() === 7) {
-  //         acc.push(ts);
-  //       }
-  //       return acc;
-  //     }, []);
-  //   }
+    if (payloadPayload) {
+      return [
+        ...payload.map(item => {
+          return {
+            ...item,
+            stroke: thresholds[payloadPayload.ranking].color || undefined,
+          };
+        }),
+      ];
+    }
 
-  //   // Show ticks every 15 minutes
-  //   if (precision === '1min') {
-  //     ticks = data.reduce((acc, { ts }) => {
-  //       if (moment(ts).minutes() % 15 === 0) {
-  //         acc.push(ts);
-  //       }
-  //       return acc;
-  //     }, []);
-  //   }
-
-  //   // Show ticks every 30 minutes
-  //   if (precision === '15min') {
-  //     ticks = data.reduce((acc, { ts }) => {
-  //       if (moment(ts).minutes() % 30 === 0) {
-  //         acc.push(ts);
-  //       }
-  //       return acc;
-  //     }, []);
-  //   }
-
-  //   return ticks;
-  // }
+    return payload;
+  }
 
   return (
     <Panel sectioned title={`${formatDate(filters.from)} – ${formatDate(filters.to)}`}>
@@ -177,7 +159,14 @@ export function HealthScoreChart(props) {
 
                   <Tooltip
                     cursor={<LineChart.Cursor data={history} />}
-                    content={<LineChart.CustomTooltip showTooltip={true} />}
+                    content={({ payload, ...props }) => {
+                      return (
+                        <LineChart.CustomTooltip
+                          {...props}
+                          payload={formatTooltipPayload(payload)}
+                        />
+                      );
+                    }}
                     wrapperStyle={lineChartConfig.tooltipStyles}
                     isAnimationActive={false}
                     labelFormatter={formatDate}
@@ -185,11 +174,23 @@ export function HealthScoreChart(props) {
                     formatter={val => val}
                   />
 
-                  <ReferenceLine {...lineChartConfig.referenceLineProps} y={100} />
+                  <ReferenceLine
+                    {...lineChartConfig.referenceLineProps}
+                    strokeDasharray="none"
+                    y={100}
+                  />
 
-                  <ReferenceLine {...lineChartConfig.referenceLineProps} y={80} />
+                  <ReferenceLine
+                    {...lineChartConfig.referenceLineProps}
+                    y={80}
+                    style={{ stroke: tokens.color_green_700 }}
+                  />
 
-                  <ReferenceLine {...lineChartConfig.referenceLineProps} y={55} />
+                  <ReferenceLine
+                    {...lineChartConfig.referenceLineProps}
+                    y={55}
+                    style={{ stroke: tokens.color_red_700 }}
+                  />
 
                   <Line
                     {...lineChartConfig.lineProps}

--- a/src/pages/signals/tests/HealthScorePage.test.js
+++ b/src/pages/signals/tests/HealthScorePage.test.js
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import { HealthScorePage } from '../HealthScorePage';
+import { HealthScorePageClassComponent as HealthScorePage } from '../HealthScorePage';
 
 describe('Signals Health Score Page', () => {
   let wrapper;
@@ -10,16 +10,16 @@ describe('Signals Health Score Page', () => {
       date: '2017-01-01',
       weights: [
         { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
-        { weight_type: 'eng cohorts: new, 14-day', weight: -0.5, weight_value: 0.25 }
-      ]
+        { weight_type: 'eng cohorts: new, 14-day', weight: -0.5, weight_value: 0.25 },
+      ],
     },
     {
       date: '2017-01-02',
       weights: [
         { weight_type: 'List Quality', weight: 0.8, weight_value: 0.25 },
-        { weight_type: 'Other bounces', weight: -0.8, weight_value: 0.25 }
-      ]
-    }
+        { weight_type: 'Other bounces', weight: -0.8, weight_value: 0.25 },
+      ],
+    },
   ];
 
   beforeEach(() => {
@@ -34,9 +34,9 @@ describe('Signals Health Score Page', () => {
       gap: 0.25,
       loading: false,
       empty: false,
-      xTicks: []
+      xTicks: [],
     };
-    wrapper = shallow(<HealthScorePage {...props}/>);
+    wrapper = shallow(<HealthScorePage {...props} />);
     wrapper.setProps({ data });
   });
 
@@ -57,16 +57,18 @@ describe('Signals Health Score Page', () => {
   it('does not render SpamTrapsPreview when facet is mb_provider', () => {
     wrapper.setProps({ facet: 'mb_provider' });
     wrapper.update();
-    expect(wrapper.find('withRouter(Connect(WithDetails(SpamTrapsPreview)))')).not.toContainMatchingElement();
+    expect(
+      wrapper.find('withRouter(Connect(WithDetails(SpamTrapsPreview)))'),
+    ).not.toContainMatchingElement();
   });
 
   it('renders error correctly', () => {
-    wrapper.setProps({ error: { message: 'error message' }});
+    wrapper.setProps({ error: { message: 'error message' } });
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders empty weights', () => {
-    wrapper.setProps({ data: [{ date: '2017-01-01' }]});
+    wrapper.setProps({ data: [{ date: '2017-01-01' }] });
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -74,19 +76,29 @@ describe('Signals Health Score Page', () => {
     const newData = [
       {
         date: '2017-01-01',
-        weights: [{ weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0 }]
+        weights: [{ weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0 }],
       },
       {
         date: '2017-01-02',
-        weights: [{ weight_type: 'Hard Bounces', weight: 0.5, weight_value: undefined }]
-      }
+        weights: [{ weight_type: 'Hard Bounces', weight: 0.5, weight_value: undefined }],
+      },
     ];
     wrapper.setProps({ data: newData });
-    expect(wrapper.find('BarChart').at(2).prop('yDomain')).toEqual([0, 1]);
+    expect(
+      wrapper
+        .find('BarChart')
+        .at(2)
+        .prop('yDomain'),
+    ).toEqual([0, 1]);
   });
 
   it('renders component weights bar height dynamically', () => {
-    expect(wrapper.find('DivergingBar').at(0).prop('barHeight')).toEqual(140);
+    expect(
+      wrapper
+        .find('DivergingBar')
+        .at(0)
+        .prop('barHeight'),
+    ).toEqual(140);
     const newData = [
       {
         date: '2017-01-01',
@@ -94,56 +106,110 @@ describe('Signals Health Score Page', () => {
           { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
           { weight_type: 'eng cohorts: new, 14-day', weight: -0.5, weight_value: 0.25 },
           { weight_type: 'List Quality', weight: 0.8, weight_value: 0.25 },
-          { weight_type: 'Other bounces', weight: -0.8, weight_value: 0.25 }
-        ]
-      }
+          { weight_type: 'Other bounces', weight: -0.8, weight_value: 0.25 },
+        ],
+      },
     ];
     wrapper.setProps({ data: newData });
-    expect(wrapper.find('DivergingBar').at(0).prop('barHeight')).toEqual(70);
+    expect(
+      wrapper
+        .find('DivergingBar')
+        .at(0)
+        .prop('barHeight'),
+    ).toEqual(70);
   });
 
   describe('local state', () => {
     it('handles component select', () => {
-      wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'eng cohorts: new, 14-day' }});
-      expect(wrapper.find('DivergingBar').at(0).prop('selected')).toEqual('eng cohorts: new, 14-day');
+      wrapper
+        .find('DivergingBar')
+        .at(0)
+        .simulate('click', { payload: { weight_type: 'eng cohorts: new, 14-day' } });
+      expect(
+        wrapper
+          .find('DivergingBar')
+          .at(0)
+          .prop('selected'),
+      ).toEqual('eng cohorts: new, 14-day');
     });
 
     it('uses first component weight with an existing date and new data', () => {
-      wrapper = shallow(<HealthScorePage {...props} selectedDate='first-date'/>);
-      wrapper.setProps({ data: [{ date: 'first-date', weights: [
-        { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
-        { weight_type: 'Complaints', weight: 0.5, weight_value: 0.25 }
-      ]}, { date: 'last-date' }]});
-      expect(wrapper.find('DivergingBar').at(0).prop('selected')).toEqual('Hard Bounces');
+      wrapper = shallow(<HealthScorePage {...props} selectedDate="first-date" />);
+      wrapper.setProps({
+        data: [
+          {
+            date: 'first-date',
+            weights: [
+              { weight_type: 'Hard Bounces', weight: 0.5, weight_value: 0.25 },
+              { weight_type: 'Complaints', weight: 0.5, weight_value: 0.25 },
+            ],
+          },
+          { date: 'last-date' },
+        ],
+      });
+      expect(
+        wrapper
+          .find('DivergingBar')
+          .at(0)
+          .prop('selected'),
+      ).toEqual('Hard Bounces');
     });
   });
 
   describe('bar chart props', () => {
     it('renders tooltip content for health score', () => {
-      const Tooltip = wrapper.find('BarChart').at(0).prop('tooltipContent');
-      expect(shallow(<Tooltip payload={{ health_score: 0.12, ranking: 'danger' }} />)).toMatchSnapshot();
+      const Tooltip = wrapper
+        .find('BarChart')
+        .at(0)
+        .prop('tooltipContent');
+      expect(
+        shallow(<Tooltip payload={{ health_score: 0.12, ranking: 'danger' }} />),
+      ).toMatchSnapshot();
     });
 
     it('renders tooltip content for injections', () => {
-      const Tooltip = wrapper.find('BarChart').at(1).prop('tooltipContent');
-      expect(shallow(<Tooltip payload={{ injections: 1000, ranking: 'good' }} />)).toMatchSnapshot();
+      const Tooltip = wrapper
+        .find('BarChart')
+        .at(1)
+        .prop('tooltipContent');
+      expect(
+        shallow(<Tooltip payload={{ injections: 1000, ranking: 'good' }} />),
+      ).toMatchSnapshot();
     });
 
     it('renders tooltip content for selected component', () => {
-      wrapper.find('DivergingBar').at(0).simulate('click', { payload: { weight_type: 'eng cohorts: new, 14-day' }});
-      const Tooltip = wrapper.find('BarChart').at(2).prop('tooltipContent');
-      expect(shallow(<Tooltip payload={{ weight_value: 0.0012345, ranking: 'danger' }} />)).toMatchSnapshot();
+      wrapper
+        .find('DivergingBar')
+        .at(0)
+        .simulate('click', { payload: { weight_type: 'eng cohorts: new, 14-day' } });
+      const Tooltip = wrapper
+        .find('BarChart')
+        .at(2)
+        .prop('tooltipContent');
+      expect(
+        shallow(<Tooltip payload={{ weight_value: 0.0012345, ranking: 'danger' }} />),
+      ).toMatchSnapshot();
     });
 
     it('renders tooltip content for hovered component', () => {
-      wrapper.find('BarChart').at(0).simulate('onMouseOver', { payload: { health_score: 0.75, ranking: 'warning', date: '2017-01-02' }});
-      const Tooltip = wrapper.find('BarChart').at(0).prop('tooltipContent');
+      wrapper
+        .find('BarChart')
+        .at(0)
+        .simulate('onMouseOver', {
+          payload: { health_score: 0.75, ranking: 'warning', date: '2017-01-02' },
+        });
+      const Tooltip = wrapper
+        .find('BarChart')
+        .at(0)
+        .prop('tooltipContent');
       expect(shallow(<Tooltip payload={{ health_score: 0.75 }} />)).toMatchSnapshot();
     });
 
     it('renders tooltip content for component weights', () => {
       const Tooltip = wrapper.find('DivergingBar').prop('tooltipContent');
-      expect(shallow(<Tooltip payload={{ weight_type: 'Other bounces', ranking: 'warning' }} />)).toMatchSnapshot();
+      expect(
+        shallow(<Tooltip payload={{ weight_type: 'Other bounces', ranking: 'warning' }} />),
+      ).toMatchSnapshot();
     });
 
     it('renders y label content for component weights', () => {
@@ -152,23 +218,35 @@ describe('Signals Health Score Page', () => {
     });
 
     it('gets x axis props', () => {
-      const axisProps = wrapper.find('BarChart').at(0).prop('xAxisProps');
+      const axisProps = wrapper
+        .find('BarChart')
+        .at(0)
+        .prop('xAxisProps');
       expect(axisProps).toMatchSnapshot();
       expect(axisProps.tickFormatter('2018-12-05')).toEqual('12/5');
     });
 
     it('renders health score y ticks', () => {
-      const axisProps = wrapper.find('BarChart').at(0).prop('yAxisProps');
+      const axisProps = wrapper
+        .find('BarChart')
+        .at(0)
+        .prop('yAxisProps');
       expect(axisProps.tickFormatter(0.2468)).toEqual(24);
     });
 
     it('renders injections y ticks', () => {
-      const axisProps = wrapper.find('BarChart').at(1).prop('yAxisProps');
+      const axisProps = wrapper
+        .find('BarChart')
+        .at(1)
+        .prop('yAxisProps');
       expect(axisProps.tickFormatter(2468)).toEqual('2.47K');
     });
 
     it('renders component y ticks', () => {
-      const axisProps = wrapper.find('BarChart').at(2).prop('yAxisProps');
+      const axisProps = wrapper
+        .find('BarChart')
+        .at(2)
+        .prop('yAxisProps');
       axisProps.tickFormatter(0.003);
       expect(axisProps.tickFormatter(0.003)).toEqual('0.3%');
     });


### PR DESCRIPTION
[FE-1115](https://jira.int.messagesystems.com/browse/FE-1115)

**Note:** Making progress, though after following up with UX they want to do a quick review before moving forward.

### What Changed

- Introduces new, Hibana-only, global `LineChart` component

### How To Test


### To Do
- [ ] Fix health score data formatting inconsistency - could this be handled with a selector? on `HealthScorePage.js`
- [ ] Figure out a way to turn Hibana on in the storybook docs
- [ ] Document component