### PR TITLE
AC-1557 - (UI) App should enforce online support via billing subscription

### DIFF
--- a/src/components/support/components/SupportForm.js
+++ b/src/components/support/components/SupportForm.js
@@ -9,7 +9,7 @@ import * as supportActions from 'src/actions/support';
 import { SelectWrapper, TextFieldWrapper } from 'src/components';
 import FileFieldWrapper from 'src/components/reduxFormWrappers/FileFieldWrapper';
 import config from 'src/config';
-import { hasOnlineSupport, isAws } from 'src/helpers/conditions/account';
+import { isAws } from 'src/helpers/conditions/account';
 import { isHeroku } from 'src/helpers/conditions/user';
 import { getBase64Contents } from 'src/helpers/file';
 import { required, maxFileSize } from 'src/helpers/validation';
@@ -18,6 +18,7 @@ import {
   selectSupportIssue,
   selectSupportIssues,
 } from 'src/selectors/support';
+import { hasOnlineSupport } from 'src/selectors/accountBillingInfo';
 import NoIssues from './NoIssues';
 import HerokuMessage from './HerokuMessage';
 import styles from '../Support.module.scss';

--- a/src/config/supportIssues.js
+++ b/src/config/supportIssues.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import {
-  hasOnlineSupport,
   hasStatus,
   hasStatusReasonCategory,
   isSuspendedForBilling,
   onPlanWithStatus,
   isSelfServeBilling,
+  hasProductOnSubscription,
 } from 'src/helpers/conditions/account';
 import { isEmailVerified } from 'src/helpers/conditions/user';
 import { all, not, any } from 'src/helpers/conditions';
@@ -21,7 +21,7 @@ const LIMITS = 'DailyLimits';
 const SUPPORT = 'Support';
 
 const defaultMessageLabel = 'Tell us more about your issue';
