### PR TITLE
AC-1608 - Remove the GET /billing/subscription call for AWS users

### DIFF
--- a/src/__func__/auth/__snapshots__/login.test.js.snap
+++ b/src/__func__/auth/__snapshots__/login.test.js.snap
@@ -52,12 +52,9 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {
-        "beta": false,
-        "role": "admin",
-      },
+      "params": Object {},
       "responseType": "json",
-      "url": "/v1/authenticate/grants",
+      "url": "/v1/account",
     },
   ],
   Array [
@@ -67,9 +64,12 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {},
+      "params": Object {
+        "beta": false,
+        "role": "admin",
+      },
       "responseType": "json",
-      "url": "/v1/account",
+      "url": "/v1/authenticate/grants",
     },
   ],
   Array [

--- a/src/__func__/auth/__snapshots__/loginRememberMe.test.js.snap
+++ b/src/__func__/auth/__snapshots__/loginRememberMe.test.js.snap
@@ -52,12 +52,9 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {
-        "beta": false,
-        "role": "admin",
-      },
+      "params": Object {},
       "responseType": "json",
-      "url": "/v1/authenticate/grants",
+      "url": "/v1/account",
     },
   ],
   Array [
@@ -67,9 +64,12 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {},
+      "params": Object {
+        "beta": false,
+        "role": "admin",
+      },
       "responseType": "json",
-      "url": "/v1/account",
+      "url": "/v1/authenticate/grants",
     },
   ],
   Array [

--- a/src/__func__/auth/__snapshots__/ssoReturn.test.js.snap
+++ b/src/__func__/auth/__snapshots__/ssoReturn.test.js.snap
@@ -21,12 +21,9 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {
-        "beta": false,
-        "role": undefined,
-      },
+      "params": Object {},
       "responseType": "json",
-      "url": "/v1/authenticate/grants",
+      "url": "/v1/account",
     },
   ],
   Array [
@@ -36,9 +33,12 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {},
+      "params": Object {
+        "beta": false,
+        "role": undefined,
+      },
       "responseType": "json",
-      "url": "/v1/account",
+      "url": "/v1/authenticate/grants",
     },
   ],
   Array [

--- a/src/__func__/auth/__snapshots__/tfa.test.js.snap
+++ b/src/__func__/auth/__snapshots__/tfa.test.js.snap
@@ -64,12 +64,9 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {
-        "beta": false,
-        "role": "admin",
-      },
+      "params": Object {},
       "responseType": "json",
-      "url": "/v1/authenticate/grants",
+      "url": "/v1/account",
     },
   ],
   Array [
@@ -79,9 +76,12 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {},
+      "params": Object {
+        "beta": false,
+        "role": "admin",
+      },
       "responseType": "json",
-      "url": "/v1/account",
+      "url": "/v1/authenticate/grants",
     },
   ],
   Array [

--- a/src/__func__/auth/__snapshots__/tfaEnableOnLogin.test.js.snap
+++ b/src/__func__/auth/__snapshots__/tfaEnableOnLogin.test.js.snap
@@ -81,12 +81,9 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {
-        "beta": false,
-        "role": undefined,
-      },
+      "params": Object {},
       "responseType": "json",
-      "url": "/v1/authenticate/grants",
+      "url": "/v1/account",
     },
   ],
   Array [
@@ -96,9 +93,12 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {},
+      "params": Object {
+        "beta": false,
+        "role": undefined,
+      },
       "responseType": "json",
-      "url": "/v1/account",
+      "url": "/v1/authenticate/grants",
     },
   ],
   Array [

--- a/src/__func__/signup/__snapshots__/join.test.js.snap
+++ b/src/__func__/signup/__snapshots__/join.test.js.snap
@@ -77,12 +77,9 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {
-        "beta": false,
-        "role": "admin",
-      },
+      "params": Object {},
       "responseType": "json",
-      "url": "/v1/authenticate/grants",
+      "url": "/v1/account",
     },
   ],
   Array [
@@ -92,9 +89,12 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {},
+      "params": Object {
+        "beta": false,
+        "role": "admin",
+      },
       "responseType": "json",
-      "url": "/v1/account",
+      "url": "/v1/authenticate/grants",
     },
   ],
   Array [

--- a/src/__func__/signup/__snapshots__/joinEmailOptIn.test.js.snap
+++ b/src/__func__/signup/__snapshots__/joinEmailOptIn.test.js.snap
@@ -77,12 +77,9 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {
-        "beta": false,
-        "role": "admin",
-      },
+      "params": Object {},
       "responseType": "json",
-      "url": "/v1/authenticate/grants",
+      "url": "/v1/account",
     },
   ],
   Array [
@@ -92,9 +89,12 @@ Array [
         "Authorization": "mock-access-token",
       },
       "method": "get",
-      "params": Object {},
+      "params": Object {
+        "beta": false,
+        "role": "admin",
+      },
       "responseType": "json",
-      "url": "/v1/account",
+      "url": "/v1/authenticate/grants",
     },
   ],
   Array [

--- a/src/actions/accessControl.js
+++ b/src/actions/accessControl.js
@@ -2,6 +2,7 @@ import { fetch as fetchAccount } from './account';
 import { get as getCurrentUser, getGrants } from './currentUser';
 import { getPlans, getBundles, getSubscription } from './billing';
 import { isHeroku, isAzure } from 'src/helpers/conditions/user';
+import { isAws } from 'src/helpers/conditions/account';
 
 // initialize some state used for access control
 export function initializeAccessControl() {
@@ -10,21 +11,21 @@ export function initializeAccessControl() {
   const meta = { showErrorAlert: false };
 
   return (dispatch, getState) =>
-    dispatch(getCurrentUser({ meta })).then(({ access_level }) => {
-      const allInitialCalls = [
-        dispatch(getGrants({ role: access_level, meta })),
-        dispatch(fetchAccount({ meta })),
-        dispatch(getPlans({ meta })),
-        dispatch(getBundles({ meta })),
-      ];
-
-      if (isHeroku(getState()) || isAzure(getState())) {
-        return Promise.all([...allInitialCalls]).then(() =>
+    Promise.all([dispatch(getCurrentUser({ meta })), dispatch(fetchAccount({ meta }))]).then(
+      ([currentUser]) => {
+        const allInitialCalls = [
+          dispatch(getGrants({ role: currentUser.access_level, meta })),
+          dispatch(getPlans({ meta })),
+          dispatch(getBundles({ meta })),
+        ];
+        if (isHeroku(getState()) || isAzure(getState()) || isAws(getState())) {
+          return Promise.all([...allInitialCalls]).then(() =>
+            dispatch({ type: 'ACCESS_CONTROL_READY' }),
+          );
+        }
+        return Promise.all([...allInitialCalls, dispatch(getSubscription({ meta }))]).then(() =>
           dispatch({ type: 'ACCESS_CONTROL_READY' }),
         );
-      }
-      return Promise.all([...allInitialCalls, dispatch(getSubscription({ meta }))]).then(() =>
-        dispatch({ type: 'ACCESS_CONTROL_READY' }),
-      );
-    });
+      },
+    );
 }

--- a/src/actions/tests/accessControl.test.js
+++ b/src/actions/tests/accessControl.test.js
@@ -48,4 +48,21 @@ describe('Action: Initialize Access Control', () => {
     expect(getSubscription).not.toHaveBeenCalled();
     expect(dispatch).toHaveBeenCalledTimes(6);
   });
+
+  it('should initialize access control with a series of calls for aws users', async () => {
+    const thunk = initializeAccessControl();
+    const state = {
+      currentUser: { access_level: 'admin' },
+      account: { subscription: { type: 'aws' } },
+    };
+
+    await thunk(dispatch, () => state);
+    expect(getCurrentUser).toHaveBeenCalledWith({ meta });
+    expect(getGrants).toHaveBeenCalledWith({ role: 'admin', meta });
+    expect(fetchAccount).toHaveBeenCalledWith({ meta });
+    expect(getPlans).toHaveBeenCalledWith({ meta });
+    expect(getBundles).toHaveBeenCalledWith({ meta });
+    expect(getSubscription).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledTimes(6);
+  });
 });

--- a/src/pages/recipientValidation/RecipientValidationPage.js
+++ b/src/pages/recipientValidation/RecipientValidationPage.js
@@ -20,7 +20,8 @@ import ValidateSection from './components/ValidateSection';
 import { FORMS } from 'src/constants';
 import RVPriceModal from './components/RVPriceModal';
 import { PageDescription } from 'src/components/text';
-
+import { isHeroku, isAzure } from 'src/helpers/conditions/user';
+import { isAws } from 'src/helpers/conditions/account';
 import OGStyles from './RecipientValidationPage.module.scss';
 import hibanaStyles from './RecipientValidationPageHibana.module.scss';
 import useHibanaOverride from 'src/hooks/useHibanaOverride';
@@ -57,6 +58,9 @@ export function RecipientValidationPage(props) {
     history,
     reset,
     handleSubmit,
+    isHeroku,
+    isAzure,
+    isAws,
   } = props;
 
   const [useSavedCC, setUseSavedCC] = useState(Boolean(billing.credit_card));
@@ -82,8 +86,10 @@ export function RecipientValidationPage(props) {
     getBillingInfo();
   }, [getBillingInfo]);
   useEffect(() => {
-    getBillingSubscription();
-  }, [getBillingSubscription]);
+    if (!isHeroku && !isAzure && !isAws) {
+      getBillingSubscription();
+    }
+  }, [getBillingSubscription, isAws, isAzure, isHeroku]);
   useEffect(() => {
     setUseSavedCC(Boolean(billing.credit_card));
   }, [billing, billing.credit_card]);
