### PR TITLE
AC-1588 - (UI) Update the override condition for subaccounts

### DIFF
--- a/cypress/fixtures/account/200.get.250k-premier-plan.json
+++ b/cypress/fixtures/account/200.get.250k-premier-plan.json
@@ -12,7 +12,7 @@
 	  "tfa_required": false,
 	  "updated": "2019-12-10T21:00:45.997Z",
 	  "subscription": {
-		"code": "250k-premier-0519",
+		"code": "250K-premier-0519",
 		"name": "250k Premier",
 		"plan_volume": 250000,
 		"period": "month",

--- a/cypress/fixtures/billing/subscription/200.get.premier-plan-with-limitoverride.json
+++ b/cypress/fixtures/billing/subscription/200.get.premier-plan-with-limitoverride.json
@@ -1,0 +1,41 @@
+{
+  "results": {
+    "bill_cycle_day": 31,
+    "pending_downgrades": [],
+    "products": [
+      {
+        "plan": "subaccounts-premier",
+        "product": "subaccounts",
+        "limit": 15,
+        "limit_override": 2,
+        "quantity": 5
+      },
+      {
+        "plan": "sso",
+        "product": "sso"
+      },
+      {
+        "plan": "tfa-required",
+        "product": "tfa_required"
+      },
+      {
+        "plan": "online-support",
+        "product": "online_support"
+      },
+      {
+        "plan": "250K-premier-0519",
+        "product": "messaging"
+      },
+      {
+        "plan": "ip-0519",
+        "product": "dedicated_ip",
+        "limit": 4
+      },
+      {
+        "plan": "phone-support",
+        "product": "phone_support"
+      }
+    ],
+    "type": "active"
+  }
+}

--- a/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/changeBillingPlanPage.spec.js
@@ -582,6 +582,31 @@ describe('Change Billing Plan Page', () => {
     cy.url().should('equal', `${Cypress.config().baseUrl}/account/billing`);
   });
 
+  it('downgrades from premier to starter with quantity excedding limit_override', () => {
+    cy.stubRequest({
+      url: '/api/v1/account',
+      fixture: 'account/200.get.250k-premier-plan.json',
+      requestAlias: 'accountGet',
+    });
+    cy.stubRequest({
+      url: '/api/v1/billing',
+      fixture: 'billing/200.get.json',
+      fixtureAlias: 'billingGet',
+      requestAlias: 'billingGet',
+    });
+    cy.stubRequest({
+      url: '/api/v1/billing/subscription',
+      fixture: 'billing/subscription/200.get.premier-plan-with-limitoverride.json',
+      requestAlias: 'subscriptionGet',
+    });
+
+    cy.visit('/account/billing/plan');
+
+    cy.get('[data-id=select-plan-50K-starter-0519]').click();
+
+    cy.findByText(/Update Status*/).should('be.visible');
+  });
+
   it('Upgrades from free to paid using a promo code', () => {
     cy.stubRequest({
       url: '/api/v1/account',

--- a/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
+++ b/src/pages/billing/context/tests/__snapshots__/FeatureChangeContext.test.js.snap
@@ -48,7 +48,9 @@ Object {
       </Button>,
       "condition": false,
       "description": <div>
-        Your new plan doesn't include subaccounts.
+        <React.Fragment>
+          Your new plan doesn't include subaccounts.
+        </React.Fragment>
         <React.Fragment>
           <span>
              Please 


### PR DESCRIPTION
AC-1588 - (UI) Update the override condition for subaccounts

### What Changed
 - User needs to be prompted to update the subaccount status if the qty > limit_override && limit_override > limit of the new selected plan


### How To Test
 - The cypress test added in this ticket can help in testing this scenario.

### To Do
- [ ] Address feedback
