### PR TITLE
FE-1194 - Add the Modal for Domain Alignment

### DIFF
--- a/cypress/tests/integration/domains/createPage.spec.js
+++ b/cypress/tests/integration/domains/createPage.spec.js
@@ -41,6 +41,12 @@ describe('The domains create page', () => {
       cy.findByLabelText('Principal and all Subaccounts').should('be.checked');
       cy.findByRole('button', { name: 'Save and Continue' }).click();
 
+      cy.withinModal(() => {
+        cy.findByText('Domain Alignment').should('be.visible');
+        cy.findByLabelText('Yes').should('be.checked');
+        cy.findByRole('button', { name: 'Save and Continue' }).click();
+      });
+
       cy.wait('@sendingDomainsReq').then(xhr => {
         const { domain, shared_with_subaccounts } = xhr.request.body;
 
@@ -50,8 +56,8 @@ describe('The domains create page', () => {
 
       cy.findByText('Sending Domain example.com created').should('be.visible');
       cy.url().should('include', '/domains/details/example.com/verify-sending');
-      cy.title().should('include', 'Verify Sending Domain | Domains');
-      cy.findByRole('heading', { name: 'Verify Sending Domain' }).should('be.visible');
+      cy.title().should('include', 'Verify Sending/Bounce Domain | Domains');
+      cy.findByRole('heading', { name: 'Verify Sending/Bounce Domain' }).should('be.visible');
     });
 
     it('creates a new sending domain for the principal account only', () => {
@@ -62,6 +68,12 @@ describe('The domains create page', () => {
       cy.findByLabelText('Domain').type('example.com');
       cy.findByLabelText('Principal Account only').check({ force: true }); // `force` required to workaround Matchbox CSS implementation
       cy.findByRole('button', { name: 'Save and Continue' }).click();
+
+      cy.withinModal(() => {
+        cy.findByText('Domain Alignment').should('be.visible');
+        cy.findByLabelText('No').check({ force: true });
+        cy.findByRole('button', { name: 'Save and Continue' }).click();
+      });
 
       cy.wait('@sendingDomainsReq').then(xhr => {
         const { domain, shared_with_subaccounts } = xhr.request.body;
@@ -89,6 +101,12 @@ describe('The domains create page', () => {
       cy.findByRole('option', { name: /Fake Subaccount 1/g }).click();
       cy.findByRole('button', { name: 'Save and Continue' }).click();
 
+      cy.withinModal(() => {
+        cy.findByText('Domain Alignment').should('be.visible');
+        cy.findByLabelText('Yes').should('be.checked');
+        cy.findByRole('button', { name: 'Save and Continue' }).click();
+      });
+
       cy.wait('@sendingDomainsReq').then(xhr => {
         const { domain, shared_with_subaccounts } = xhr.request.body;
 
@@ -99,8 +117,8 @@ describe('The domains create page', () => {
 
       cy.findByText('Sending Domain example.com created').should('be.visible');
       cy.url().should('include', '/domains/details/example.com/verify-sending');
-      cy.title().should('include', 'Verify Sending Domain | Domains');
-      cy.findByRole('heading', { name: 'Verify Sending Domain' }).should('be.visible');
+      cy.title().should('include', 'Verify Sending/Bounce Domain | Domains');
+      cy.findByRole('heading', { name: 'Verify Sending/Bounce Domain' }).should('be.visible');
     });
 
     it('handles sending domain creation errors', () => {
@@ -116,6 +134,12 @@ describe('The domains create page', () => {
       cy.findByLabelText(/Sending Domain/g).check();
       cy.findByLabelText('Domain').type('example.com');
       cy.findByRole('button', { name: 'Save and Continue' }).click();
+
+      cy.withinModal(() => {
+        cy.findByText('Domain Alignment').should('be.visible');
+        cy.findByLabelText('Yes').should('be.checked');
+        cy.findByRole('button', { name: 'Save and Continue' }).click();
+      });
 
       cy.wait('@sendingDomainsReq');
 

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -762,6 +762,15 @@ const appRoutes = [
     subcategory: 'Domains',
   },
   {
+    path: '/domains/details/:id/verify-sending-bounce',
+    component: domains.VerifySendingBounceDomainPage,
+    condition: all(isAccountUiOptionSet('allow_domains_v2'), isUserUiOptionSet('isHibanaEnabled')),
+    layout: App,
+    title: 'Verify Sending/Bounce Domain | Domains',
+    category: 'Configuration',
+    subcategory: 'Domains',
+  },
+  {
     path: '/domains/details/:id/verify-tracking',
     component: domains.VerifyTrackingDomainPage,
     condition: all(isAccountUiOptionSet('allow_domains_v2'), isUserUiOptionSet('isHibanaEnabled')),

--- a/src/pages/domains/VerifySendingBounceDomainPage.js
+++ b/src/pages/domains/VerifySendingBounceDomainPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Page } from 'src/components/matchbox';
+import Domains from './components';
+
+export default function VerifySendingBounceDomainPage() {
+  return (
+    <Domains.Container>
+      <Page title="Verify Sending/Bounce Domain"></Page>
+    </Domains.Container>
+  );
+}

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -177,9 +177,33 @@ export default function CreateForm() {
           <Layout.Section>
             <Panel>
               <Panel.Section>
-                <Stack space="300">
-                  <Radio.Group label="Subaccount Assignment">
-                    {(watchedPrimaryUse === 'sending' || watchedPrimaryUse === 'bounce') && (
+                <TextField
+                  ref={register({ required: 'A valid domain is required.' })}
+                  disabled={createPending}
+                  label="Domain"
+                  control={control}
+                  name="domain"
+                  id="textfield-domain"
+                  placeholder="e.g. sub.domain.com"
+                  error={errors.domain?.message}
+                />
+              </Panel.Section>
+
+              {hasSubaccounts && (
+                <Panel.Section>
+                  <Stack space="300">
+                    <Radio.Group label="Subaccount Assignment">
+                      {(watchedPrimaryUse === 'sending' || watchedPrimaryUse === 'bounce') && (
+                        <Radio
+                          ref={register}
+                          disabled={createPending}
+                          label="Principal and all Subaccounts"
+                          id="assign-to-shared"
+                          value="shared"
+                          name="assignTo"
+                        />
+                      )}
+
                       <Radio
                         ref={register}
                         disabled={createPending}
@@ -188,26 +212,25 @@ export default function CreateForm() {
                         value="principalOnly"
                         name="assignTo"
                       />
-                    )}
 
-                    <Radio
-                      ref={register}
-                      disabled={createPending}
-                      label="Single Subaccount"
-                      id="assign-to-subaccount"
-                      value="singleSubaccount"
-                      name="assignTo"
+                      <Radio
+                        ref={register}
+                        disabled={createPending}
+                        label="Single Subaccount"
+                        id="assign-to-subaccount"
+                        value="singleSubaccount"
+                        name="assignTo"
+                      />
+                    </Radio.Group>
+
+                    {/* See https://react-hook-form.com/api#useWatch */}
+                    <IsolatedSubaccountsField
+                      control={control}
+                      errors={errors}
+                      createPending={createPending}
                     />
-                  </Radio.Group>
-
-                  {/* See https://react-hook-form.com/api#useWatch */}
-                  <IsolatedSubaccountsField
-                    control={control}
-                    errors={errors}
-                    createPending={createPending}
-                  />
-                </Stack>
-              </Panel.Section>
+                  </Stack>
+                </Panel.Section>
               )}
             </Panel>
           </Layout.Section>

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -50,7 +50,7 @@ export default function CreateForm() {
   }, [watchedPrimaryUse, setValue]);
 
   const onSubmit = data => {
-    const { domain, primaryUse, subaccount } = data;
+    const { assignTo, domain, primaryUse, subaccount } = data;
 
     if (primaryUse === 'tracking') {
       return createTrackingDomain({

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -17,6 +17,8 @@ import { SubduedText, TranslatableText } from 'src/components/text';
 import useRouter from 'src/hooks/useRouter';
 import SubaccountTypeahead from 'src/components/typeahead/SubaccountTypeahead';
 import useDomains from '../hooks/useDomains';
+import { DomainAlignmentModal } from './DomainAlignmentModal';
+import useModal from 'src/hooks/useModal';
 
 export default function CreateForm() {
   const { history } = useRouter();
@@ -33,6 +35,12 @@ export default function CreateForm() {
       assignTo: 'shared',
     },
   });
+  const {
+    closeModal,
+    isModalOpen,
+    openModal,
+    meta: { assignTo, domain, subaccount } = {},
+  } = useModal();
   const watchedPrimaryUse = watch('primaryUse');
 
   useEffect(() => {
@@ -42,7 +50,7 @@ export default function CreateForm() {
   }, [watchedPrimaryUse, setValue]);
 
   const onSubmit = data => {
-    const { assignTo, domain, primaryUse, subaccount } = data;
+    const { domain, primaryUse, subaccount } = data;
 
     if (primaryUse === 'tracking') {
       return createTrackingDomain({
@@ -64,110 +72,110 @@ export default function CreateForm() {
       });
     }
 
+    if (primaryUse === 'sending') {
+      openModal({ name: 'Domain Alignment', ...data });
+    }
+  };
+
+  const onSubmitDomainAlignmentModal = data => {
+    const { strictalignment } = data;
     return createSendingDomain({
       assignTo,
       domain,
       subaccount,
     }).then(() => {
       showAlert({ type: 'success', message: `Sending Domain ${domain} created` });
-      history.push(`/domains/details/${domain}/verify-sending`);
+      if (strictalignment === 'yes') {
+        history.push(`/domains/details/${domain}/verify-sending-bounce`);
+      } else history.push(`/domains/details/${domain}/verify-sending`);
     });
   };
-
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <Layout>
-        <Layout.Section annotated>
-          <Layout.SectionTitle>Domain Type</Layout.SectionTitle>
+    <>
+      <DomainAlignmentModal
+        isOpen={isModalOpen}
+        onSubmit={onSubmitDomainAlignmentModal}
+        onClose={closeModal}
+      />
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Layout>
+          <Layout.Section annotated>
+            <Layout.SectionTitle>Domain Type</Layout.SectionTitle>
 
-          <Stack>
+            <Stack>
+              <SubduedText>
+                Adding a domain is very easy. You&rsquo;ll want to configure at least one domain for
+                each domain type in order to get the most out of our sending and analytics.
+              </SubduedText>
+
+              <SubduedLink as={ExternalLink} to={LINKS.SENDING_REQS}>
+                Domains Documentation
+              </SubduedLink>
+            </Stack>
+          </Layout.Section>
+
+          <Layout.Section>
+            <Panel>
+              <Panel.Section>
+                <RadioCard.Group label="Primary Use for Domain">
+                  <RadioCard
+                    ref={register}
+                    disabled={createPending}
+                    label="Sending Domain"
+                    id="primary-use-sending-domain"
+                    value="sending"
+                    name="primaryUse"
+                  >
+                    <TranslatableText>
+                      A Sending Domain lets customers know where their mail is
+                      &ldquo;From&rdquo;.&nbsp;
+                    </TranslatableText>
+                    <Abbreviation title="Domain Name System">DNS</Abbreviation>
+                    <TranslatableText>
+                      &nbsp;records should be configured based on this domain.
+                    </TranslatableText>
+                  </RadioCard>
+
+                  <RadioCard
+                    ref={register}
+                    disabled={createPending}
+                    label="Bounce Domain"
+                    id="primary-use-bounce-domain"
+                    value="bounce"
+                    name="primaryUse"
+                  >
+                    Bounce domains are the return path address and are used for report bounces,
+                    emails rejected from the recipient server.
+                  </RadioCard>
+
+                  <RadioCard
+                    ref={register}
+                    disabled={createPending}
+                    label="Tracking Domain"
+                    id="primary-use-tracking-domain"
+                    value="tracking"
+                    name="primaryUse"
+                  >
+                    Tracking domains are used to report engagement for your mail streams.
+                  </RadioCard>
+                </RadioCard.Group>
+              </Panel.Section>
+            </Panel>
+          </Layout.Section>
+        </Layout>
+        <Layout>
+          <Layout.Section annotated>
+            <Layout.SectionTitle>Domain and Assignment</Layout.SectionTitle>
+
             <SubduedText>
-              Adding a domain is very easy. You&rsquo;ll want to configure at least one domain for
-              each domain type in order to get the most out of our sending and analytics.
+              We recommend using a subdomain e.g. mail.mydomain.com. Depending on how you want to
+              use your domain, you may not be able to completely configure your DNS records if you
+              use your organizational domain.
             </SubduedText>
+          </Layout.Section>
 
-            <SubduedLink as={ExternalLink} to={LINKS.SENDING_REQS}>
-              Domains Documentation
-            </SubduedLink>
-          </Stack>
-        </Layout.Section>
-
-        <Layout.Section>
-          <Panel>
-            <Panel.Section>
-              <RadioCard.Group label="Primary Use for Domain">
-                <RadioCard
-                  ref={register}
-                  disabled={createPending}
-                  label="Sending Domain"
-                  id="primary-use-sending-domain"
-                  value="sending"
-                  name="primaryUse"
-                >
-                  <TranslatableText>
-                    A Sending Domain lets customers know where their mail is
-                    &ldquo;From&rdquo;.&nbsp;
-                  </TranslatableText>
-                  <Abbreviation title="Domain Name System">DNS</Abbreviation>
-                  <TranslatableText>
-                    &nbsp;records should be configured based on this domain.
-                  </TranslatableText>
-                </RadioCard>
-
-                <RadioCard
-                  ref={register}
-                  disabled={createPending}
-                  label="Bounce Domain"
-                  id="primary-use-bounce-domain"
-                  value="bounce"
-                  name="primaryUse"
-                >
-                  Bounce domains are the return path address and are used for report bounces, emails
-                  rejected from the recipient server.
-                </RadioCard>
-
-                <RadioCard
-                  ref={register}
-                  disabled={createPending}
-                  label="Tracking Domain"
-                  id="primary-use-tracking-domain"
-                  value="tracking"
-                  name="primaryUse"
-                >
-                  Tracking domains are used to report engagement for your mail streams.
-                </RadioCard>
-              </RadioCard.Group>
-            </Panel.Section>
-          </Panel>
-        </Layout.Section>
-      </Layout>
-      <Layout>
-        <Layout.Section annotated>
-          <Layout.SectionTitle>Domain and Assignment</Layout.SectionTitle>
-
-          <SubduedText>
-            We recommend using a subdomain e.g. mail.mydomain.com. Depending on how you want to use
-            your domain, you may not be able to completely configure your DNS records if you use
-            your organizational domain.
-          </SubduedText>
-        </Layout.Section>
-
-        <Layout.Section>
-          <Panel>
-            <Panel.Section>
-              <TextField
-                ref={register({ required: 'A valid domain is required.' })}
-                disabled={createPending}
-                label="Domain"
-                control={control}
-                name="domain"
-                id="textfield-domain"
-                placeholder="e.g. sub.domain.com"
-                error={errors.domain?.message}
-              />
-            </Panel.Section>
-
-            {hasSubaccounts && (
+          <Layout.Section>
+            <Panel>
               <Panel.Section>
                 <Stack space="300">
                   <Radio.Group label="Subaccount Assignment">
@@ -175,21 +183,12 @@ export default function CreateForm() {
                       <Radio
                         ref={register}
                         disabled={createPending}
-                        label="Principal and all Subaccounts"
-                        id="assign-to-shared"
-                        value="shared"
+                        label="Principal Account only"
+                        id="assign-to-principal-only"
+                        value="principalOnly"
                         name="assignTo"
                       />
                     )}
-
-                    <Radio
-                      ref={register}
-                      disabled={createPending}
-                      label="Principal Account only"
-                      id="assign-to-principal-only"
-                      value="principalOnly"
-                      name="assignTo"
-                    />
 
                     <Radio
                       ref={register}
@@ -209,21 +208,22 @@ export default function CreateForm() {
                   />
                 </Stack>
               </Panel.Section>
-            )}
-          </Panel>
-        </Layout.Section>
-      </Layout>
+              )}
+            </Panel>
+          </Layout.Section>
+        </Layout>
 
-      <Layout>
-        <Layout.Section annotated />
+        <Layout>
+          <Layout.Section annotated />
 
-        <Layout.Section>
-          <Button loading={createPending} variant="primary" type="submit">
-            Save and Continue
-          </Button>
-        </Layout.Section>
-      </Layout>
-    </form>
+          <Layout.Section>
+            <Button loading={createPending} variant="primary" type="submit">
+              Save and Continue
+            </Button>
+          </Layout.Section>
+        </Layout>
+      </form>
+    </>
   );
 }
 

--- a/src/pages/domains/components/DomainAlignmentModal.js
+++ b/src/pages/domains/components/DomainAlignmentModal.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Button, Modal, Text, Radio, Stack } from 'src/components/matchbox';
+import { Bold, TranslatableText } from 'src/components/text';
 import { useForm } from 'react-hook-form';
-import { TranslatableText } from 'src/components/text';
+import useDomains from '../hooks/useDomains';
+
 export function DomainAlignmentModal(props) {
   const { isOpen, onSubmit, onClose } = props;
   const { register, handleSubmit } = useForm({
@@ -9,38 +11,35 @@ export function DomainAlignmentModal(props) {
       strictalignment: 'yes',
     },
   });
+  const { createPending } = useDomains();
   return (
-    <form onSubmit={handleSubmit(onSubmit)} id="domainAlignmentForm">
-      <Modal open={isOpen} onClose={onClose}>
-        <Modal.Header showCloseButton>Domain Alignment</Modal.Header>
-        <Modal.Content>
-          <Stack>
-            <Text as="p">
-              Alignment in email refers to the relationship between the sending and bounce domain
-              used for outbound messages.
-            </Text>
-            <Text as="p">
-              <Text as="span" fontWeight="semibold">
-                Strict{' '}
-              </Text>
-              <TranslatableText>
-                alignment is when sending and bounce domain are the same value (e.g. sending domain
-                = sparkpost.com and bounce domain = sparkpost.com)
-              </TranslatableText>
-            </Text>
-            <Text as="p">
-              <Text as="span" fontWeight="semibold">
-                Relaxed{' '}
-              </Text>
-              <TranslatableText>
-                alignment is when bounce domain is a subdomain of the sending domain (e.g. sending
-                domain = sparkpost.com while bounce domain = bounces.sparkpost.com)
-              </TranslatableText>
-            </Text>
-            <Text as="p">
-              Use of strict or relaxed alignment is considered best practice by many mailbox
-              providers. Note, there is no inherent advantage to one over the other.
-            </Text>
+    <Modal open={isOpen} onClose={onClose}>
+      <Modal.Header showCloseButton>Domain Alignment</Modal.Header>
+      <Modal.Content>
+        <Stack>
+          <Text>
+            Alignment in email refers to the relationship between the sending and bounce domain used
+            for outbound messages.
+          </Text>
+          <Text>
+            <Bold>Strict </Bold>
+            <TranslatableText>
+              alignment is when sending and bounce domain are the same value (e.g. sending domain =
+              sparkpost.com and bounce domain = sparkpost.com)
+            </TranslatableText>
+          </Text>
+          <Text>
+            <Bold>Relaxed </Bold>
+            <TranslatableText>
+              alignment is when bounce domain is a subdomain of the sending domain (e.g. sending
+              domain = sparkpost.com while bounce domain = bounces.sparkpost.com)
+            </TranslatableText>
+          </Text>
+          <Text>
+            Use of strict or relaxed alignment is considered best practice by many mailbox
+            providers. Note, there is no inherent advantage to one over the other.
+          </Text>
+          <form onSubmit={handleSubmit(onSubmit)} id="domainAlignmentForm">
             <Radio.Group label="Verify domain for bounce for strict alignment">
               <Radio
                 ref={register}
@@ -48,6 +47,7 @@ export function DomainAlignmentModal(props) {
                 id="yes-to-strict-alignment"
                 value="yes"
                 name="strictalignment"
+                disabled={createPending}
               />
               <Radio
                 ref={register}
@@ -55,19 +55,26 @@ export function DomainAlignmentModal(props) {
                 id="no-to-strict-alignment"
                 value="no"
                 name="strictalignment"
+                disabled={createPending}
               />
             </Radio.Group>
-          </Stack>
-        </Modal.Content>
-        <Modal.Footer>
-          <Button variant="primary" type="submit" form="domainAlignmentForm">
-            Save and Continue
-          </Button>
-          <Button variant="secondary" onClick={onClose}>
-            Cancel
-          </Button>
-        </Modal.Footer>
-      </Modal>
-    </form>
+          </form>
+        </Stack>
+      </Modal.Content>
+      <Modal.Footer>
+        <Button
+          variant="primary"
+          type="submit"
+          form="domainAlignmentForm"
+          loading={createPending}
+          loadingLabel="Loading"
+        >
+          Save and Continue
+        </Button>
+        <Button variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+      </Modal.Footer>
+    </Modal>
   );
 }

--- a/src/pages/domains/components/DomainAlignmentModal.js
+++ b/src/pages/domains/components/DomainAlignmentModal.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Button, Modal, Text, Radio, Stack } from 'src/components/matchbox';
+import { useForm } from 'react-hook-form';
+import { TranslatableText } from 'src/components/text';
+export function DomainAlignmentModal(props) {
+  const { isOpen, onSubmit, onClose } = props;
+  const { register, handleSubmit } = useForm({
+    defaultValues: {
+      strictalignment: 'yes',
+    },
+  });
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} id="domainAlignmentForm">
+      <Modal open={isOpen}>
+        <Modal.Header showCLoseButton>Domain Alignment</Modal.Header>
+        <Modal.Content>
+          <Stack>
+            <Text as="p">
+              Alignment in email refers to the relationship between the sending and bounce domain
+              used for outbound messages.
+            </Text>
+            <Text as="p">
+              <Text as="span" fontWeight="semibold">
+                Strict{' '}
+              </Text>
+              <TranslatableText>
+                alignment is when sending and bounce domain are the same value (e.g. sending domain
+                = sparkpost.com and bounce domain = sparkpost.com)
+              </TranslatableText>
+            </Text>
+            <Text as="p">
+              <Text as="span" fontWeight="semibold">
+                Relaxed{' '}
+              </Text>
+              <TranslatableText>
+                alignment is when bounce domain is a subdomain of the sending domain (e.g. sending
+                domain = sparkpost.com while bounce domain = bounces.sparkpost.com)
+              </TranslatableText>
+            </Text>
+            <Text as="p">
+              Use of strict or relaxed alignment is considered best practice by many mailbox
+              providers. Note, there is no inherent advantage to one over the other.
+            </Text>
+            <Radio.Group label="Verify domain for bounce for strict alignment">
+              <Radio
+                ref={register}
+                label="Yes"
+                id="yes-to-strict-alignment"
+                value="yes"
+                name="strictalignment"
+              />
+              <Radio
+                ref={register}
+                label="No"
+                id="no-to-strict-alignment"
+                value="no"
+                name="strictalignment"
+              />
+            </Radio.Group>
+          </Stack>
+        </Modal.Content>
+        <Modal.Footer>
+          <Button variant="primary" type="submit" form="domainAlignmentForm">
+            Save and Continue
+          </Button>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </form>
+  );
+}

--- a/src/pages/domains/components/DomainAlignmentModal.js
+++ b/src/pages/domains/components/DomainAlignmentModal.js
@@ -11,8 +11,8 @@ export function DomainAlignmentModal(props) {
   });
   return (
     <form onSubmit={handleSubmit(onSubmit)} id="domainAlignmentForm">
-      <Modal open={isOpen}>
-        <Modal.Header showCLoseButton>Domain Alignment</Modal.Header>
+      <Modal open={isOpen} onClose={onClose}>
+        <Modal.Header showCloseButton>Domain Alignment</Modal.Header>
         <Modal.Content>
           <Stack>
             <Text as="p">

--- a/src/pages/domains/index.js
+++ b/src/pages/domains/index.js
@@ -3,6 +3,7 @@ import CreatePage from './CreatePage';
 import DetailsPage from './DetailsPage';
 import VerifyBounceDomainPage from './VerifyBounceDomainPage';
 import VerifySendingDomainPage from './VerifySendingDomainPage';
+import VerifySendingBounceDomainPage from './VerifySendingBounceDomainPage';
 import VerifyTrackingDomainPage from './VerifyTrackingDomainPage';
 
 export default {
@@ -11,5 +12,6 @@ export default {
   DetailsPage,
   VerifyBounceDomainPage,
   VerifySendingDomainPage,
+  VerifySendingBounceDomainPage,
   VerifyTrackingDomainPage,
 };


### PR DESCRIPTION
FE-1194 - Add the Modal for Domain Alignment

### What Changed
- Added the Modal as in the mocks. This modal shows up when user clicks on Save and Continue for a sending domain.

- If the user clicks on ‘Yes’ for ‘Strict Alignment’ then redirect to Sending/Bounce Verification Page - domains/details/:id/verify-sending-bounce

- if the user clicks on ‘No’ for ‘Strict Alignment’ then redirect to Sending Verification Page - domains/details/:id/verify-sending

mock - https://sparkpost.invisionapp.com/console/share/CF19LDYPB2/479035680

### How To Test
 - Create a Sending Domain from /domains/create and Select Yes or No and check if it redirects to the correct page

### To Do
- [ ] Address feedback