-const defaultCondition = all(hasOnlineSupport, hasStatus('active'));
+const defaultCondition = all(hasProductOnSubscription('online_support'), hasStatus('active'));
 
 /**
  * @example
@@ -117,7 +117,7 @@ const supportIssues = [
     messageLabel: 'What limit do you need and why?',
     type: LIMITS,
     condition: all(
-      hasOnlineSupport,
+      hasProductOnSubscription('online_support'),
       isAdmin,
       isEmailVerified,
       hasStatus('active'),

--- a/src/helpers/conditions/account.js
+++ b/src/helpers/conditions/account.js
@@ -24,7 +24,7 @@ export const isAws = ({ account }) => _.get(account, 'subscription.type') === 'a
 export const isManuallyBilled = ({ account }) => _.get(account, 'subscription.type') === 'manual';
 export const isCustomBilling = ({ account }) => _.get(account, 'subscription.custom', false);
 export const isSelfServeBilling = any(subscriptionSelfServeIsTrue, isAws);
-export const hasOnlineSupport = ({ account }) => _.get(account, 'support.online', false);
+
 export const isAccountUiOptionSet = (option, defaultValue) => ({ account }) => {
   return Boolean(_.get(account.options, `ui.${option}`, defaultValue));
 };

--- a/src/helpers/conditions/tests/account.test.js
+++ b/src/helpers/conditions/tests/account.test.js
@@ -9,7 +9,7 @@ import {
   hasStatusReasonCategory,
   isCustomBilling,
   isSelfServeBilling,
-  hasOnlineSupport,
+  hasProductOnSubscription,
   isAccountUiOptionSet,
   hasAccountOptionEnabled,
   getAccountUiOptionValue,
@@ -147,22 +147,36 @@ describe('Condition: isSelfServeBilling', () => {
   });
 });
 
-describe('Condition: hasOnlineSupport', () => {
-  it('should return true for accounts with online support', () => {
+describe('Condition: hasProductOnSubscription', () => {
+  it('should return true for if a certain product is on subscription', () => {
     const state = {
-      account: {
-        support: {
-          online: true,
-        },
+      accountPlan: {
+        products: [
+          {
+            plan: 'online-support',
+            product: 'online_support',
+            price: 0,
+          },
+        ],
       },
     };
 
-    expect(hasOnlineSupport(state)).toEqual(true);
+    expect(hasProductOnSubscription('online_support')(state)).toEqual(true);
   });
 
-  it('should return false for accounts without online support', () => {
-    const state = {};
-    expect(hasOnlineSupport(state)).toEqual(false);
+  it('should return false for if a certain product is not on subscription', () => {
+    const state = {
+      accountPlan: {
+        products: [
+          {
+            plan: 'online-support',
+            product: 'online_support',
+            price: 0,
+          },
+        ],
+      },
+    };
+    expect(hasProductOnSubscription('phone_support')(state)).toEqual(false);
   });
 });
 

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -27,6 +27,7 @@ const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
 const selectIsFree1 = selectCondition(onPlan('free1'));
 const selectOnZuoraPlan = selectCondition(onZuoraPlan);
 const hasDedicatedIpsOnSubscription = selectCondition(hasProductOnSubscription('dedicated_ip'));
+export const hasOnlineSupport = selectCondition(hasProductOnSubscription('online_support'));
 const selectPhoneSupportOnSubscription = selectCondition(hasProductOnSubscription('phone_support'));
 const selectBillingSubscription = state => state.billing.subscription || {};
 const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'];

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -27,7 +27,9 @@ const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
 const selectIsFree1 = selectCondition(onPlan('free1'));
 const selectOnZuoraPlan = selectCondition(onZuoraPlan);
 const hasDedicatedIpsOnSubscription = selectCondition(hasProductOnSubscription('dedicated_ip'));
-export const hasOnlineSupport = selectCondition(hasProductOnSubscription('online_support'));
+const selectOnlineSupportOnSubscription = selectCondition(
+  hasProductOnSubscription('online_support'),
+);
 const selectPhoneSupportOnSubscription = selectCondition(hasProductOnSubscription('phone_support'));
 const selectBillingSubscription = state => state.billing.subscription || {};
 const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'];
@@ -37,6 +39,10 @@ export const currentSubscriptionSelector = state => state.account.subscription;
 export const hasPhoneSupport = createSelector(
   [selectPhoneSupportOnSubscription],
   hasPhoneSupport => hasPhoneSupport,
+);
+export const hasOnlineSupport = createSelector(
+  [selectOnlineSupportOnSubscription],
+  hasOnlineSupport => hasOnlineSupport,
 );
 /**
  * Returns current subscription's code

--- a/src/selectors/accountBillingInfo.js
+++ b/src/selectors/accountBillingInfo.js
@@ -27,23 +27,13 @@ const selectIsCcFree1 = selectCondition(onPlan('ccfree1'));
 const selectIsFree1 = selectCondition(onPlan('free1'));
 const selectOnZuoraPlan = selectCondition(onZuoraPlan);
 const hasDedicatedIpsOnSubscription = selectCondition(hasProductOnSubscription('dedicated_ip'));
-const selectOnlineSupportOnSubscription = selectCondition(
-  hasProductOnSubscription('online_support'),
-);
-const selectPhoneSupportOnSubscription = selectCondition(hasProductOnSubscription('phone_support'));
+export const hasOnlineSupport = selectCondition(hasProductOnSubscription('online_support'));
+export const hasPhoneSupport = selectCondition(hasProductOnSubscription('phone_support'));
 const selectBillingSubscription = state => state.billing.subscription || {};
 const currentFreePlans = ['free500-1018', 'free15K-1018', 'free500-0419', 'free500-SPCEU-0419'];
 export const isManuallyBilled = state => _.get(state, 'billing.subscription.type') === 'manual';
 const getRecipientValidationUsage = state => _.get(state, 'account.rvUsage.recipient_validation');
 export const currentSubscriptionSelector = state => state.account.subscription;
-export const hasPhoneSupport = createSelector(
-  [selectPhoneSupportOnSubscription],
-  hasPhoneSupport => hasPhoneSupport,
-);
-export const hasOnlineSupport = createSelector(
-  [selectOnlineSupportOnSubscription],
-  hasOnlineSupport => hasOnlineSupport,
-);
 /**
  * Returns current subscription's code
  * @param state


### PR DESCRIPTION
AC-1557 - (UI) App should enforce online support via billing subscription

### What Changed
 - Show online support tab on help form if "online_support" product is returned from GET /billing/subscription

### How To Test
 - Check if you see the options(eg Daily Sending Limit Increase) in the menu in "Submit A ticket" tab on Support Form on the basis of whether you have "online_support" in subscription or not.

### To Do
- [ ] Address feedback