@@ -216,6 +222,9 @@ const mapStateToProps = (state, props) => {
     addRVFormValues: state.addRVtoSubscription.formValues,
     addRVtoSubscriptionerror: state.addRVtoSubscription.addRVtoSubscriptionerror,
     addRVtoSubscriptionsuccess: state.addRVtoSubscription.addRVtoSubscriptionsuccess,
+    isHeroku: isHeroku(state),
+    isAzure: isAzure(state),
+    isAws: isAws(state),
   };
 };
 

--- a/src/pages/recipientValidation/UploadedListPage.js
+++ b/src/pages/recipientValidation/UploadedListPage.js
@@ -23,7 +23,8 @@ import addRVtoSubscription from 'src/actions/addRVtoSubscription';
 import { getSubscription as getBillingSubscription } from 'src/actions/billing';
 import { withRouter } from 'react-router-dom';
 import _ from 'lodash';
-
+import { isHeroku, isAzure } from 'src/helpers/conditions/user';
+import { isAws } from 'src/helpers/conditions/account';
 import { OGOnlyWrapper } from 'src/components/hibana';
 
 import OGStyles from './UploadedListPage.module.scss';
@@ -51,6 +52,9 @@ export function UploadedListPage(props) {
     addRVtoSubscriptionloading,
     addRVtoSubscriptionerror,
     triggerJob,
+    isHeroku,
+    isAzure,
+    isAws,
   } = props;
 
   const [useSavedCC, setUseSavedCC] = useState(Boolean(billing.credit_card));
