### PR TITLE
AC-1680 Followup - Mixpanel ignores first segment argument for group call

### DIFF
--- a/src/helpers/segment.js
+++ b/src/helpers/segment.js
@@ -59,9 +59,14 @@ export const segmentIdentify = traits => {
       `${filteredTraits[SEGMENT_TRAITS.EMAIL]}//${traits[SEGMENT_TRAITS.CUSTOMER_ID]}`,
       filteredTraits,
     );
-    window.analytics.group(
-      `${filteredTraits[SEGMENT_TRAITS.TENANT]}//${traits[SEGMENT_TRAITS.CUSTOMER_ID]}`,
-    );
+    const groupIdentifier = `${filteredTraits[SEGMENT_TRAITS.TENANT]}//${
+      traits[SEGMENT_TRAITS.CUSTOMER_ID]
+    }`;
+
+    // Mixpanel ignores the first argument for grouping, so we need to pass it twice
+    window.analytics.group(groupIdentifier, {
+      groupId: groupIdentifier,
+    });
   }
 };
 

--- a/src/helpers/tests/segment.test.js
+++ b/src/helpers/tests/segment.test.js
@@ -23,7 +23,7 @@ describe('segment helpers', () => {
         [SEGMENT_TRAITS.USER_ID]: 'username',
         [SEGMENT_TRAITS.TENANT]: 'tenant',
       });
-      expect(window.analytics.group).toBeCalledWith('tenant//123');
+      expect(window.analytics.group).toBeCalledWith('tenant//123', { groupId: 'tenant//123' });
     });
 
     it('does not call window.analytics.identify without user id/email', () => {
@@ -47,7 +47,9 @@ describe('segment helpers', () => {
 
       segmentIdentify(traits);
       expect(window.analytics.identify).toBeCalledWith('email@abc.com//123', traits);
-      expect(window.analytics.group).toBeCalledWith('test-tenant//123');
+      expect(window.analytics.group).toBeCalledWith('test-tenant//123', {
+        groupId: 'test-tenant//123',
+      });
     });
   });
 


### PR DESCRIPTION
### What Changed
 - It turns out that Mixpanel ignores the first argument of the Segment `group` call, so we need to be redundant and send it as a trait. See https://help.mixpanel.com/hc/en-us/articles/115004560846-Segment-Set-Up-Guide under "Integrating Group Analytics via Segment"

### How To Test
 - Do anything in the web app (load page, etc.)
 - Ensure the "Group" event is in the debugger: https://app.segment.com/sparkpost-daniel-chalef/sources/webui_dev/debugger with the additional trait "groupId"
