### PR TITLE
FE-1193: Add the Option to create Bounce Domain to Add a Domain Form

### DIFF
--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -53,6 +53,17 @@ export default function CreateForm() {
       });
     }
 
+    if (primaryUse === 'bounce') {
+      return createSendingDomain({
+        assignTo,
+        domain,
+        subaccount,
+      }).then(() => {
+        showAlert({ type: 'success', message: `Bounce Domain ${domain} created` });
+        history.push(`/domains/details/${domain}/verify-bounce`);
+      });
+    }
+
     return createSendingDomain({
       assignTo,
       domain,
@@ -103,16 +114,16 @@ export default function CreateForm() {
                   </TranslatableText>
                 </RadioCard>
 
-                {/* TODO: Bounce domains cannot be created - a sending domain has to be created and verified via `CNAME` or `MX` records */}
-                {/* <RadioCard
+                <RadioCard
                   ref={register}
                   label="Bounce Domain"
                   id="primary-use-bounce-domain"
                   value="bounce"
                   name="primaryUse"
                 >
-                  Mauris sit amet ex eu dolor vestibulum gravida quis sagittis risus.
-                </RadioCard> */}
+                  Bounce domains are the return path address and are used for report bounces, emails
+                  rejected from the recipient server.
+                </RadioCard>
 
                 <RadioCard
                   ref={register}

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -116,13 +116,16 @@ export default function CreateForm() {
 
                 <RadioCard
                   ref={register}
+                  disabled={createPending}
                   label="Bounce Domain"
                   id="primary-use-bounce-domain"
                   value="bounce"
                   name="primaryUse"
                 >
-                  Bounce domains are the return path address and are used for report bounces, emails
-                  rejected from the recipient server.
+                  <TranslatableText>
+                    Bounce domains are the return path address and are used for report bounces,
+                    emails rejected from the recipient server.
+                  </TranslatableText>
                 </RadioCard>
 
                 <RadioCard
@@ -170,7 +173,7 @@ export default function CreateForm() {
               <Panel.Section>
                 <Stack space="300">
                   <Radio.Group label="Subaccount Assignment">
-                    {watchedPrimaryUse === 'sending' && (
+                    {(watchedPrimaryUse === 'sending' || watchedPrimaryUse === 'bounce') && (
                       <Radio
                         ref={register}
                         disabled={createPending}

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -122,10 +122,8 @@ export default function CreateForm() {
                   value="bounce"
                   name="primaryUse"
                 >
-                  <TranslatableText>
-                    Bounce domains are the return path address and are used for report bounces,
-                    emails rejected from the recipient server.
-                  </TranslatableText>
+                  Bounce domains are the return path address and are used for report bounces, emails
+                  rejected from the recipient server.
                 </RadioCard>
 
                 <RadioCard


### PR DESCRIPTION
FE-1193: Add the Option to create Bounce Domain to Add a Domain Form

### What Changed
 - Added the option for Bounce Domain in Add a Domain Form.

 - On Selecting this option and creating a Bounce Domain it redirects to Bounce only verification Page (Hibana_Domains ) /domains/details/:id/verify-bounce; this verification page is being completed as part of FE-1173 which is in review.

- Added cypress tests for creation of Bounce Domain

 - Updated condition for Principal and all Subaccounts to show up even when bounce domains are created

mock - https://sparkpost.invisionapp.com/console/share/CF19LDYPB2/478910829

### How To Test
 - Create a bounce domain from /domains/create
 - After adding a bounce domain you should be redirected to /domains/details/:id/verify-bounce
### To Do
- [ ] Address feedback
