### PR TITLE
AC-1668 Add Hibana Toggled On and Hibana Toggled Off to Segment

### DIFF
--- a/src/context/HibanaContext.js
+++ b/src/context/HibanaContext.js
@@ -27,11 +27,11 @@ const mapDispatchToProps = {
   setIsHibanaEnabled: bool => {
     if (window.pendo && window.pendo.track) {
       window.pendo.track(`Hibana Toggle - ${Boolean(bool) ? 'On' : 'Off'}`);
-      if (bool) {
-        segmentTrack(SEGMENT_EVENTS.HIBANA_TOGGLED_ON);
-      } else {
-        segmentTrack(SEGMENT_EVENTS.HIBANA_TOGGLED_OFF);
-      }
+    }
+    if (bool) {
+      segmentTrack(SEGMENT_EVENTS.HIBANA_TOGGLED_ON);
+    } else {
+      segmentTrack(SEGMENT_EVENTS.HIBANA_TOGGLED_OFF);
     }
 
     // Always dismiss the banner when the user toggles their theme

--- a/src/context/HibanaContext.js
+++ b/src/context/HibanaContext.js
@@ -4,6 +4,7 @@ import { updateUserUIOptions } from 'src/actions/currentUser';
 import { showAlert } from 'src/actions/globalAlert';
 import { isUserUiOptionSet } from 'src/helpers/conditions/user';
 import { selectCondition } from 'src/selectors/accessConditionState';
+import { segmentTrack, SEGMENT_EVENTS } from '../helpers/segment';
 
 const HibanaStateContext = createContext();
 
@@ -26,6 +27,11 @@ const mapDispatchToProps = {
   setIsHibanaEnabled: bool => {
     if (window.pendo && window.pendo.track) {
       window.pendo.track(`Hibana Toggle - ${Boolean(bool) ? 'On' : 'Off'}`);
+      if (bool) {
+        segmentTrack(SEGMENT_EVENTS.HIBANA_TOGGLED_ON);
+      } else {
+        segmentTrack(SEGMENT_EVENTS.HIBANA_TOGGLED_OFF);
+      }
     }
 
     // Always dismiss the banner when the user toggles their theme

--- a/src/helpers/segment.js
+++ b/src/helpers/segment.js
@@ -11,9 +11,13 @@ export const SEGMENT_EVENTS = {
   ACCOUNT_UPGRADED: 'Account Upgraded',
   ALERT_CREATED: 'Alert Created',
   API_KEY_CREATED: 'API Key Created',
+  HIBANA_TOGGLED_ON: 'Hibana Toggled On',
+  HIBANA_TOGGLED_OFF: 'Hibana Toggled Off',
   INVITE_SENT: 'Invite Sent',
   SENDING_DOMAIN_VERIFIED: 'Sending Domain Verified',
 };
+
+const UX_EVENTS = [SEGMENT_EVENTS.HIBANA_TOGGLED_ON, SEGMENT_EVENTS.HIBANA_TOGGLED_OFF];
 
 export const SEGMENT_TRAITS = {
   COMPANY: 'company',
@@ -64,6 +68,10 @@ export const segmentPage = () => {
 
 export const segmentTrack = (eventType, traits = {}) => {
   if (window.analytics && window.analytics.track) {
-    window.analytics.track(eventType, traits);
+    if (UX_EVENTS.includes(eventType)) {
+      window.analytics.track(eventType, { ...traits, ux: true });
+    } else {
+      window.analytics.track(eventType, traits);
+    }
   }
 };


### PR DESCRIPTION
### What Changed
 - In addition to logging to pendo, log the hibana toggled event to Segment

### How To Test
 - Toggle Hibana on and off via the profile page
 - Ensure events are being logged via the debugger: https://app.segment.com/sparkpost-daniel-chalef/sources/webui_dev/debugger
 - Ensure the event has an attribute `ux`, which we will be able to filter by in mixpanel, etc.
