### PR TITLE
AC-1195 - (UI) App should enforce phone support via billing subscription

### DIFF
--- a/src/components/support/Support.js
+++ b/src/components/support/Support.js
@@ -6,10 +6,10 @@ import * as supportActions from 'src/actions/support';
 import { AccessControl } from 'src/components/auth';
 import { Panel, Tabs, UnstyledLink, Modal } from 'src/components/matchbox';
 import findRouteByPath from 'src/helpers/findRouteByPath';
-import { authorizedToSubmitSupportTickets, entitledToPhoneSupport } from 'src/selectors/support';
+import { authorizedToSubmitSupportTickets } from 'src/selectors/support';
 import SearchPanel from './components/SearchPanel';
 import SupportForm from './components/SupportForm';
-
+import { hasPhoneSupport } from 'src/selectors/accountBillingInfo';
 import styles from './Support.module.scss';
 
 export class Support extends Component {
@@ -98,7 +98,7 @@ export class Support extends Component {
 }
 
 const mapStateToProps = state => ({
-  authorizedToCallSupport: entitledToPhoneSupport(state),
+  authorizedToCallSupport: hasPhoneSupport(state),
   authorizedToSubmitSupportTickets: authorizedToSubmitSupportTickets(state),
   currentSupportView: state.support.currentView,
   loggedIn: state.auth.loggedIn,

--- a/src/components/support/tests/Support.test.js
+++ b/src/components/support/tests/Support.test.js
@@ -10,9 +10,11 @@ describe('Support', () => {
   let props;
   let wrapper;
 
-  const findTab = (content) => (
-    wrapper.find('Tabs').prop('tabs').find((tab) => tab.content === content)
-  );
+  const findTab = content =>
+    wrapper
+      .find('Tabs')
+      .prop('tabs')
+      .find(tab => tab.content === content);
 
   beforeEach(() => {
     findRouteByPath.mockImplementation(() => ({ path: '/example' }));
@@ -22,12 +24,12 @@ describe('Support', () => {
       closeSupportPanel: jest.fn(),
       currentSupportView: 'docs',
       location: {
-        search: ''
+        search: '',
       },
       loggedIn: true,
       openSupportPanel: jest.fn(),
       openSupportTicketForm: jest.fn(),
-      showSupportPanel: true
+      showSupportPanel: true,
     };
 
     wrapper = shallow(<Support {...props} />);
@@ -50,7 +52,7 @@ describe('Support', () => {
   it('renders search panel with current page search term', () => {
     findRouteByPath.mockImplementationOnce(() => ({
       path: '/example',
-      supportDocSearch: 'exampleKeyword'
+      supportDocSearch: 'exampleKeyword',
     }));
     wrapper.setProps({ currentSupportView: 'docs' });
 
@@ -60,7 +62,7 @@ describe('Support', () => {
   it('renders search panel without tabs', () => {
     wrapper.setProps({
       authorizedToCallSupport: false,
-      authorizedToSubmitSupportTickets: false
+      authorizedToSubmitSupportTickets: false,
     });
 
     expect(wrapper).toMatchSnapshot();
@@ -104,33 +106,33 @@ describe('Support', () => {
 
   it('opens support ticket tab on mount with deep link', () => {
     const location = {
-      search: '?supportTicket=true&supportIssue=test_issue&supportMessage=testmessage'
+      search: '?supportTicket=true&supportIssue=test_issue&supportMessage=testmessage',
     };
     wrapper = shallow(<Support {...props} location={location} />);
 
     expect(props.openSupportTicketForm).toHaveBeenCalledWith({
       issueId: 'test_issue',
-      message: 'testmessage'
+      message: 'testmessage',
     });
   });
 
   it('opens support ticket tab on location update with deep link', () => {
     wrapper.setProps({
       location: {
-        search: '?supportTicket=true&supportIssue=test_issue&supportMessage=testmessage'
-      }
+        search: '?supportTicket=true&supportIssue=test_issue&supportMessage=testmessage',
+      },
     });
 
     expect(props.openSupportTicketForm).toHaveBeenCalledWith({
       issueId: 'test_issue',
-      message: 'testmessage'
+      message: 'testmessage',
     });
   });
 
   it('only calls openSupportTicketForm once when location stays the same', () => {
     const search = '?supportTicket=true&supportIssue=test_issue&supportMessage=testmessage';
-    wrapper.setProps({ location: { search }});
-    wrapper.setProps({ location: { search }});
+    wrapper.setProps({ location: { search } });
+    wrapper.setProps({ location: { search } });
 
     expect(props.openSupportTicketForm).toHaveBeenCalledTimes(1);
   });

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -27,11 +27,16 @@ const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
 const selectIsFree1 = selectCondition(onPlan('free1'));
 const selectOnZuoraPlan = selectCondition(onZuoraPlan);
 const hasDedicatedIpsOnSubscription = selectCondition(hasProductOnSubscription('dedicated_ip'));
+const selectPhoneSupportOnSubscription = selectCondition(hasProductOnSubscription('phone_support'));
 const selectBillingSubscription = state => state.billing.subscription || {};
 const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'];
 export const isManuallyBilled = state => _.get(state, 'billing.subscription.type') === 'manual';
 const getRecipientValidationUsage = state => _.get(state, 'account.rvUsage.recipient_validation');
 export const currentSubscriptionSelector = state => state.account.subscription;
+export const hasPhoneSupport = createSelector(
+  [selectPhoneSupportOnSubscription],
+  hasPhoneSupport => hasPhoneSupport,
+);
 /**
  * Returns current subscription's code
  * @param state

--- a/src/selectors/support.js
+++ b/src/selectors/support.js
@@ -4,34 +4,28 @@ import accessConditionState from './accessConditionState';
 import supportIssues from 'src/config/supportIssues';
 import hasGrants from 'src/helpers/conditions/hasGrants';
 
-const getAccountSupport = (state) => state.account.support;
 const getSupportIssueId = (state, id) => id;
 
-export const entitledToPhoneSupport = createSelector(
-  [getAccountSupport],
-  (support) => support && support.phone
-);
-
-export const currentLimitSelector = (state) => {
+export const currentLimitSelector = state => {
   const { account } = state;
   return _.get(account, 'usage.day.limit', 0);
 };
 
-export const selectSupportIssues = createSelector(accessConditionState, (state) => (
-  supportIssues.filter(({ condition = () => true }) => condition(state))
-));
+export const selectSupportIssues = createSelector(accessConditionState, state =>
+  supportIssues.filter(({ condition = () => true }) => condition(state)),
+);
 
 export const selectSupportIssue = createSelector(
   [selectSupportIssues, getSupportIssueId],
-  (issues, id) => _.find(issues, { id })
+  (issues, id) => _.find(issues, { id }),
 );
 
 export const authorizedToSubmitSupportTickets = createSelector(
   [selectSupportIssues, accessConditionState],
-  (issues, state) => issues.length > 0 && hasGrants('support/manage')(state)
+  (issues, state) => issues.length > 0 && hasGrants('support/manage')(state),
 );
 
 export const notAuthorizedToSubmitSupportTickets = createSelector(
   authorizedToSubmitSupportTickets,
-  (authorized) => !authorized
+  authorized => !authorized,
 );

--- a/src/selectors/tests/support.test.js
+++ b/src/selectors/tests/support.test.js
@@ -3,45 +3,12 @@ import * as selectors from '../support';
 jest.mock('src/config/supportIssues', () => [
   { id: 'without_condition' },
   { id: 'when_satisfied', condition: jest.fn(() => true) },
-  { id: 'when_not_satisfied', condition: jest.fn(() => false) }
+  { id: 'when_not_satisfied', condition: jest.fn(() => false) },
 ]);
 
-jest.mock('src/selectors/accessConditionState', () => jest.fn((s) => s));
+jest.mock('src/selectors/accessConditionState', () => jest.fn(s => s));
 
 describe('Selectors: support', () => {
-  describe('entitled to support', () => {
-    it('when account is not loaded', () => {
-      const state = {
-        account: {}
-      };
-      expect(selectors.entitledToPhoneSupport(state)).toBeFalsy();
-    });
-
-    it('when account is not entitled to phone support', () => {
-      const state = {
-        account: {
-          support: {
-            phone: true
-          }
-        }
-      };
-
-      expect(selectors.entitledToPhoneSupport(state)).toBeTruthy();
-    });
-
-    it('when account entitled to phone support', () => {
-      const state = {
-        account: {
-          support: {
-            phone: false
-          }
-        }
-      };
-
-      expect(selectors.entitledToPhoneSupport(state)).toBeFalsy();
-    });
-  });
-
   describe('currentLimitSelector', () => {
     let account;
     let state;
@@ -50,15 +17,14 @@ describe('Selectors: support', () => {
       account = {
         usage: {
           day: {
-            limit: 1000
-          }
-        }
+            limit: 1000,
+          },
+        },
       };
 
       state = {
-        account
+        account,
       };
-
     });
 
     it('returns correct limit', () => {
@@ -73,7 +39,7 @@ describe('Selectors: support', () => {
 
   describe('selectSupportIssues', () => {
     it('should return issues that satisfied condition', () => {
-      const state = { account: { id: 'stubbed_for_snapshot' }};
+      const state = { account: { id: 'stubbed_for_snapshot' } };
       expect(selectors.selectSupportIssues(state)).toMatchSnapshot();
     });
   });
@@ -96,22 +62,23 @@ describe('Selectors: support', () => {
   });
 
   describe('authorizedToSubmitSupportTickets', () => {
-    const issues = [ 'issue1', 'issue2' ];
+    const issues = ['issue1', 'issue2'];
     const accessControlState = {
       currentUser: {
-        grants: [ { key: 'support/manage' } ]
-      }
+        grants: [{ key: 'support/manage' }],
+      },
     };
 
     // selector.resultFunc: https://github.com/reduxjs/reselect#q-how-do-i-test-a-selector
-    const subject = ({ issues, accessControlState }) => selectors.authorizedToSubmitSupportTickets.resultFunc(issues, accessControlState);
+    const subject = ({ issues, accessControlState }) =>
+      selectors.authorizedToSubmitSupportTickets.resultFunc(issues, accessControlState);
 
     it('should allow users who are allowed to submit >0 ticket types and have the grant', () => {
       expect(subject({ issues, accessControlState })).toBeTruthy();
     });
 
     it('should block users without the correct grant', () => {
-      const emptyState = { currentUser: { grants: [{ key: 'robot/dance' }]}};
+      const emptyState = { currentUser: { grants: [{ key: 'robot/dance' }] } };
       expect(subject({ issues, accessControlState: emptyState })).toBeFalsy();
     });
 


### PR DESCRIPTION
AC-1195 - (UI) App should enforce phone support via billing subscription
**This branch is based from AC-1325**

### What Changed

- phone support for a user is now checked using products returned by their GET billing/subscription
- Added selector for the same

### How To Test
- check if you see/not see phone support tab in the support modal based on your plan

### To Do
- [] Address feedback
