### PR TITLE
FE-1122: Upgrade axios to v0.19.2 for 2web2ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14139,12 +14139,21 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        }
       }
     },
     "axobject-query": {
@@ -22421,6 +22430,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
       "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "dev": true,
       "requires": {
         "debug": "^3.1.0"
       }
@@ -25846,7 +25856,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@sparkpost/matchbox-hibana": "npm:@sparkpost/matchbox@4.0.0-hibana.25",
     "@sparkpost/matchbox-icons": "^1.3.0",
     "@styled-system/props": "^5.1.5",
-    "axios": "^0.18.0",
+    "axios": "^0.19.2",
     "bowser": "2.1.2",
     "classnames": "^2.2.5",
     "color": "^3.0.0",


### PR DESCRIPTION
### What Changed
 - Upgrade axios from v0.18.0 to v0.19.2 ([release notes](https://github.com/axios/axios/releases))

### How To Test

Before testing, it is very important to understand what "fixes and functionality" are included in the upgrade.

v0.19.0
 - Unzip response body only for statuses != 204 (#1129) - drawski
   - n/a, we don't set the Content-Encoding header
 - Destroy stream on exceeding maxContentLength (fixes #1098) (#1485) - Gadzhi Gadzhiev
   - n/a, we don't stream
 - Makes Axios error generic to use AxiosResponse (#1738) - Suman Lama
   - n/a, just the typescript definition
 - Fixing Mocha tests by locking follow-redirects version to 1.5.10 (#1993) - grumblerchester
   - n/a, tests
 - Allow uppercase methods in typings. (#1781) - Ken Powers
   - n/a, more typescript definition tweaks
 - Fixing .eslintrc without extension (#1789) - Manoel
   - n/a, just eslint
 - Consistent coding style (#1787) - Ali Servet Donmez
   - n/a, prettier
 - Fixing building url with hash mark (#1771) - Anatoly Ryabov, This commit fix building url with hash map (fragment identifier) when parameters are present: they must not be added after, because client cut everything after
   - n/a, we don't make any requests with hashes
 - Preserve HTTP method when following redirect (#1758) - Rikki Gibson
   - n/a, looks related to typescript tweaks to verbs
 - Add getUri signature to TypeScript definition. (#1736) - Alexander Trauzzi
   - n/a, another definition
 - Adding isAxiosError flag to errors thrown by axios (#1419) - Ayush Gupta
   - n/a, hmm, this could be dangerous
 - Fix failing SauceLabs tests by updating configuration - Emily Morehouse
   - n/a, tests

v0.19.1
 - Fixing invalid agent issue (#1904)
   - n/a, we don't set the httpsAgent
 - Fix ignore set withCredentials false (#2582)
   - n/a, we set `withCredentials` to `true`, but we don't set it to `false`
 - Delete useless default to hash (#2458)
   - n/a, can ignore
 - Fix HTTP/HTTPs agents passing to follow-redirect (#1904)
   - n/a, duplicate, see above
 - Fix CI build failure (#2570)
   - n/a, build
 - Remove dependency on is-buffer from package.json (#1816)
   - n/a
 - Adding options typings (#2341)
   - n/a, typescript definition again
 - Adding Typescript HTTP method definition for LINK and UNLINK. (#2444)
   - n/a, more typescript defintions
 - Update dist with newest changes, fixes Custom Attributes issue
   - n/a
 - Change syntax to see if build passes (#2488)
   - n/a, build
 - Update Webpack + deps, remove now unnecessary polyfills (#2410)
   - n/a, more build
 - Fix to prevent XSS, throw an error when the URL contains a JS script (#2464)
   - n/a
 - Add custom timeout error copy in config (#2275)
   - n/a
 - Add error toJSON example (#2466)
   - n/a, oops just docs
 - Fixing Vulnerability A Fortify Scan finds a critical Cross-Site Scrip… (#2451)
   - n/a, dup
 - Fixing subdomain handling on no_proxy (#2442)
   - n/a
 - Make redirection from HTTP to HTTPS work ([#2426](https://github.com/axios/axios/pull/2426] and (#2547)
   - n/a
 - Add toJSON property to AxiosError type (#2427)
   - n/a
 - Fixing socket hang up error on node side for slow response. (#1752)
   - n/a
 - Alternative syntax to send data into the body (#2317)
   - n/a
 - Fixing custom config options (#2207)
   - n/a
 - Fixing set config.method after mergeConfig for Axios.prototype.request (#2383)
   - n/a
 - Axios create url bug (#2290)
   - n/a
 - Do not modify config.url when using a relative baseURL (resolves #1628) (#2391)
   - n/a
 - Add typescript HTTP method definition for LINK and UNLINK (#2444)
   - n/a, 

v0.19.2
 - Remove unnecessary XSS check (#2679) (see (#2646) for discussion)
   - n/a