@@ -59,8 +63,10 @@ export function UploadedListPage(props) {
     getJobStatus(listId);
   }, [getJobStatus, listId]);
   useEffect(() => {
-    getBillingSubscription();
-  }, [getBillingSubscription]);
+    if (!isHeroku && !isAzure && !isAws) {
+      getBillingSubscription();
+    }
+  }, [getBillingSubscription, isAws, isAzure, isHeroku]);
   useEffect(() => {
     getBillingInfo();
   }, [getBillingInfo]);
@@ -167,6 +173,9 @@ const mapStateToProps = (state, props) => {
     isManuallyBilled: isManuallyBilled(state),
     addRVtoSubscriptionloading: state.addRVtoSubscription.addRVtoSubscriptionloading,
     addRVtoSubscriptionerror: state.addRVtoSubscription.addRVtoSubscriptionerror,
+    isHeroku: isHeroku(state),
+    isAzure: isAzure(state),
+    isAws: isAws(state),
   };
 };
 


### PR DESCRIPTION
AC-1608 - Remove the GET /billing/subscription call for AWS users

### What Changed
 - Removed the GET /billing/subscription call for aws users from accessControlState

### How To Test
- Verify that app loads for aws users. [I can invite to a aws account]

### To Do
- [ ] Address feedback
