### PR TITLE
AC-1597 - Empty Subaccount section should not show in Features after updating the status of subaccounts

### DIFF
--- a/src/pages/billing/context/FeatureChangeContext.js
+++ b/src/pages/billing/context/FeatureChangeContext.js
@@ -22,6 +22,7 @@ export const FeatureChangeProvider = ({
   }, [getSubscription]);
 
   const checkConditions = useCallback(() => {
+    updateActions({});
     getSubscription();
   }, [getSubscription]);
   useEffect(() => {


### PR DESCRIPTION
AC-1597 - Empty Subaccount section should not show in Features after updating the status of subaccounts

### What changed
 - Empty Subaccount section will not render in Features after updating the status of subaccounts

### How To Test
 - Steps to reproduce the bug :
      - Create an account on premier plan with limit_override = 2, Create 3 subaccounts
[to set the override - PUT /billing/subscription/control/product/subaccounts
{limit_override : 2}]
      - Navigate to change plan page and select starter plan
      -  Click on Update Status in Subaccount Section
      - terminate 1 subaccount in new tab and navigate back to old tab, empty subaccount section shouldn't shows up now

### To Do
- [ ] Address feedback