### PR TITLE
[FE-1195] Added the Bounce domain section for unverified sending and bounce domains details page

### DIFF
--- a/cypress/fixtures/sending-domains/200.get.bounce-verified-sending-unverified.json
+++ b/cypress/fixtures/sending-domains/200.get.bounce-verified-sending-unverified.json
@@ -1,0 +1,25 @@
+{
+  "results": {
+    "dkim": {
+      "signing_domain": "bounce2.spappteam.com",
+      "headers": "from:to:subject:date",
+      "public": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBTu/gLuz7UulDWh8BV2T7+C3chM6xh5HtG2b9qjpExVu2RpXYgXpm/ifi4rHkStKlhPJ3gxaa939in3nb8GC6U/2uqRJjPXN5x4KKOVXLAsWFdJwZLCk+lUhe1qZ297bt4yxH0yDhi3zW00o7m6gP3fZKSBI58uaXJndoLBJuOQIDAQAB",
+      "selector": "scph1117"
+    },
+    "creation_time": "2017-11-20T15:03:31+00:00",
+    "tracking_domain": "track.spappteam.com",
+    "status": {
+      "mx_status": "unverified",
+      "spf_status": "valid",
+      "cname_status": "valid",
+      "ownership_verified": false,
+      "abuse_at_status": "unverified",
+      "compliance_status": "valid",
+      "verification_mailbox_status": "unverified",
+      "dkim_status": "unverified",
+      "postmaster_at_status": "unverified"
+    },
+    "is_default_bounce_domain": true,
+    "shared_with_subaccounts": false
+  }
+}

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -196,6 +196,31 @@ describe('The domains details page', () => {
         cy.findByRole('heading', { name: 'DNS Verification' }).should('not.be.visible');
         cy.findByRole('heading', { name: 'Email Verification' }).should('not.be.visible');
       });
+      it('renders correct sections for verified bounce domain and unverified sending domain', () => {
+        cy.stubRequest({
+          url: '/api/v1/tracking-domains',
+          fixture: 'tracking-domains/200.get.domain-details.json',
+          requestAlias: 'trackingDomainsList',
+        });
+        cy.stubRequest({
+          url: '/api/v1/sending-domains/bounce2.spappteam.com',
+          fixture: 'sending-domains/200.get.bounce-verified-sending-unverified.json',
+          requestAlias: 'verifiedDomains',
+        });
+        cy.visit(`${BASE_UI_URL}/bounce2.spappteam.com`);
+        cy.wait(['@verifiedDomains', '@trackingDomainsList']);
+        cy.wait('@accountDomainsReq');
+        cy.findByRole('heading', { name: 'Domain Status' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Sending and Bounce' }).should('not.be.visible');
+        cy.findByRole('heading', { name: 'Link Tracking Domain' }).should('not.be.visible');
+        cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Sending' }).should('not.be.visible');
+        cy.findByRole('heading', { name: 'Bounce' }).should('be.visible');
+        cy.findByRole('button', { name: 'Verify Domain' }).should('be.visible');
+        cy.findByRole('button', { name: 'Authenticate for SPF' }).should('not.be.visible');
+        cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Email Verification' }).should('be.visible');
+      });
 
       it('delete tracking domain prompts confirmation modal first (with different verbiage)', () => {
         cy.stubRequest({

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -62,7 +62,7 @@ describe('The domains details page', () => {
         cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
         cy.findByRole('heading', { name: 'Email Verification' }).should('be.visible');
         cy.findByRole('heading', { name: 'Sending' }).should('not.be.visible');
-        cy.findByRole('heading', { name: 'Bounce' }).should('not.be.visible');
+        cy.findByRole('heading', { name: 'Bounce' }).should('be.visible');
         cy.findByRole('heading', { name: 'Sending and Bounce' }).should('not.be.visible');
         cy.findByRole('heading', { name: 'Link Tracking Domain' }).should('not.be.visible');
         cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -120,7 +120,7 @@ function DetailsPage(props) {
           isSectionVisible={
             resolvedStatus !== 'blocked' &&
             !isTracking &&
-            resolvedStatus === 'unverified' &&
+            (!readyFor.bounce || !(domain.status.spf_status === 'valid')) &&
             !displaySendingAndBounceSection
           }
         />

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -120,7 +120,7 @@ function DetailsPage(props) {
           isSectionVisible={
             resolvedStatus !== 'blocked' &&
             !isTracking &&
-            resolvedStatus !== 'unverified' &&
+            resolvedStatus === 'unverified' &&
             !displaySendingAndBounceSection
           }
         />

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -118,20 +118,14 @@ function DetailsPage(props) {
           domain={domain}
           isByoipAccount={isByoipAccount}
           isSectionVisible={
-            resolvedStatus !== 'blocked' &&
-            !isTracking &&
-            (!readyFor.bounce || !(domain.status.spf_status === 'valid')) &&
-            !displaySendingAndBounceSection
+            resolvedStatus !== 'blocked' && !isTracking && !displaySendingAndBounceSection
           }
         />
         <Domains.SendingAndBounceDomainSection
           domain={domain}
           isByoipAccount={isByoipAccount}
           isSectionVisible={
-            resolvedStatus !== 'blocked' &&
-            !isTracking &&
-            resolvedStatus !== 'unverified' &&
-            displaySendingAndBounceSection
+            resolvedStatus !== 'blocked' && !isTracking && displaySendingAndBounceSection
           }
         />
 


### PR DESCRIPTION
[FE-1195] Added the Bounce domain section for unverified sending and bounce domains

### What Changed
 - updated the isSectionVisible condition for bounce section

### How To Test
 - On an unverified sending domain page, bounce section should also be visible

### To Do
- [ ] Address feedback
- [x] Write a cypress test to check what the page looks like bounce only verified and sending unverified details page.


[FE-1195]: https://sparkpost.atlassian.net/browse/FE-1195