### PR TITLE
AC-1553 - Starter plan description should not include "First dedicated IP address is free"

### DIFF
--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -115,7 +115,6 @@ export default class BillingSummary extends Component {
       currentPlan,
       canChangePlan,
       canUpdateBillingInfo,
-      canPurchaseIps,
       invoices,
       accountAgeInDays,
     } = this.props;
@@ -148,7 +147,7 @@ export default class BillingSummary extends Component {
               <PlanSummary plan={account.subscription} pendingCancellation={pending_cancellation} />
             </LabelledValue>
           </Panel.Section>
-          {canPurchaseIps && this.renderDedicatedIpSummarySection(isTransitioningToSelfServe)}
+          {this.renderDedicatedIpSummarySection(isTransitioningToSelfServe)}
           {rvUsage && this.renderRecipientValidationSection({ rvUsage })}
         </Panel>
 

--- a/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
@@ -245,6 +245,17 @@ exports[`Component: Billing Summary should render correctly for a standard free 
         />
       </LabelledValue>
     </Panel.Section>
+    <DedicatedIpSummarySection
+      canPurchaseIps={false}
+      count={0}
+      isTransitioningToSelfServe={false}
+      onClick={[Function]}
+      plan={
+        Object {
+          "isFree": true,
+        }
+      }
+    />
     <Panel.Section>
       <LabelledValue
         label="Recipient Validation"
@@ -370,6 +381,17 @@ exports[`Component: Billing Summary should render correctly if you can't buy IPs
         />
       </LabelledValue>
     </Panel.Section>
+    <DedicatedIpSummarySection
+      canPurchaseIps={false}
+      count={0}
+      isTransitioningToSelfServe={false}
+      onClick={[Function]}
+      plan={
+        Object {
+          "isFree": true,
+        }
+      }
+    />
     <Panel.Section>
       <LabelledValue
         label="Recipient Validation"

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -24,9 +24,7 @@ export const getCurrentAccountPlan = createSelector(
       code: currentPlan.plan,
       includesIp:
         Boolean(currentPlan.status) &&
-        !_.isEmpty(_.find(currentBundle.products, { product: 'dedicated_ip' })) //second condition added for starter plans
-          ? true
-          : false,
+        !_.isEmpty(_.find(currentBundle.products, { product: 'dedicated_ip' })), //second condition added for starter plans,
       isFree: currentFreePlans.includes(currentPlan.plan),
       status: !currentPlan.status ? 'deprecated' : currentPlan.status, //since bundlePlans don't return deprecated plans;
       ...currentPlan,

--- a/src/selectors/accessConditionState.js
+++ b/src/selectors/accessConditionState.js
@@ -11,15 +11,22 @@ const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free5
 export const getCurrentAccountPlan = createSelector(
   [getAccount, getBundlePlans, getBundles, getBillingSubscription],
   (account, bundlePlans, bundles, subscription) => {
+    const currentMessagingPlanDetails =
+      bundlePlans.find(plan => plan.plan === account.subscription.code) || {};
+    const currentBundle = bundles.find(bundle => bundle.bundle === account.subscription.code) || {};
     const currentPlan = {
-      ...bundlePlans.find(plan => plan.plan === account.subscription.code),
-      ...bundles.find(bundle => bundle.bundle === account.subscription.code),
+      ...currentMessagingPlanDetails,
+      ...currentBundle,
       products: subscription.products,
     };
     return {
       billingId: currentPlan.billing_id,
       code: currentPlan.plan,
-      includesIp: !currentPlan.status ? false : true,
+      includesIp:
+        Boolean(currentPlan.status) &&
+        !_.isEmpty(_.find(currentBundle.products, { product: 'dedicated_ip' })) //second condition added for starter plans
+          ? true
+          : false,
       isFree: currentFreePlans.includes(currentPlan.plan),
       status: !currentPlan.status ? 'deprecated' : currentPlan.status, //since bundlePlans don't return deprecated plans;
       ...currentPlan,

--- a/src/selectors/tests/accessConditionState.test.js
+++ b/src/selectors/tests/accessConditionState.test.js
@@ -82,7 +82,7 @@ describe('Selector: Access Condition State', () => {
         billing_id: 'id1',
         bundle: '5M-0817',
         code: '5M-0817',
-        includesIp: true,
+        includesIp: false,
         isFree: false,
         overage: 0.3,
         plan: '5M-0817',


### PR DESCRIPTION
AC-1553 - Starter plan description should not include "First dedicated IP address is free"

### What Changed
 - includesIps is set to true when (currentBundle has 'dedicated_ip' on it) &&  (current plan is not deprecated), otherwise it is set to false
- Dedicated Ip Panel shows up on billing page irrespective of canPurchaseIps.

### How To Test
 - Create an account on a starter plan and confirm that 'First dedicated IP address is free' line doesn't show on /account/billing/plan . 

### To Do
- [ ] Address feedback
- [x] confirm if canPurchaseIps condition needs to be changed too ?
