### PR TITLE
FE-1196 - Default Domain Confirmation Modal

### DIFF
--- a/cypress/fixtures/tracking-domains/200.put.json
+++ b/cypress/fixtures/tracking-domains/200.put.json
@@ -1,0 +1,1 @@
+{"results":{"domain":"fad-5415.io"}}

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,16 +12,12 @@ const path = require('path');
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
-
 const WEBPACK_OPTIONS = {
   mode: 'development',
   resolve: {
     alias: {
-      'src/helpers': path.resolve('.', 'src/helpers'),
-      'src/config': path.resolve('.', 'src/config'),
-      'src/constants': path.resolve('.', 'src/constants'),
-      'cypress/helpers': path.resolve('.', 'cypress/helpers'),
-      'cypress/constants': path.resolve('.', 'cypress/constants'),
+      src: path.join(__dirname, '../../src'),
+      cypress: path.join(__dirname, '../../cypress'),
     },
   },
 };

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -210,19 +210,21 @@ describe('The domains details page', () => {
         cy.findByRole('heading', { name: 'Domain Details' }).should('be.visible');
 
         cy.findAllByLabelText('Set as Default Tracking Domain').should('be.visible');
+
         cy.findAllByLabelText('Set as Default Tracking Domain').should('be.checked');
 
-        // todo: why am I having to force click?
         cy.findAllByLabelText('Set as Default Tracking Domain').click({ force: true });
 
         cy.withinModal(() => {
+          cy.server();
+
           cy.stubRequest({
             method: 'PUT',
             url: '/api/v1/tracking-domains/verified-and-default.com',
-            response: 'tracking-domains/200.put.json',
-          }).as('trackingDomainUpdate');
+            fixture: 'tracking-domains/200.put.json',
+            requestAlias: 'trackingDomainUpdate',
+          });
 
-          cy.server();
           cy.route({
             method: 'GET',
             url: '/api/v1/tracking-domains',
@@ -274,13 +276,15 @@ describe('The domains details page', () => {
         cy.findAllByLabelText('Set as Default Tracking Domain').click({ force: true });
 
         cy.withinModal(() => {
+          cy.server();
+
           cy.stubRequest({
             method: 'PUT',
             url: '/api/v1/tracking-domains/verified.com',
-            response: 'tracking-domains/200.put.json',
-          }).as('trackingDomainUpdate');
+            fixture: 'tracking-domains/200.put.json',
+            requestAlias: 'trackingDomainUpdate',
+          });
 
-          cy.server();
           cy.route({
             method: 'GET',
             url: '/api/v1/tracking-domains',

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -205,8 +205,7 @@ describe('The domains details page', () => {
         });
 
         cy.visit(`${BASE_UI_URL}/verified-and-default.com`);
-        cy.wait(['@trackingDomainsList']);
-        cy.wait('@accountDomainsReq');
+        cy.wait(['@trackingDomainsList', '@accountDomainsReq']);
 
         cy.findByRole('heading', { name: 'Domain Details' }).should('be.visible');
 
@@ -217,14 +216,13 @@ describe('The domains details page', () => {
         cy.findAllByLabelText('Set as Default Tracking Domain').click({ force: true });
 
         cy.withinModal(() => {
-          cy.server();
-
-          cy.route({
+          cy.stubRequest({
             method: 'PUT',
             url: '/api/v1/tracking-domains/verified-and-default.com',
             response: 'tracking-domains/200.put.json',
           }).as('trackingDomainUpdate');
 
+          cy.server();
           cy.route({
             method: 'GET',
             url: '/api/v1/tracking-domains',
@@ -266,8 +264,7 @@ describe('The domains details page', () => {
         });
 
         cy.visit(`${BASE_UI_URL}/verified.com`);
-        cy.wait(['@trackingDomainsList']);
-        cy.wait('@accountDomainsReq');
+        cy.wait(['@trackingDomainsList', '@accountDomainsReq']);
 
         cy.findByRole('heading', { name: 'Domain Details' }).should('be.visible');
 
@@ -277,14 +274,13 @@ describe('The domains details page', () => {
         cy.findAllByLabelText('Set as Default Tracking Domain').click({ force: true });
 
         cy.withinModal(() => {
-          cy.server();
-
-          cy.route({
+          cy.stubRequest({
             method: 'PUT',
             url: '/api/v1/tracking-domains/verified.com',
             response: 'tracking-domains/200.put.json',
           }).as('trackingDomainUpdate');
 
+          cy.server();
           cy.route({
             method: 'GET',
             url: '/api/v1/tracking-domains',
@@ -333,8 +329,7 @@ describe('The domains details page', () => {
           requestAlias: 'deleteDomain',
         });
         cy.visit(`${BASE_UI_URL}/bounce2.spappteam.com`);
-        cy.wait(['@verifiedDomains', '@trackingDomainsList']);
-        cy.wait('@accountDomainsReq');
+        cy.wait(['@verifiedDomains', '@trackingDomainsList', '@accountDomainsReq']);
         cy.findByRole('button', { name: 'Delete Domain' }).click();
         cy.wait('@deleteDomain');
         cy.findAllByText('Domain bounce2.spappteam.com deleted.');
@@ -348,8 +343,7 @@ describe('The domains details page', () => {
           requestAlias: 'trackingDomainsList',
         });
         cy.visit(`${BASE_UI_URL}/click3.spappteam.com`);
-        cy.wait(['@trackingDomainsList']);
-        cy.wait('@accountDomainsReq');
+        cy.wait(['@trackingDomainsList', '@accountDomainsReq']);
         cy.findByRole('heading', { name: 'Domain Status' }).should('be.visible');
         cy.findByRole('heading', { name: 'Tracking' }).should('be.visible');
         cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -1,6 +1,9 @@
 import { IS_HIBANA_ENABLED } from 'cypress/constants';
+
 const BASE_UI_URL = '/domains/details';
-const PAGE_URL = '/domains/details/fake-domain.com';
+const PAGE_URL = `${BASE_UI_URL}/fake-domain.com`;
+
+let trackingDomainsList = require('../../../fixtures/tracking-domains/200.get.json');
 
 describe('The domains details page', () => {
   beforeEach(() => {
@@ -17,6 +20,7 @@ describe('The domains details page', () => {
           requestAlias: 'accountDomainsReq',
         });
       });
+
       it('renders with a relevant page title when the "allow_domains_v2" account UI flag is enabled', () => {
         cy.visit(PAGE_URL);
 
@@ -193,6 +197,124 @@ describe('The domains details page', () => {
         cy.findByRole('heading', { name: 'Email Verification' }).should('not.be.visible');
       });
 
+      it('confirms removal of default domain tracking.', () => {
+        cy.stubRequest({
+          url: '/api/v1/tracking-domains',
+          fixture: 'tracking-domains/200.get.json',
+          requestAlias: 'trackingDomainsList',
+        });
+
+        cy.visit(`${BASE_UI_URL}/verified-and-default.com`);
+        cy.wait(['@trackingDomainsList']);
+        cy.wait('@accountDomainsReq');
+
+        cy.findByRole('heading', { name: 'Domain Details' }).should('be.visible');
+
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('be.visible');
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('be.checked');
+
+        // todo: why am I having to force click?
+        cy.findAllByLabelText('Set as Default Tracking Domain').click({ force: true });
+
+        cy.withinModal(() => {
+          cy.server();
+
+          cy.route({
+            method: 'PUT',
+            url: '/api/v1/tracking-domains/verified-and-default.com',
+            response: 'tracking-domains/200.put.json',
+          }).as('trackingDomainUpdate');
+
+          cy.route({
+            method: 'GET',
+            url: '/api/v1/tracking-domains',
+            response: {
+              results: trackingDomainsList.results.map(result => {
+                if (result.domain === 'verified.com') {
+                  result.default = true;
+                } else if (result.domain === 'verified-and-default.com') {
+                  result.default = false;
+                }
+
+                return result;
+              }),
+            },
+          }).as('updatedTrackingDomainsList');
+
+          cy.findAllByText('Remove default tracking domain (verified-and-default.com)').should(
+            'be.visible',
+          );
+          cy.findAllByText(
+            "Transmissions and templates that don't specify a tracking domain will no longer use verified-and-default.com. Instead, they will use the system default until another default is selected.",
+          ).should('be.visible');
+          cy.findByRole('button', { name: 'Remove Default' }).should('be.visible');
+          cy.findByRole('button', { name: 'Cancel' }).should('be.visible');
+
+          cy.findByRole('button', { name: 'Remove Default' }).click();
+          cy.wait('@trackingDomainUpdate');
+        });
+
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('be.visible');
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('not.be.checked');
+      });
+
+      it('confirms setting a default domain tracking.', () => {
+        cy.stubRequest({
+          url: '/api/v1/tracking-domains',
+          fixture: 'tracking-domains/200.get.json',
+          requestAlias: 'trackingDomainsList',
+        });
+
+        cy.visit(`${BASE_UI_URL}/verified.com`);
+        cy.wait(['@trackingDomainsList']);
+        cy.wait('@accountDomainsReq');
+
+        cy.findByRole('heading', { name: 'Domain Details' }).should('be.visible');
+
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('be.visible');
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('not.be.checked');
+
+        cy.findAllByLabelText('Set as Default Tracking Domain').click({ force: true });
+
+        cy.withinModal(() => {
+          cy.server();
+
+          cy.route({
+            method: 'PUT',
+            url: '/api/v1/tracking-domains/verified.com',
+            response: 'tracking-domains/200.put.json',
+          }).as('trackingDomainUpdate');
+
+          cy.route({
+            method: 'GET',
+            url: '/api/v1/tracking-domains',
+            response: {
+              results: trackingDomainsList.results.map(result => {
+                if (result.domain === 'verified.com') {
+                  result.default = true;
+                } else if (result.domain === 'verified-and-default.com') {
+                  result.default = false;
+                }
+
+                return result;
+              }),
+            },
+          }).as('updatedTrackingDomainsList');
+
+          cy.findAllByText('Set default tracking domain (verified.com)').should('be.visible');
+          cy.findAllByText(
+            "Transmissions and templates that don't specify a tracking domain will now use verified.com.",
+          ).should('be.visible');
+          cy.findByRole('button', { name: 'Set as Default' }).should('be.visible');
+          cy.findByRole('button', { name: 'Cancel' }).should('be.visible');
+
+          cy.findByRole('button', { name: 'Set as Default' }).click();
+        });
+
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('be.visible');
+        cy.findAllByLabelText('Set as Default Tracking Domain').should('be.checked');
+      });
+
       it('on deleting a domain successfully redirects to list page', () => {
         cy.stubRequest({
           url: '/api/v1/tracking-domains',
@@ -218,6 +340,7 @@ describe('The domains details page', () => {
         cy.findAllByText('Domain bounce2.spappteam.com deleted.');
         cy.findByRole('heading', { name: 'Domains' }).should('be.visible');
       });
+
       it('renders correct section for Tracking Domains Details Section', () => {
         cy.stubRequest({
           url: '/api/v1/tracking-domains',

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -3,7 +3,7 @@ import { IS_HIBANA_ENABLED } from 'cypress/constants';
 const BASE_UI_URL = '/domains/details';
 const PAGE_URL = `${BASE_UI_URL}/fake-domain.com`;
 
-let trackingDomainsList = require('../../../fixtures/tracking-domains/200.get.json');
+let trackingDomainsList = require('cypress/fixtures/tracking-domains/200.get.json');
 
 describe('The domains details page', () => {
   beforeEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8242,6 +8242,89 @@
         }
       }
     },
+    "@sparkpost/matchbox-hibana": {
+      "version": "npm:@sparkpost/matchbox@4.4.0",
+      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-4.4.0.tgz",
+      "integrity": "sha512-pFRmAJK8mlwXrpcydQZqfBqyVMKL/rTWFq9Y7eEK+GJhlxG/f8TUAe9CGaB+3SPnVbnocBvLTHIX1FnW+ogieg==",
+      "requires": {
+        "@sparkpost/design-tokens": "^4.4.0",
+        "@styled-system/prop-types": "^5.1.2",
+        "@styled-system/props": "^5.1.5",
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.7.2",
+        "react-focus-lock": "^2.4.0",
+        "react-scrolllock": "^5.0.1",
+        "react-transition-group": "^2.3.0",
+        "resize-observer-polyfill": "^1.5.1",
+        "styled-normalize": "^8.0.7",
+        "styled-system": "^5.1.2"
+      },
+      "dependencies": {
+        "@sparkpost/design-tokens": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/@sparkpost/design-tokens/-/design-tokens-4.4.0.tgz",
+          "integrity": "sha512-KfsI2GQWQT5Dm/l7oOrVtCBZENCtDRVYYBsZRuG7lyPTyJ+iVKDsc72yUnMO77t/uAXycZ47Eax5UlGt1y52hA=="
+        },
+        "copy-to-clipboard": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+          "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+          "requires": {
+            "toggle-selection": "^1.0.6"
+          }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "focus-lock": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.7.0.tgz",
+          "integrity": "sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw=="
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "react-focus-lock": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.4.1.tgz",
+          "integrity": "sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "focus-lock": "^0.7.0",
+            "prop-types": "^15.6.2",
+            "react-clientside-effect": "^1.2.2",
+            "use-callback-ref": "^1.2.1",
+            "use-sidecar": "^1.0.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "resize-observer-polyfill": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+          "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+        }
+      }
+    },
     "@sparkpost/matchbox-icons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@sparkpost/matchbox-icons/-/matchbox-icons-1.3.0.tgz",
@@ -14127,6 +14210,14 @@
       "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
       "requires": {
         "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/prop-types": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/prop-types/-/prop-types-5.1.5.tgz",
+      "integrity": "sha512-D/0d0ltp8QGhwrRifivQeIdoKkQDpFIGi98DXdpRXOaJStYXLx6aBSfS/YYIijbF1nZs1hWlAgXxYvDhCxHLSA==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "@styled-system/props": {
@@ -26788,6 +26879,11 @@
       "requires": {
         "pify": "^2.2.0"
       }
+    },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exit": {
       "version": "0.1.2",
@@ -46476,6 +46572,14 @@
         }
       }
     },
+    "react-scrolllock": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-5.0.1.tgz",
+      "integrity": "sha512-poeEsjnZAlpA6fJlaNo4rZtcip2j6l5mUGU/SJe1FFlicEudS943++u7ZSdA7lk10hoyYK3grOD02/qqt5Lxhw==",
+      "requires": {
+        "exenv": "^1.2.2"
+      }
+    },
     "react-side-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
@@ -50760,6 +50864,11 @@
           }
         }
       }
+    },
+    "styled-normalize": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
+      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ=="
     },
     "styled-system": {
       "version": "5.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5870,9 +5870,9 @@
       }
     },
     "@cypress/webpack-preprocessor": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.5.tgz",
-      "integrity": "sha512-KH9B//f5DanvnO4RxyEq9RRGqeFqbzsk/wvINWhJAZcyCSZ9iD/J5E1picHt7UZxw9iXw3hzJWcuKNxdR4nk5w==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.6.tgz",
+      "integrity": "sha512-78hWoTUUEncv647badwVbyszvmwI1r9GaY/xy7V0sz0VVC90ByuDkLpvN+J0VP6enthob4dIPXcm0f9Tb1UKQQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.7.1",
@@ -5887,12 +5887,12 @@
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "lodash": {
@@ -8239,89 +8239,6 @@
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
           }
-        }
-      }
-    },
-    "@sparkpost/matchbox-hibana": {
-      "version": "npm:@sparkpost/matchbox@4.3.1",
-      "resolved": "https://registry.npmjs.org/@sparkpost/matchbox/-/matchbox-4.3.1.tgz",
-      "integrity": "sha512-+szaf53dlLnqG2yu2C7/TDV4ckIr+kibM+z/dDZQpHq5OFPSizcIqYBDlc4GKp1zDQu8btiCcnvY61C9mRYCmg==",
-      "requires": {
-        "@sparkpost/design-tokens": "^4.3.0",
-        "@styled-system/prop-types": "^5.1.2",
-        "@styled-system/props": "^5.1.5",
-        "copy-to-clipboard": "^3.3.1",
-        "prop-types": "^15.7.2",
-        "react-focus-lock": "^2.4.0",
-        "react-scrolllock": "^5.0.1",
-        "react-transition-group": "^2.3.0",
-        "resize-observer-polyfill": "^1.5.1",
-        "styled-normalize": "^8.0.7",
-        "styled-system": "^5.1.2"
-      },
-      "dependencies": {
-        "@sparkpost/design-tokens": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/@sparkpost/design-tokens/-/design-tokens-4.3.0.tgz",
-          "integrity": "sha512-6gyNEcnCBAmaRfMX9pg8qsse+I5uuFnqaF/eS4Kx8/DgZaDLTAZdXyRSqSrJpm7CibX8ujW5yW7sGE0EAqJgmg=="
-        },
-        "copy-to-clipboard": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-          "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
-          "requires": {
-            "toggle-selection": "^1.0.6"
-          }
-        },
-        "dom-helpers": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        },
-        "focus-lock": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.7.0.tgz",
-          "integrity": "sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw=="
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "react-focus-lock": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.4.1.tgz",
-          "integrity": "sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "focus-lock": "^0.7.0",
-            "prop-types": "^15.6.2",
-            "react-clientside-effect": "^1.2.2",
-            "use-callback-ref": "^1.2.1",
-            "use-sidecar": "^1.0.1"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "resize-observer-polyfill": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-          "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         }
       }
     },
@@ -14210,14 +14127,6 @@
       "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
       "requires": {
         "@styled-system/core": "^5.1.2"
-      }
-    },
-    "@styled-system/prop-types": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@styled-system/prop-types/-/prop-types-5.1.5.tgz",
-      "integrity": "sha512-D/0d0ltp8QGhwrRifivQeIdoKkQDpFIGi98DXdpRXOaJStYXLx6aBSfS/YYIijbF1nZs1hWlAgXxYvDhCxHLSA==",
-      "requires": {
-        "prop-types": "^15.7.2"
       }
     },
     "@styled-system/props": {
@@ -26879,11 +26788,6 @@
       "requires": {
         "pify": "^2.2.0"
       }
-    },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exit": {
       "version": "0.1.2",
@@ -46572,14 +46476,6 @@
         }
       }
     },
-    "react-scrolllock": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-5.0.1.tgz",
-      "integrity": "sha512-poeEsjnZAlpA6fJlaNo4rZtcip2j6l5mUGU/SJe1FFlicEudS943++u7ZSdA7lk10hoyYK3grOD02/qqt5Lxhw==",
-      "requires": {
-        "exenv": "^1.2.2"
-      }
-    },
     "react-side-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
@@ -50864,11 +50760,6 @@
           }
         }
       }
-    },
-    "styled-normalize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
-      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ=="
     },
     "styled-system": {
       "version": "5.1.5",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@babel/core": "7.10.5",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@cypress/code-coverage": "^3.8.1",
-    "@cypress/webpack-preprocessor": "^5.4.3",
+    "@cypress/webpack-preprocessor": "^5.4.6",
     "@sheerun/mutationobserver-shim": "^0.3.3",
     "@storybook/addon-docs": "^5.2.6",
     "@storybook/addon-links": "^5.2.6",

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -36,7 +36,6 @@ function mapStateToProps(state) {
       state.trackingDomains.listLoading ||
       state.subaccounts.listLoading,
     createPending: state.sendingDomains.createLoading || state.trackingDomains.createLoading,
-    deletePending: state.trackingDomains.deleting || state.sendingDomains.deleting,
     hasSubaccounts: hasSubaccounts(state),
     subaccounts: state.subaccounts.list,
     trackingDomains: selectTrackingDomainsRows(state),

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -36,6 +36,7 @@ function mapStateToProps(state) {
       state.trackingDomains.listLoading ||
       state.subaccounts.listLoading,
     createPending: state.sendingDomains.createLoading || state.trackingDomains.createLoading,
+    updateTrackingPending: state.trackingDomains.updating,
     hasSubaccounts: hasSubaccounts(state),
     subaccounts: state.subaccounts.list,
     trackingDomains: selectTrackingDomainsRows(state),

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -36,6 +36,7 @@ function mapStateToProps(state) {
       state.trackingDomains.listLoading ||
       state.subaccounts.listLoading,
     createPending: state.sendingDomains.createLoading || state.trackingDomains.createLoading,
+    deletePending: state.trackingDomains.deleting || state.sendingDomains.deleting,
     hasSubaccounts: hasSubaccounts(state),
     subaccounts: state.subaccounts.list,
     trackingDomains: selectTrackingDomainsRows(state),

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -33,7 +33,6 @@ export default function DomainStatusSection({
     trackingDomains,
     updateTrackingDomain,
     listTrackingDomains,
-    deletePending,
   } = useDomains();
   const trackingDomain = _.find(trackingDomains, ['domainName', id]);
 
@@ -134,7 +133,6 @@ export default function DomainStatusSection({
                         : `Transmissions and templates that don't specify a tracking domain will now use ${domainName}.`}
                     </p>
                   }
-                  isPending={deletePending}
                   onCancel={() => closeModal()}
                   onConfirm={() => toggleDefaultTracking()}
                   confirmVerb={isDefault ? 'Remove Default' : 'Set as Default'}

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Layout, Stack, Text } from 'src/components/matchbox';
 import { Checkbox, Columns, Column, Panel } from 'src/components/matchbox';
 import { Heading, SubduedText } from 'src/components/text';
@@ -10,6 +10,7 @@ import useDomains from '../hooks/useDomains';
 import { ExternalLink, SubduedLink } from 'src/components/links';
 import { ToggleBlock } from 'src/components';
 import { EXTERNAL_LINKS } from '../constants';
+import { ConfirmationModal } from 'src/components/modals';
 import _ from 'lodash';
 
 export default function DomainStatusSection({
@@ -19,6 +20,7 @@ export default function DomainStatusSection({
   id,
   isTracking,
 }) {
+  const [isConfirmationModalOpen, setConfirmationModalOpen] = useState(false);
   const readyFor = resolveReadyFor(domain.status);
   const resolvedStatus = resolveStatus(domain.status);
   const showDefaultBounceSubaccount =
@@ -64,6 +66,9 @@ export default function DomainStatusSection({
   };
 
   if (isTracking && trackingDomain) {
+    const isDefault = trackingDomain.defaultTrackingDomain;
+    const domainName = trackingDomain?.domainName;
+
     return (
       <Layout>
         <Layout.Section annotated>
@@ -84,7 +89,7 @@ export default function DomainStatusSection({
                   <Heading as="h3" looksLike="h5">
                     Domain
                   </Heading>
-                  <Text as="p">{trackingDomain?.domainName}</Text>
+                  <Text as="p">{domainName}</Text>
                 </Column>
                 <Column>
                   <Heading as="h3" looksLike="h5">
@@ -107,19 +112,35 @@ export default function DomainStatusSection({
             {trackingDomain.verified && (
               <Panel.Section>
                 <Checkbox
-                  id="set-as-default-domain"
+                  id="set-as-default-tracking-domain"
                   label={
                     <>
                       Set as Default Tracking Domain <Bookmark color="green" />
                     </>
                   }
                   checked={trackingDomain.defaultTrackingDomain}
-                  onClick={() =>
+                  onClick={() => setConfirmationModalOpen(true)}
+                />
+
+                <ConfirmationModal
+                  open={isConfirmationModalOpen}
+                  title={`${isDefault ? 'Remove' : 'Set'} default tracking domain (${domainName})`}
+                  content={
+                    <p>
+                      {isDefault
+                        ? `Transmissions and templates that don't specify a tracking domain will no longer use ${domainName}. Instead, they will use the system default until another default is selected.`
+                        : `Transmissions and templates that don't specify a tracking domain will now use ${domainName}.`}
+                    </p>
+                  }
+                  isPending={false}
+                  onCancel={() => setConfirmationModalOpen(false)}
+                  onConfirm={() =>
                     toggleDefaultTracking({
-                      domain: trackingDomain?.domainName,
+                      domain: domainName,
                       subaccount: trackingDomain.subaccountId,
                     })
                   }
+                  confirmVerb={isDefault ? 'Remove Default' : 'Set as Default'}
                 />
               </Panel.Section>
             )}
@@ -217,7 +238,7 @@ export default function DomainStatusSection({
                 <>
                   <Panel.Section>
                     <Checkbox
-                      id="set-as-default-domain"
+                      id="set-as-default-bounce-domain"
                       label={
                         <>
                           Set as Default Bounce Domain <Bookmark color="green" />

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Layout, Stack, Text } from 'src/components/matchbox';
 import { Checkbox, Columns, Column, Panel } from 'src/components/matchbox';
 import { Heading, SubduedText } from 'src/components/text';
@@ -7,6 +7,7 @@ import TrackingDomainStatusCell from './TrackingDomainStatusCell';
 import { Bookmark } from '@sparkpost/matchbox-icons';
 import { resolveStatus, resolveReadyFor } from 'src/helpers/domains';
 import useDomains from '../hooks/useDomains';
+import useModal from 'src/hooks/useModal';
 import { ExternalLink, SubduedLink } from 'src/components/links';
 import { ToggleBlock } from 'src/components';
 import { EXTERNAL_LINKS } from '../constants';
@@ -20,7 +21,7 @@ export default function DomainStatusSection({
   id,
   isTracking,
 }) {
-  const [isConfirmationModalOpen, setConfirmationModalOpen] = useState(false);
+  const { closeModal, isModalOpen, openModal } = useModal();
   const readyFor = resolveReadyFor(domain.status);
   const resolvedStatus = resolveStatus(domain.status);
   const showDefaultBounceSubaccount =
@@ -45,10 +46,10 @@ export default function DomainStatusSection({
     });
   };
 
-  const toggleDefaultTracking = ({ domain, subaccount }) => {
+  const toggleDefaultTracking = () => {
     return updateTrackingDomain({
-      domain,
-      subaccount,
+      domain: trackingDomain?.domainName,
+      subaccount: trackingDomain.subaccountId,
       default: !trackingDomain.defaultTrackingDomain,
     })
       .catch(_.noop) // ignore errors
@@ -119,11 +120,11 @@ export default function DomainStatusSection({
                     </>
                   }
                   checked={trackingDomain.defaultTrackingDomain}
-                  onClick={() => setConfirmationModalOpen(true)}
+                  onClick={() => openModal()}
                 />
 
                 <ConfirmationModal
-                  open={isConfirmationModalOpen}
+                  open={isModalOpen}
                   title={`${isDefault ? 'Remove' : 'Set'} default tracking domain (${domainName})`}
                   content={
                     <p>
@@ -133,13 +134,8 @@ export default function DomainStatusSection({
                     </p>
                   }
                   isPending={false}
-                  onCancel={() => setConfirmationModalOpen(false)}
-                  onConfirm={() =>
-                    toggleDefaultTracking({
-                      domain: domainName,
-                      subaccount: trackingDomain.subaccountId,
-                    })
-                  }
+                  onCancel={() => closeModal()}
+                  onConfirm={() => toggleDefaultTracking()}
                   confirmVerb={isDefault ? 'Remove Default' : 'Set as Default'}
                 />
               </Panel.Section>

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -33,6 +33,7 @@ export default function DomainStatusSection({
     trackingDomains,
     updateTrackingDomain,
     listTrackingDomains,
+    deletePending,
   } = useDomains();
   const trackingDomain = _.find(trackingDomains, ['domainName', id]);
 
@@ -133,7 +134,7 @@ export default function DomainStatusSection({
                         : `Transmissions and templates that don't specify a tracking domain will now use ${domainName}.`}
                     </p>
                   }
-                  isPending={false}
+                  isPending={deletePending}
                   onCancel={() => closeModal()}
                   onConfirm={() => toggleDefaultTracking()}
                   confirmVerb={isDefault ? 'Remove Default' : 'Set as Default'}

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -33,6 +33,7 @@ export default function DomainStatusSection({
     trackingDomains,
     updateTrackingDomain,
     listTrackingDomains,
+    updateTrackingPending,
   } = useDomains();
   const trackingDomain = _.find(trackingDomains, ['domainName', id]);
 
@@ -133,6 +134,7 @@ export default function DomainStatusSection({
                         : `Transmissions and templates that don't specify a tracking domain will now use ${domainName}.`}
                     </p>
                   }
+                  isPending={updateTrackingPending}
                   onCancel={() => closeModal()}
                   onConfirm={() => toggleDefaultTracking()}
                   confirmVerb={isDefault ? 'Remove Default' : 'Set as Default'}

--- a/src/reducers/sendingDomains.js
+++ b/src/reducers/sendingDomains.js
@@ -31,15 +31,6 @@ export default (state = initialState, { type, payload, meta }) => {
     case 'LIST_SENDING_DOMAINS_FAIL':
       return { ...state, listError: payload, listLoading: false };
 
-    case 'DELETE_SENDING_DOMAIN_PENDING':
-      return { ...state, deleting: meta.domain, deleteError: null };
-
-    case 'DELETE_SENDING_DOMAIN_FAIL':
-      return { ...state, deleting: false, deleteError: payload };
-
-    case 'DELETE_SENDING_DOMAIN_SUCCESS':
-      return { ...state, deleting: false, list: state.list.filter(d => d.domain !== meta.domain) };
-
     case 'GET_SENDING_DOMAIN_PENDING':
       return { ...state, getLoading: true, getError: null };
 

--- a/src/reducers/sendingDomains.js
+++ b/src/reducers/sendingDomains.js
@@ -31,6 +31,15 @@ export default (state = initialState, { type, payload, meta }) => {
     case 'LIST_SENDING_DOMAINS_FAIL':
       return { ...state, listError: payload, listLoading: false };
 
+    case 'DELETE_SENDING_DOMAIN_PENDING':
+      return { ...state, deleting: meta.domain, deleteError: null };
+
+    case 'DELETE_SENDING_DOMAIN_FAIL':
+      return { ...state, deleting: false, deleteError: payload };
+
+    case 'DELETE_SENDING_DOMAIN_SUCCESS':
+      return { ...state, deleting: false, list: state.list.filter(d => d.domain !== meta.domain) };
+
     case 'GET_SENDING_DOMAIN_PENDING':
       return { ...state, getLoading: true, getError: null };
 


### PR DESCRIPTION
### What Changed
 - Added a confirmation modal and cypress tests to the new domain details page.

### How To Test
 - Run the cypress tests for domains/domainDetails.spec.js
 - Load the app the navigate to `http://localhost:3100/domains/details/fad-5415.io` logged in with appteam. Then toggle the "Set as Default Tracking Domain" checkbox.

### To Do
- [ ] Address any feedback/suggestions that the team finds important to this work. 
