### PR TITLE
FE-1113 - The CancellationPanel logs an error when window.pendo does not exist

### DIFF
--- a/src/pages/account/components/CancellationPanel.js
+++ b/src/pages/account/components/CancellationPanel.js
@@ -27,7 +27,9 @@ export function CancellationPanel(props) {
         setShowCancelAccountModal(true);
       }
     } catch (error) {
-      ErrorTracker.report('account-cancellation-pendo-guide-error', error);
+      ErrorTracker.report('account-cancellation-pendo-guide-warning', error, {
+        level: 'warning',
+      });
       setShowCancelAccountModal(true);
     }
   };


### PR DESCRIPTION
[FE-1113] The CancellationPanel logs an error when window.pendo does not exist

### What Changed
 - Changed this sentry error to a sentry warning instead.

### How To Test
 - Block Pendo cdn and click on Cancel Account, this should trigger a sentry warning. 
ref - https://sentry.io/organizations/sparkpost/issues/1773564134/?project=232588&query=is%3Aunresolved

### To Do
- [ ] Address feedback