### PR TITLE
[AC-1471] Update support.algolia.index in config for new WP VIP indices

### DIFF
--- a/src/config/env/dev-config.js
+++ b/src/config/env/dev-config.js
@@ -45,7 +45,7 @@ export default {
     algolia: {
       appID: 'SFXAWCYDV8',
       apiKey: '9ba87280f36f539fcc0a318c2d4fcfe6',
-      index: 'development_site_posts_support_article',
+      index: 'wp_vip_site_develop_posts_support_article',
     },
   },
   website: {

--- a/src/config/env/production-config.js
+++ b/src/config/env/production-config.js
@@ -11,7 +11,7 @@ const productionConfig = {
     algolia: {
       apiKey: '9ba87280f36f539fcc0a318c2d4fcfe6',
       appID: 'SFXAWCYDV8',
-      index: 'production_site_posts_support_article',
+      index: 'wp_vip_site_production_posts_support_article',
     },
   },
   vwo: {

--- a/src/config/env/staging-config.js
+++ b/src/config/env/staging-config.js
@@ -11,7 +11,7 @@ const stagingConfig = {
     algolia: {
       apiKey: '9ba87280f36f539fcc0a318c2d4fcfe6',
       appID: 'SFXAWCYDV8',
-      index: 'staging_site_posts_support_article',
+      index: 'wp_vip_site_preprod_posts_support_article',
     },
     enabled: true,
   },

--- a/src/config/env/uat-config.js
+++ b/src/config/env/uat-config.js
@@ -11,7 +11,7 @@ const uatConfig = {
     algolia: {
       apiKey: '9ba87280f36f539fcc0a318c2d4fcfe6',
       appID: 'SFXAWCYDV8',
-      index: 'development_site_posts_support_article',
+      index: 'wp_vip_site_develop_posts_support_article',
     },
     enabled: true,
   },


### PR DESCRIPTION
[AC-1471] Update support.algolia.index in config for new WP VIP indices

### What Changed
 - Change these index names:
        - development_site_posts_support_article -> wp_vip_site_develop_posts_support_article
        - staging_site_posts_support_article -> wp_vip_site_preprod_posts_support_article
        - production_site_posts_support_article -> wp_vip_site_production_posts_support_article

### How To Test
 - Open the support modal and Check if the network request are sent to updated index names.

### To Do
- [ ] Address feedback
