### PR TITLE
AC-1618 Send API_KEY_CREATED event

### DIFF
--- a/src/pages/api-keys/CreatePage.js
+++ b/src/pages/api-keys/CreatePage.js
@@ -11,6 +11,8 @@ import ApiKeyForm from './components/ApiKeyForm';
 import { Loading } from 'src/components';
 import { PageLink } from 'src/components/links';
 import { Page, Panel } from 'src/components/matchbox';
+import { segmentTrack } from 'src/helpers/segment';
+import { SEGMENT_EVENTS } from '../../helpers/segment';
 
 const breadcrumbAction = {
   content: 'API Keys',
@@ -32,6 +34,7 @@ export class CreatePage extends React.Component {
     return createApiKey(values).then(() => {
       showAlert({ type: 'success', message: 'API key created' });
       history.push('/account/api-keys');
+      segmentTrack(SEGMENT_EVENTS.API_KEY_CREATED);
     });
   };
 

--- a/src/pages/api-keys/tests/CreatePage.test.js
+++ b/src/pages/api-keys/tests/CreatePage.test.js
@@ -1,8 +1,11 @@
 import { shallow } from 'enzyme';
 import React from 'react';
+import * as segmentHelpers from 'src/helpers/segment';
 
 import { CreatePage } from '../CreatePage';
 let wrapper;
+
+segmentHelpers.segmentTrack = jest.fn();
 
 beforeEach(() => {
   const props = {
@@ -12,7 +15,7 @@ beforeEach(() => {
     listSubaccountGrants: jest.fn(),
     createApiKey: jest.fn(() => Promise.resolve()),
     history: { push: jest.fn() },
-    showAlert: jest.fn()
+    showAlert: jest.fn(),
   };
 
   wrapper = shallow(<CreatePage {...props} />);
@@ -39,9 +42,15 @@ it('should show loading component while loading', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-it('submits correctly', async() => {
+it('submits correctly', async () => {
   await wrapper.instance().onSubmit('test');
   expect(wrapper.instance().props.createApiKey).toHaveBeenCalledWith('test');
-  expect(wrapper.instance().props.showAlert).toHaveBeenCalledWith({ type: 'success', message: 'API key created' });
+  expect(segmentHelpers.segmentTrack).toHaveBeenCalledWith(
+    segmentHelpers.SEGMENT_EVENTS.API_KEY_CREATED,
+  );
+  expect(wrapper.instance().props.showAlert).toHaveBeenCalledWith({
+    type: 'success',
+    message: 'API key created',
+  });
   expect(wrapper.instance().props.history.push).toHaveBeenCalledWith('/account/api-keys');
 });


### PR DESCRIPTION
### What Changed
 - Sending an event every time an API Key is created

### How To Test
 - Complete the Create API Key form
 - Check the segment debugger to find the event: https://app.segment.com/sparkpost-daniel-chalef/sources/webui_dev/debugger

