### PR TITLE
AC-1340 -  (UI) Replace PUT /api/v1/account/billing with PUT /api/v1/billing

### DIFF
--- a/cypress/tests/integration/accounts/billing/billingPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/billingPage.spec.js
@@ -318,7 +318,7 @@ describe('Billing Page', () => {
             .last()
             .click({ force: true });
 
-          cy.findAllByText('Required').should('have.length', 5);
+          cy.findAllByText(/Required */i).should('have.length', 5);
         });
       });
 

--- a/cypress/tests/integration/accounts/billing/billingPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/billingPage.spec.js
@@ -524,7 +524,7 @@ describe('Billing Page', () => {
 
         cy.stubRequest({
           method: 'PUT',
-          url: `${ACCOUNT_API_BASE_URL}/billing`,
+          url: `${BILLING_API_BASE_URL}`,
           fixture: 'billing/200.put.json',
           requestAlias: 'billingUpdate',
         });
@@ -549,7 +549,7 @@ describe('Billing Page', () => {
         cy.stubRequest({
           method: 'PUT',
           statusCode: 400,
-          url: `${ACCOUNT_API_BASE_URL}/billing`,
+          url: `${BILLING_API_BASE_URL}`,
           fixture: '400.json',
         });
 

--- a/src/__func__/billing/__snapshots__/updateContactDetails.test.js.snap
+++ b/src/__func__/billing/__snapshots__/updateContactDetails.test.js.snap
@@ -128,7 +128,7 @@ Array [
       "method": "put",
       "params": undefined,
       "responseType": "json",
-      "url": "/v1/account/billing",
+      "url": "/v1/billing",
     },
   ],
   Array [

--- a/src/actions/billing.js
+++ b/src/actions/billing.js
@@ -70,7 +70,7 @@ export function updateBillingContact(data) {
     type: 'UPDATE_BILLING_CONTACT',
     meta: {
       method: 'PUT',
-      url: '/v1/account/billing',
+      url: '/v1/billing',
       data: formatContactData(data),
     },
   });


### PR DESCRIPTION
AC-1340 -  Replace PUT /api/v1/account/billing with PUT /api/v1/billing

### What Changed
 - replaced PUT /account/billing with /billing to update billing contact details

### How To Test
 - On billing page, update the billing contact details and check if the network call is being made to /billing instead of /account/billing

~**need to wait on AC-1327 on being merged before testing this.**~ ✅ 
### To Do
- [ ] Address feedback
