### PR TITLE
AC-1680 Call Segment Group function every time Identify is called

### DIFF
--- a/src/helpers/segment.js
+++ b/src/helpers/segment.js
@@ -35,17 +35,18 @@ export const SEGMENT_TRAITS = {
 };
 
 /**
- * Helper to identify a user, partial updates are supported but must
- * always include the username and email
+ * Helper to identify and group a user, partial updates are supported
  * @param {} traits must include SEGMENT_TRAITS.USER_ID, SEGMENT_TRAITS.CUSTOMER_ID, and SEGMENT_TRAITS.EMAIL
  */
 export const segmentIdentify = traits => {
   if (
     window.analytics &&
     window.analytics.identify &&
+    window.analytics.group &&
     traits[SEGMENT_TRAITS.CUSTOMER_ID] &&
     traits[SEGMENT_TRAITS.USER_ID] &&
-    traits[SEGMENT_TRAITS.EMAIL]
+    traits[SEGMENT_TRAITS.EMAIL] &&
+    traits[SEGMENT_TRAITS.TENANT]
   ) {
     const filteredTraits = Object.values(SEGMENT_TRAITS).reduce((filtered, key) => {
       if (traits[key]) {
@@ -57,6 +58,9 @@ export const segmentIdentify = traits => {
     window.analytics.identify(
       `${filteredTraits[SEGMENT_TRAITS.EMAIL]}//${traits[SEGMENT_TRAITS.CUSTOMER_ID]}`,
       filteredTraits,
+    );
+    window.analytics.group(
+      `${filteredTraits[SEGMENT_TRAITS.TENANT]}//${traits[SEGMENT_TRAITS.CUSTOMER_ID]}`,
     );
   }
 };

--- a/src/helpers/tests/segment.test.js
+++ b/src/helpers/tests/segment.test.js
@@ -47,7 +47,7 @@ describe('segment helpers', () => {
 
       segmentIdentify(traits);
       expect(window.analytics.identify).toBeCalledWith('email@abc.com//123', traits);
-      expect(window.analytics.group).toBeCalledWith('test-tenant//123', traits);
+      expect(window.analytics.group).toBeCalledWith('test-tenant//123');
     });
   });
 

--- a/src/helpers/tests/segment.test.js
+++ b/src/helpers/tests/segment.test.js
@@ -21,6 +21,7 @@ describe('segment helpers', () => {
         [SEGMENT_TRAITS.CUSTOMER_ID]: 123,
         [SEGMENT_TRAITS.EMAIL]: 'email@abc.com',
         [SEGMENT_TRAITS.USER_ID]: 'username',
+        [SEGMENT_TRAITS.TENANT]: 'tenant',
       });
       expect(window.analytics.group).toBeCalledWith('tenant//123');
     });

--- a/src/helpers/tests/segment.test.js
+++ b/src/helpers/tests/segment.test.js
@@ -5,6 +5,7 @@ describe('segment helpers', () => {
     beforeEach(() => {
       window.analytics = {};
       window.analytics.identify = jest.fn();
+      window.analytics.group = jest.fn();
     });
 
     it('does not pass invalid traits to segment', () => {
@@ -12,6 +13,7 @@ describe('segment helpers', () => {
         [SEGMENT_TRAITS.CUSTOMER_ID]: 123,
         [SEGMENT_TRAITS.EMAIL]: 'email@abc.com',
         [SEGMENT_TRAITS.USER_ID]: 'username',
+        [SEGMENT_TRAITS.TENANT]: 'tenant',
         'invalid-trait': 'this-is-invalid',
       };
       segmentIdentify(traits);
@@ -20,6 +22,7 @@ describe('segment helpers', () => {
         [SEGMENT_TRAITS.EMAIL]: 'email@abc.com',
         [SEGMENT_TRAITS.USER_ID]: 'username',
       });
+      expect(window.analytics.group).toBeCalledWith('tenant//123');
     });
 
     it('does not call window.analytics.identify without user id/email', () => {
@@ -30,6 +33,7 @@ describe('segment helpers', () => {
       };
       segmentIdentify(traits);
       expect(window.analytics.identify).toBeCalledTimes(0);
+      expect(window.analytics.group).toBeCalledTimes(0);
     });
 
     it('calls window.analytics.identify with the correct id', () => {
@@ -42,6 +46,7 @@ describe('segment helpers', () => {
 
       segmentIdentify(traits);
       expect(window.analytics.identify).toBeCalledWith('email@abc.com//123', traits);
+      expect(window.analytics.group).toBeCalledWith('test-tenant//123', traits);
     });
   });
 


### PR DESCRIPTION
### What Changed
 - Every time we `identify` we also `group`, which allows us to group analytics per tenant/account combination.

### How To Test
 - Pretty much do anything in the app (load a page, for example)
 - Check segment debugger to see a "Group" event: https://app.segment.com/sparkpost-daniel-chalef/sources/webui_dev/debugger

