### PR TITLE
FE-1187 - Add the Sending/Bounce Verification Page

### DIFF
--- a/cypress/fixtures/sending-domains/200.get.all-verified.json
+++ b/cypress/fixtures/sending-domains/200.get.all-verified.json
@@ -16,7 +16,7 @@
       "abuse_at_status": "unverified",
       "compliance_status": "valid",
       "verification_mailbox_status": "unverified",
-      "dkim_status": "invalid",
+      "dkim_status": "valid",
       "postmaster_at_status": "unverified"
     },
     "is_default_bounce_domain": true,

--- a/cypress/fixtures/sending-domains/200.get.unverified-dkim-bounce.json
+++ b/cypress/fixtures/sending-domains/200.get.unverified-dkim-bounce.json
@@ -1,0 +1,25 @@
+{
+  "results": {
+    "dkim": {
+      "signing_domain": "sending-bounce.net",
+      "headers": "from:to:subject:date",
+      "public": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCpvvVTbW5Bmo/Cef+MHqcle4Ko/lc5CQh+tCdED/u6ATQTyTYNYM5zUtIL1+7z5n2V+Hncxr23d5FE6n+rFxSib3ZuvehQqwKsdBiIQPUP4m1excbtjizHd0Sp0MCqcK5+fom0RY+A/PdncsgLRr/Or7vd0IFeJhniptk7EduhQwIDAQAB",
+      "selector": "scph0118"
+    },
+    "creation_time": "2018-01-29T14:10:53+00:00",
+    "is_default_bounce_domain": false,
+    "status": {
+      "mx_status": "unverified",
+      "spf_status": "unverified",
+      "cname_status": "invalid",
+      "ownership_verified": false,
+      "abuse_at_status": "unverified",
+      "compliance_status": "valid",
+      "verification_mailbox": "jose",
+      "verification_mailbox_status": "unverified",
+      "dkim_status": "unverified",
+      "postmaster_at_status": "unverified"
+    },
+    "shared_with_subaccounts": false
+  }
+}

--- a/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
@@ -1,0 +1,103 @@
+import { IS_HIBANA_ENABLED } from 'cypress/constants';
+
+const PAGE_URL = '/domains/details/fake-domain.com/verify-sending-bounce';
+
+describe('The verify sending/bounce domain page', () => {
+  beforeEach(() => {
+    cy.stubAuth();
+    cy.login({ isStubbed: true });
+  });
+
+  if (IS_HIBANA_ENABLED) {
+    describe('Verify Sending/Bounce Domain Page', () => {
+      beforeEach(() => {
+        cy.stubRequest({
+          url: '/api/v1/account',
+          fixture: 'account/200.get.has-domains-v2.json',
+          requestAlias: 'accountDomainsReq',
+        });
+      });
+      it('renders with a relevant page title when the "allow_domains_v2" account UI flag is enabled', () => {
+        cy.visit(PAGE_URL);
+        cy.wait('@accountDomainsReq');
+
+        cy.title().should('include', 'Verify Sending/Bounce Domain');
+        cy.findByRole('heading', { name: 'Verify Sending/Bounce Domain' }).should('be.visible');
+      });
+      it('renders sections correclty in case of unverified sending/bounce domain', () => {
+        cy.stubRequest({
+          url: '/api/v1/sending-domains/sending-bounce.net',
+          fixture: 'sending-domains/200.get.unverified-dkim-bounce.json',
+          requestAlias: 'unverifiedDkimBounce',
+        });
+        cy.stubRequest({
+          method: 'POST',
+          url: '/api/v1/sending-domains/sending-bounce.net/verify',
+          fixture: 'sending-domains/verify/200.post.json',
+          requestAlias: 'verifyDomain',
+        });
+
+        cy.visit('/domains/details/sending-bounce.net/verify-sending-bounce');
+        cy.wait(['@accountDomainsReq', '@unverifiedDkimBounce']);
+        cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Add DKIM Record' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Add Bounce Record' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Add SPF Record' }).should('be.visible');
+        cy.findByRole('button', { name: 'Authenticate Domain' }).should('be.visible');
+      });
+      it('clicking on the Authenticate Domain renders success message on succesful verification of dkim and cname of domain and renders correct section titles after', () => {
+        cy.stubRequest({
+          url: '/api/v1/sending-domains/sending-bounce.net',
+          fixture: 'sending-domains/200.get.unverified-dkim-bounce.json',
+          requestAlias: 'unverifiedDkimBounce',
+        });
+        cy.stubRequest({
+          method: 'POST',
+          url: '/api/v1/sending-domains/sending-bounce.net/verify',
+          fixture: 'sending-domains/verify/200.post.json',
+          requestAlias: 'verifyDomain',
+        });
+
+        cy.visit('/domains/details/sending-bounce.net/verify-sending-bounce');
+        cy.wait(['@accountDomainsReq', '@unverifiedDkimBounce']);
+        cy.findByLabelText('The TXT and CNAME records have been added to the DNS provider').check({
+          force: true,
+        });
+        cy.findByRole('button', { name: 'Authenticate Domain' }).click();
+        cy.wait('@verifyDomain');
+        cy.findAllByText('You have successfully verified DKIM record of sending-bounce.net').should(
+          'be.visible',
+        );
+        cy.findAllByText(
+          'You have successfully verified cname record of sending-bounce.net',
+        ).should('be.visible');
+        cy.findByRole('heading', { name: 'TXT record for DKIM' }).should('be.visible');
+        cy.findByRole('heading', { name: 'CNAME record for Bounce' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Add SPF Record' }).should('be.visible');
+        cy.findByRole('button', { name: 'Authenticate for SPF' }).should('be.visible');
+      });
+      it('clicking on the Authenticate Domain renders validation error if the checkbox is not checked', () => {
+        cy.stubRequest({
+          url: '/api/v1/sending-domains/sending-bounce.net',
+          fixture: 'sending-domains/200.get.unverified-dkim-bounce.json',
+          requestAlias: 'unverifiedDkimBounce',
+        });
+
+        cy.visit('/domains/details/sending-bounce.net/verify-sending-bounce');
+        cy.wait(['@accountDomainsReq', '@unverifiedDkimBounce']);
+        cy.findByRole('button', { name: 'Authenticate Domain' }).click();
+
+        cy.findAllByText('Adding TXT and CNAME is required').should('be.visible');
+      });
+    });
+  }
+
+  if (!IS_HIBANA_ENABLED) {
+    it('renders the 404 page when the user does not have Hibana enabled', () => {
+      cy.visit(PAGE_URL);
+
+      cy.findByRole('heading', { name: 'Page Not Found' }).should('be.visible');
+      cy.url().should('include', '404');
+    });
+  }
+});

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -28,7 +28,7 @@ function DetailsPage(props) {
   const [warningBanner, toggleBanner] = useState(true);
   const readyFor = resolveReadyFor(domain.status);
   const displaySendingAndBounceSection =
-    resolvedStatus === 'verified' && readyFor.bounce && domain.status.spf_status === 'valid';
+    readyFor.dkim && readyFor.bounce && domain.status.spf_status === 'valid';
   const isTracking = Boolean(_.find(trackingDomainList, ['domain', match.params.id.toLowerCase()]));
 
   useEffect(() => {

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -3,20 +3,11 @@ import { Page, Banner, Button } from 'src/components/matchbox';
 import { get as getDomain } from 'src/actions/sendingDomains';
 import Domains from './components';
 import { connect } from 'react-redux';
-import {
-  selectAllowDefaultBounceDomains,
-  selectAllSubaccountDefaultBounceDomains,
-} from 'src/selectors/account';
 import { selectDomain } from 'src/selectors/sendingDomains';
 import { resolveReadyFor, resolveStatus } from 'src/helpers/domains';
 import { ExternalLink, SupportTicketLink } from 'src/components/links';
-import {
-  selectTrackingDomainsOptions,
-  selectTrackingDomainsList,
-} from 'src/selectors/trackingDomains';
-import { selectCondition } from 'src/selectors/accessConditionState';
-import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
-import { selectHasAnyoneAtDomainVerificationEnabled } from 'src/selectors/account';
+import { selectTrackingDomainsList } from 'src/selectors/trackingDomains';
+
 import { Loading } from 'src/components/loading/Loading';
 import { listTrackingDomains } from 'src/actions/trackingDomains';
 import _ from 'lodash';
@@ -30,12 +21,7 @@ function DetailsPage(props) {
     history,
     sendingDomainsPending,
     trackingDomainListPending,
-    allowSubaccountDefault,
-    allowDefault,
     domain,
-    isByoipAccount,
-    trackingDomains,
-    hasAnyoneAtEnabled,
     getDomain,
     listTrackingDomains,
   } = props;
@@ -98,17 +84,10 @@ function DetailsPage(props) {
           </Banner>
         )}
 
-        <Domains.DomainStatusSection
-          domain={domain}
-          id={match.params.id}
-          allowSubaccountDefault={allowSubaccountDefault}
-          allowDefault={allowDefault}
-          isTracking={isTracking}
-        />
+        <Domains.DomainStatusSection domain={domain} id={match.params.id} isTracking={isTracking} />
 
         <Domains.SetupForSending
           domain={domain}
-          id={match.params.id}
           resolvedStatus={resolvedStatus}
           isSectionVisible={
             resolvedStatus !== 'blocked' && !isTracking && !displaySendingAndBounceSection
@@ -116,14 +95,12 @@ function DetailsPage(props) {
         />
         <Domains.SetupBounceDomainSection
           domain={domain}
-          isByoipAccount={isByoipAccount}
           isSectionVisible={
             resolvedStatus !== 'blocked' && !isTracking && !displaySendingAndBounceSection
           }
         />
         <Domains.SendingAndBounceDomainSection
           domain={domain}
-          isByoipAccount={isByoipAccount}
           isSectionVisible={
             resolvedStatus !== 'blocked' && !isTracking && displaySendingAndBounceSection
           }
@@ -131,7 +108,6 @@ function DetailsPage(props) {
 
         <Domains.LinkTrackingDomainSection
           domain={domain}
-          trackingDomains={trackingDomains}
           isSectionVisible={
             resolvedStatus !== 'blocked' && !isTracking && resolvedStatus !== 'unverified'
           }
@@ -139,7 +115,6 @@ function DetailsPage(props) {
 
         <Domains.VerifyEmailSection
           domain={domain}
-          hasAnyoneAtEnabled={hasAnyoneAtEnabled}
           isSectionVisible={resolvedStatus === 'unverified' && !isTracking}
         />
 
@@ -159,12 +134,7 @@ function DetailsPage(props) {
 export default connect(
   state => ({
     domain: selectDomain(state),
-    allowDefault: selectAllowDefaultBounceDomains(state),
-    allowSubaccountDefault: selectAllSubaccountDefaultBounceDomains(state),
-    trackingDomains: selectTrackingDomainsOptions(state),
     trackingDomainList: selectTrackingDomainsList(state),
-    isByoipAccount: selectCondition(hasAccountOptionEnabled('byoip_customer'))(state),
-    hasAnyoneAtEnabled: selectHasAnyoneAtDomainVerificationEnabled(state),
     sendingDomainsPending: state.sendingDomains.getLoading,
     trackingDomainListPending: state.trackingDomains.listLoading,
   }),

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -7,7 +7,6 @@ import { selectDomain } from 'src/selectors/sendingDomains';
 import { resolveReadyFor, resolveStatus } from 'src/helpers/domains';
 import { ExternalLink, SupportTicketLink } from 'src/components/links';
 import { selectTrackingDomainsList } from 'src/selectors/trackingDomains';
-
 import { Loading } from 'src/components/loading/Loading';
 import { listTrackingDomains } from 'src/actions/trackingDomains';
 import _ from 'lodash';

--- a/src/pages/domains/VerifyBounceDomainPage.js
+++ b/src/pages/domains/VerifyBounceDomainPage.js
@@ -4,13 +4,10 @@ import { get as getDomain } from 'src/actions/sendingDomains';
 import Domains from './components';
 import { connect } from 'react-redux';
 import { selectDomain } from 'src/selectors/sendingDomains';
-import { selectCondition } from 'src/selectors/accessConditionState';
-import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
-import { selectHasAnyoneAtDomainVerificationEnabled } from 'src/selectors/account';
 import _ from 'lodash';
 
 function VerifyBounceDomainPage(props) {
-  const { isByoipAccount, domain, match, getDomain } = props;
+  const { domain, match, getDomain } = props;
   useEffect(() => {
     getDomain(match.params.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -29,7 +26,6 @@ function VerifyBounceDomainPage(props) {
         <Domains.SetupBounceDomainSection
           title="DNS Verification"
           domain={domain}
-          isByoipAccount={isByoipAccount}
           isSectionVisible={true}
         />
       </Page>
@@ -41,8 +37,6 @@ export default connect(
   state => ({
     domain: selectDomain(state),
     sendingDomainsPending: state.sendingDomains.getLoading,
-    hasAnyoneAtEnabled: selectHasAnyoneAtDomainVerificationEnabled(state),
-    isByoipAccount: selectCondition(hasAccountOptionEnabled('byoip_customer'))(state),
   }),
   { getDomain },
 )(VerifyBounceDomainPage);

--- a/src/pages/domains/VerifySendingBounceDomainPage.js
+++ b/src/pages/domains/VerifySendingBounceDomainPage.js
@@ -1,11 +1,30 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Page } from 'src/components/matchbox';
 import Domains from './components';
+import { get as getDomain } from 'src/actions/sendingDomains';
+import { connect } from 'react-redux';
+import { selectDomain } from 'src/selectors/sendingDomains';
 
-export default function VerifySendingBounceDomainPage() {
+function VerifySendingBounceDomainPage(props) {
+  const { match, getDomain, domain } = props;
+
+  useEffect(() => {
+    getDomain(match.params.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <Domains.Container>
-      <Page title="Verify Sending/Bounce Domain"></Page>
+      <Page title="Verify Sending/Bounce Domain" subtitle={domain.id}>
+        <Domains.SendingAndBounceDomainSection domain={domain} isSectionVisible={true} />
+      </Page>
     </Domains.Container>
   );
 }
+
+export default connect(
+  state => ({
+    domain: selectDomain(state),
+  }),
+  { getDomain },
+)(VerifySendingBounceDomainPage);

--- a/src/pages/domains/VerifySendingDomainPage.js
+++ b/src/pages/domains/VerifySendingDomainPage.js
@@ -4,11 +4,10 @@ import { connect } from 'react-redux';
 import { get as getDomain } from 'src/actions/sendingDomains';
 import { selectDomain } from 'src/selectors/sendingDomains';
 import { resolveStatus } from 'src/helpers/domains';
-import { selectHasAnyoneAtDomainVerificationEnabled } from 'src/selectors/account';
 import Domains from './components';
 
 function VerifySendingDomainsPage(props) {
-  const { match, getDomain, domain, hasAnyoneAtEnabled } = props;
+  const { match, getDomain, domain } = props;
   const resolvedStatus = resolveStatus(domain.status);
 
   useEffect(() => {
@@ -27,15 +26,10 @@ function VerifySendingDomainsPage(props) {
       >
         <Domains.SetupForSending
           domain={domain}
-          id={match.params.id}
           resolvedStatus={resolvedStatus}
           isSectionVisible={true}
         />
-        <Domains.VerifyEmailSection
-          domain={domain}
-          hasAnyoneAtEnabled={hasAnyoneAtEnabled}
-          isSectionVisible={true}
-        />
+        <Domains.VerifyEmailSection domain={domain} isSectionVisible={true} />
       </Page>
     </Domains.Container>
   );
@@ -45,7 +39,6 @@ export default connect(
   state => ({
     domain: selectDomain(state),
     sendingDomainsPending: state.sendingDomains.getLoading,
-    hasAnyoneAtEnabled: selectHasAnyoneAtDomainVerificationEnabled(state),
   }),
   { getDomain },
 )(VerifySendingDomainsPage);

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -22,9 +22,19 @@ import {
   verifyTrackingDomain,
 } from 'src/actions/trackingDomains';
 import { selectSendingDomainsRows, selectBounceDomainsRows } from 'src/selectors/sendingDomains';
-import { selectTrackingDomainsRows } from 'src/selectors/trackingDomains';
+import {
+  selectTrackingDomainsRows,
+  selectTrackingDomainsOptions,
+} from 'src/selectors/trackingDomains';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 import { DomainsProvider } from '../context/DomainsContext';
+import { selectCondition } from 'src/selectors/accessConditionState';
+import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
+import { selectHasAnyoneAtDomainVerificationEnabled } from 'src/selectors/account';
+import {
+  selectAllowDefaultBounceDomains,
+  selectAllSubaccountDefaultBounceDomains,
+} from 'src/selectors/account';
 
 function mapStateToProps(state) {
   return {
@@ -41,8 +51,13 @@ function mapStateToProps(state) {
     hasSubaccounts: hasSubaccounts(state),
     subaccounts: state.subaccounts.list,
     trackingDomains: selectTrackingDomainsRows(state),
+    trackingDomainOptions: selectTrackingDomainsOptions(state),
     trackingDomainsListError: state.trackingDomains.error,
     userName: state.currentUser.username,
+    isByoipAccount: selectCondition(hasAccountOptionEnabled('byoip_customer'))(state),
+    hasAnyoneAtEnabled: selectHasAnyoneAtDomainVerificationEnabled(state),
+    allowDefault: selectAllowDefaultBounceDomains(state),
+    allowSubaccountDefault: selectAllSubaccountDefaultBounceDomains(state),
   };
 }
 

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -58,6 +58,10 @@ function mapStateToProps(state) {
     hasAnyoneAtEnabled: selectHasAnyoneAtDomainVerificationEnabled(state),
     allowDefault: selectAllowDefaultBounceDomains(state),
     allowSubaccountDefault: selectAllSubaccountDefaultBounceDomains(state),
+    verifyDkimLoading: state.sendingDomains.verifyDkimLoading,
+    verifyEmailLoading: state.sendingDomains.verifyEmailLoading,
+    verifyBounceLoading: state.sendingDomains.verifyBounceLoading,
+    verifyingTrackingPending: state.trackingDomains.verifyingTrackingPending,
   };
 }
 

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -14,27 +14,24 @@ import { EXTERNAL_LINKS } from '../constants';
 import { ConfirmationModal } from 'src/components/modals';
 import _ from 'lodash';
 
-export default function DomainStatusSection({
-  allowDefault,
-  allowSubaccountDefault,
-  domain,
-  id,
-  isTracking,
-}) {
+export default function DomainStatusSection({ domain, id, isTracking }) {
   const { closeModal, isModalOpen, openModal } = useModal();
-  const readyFor = resolveReadyFor(domain.status);
-  const resolvedStatus = resolveStatus(domain.status);
-  const showDefaultBounceSubaccount =
-    !domain.subaccount_id || (domain.subaccount_id && allowSubaccountDefault);
-  const showDefaultBounceToggle =
-    allowDefault && readyFor.sending && readyFor.bounce && showDefaultBounceSubaccount;
   const {
+    allowDefault,
+    allowSubaccountDefault,
     updateSendingDomain,
     trackingDomains,
     updateTrackingDomain,
     listTrackingDomains,
     updateTrackingPending,
   } = useDomains();
+  const readyFor = resolveReadyFor(domain.status);
+  const resolvedStatus = resolveStatus(domain.status);
+  const showDefaultBounceSubaccount =
+    !domain.subaccount_id || (domain.subaccount_id && allowSubaccountDefault);
+  const showDefaultBounceToggle =
+    allowDefault && readyFor.sending && readyFor.bounce && showDefaultBounceSubaccount;
+
   const trackingDomain = _.find(trackingDomains, ['domainName', id.toLowerCase()]);
 
   const toggleDefaultBounce = () => {

--- a/src/pages/domains/components/LinkTrackingDomainSection.js
+++ b/src/pages/domains/components/LinkTrackingDomainSection.js
@@ -8,10 +8,10 @@ import { Select } from 'src/components/matchbox';
 import useDomains from '../hooks/useDomains';
 import { EXTERNAL_LINKS } from '../constants';
 
-export default function LinkTrackingDomainSection({ domain, trackingDomains, isSectionVisible }) {
+export default function LinkTrackingDomainSection({ domain, isSectionVisible }) {
   const { control, handleSubmit } = useForm();
 
-  const { updateSendingDomain, showAlert } = useDomains();
+  const { trackingDomainOptions, updateSendingDomain, showAlert } = useDomains();
 
   const onSubmit = ({ trackingDomain }) => {
     const { id, subaccount_id: subaccount } = domain;
@@ -54,7 +54,7 @@ export default function LinkTrackingDomainSection({ domain, trackingDomains, isS
                   <Select
                     onChange={onChange}
                     value={value || domain.tracking_domain}
-                    options={trackingDomains || []}
+                    options={trackingDomainOptions || []}
                     label="Linked Tracking Domain"
                     helpText="Domains must be verified to be linked to a sending domain."
                   />

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -4,13 +4,11 @@ import { Panel } from 'src/components/matchbox';
 import { useForm } from 'react-hook-form';
 import LineBreak from 'src/components/lineBreak';
 import getConfig from 'src/helpers/getConfig';
+import useDomains from '../hooks/useDomains';
 
-export default function SendingAndBounceDomainSection({
-  domain,
-  isByoipAccount,
-  isSectionVisible,
-}) {
+export default function SendingAndBounceDomainSection({ domain, isSectionVisible }) {
   const { id, status } = domain;
+  const { isByoipAccount } = useDomains();
   const initVerificationType = isByoipAccount && status.mx_status === 'valid' ? 'MX' : 'CNAME';
   const bounceDomainsConfig = getConfig('bounceDomains');
   const { watch } = useForm();

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -3,14 +3,15 @@ import { Box, Layout, Stack, Text, TextField } from 'src/components/matchbox';
 import { Button, Checkbox, Panel, Tag } from 'src/components/matchbox';
 import { useForm } from 'react-hook-form';
 import LineBreak from 'src/components/lineBreak';
-import { Bold } from 'src/components/text';
+import { Bold, SubduedText } from 'src/components/text';
 import { resolveReadyFor, resolveStatus } from 'src/helpers/domains';
 import getConfig from 'src/helpers/getConfig';
 import useDomains from '../hooks/useDomains';
-import { ExternalLink } from 'src/components/links';
+import { ExternalLink, SubduedLink } from 'src/components/links';
 import { CopyField } from 'src/components';
 import { Send } from '@sparkpost/matchbox-icons';
 import styled from 'styled-components';
+import { EXTERNAL_LINKS } from '../constants';
 
 const StyledBox = styled(Box)`
   float: right;
@@ -114,6 +115,15 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
         <Layout.SectionTitle as="h2">
           {resolvedStatus === 'verified' ? 'Sending and Bounce' : 'DNS Verification'}
         </Layout.SectionTitle>
+        <Stack>
+          <SubduedText>
+            Strict alignment is when the sending and bounce domain being the same value(e.g. sending
+            domain = sparkpost.com, and bounce domain = sparkpost.com)
+          </SubduedText>
+          <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}>
+            Domain Documentation
+          </SubduedLink>
+        </Stack>
       </Layout.Section>
       <Layout.Section>
         <Panel>

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -74,12 +74,12 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
         if (result.status.spf_status === 'valid') {
           showAlert({
             type: 'success',
-            message: `You have successfully autheticated SPF`,
+            message: `You have successfully authenticated SPF`,
           });
         } else {
           showAlert({
             type: 'error',
-            message: `SPF authetication failed`,
+            message: `SPF authentication failed`,
           });
         }
       });

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -117,7 +117,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
         {(!readyFor.dkim || !readyFor.bounce) && (
           <Stack>
             <SubduedText>
-              Strict alignment is when the sending and bounce domain being the same value(e.g.
+              Strict alignment is when the sending and bounce domain being the same value (e.g.
               sending domain = sparkpost.com, and bounce domain = sparkpost.com)
             </SubduedText>
             <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}>

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -114,15 +114,17 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
         <Layout.SectionTitle as="h2">
           {readyFor.dkim ? 'Sending and Bounce' : 'DNS Verification'}
         </Layout.SectionTitle>
-        <Stack>
-          <SubduedText>
-            Strict alignment is when the sending and bounce domain being the same value(e.g. sending
-            domain = sparkpost.com, and bounce domain = sparkpost.com)
-          </SubduedText>
-          <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}>
-            Domain Documentation
-          </SubduedLink>
-        </Stack>
+        {(!readyFor.dkim || !readyFor.bounce) && (
+          <Stack>
+            <SubduedText>
+              Strict alignment is when the sending and bounce domain being the same value(e.g.
+              sending domain = sparkpost.com, and bounce domain = sparkpost.com)
+            </SubduedText>
+            <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}>
+              Domain Documentation
+            </SubduedLink>
+          </Stack>
+        )}
       </Layout.Section>
       <Layout.Section>
         <Panel>

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -1,85 +1,278 @@
 import React from 'react';
 import { Box, Layout, Stack, Text, TextField } from 'src/components/matchbox';
-import { Panel } from 'src/components/matchbox';
+import { Button, Checkbox, Panel, Tag } from 'src/components/matchbox';
 import { useForm } from 'react-hook-form';
 import LineBreak from 'src/components/lineBreak';
+import { Bold } from 'src/components/text';
+import { resolveReadyFor, resolveStatus } from 'src/helpers/domains';
 import getConfig from 'src/helpers/getConfig';
 import useDomains from '../hooks/useDomains';
+import { ExternalLink } from 'src/components/links';
+import { CopyField } from 'src/components';
+import { Send } from '@sparkpost/matchbox-icons';
+import styled from 'styled-components';
+
+const StyledBox = styled(Box)`
+  float: right;
+`;
+const Field = ({ verified, label, value }) => {
+  if (!verified) return <CopyField label={label} value={value} />;
+  return <TextField label={label} value={value} readOnly />;
+};
+
+const PlaneIcon = styled(Send)`
+  transform: translate(0, -25%) rotate(-45deg);
+`;
 
 export default function SendingAndBounceDomainSection({ domain, isSectionVisible }) {
-  const { id, status } = domain;
-  const { isByoipAccount } = useDomains();
+  const { id, status, subaccount_id } = domain;
+  const {
+    getDomain,
+    verifyDkim,
+    verify,
+    showAlert,
+    userName,
+    isByoipAccount,
+    verifyDkimLoading,
+    verifyBounceLoading,
+  } = useDomains();
   const initVerificationType = isByoipAccount && status.mx_status === 'valid' ? 'MX' : 'CNAME';
   const bounceDomainsConfig = getConfig('bounceDomains');
-  const { watch } = useForm();
+  const { errors, watch, register, handleSubmit } = useForm();
   const watchVerificationType = watch('verificationType', initVerificationType);
+
+  const resolvedStatus = resolveStatus(domain.status);
+  const readyFor = resolveReadyFor(domain.status);
+
+  const getButtonText = () => {
+    if (resolvedStatus !== 'verified' || !readyFor.bounce) return 'Authenticate Domain';
+    if (status.spf_status !== 'valid') return 'Authenticate for SPF';
+  };
+
+  const onSubmit = () => {
+    if (!readyFor.bounce) {
+      const type = watchVerificationType.toLowerCase();
+
+      verify({ id, subaccount: subaccount_id, type }).then(result => {
+        if (result[`${type}_status`] === 'valid') {
+          showAlert({
+            type: 'success',
+            message: `You have successfully verified ${type} record of ${id}`,
+          });
+        } else {
+          showAlert({
+            type: 'error',
+            message: `Unable to verify ${type} record of ${id}`,
+            details: result.dns[`${type}_error`],
+          });
+        }
+      });
+    }
+
+    if (status.spf_status !== 'valid')
+      getDomain(id).then(result => {
+        if (result.status.spf_status === 'valid') {
+          showAlert({
+            type: 'success',
+            message: `You have successfully autheticated SPF`,
+          });
+        } else {
+          showAlert({
+            type: 'error',
+            message: `SPF autheticated failed`,
+          });
+        }
+      });
+
+    if (resolveStatus !== 'verified') {
+      const { id, subaccount_id: subaccount } = domain;
+
+      verifyDkim({ id, subaccount }).then(results => {
+        const readyFor = resolveReadyFor(results);
+
+        if (readyFor.dkim) {
+          showAlert({
+            type: 'success',
+            message: `You have successfully verified DKIM record of ${id}`,
+          });
+        } else {
+          showAlert({
+            type: 'error',
+            message: `Unable to verify DKIM record of ${id}. ${results.dns.dkim_error}`,
+          });
+        }
+      });
+    }
+  };
+
   if (!isSectionVisible) {
     return null;
   }
   return (
     <Layout>
       <Layout.Section annotated>
-        <Layout.SectionTitle as="h2">Sending and Bounce</Layout.SectionTitle>
+        <Layout.SectionTitle as="h2">
+          {resolvedStatus === 'verified' ? 'Sending and Bounce' : 'DNS Verification'}
+        </Layout.SectionTitle>
       </Layout.Section>
       <Layout.Section>
         <Panel>
-          <Panel.Section>Below is the records for this domain at your DNS provider</Panel.Section>
-          <Panel.Section>
-            <Stack>
-              <Box>
-                <Text as="span" fontSize="300" fontWeight="semibold">
-                  TXT record for DKIM
-                </Text>
-              </Box>
-              <TextField label="Hostname" value={domain.dkimHostname} readOnly />
-              <TextField label="Value" value={domain.dkimValue} readOnly />
-            </Stack>
-          </Panel.Section>
-          <Panel.Section>
-            <Stack>
-              <Box>
-                <Text as="span" fontSize="300" fontWeight="semibold">
-                  {`${initVerificationType} record for Bounce`}
-                </Text>
-              </Box>
-              {watchVerificationType === 'MX' ? (
-                <Stack space="200">
-                  <TextField label="Hostname" value={id} readOnly />
-                  <TextField label="Value" value={bounceDomainsConfig.mxValue} readOnly />
-                  <LineBreak text="AND" />
+          <form onSubmit={handleSubmit(onSubmit)} id="sendingbounceForm">
+            {resolvedStatus !== 'verified' || !readyFor.bounce ? (
+              <Panel.Section>
+                Add the <Bold>TXT</Bold> and <Bold>{watchVerificationType} </Bold>
+                records, Hostnames and Values for this domain in the settings section of your DNS
+                Provider
+                <Panel.Action>
+                  <ExternalLink
+                    to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
+                    icon={PlaneIcon}
+                  >
+                    Forward to Colleague
+                  </ExternalLink>
+                </Panel.Action>
+              </Panel.Section>
+            ) : (
+              <Panel.Section>
+                'Below is the records for this domain at your DNS provider'
+              </Panel.Section>
+            )}
+
+            <Panel.Section>
+              <Stack>
+                <Box>
+                  <Text as="span" fontSize="300" fontWeight="semibold">
+                    {resolvedStatus !== 'verified' ? 'Add DKIM Record' : 'TXT record for DKIM'}
+                  </Text>
+                </Box>
+                {resolvedStatus !== 'verified' && (
                   <>
                     <Text as="label" fontWeight="500" fontSize="200">
                       Type
                     </Text>
-                    <Text as="p">{initVerificationType}</Text>
+                    <Text as="p">TXT</Text>
                   </>
-                  <TextField label="Hostname" value={id} readOnly />
+                )}
+                <Field
+                  label="Hostname"
+                  value={domain.dkimHostname}
+                  verified={resolvedStatus === 'verified'}
+                />
+                <Field
+                  label="Value"
+                  value={domain.dkimValue}
+                  verified={resolvedStatus === 'verified'}
+                />
+              </Stack>
+            </Panel.Section>
+            <Panel.Section>
+              <Stack>
+                <Box>
+                  <Text as="span" fontSize="300" fontWeight="semibold">
+                    {!readyFor.bounce
+                      ? 'Add Bounce Record'
+                      : `${initVerificationType} record for Bounce`}
+                  </Text>
+                </Box>
+                {watchVerificationType === 'MX' ? (
+                  <Stack space="200">
+                    <Field label="Hostname" value={id} />
+                    <Field label="Value" value={bounceDomainsConfig.mxValue} />
+                    <LineBreak text="AND" />
+                    <>
+                      <Text as="label" fontWeight="500" fontSize="200">
+                        Type
+                      </Text>
+                      <Text as="p">{initVerificationType}</Text>
+                    </>
+                    <Field label="Hostname" value={id} verified={readyFor.bounce} />
 
-                  <TextField
-                    label="Value"
-                    value={"v=spf1 ip4:{'<YOUR-IP-ADDRESS>'}/20 ~all"}
-                    readOnly
-                  />
-                </Stack>
-              ) : (
-                <Stack space="200">
-                  <TextField label="Hostname" value={id} readOnly />
-                  <TextField label="Value" value={bounceDomainsConfig.cnameValue} readOnly />
-                </Stack>
-              )}
-            </Stack>
-          </Panel.Section>
-          <Panel.Section>
-            <Stack>
-              <Box>
-                <Text as="span" fontSize="300" fontWeight="semibold">
-                  TXT record for SPF
-                </Text>
-              </Box>
-              <TextField label="Hostname" value={id} readOnly></TextField>
-              <TextField label="Value" value="v=spf1 mx  a    ~all" readOnly></TextField>
-            </Stack>
-          </Panel.Section>
+                    <Field
+                      label="Value"
+                      value={"v=spf1 ip4:{'<YOUR-IP-ADDRESS>'}/20 ~all"}
+                      verified={readyFor.bounce}
+                    />
+                  </Stack>
+                ) : (
+                  <Stack>
+                    {!readyFor.bounce && (
+                      <>
+                        <Text as="label" fontWeight="500" fontSize="200">
+                          Type
+                        </Text>
+                        <Text as="p">CNAME</Text>
+                      </>
+                    )}
+
+                    <Field label="Hostname" value={id} verified={readyFor.bounce} />
+                    <Field
+                      label="Value"
+                      value={bounceDomainsConfig.cnameValue}
+                      verified={readyFor.bounce}
+                    />
+                  </Stack>
+                )}
+              </Stack>
+            </Panel.Section>
+            <Panel.Section>
+              <Stack>
+                <Box>
+                  <Text as="span" fontSize="300" fontWeight="semibold">
+                    {status.spf_status !== 'valid' ? (
+                      <Box>
+                        <Box display="inline">
+                          Add SPF Record{' '}
+                          <Tag color="green" ml="400">
+                            Recommended
+                          </Tag>
+                        </Box>
+
+                        <StyledBox>
+                          <Text as="span" fontSize="200" color="gray.700" fontWeight="400">
+                            Optional
+                          </Text>
+                        </StyledBox>
+                      </Box>
+                    ) : (
+                      'TXT record for SPF'
+                    )}
+                  </Text>
+                </Box>
+                <Field label="Hostname" value={id} verified={status.spf_status === 'valid'} />
+                <Field
+                  label="Value"
+                  value="v=spf1 mx a ~all"
+                  verified={status.spf_status === 'valid'}
+                />
+              </Stack>
+            </Panel.Section>
+            {(!readyFor.bounce || resolveStatus !== 'verified') && (
+              <Panel.Section>
+                <Checkbox
+                  ref={register({ required: true })}
+                  id="add-to-dns"
+                  name="addToDns"
+                  label="The TXT and CNAME records have been added to the DNS provider"
+                  error={errors.addToDns && 'Adding TXT and CNAME is required'}
+                  disabled={verifyBounceLoading || verifyDkimLoading}
+                />
+              </Panel.Section>
+            )}
+            {(!readyFor.bounce ||
+              resolveStatus !== 'verified' ||
+              status.spf_status !== 'valid') && (
+              <Panel.Section>
+                <Button
+                  variant="primary"
+                  type="submit"
+                  name="sendingBounceForm"
+                  loading={verifyBounceLoading || verifyDkimLoading}
+                >
+                  {getButtonText()}
+                </Button>
+              </Panel.Section>
+            )}
+          </form>
         </Panel>
       </Layout.Section>
     </Layout>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -39,7 +39,14 @@ const Field = ({ verified, label, value }) => {
 
 export default function SetupBounceDomainSection({ domain, isSectionVisible, title }) {
   const { id, status, subaccount_id } = domain;
-  const { getDomain, verify, showAlert, userName, isByoipAccount } = useDomains();
+  const {
+    getDomain,
+    verify,
+    showAlert,
+    userName,
+    isByoipAccount,
+    verifyBounceLoading,
+  } = useDomains();
   const readyFor = resolveReadyFor(status);
   const initVerificationType = isByoipAccount && status.mx_status === 'valid' ? 'MX' : 'CNAME';
   const bounceDomainsConfig = getConfig('bounceDomains');
@@ -242,7 +249,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                 ></Field>
                 <Field
                   label="Value"
-                  value="v=spf1 mx  a    ~all"
+                  value="v=spf1 mx a ~all"
                   verified={domain.status.spf_status === 'valid'}
                 ></Field>
               </Stack>
@@ -253,11 +260,13 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                   <Checkbox
                     id="add-txt-to-godaddy"
                     label="The TXT record has been added to the DNS provider"
+                    disabled={verifyBounceLoading}
                   />
                 ) : (
                   <Checkbox
                     id="add-txt-to-godaddy"
                     label={`The ${watchVerificationType} record has been added to the DNS provider`}
+                    disabled={verifyBounceLoading}
                   />
                 )}
               </Panel.Section>
@@ -271,7 +280,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
             )}
             {!readyFor.bounce && (
               <Panel.Section>
-                <Button variant="primary" type="submit">
+                <Button variant="primary" type="submit" loading={verifyBounceLoading}>
                   Authenticate for Bounce
                 </Button>
               </Panel.Section>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -37,19 +37,14 @@ const Field = ({ verified, label, value }) => {
   return <TextField label={label} value={value} readOnly />;
 };
 
-export default function SetupBounceDomainSection({
-  domain,
-  isByoipAccount,
-  isSectionVisible,
-  title,
-}) {
+export default function SetupBounceDomainSection({ domain, isSectionVisible, title }) {
   const { id, status, subaccount_id } = domain;
+  const { getDomain, verify, showAlert, userName, isByoipAccount } = useDomains();
   const readyFor = resolveReadyFor(status);
   const initVerificationType = isByoipAccount && status.mx_status === 'valid' ? 'MX' : 'CNAME';
   const bounceDomainsConfig = getConfig('bounceDomains');
   const { control, handleSubmit, watch } = useForm();
   const watchVerificationType = watch('verificationType', initVerificationType);
-  const { getDomain, verify, showAlert, userName } = useDomains();
   const [warningBanner, toggleBanner] = useState(true);
 
   const onSubmit = () => {

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -20,7 +20,7 @@ const Field = ({ verified, label, value }) => {
 };
 
 export default function SetupForSending({ domain, resolvedStatus, isSectionVisible }) {
-  const { verifyDkim, showAlert, userName } = useDomains();
+  const { verifyDkim, showAlert, userName, verifyDkimLoading } = useDomains();
 
   const handleVerifyDkim = () => {
     const { id, subaccount_id: subaccount } = domain;
@@ -130,7 +130,7 @@ export default function SetupForSending({ domain, resolvedStatus, isSectionVisib
           </Panel.Section>
           {resolvedStatus !== 'verified' && (
             <Panel.Section>
-              <Button variant="primary" onClick={handleVerifyDkim}>
+              <Button variant="primary" onClick={handleVerifyDkim} loading={verifyDkimLoading}>
                 Verify Domain
               </Button>
               {/* Functionality not available */}

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -15,7 +15,7 @@ const Field = ({ verified, label, value }) => {
 };
 
 export default function TrackingDnsSection({ id, isSectionVisible, title }) {
-  const { trackingDomains, verifyTrackingDomain } = useDomains();
+  const { trackingDomains, verifyTrackingDomain, verifyingTrackingPending } = useDomains();
   let trackingDomain = _.find(trackingDomains, ['domainName', id.toLowerCase()]) || {};
   const { unverified } = trackingDomain;
 
@@ -82,7 +82,7 @@ export default function TrackingDnsSection({ id, isSectionVisible, title }) {
           </Panel.Section>
           {unverified && (
             <Panel.Section>
-              <Button variant="primary" onClick={handleVerify}>
+              <Button variant="primary" onClick={handleVerify} loading={verifyingTrackingPending}>
                 Verify Domain
               </Button>
             </Panel.Section>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -14,8 +14,9 @@ import useModal from 'src/hooks/useModal';
 import { useForm, Controller } from 'react-hook-form';
 import useDomains from '../hooks/useDomains';
 
-export default function VerifyEmailSection({ hasAnyoneAtEnabled, domain, isSectionVisible }) {
+export default function VerifyEmailSection({ domain, isSectionVisible }) {
   const { closeModal, isModalOpen, openModal, meta: { name } = {} } = useModal();
+  const { hasAnyoneAtEnabled } = useDomains();
   const [warningBanner, toggleBanner] = useState(true);
   if (!isSectionVisible) {
     return null;

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -69,20 +69,16 @@ export default function VerifyEmailSection({ domain, isSectionVisible }) {
 
 function VerifyButton({ onClick, variant = 'primary', submitting }) {
   return (
-    <Button variant={variant} disabled={submitting} onClick={onClick}>
-      {submitting ? 'Sending Email...' : 'Send Email'}
+    <Button variant={variant} loading={submitting} onClick={onClick}>
+      Send Email
     </Button>
   );
 }
 function AllowAnyoneAtModal(props) {
-  const {
-    onCancel,
-    domain,
-    submitting, //todo
-  } = props;
+  const { onCancel, domain } = props;
   const { id, subaccount_id: subaccount } = domain;
   const { control, handleSubmit, errors } = useForm();
-  const { verifyMailbox, showAlert } = useDomains();
+  const { verifyMailbox, showAlert, verifyEmailLoading } = useDomains();
 
   const onSubmit = data => {
     const localPart = data.localPart;
@@ -126,7 +122,7 @@ function AllowAnyoneAtModal(props) {
         </Modal.Content>
 
         <Modal.Footer>
-          <Button variant="primary" type="submit" form="modalForm" loading={submitting}>
+          <Button variant="primary" type="submit" form="modalForm" loading={verifyEmailLoading}>
             Send Email
           </Button>
         </Modal.Footer>
@@ -136,11 +132,7 @@ function AllowAnyoneAtModal(props) {
 }
 
 function MailboxVerificationModal(props) {
-  const {
-    onCancel,
-    domain,
-    submitting, //todo
-  } = props;
+  const { onCancel, domain, verifyEmailLoading } = props;
   const { id, subaccount_id: subaccount } = domain;
   const { verifyAbuse, verifyPostmaster, showAlert } = useDomains();
 
@@ -177,7 +169,7 @@ function MailboxVerificationModal(props) {
               <VerifyButton
                 onClick={verifyWithPostmaster}
                 variant="secondary"
-                submitting={submitting}
+                submitting={verifyEmailLoading}
               />
             </Grid.Column>
           </Grid>
@@ -189,7 +181,11 @@ function MailboxVerificationModal(props) {
               </p>
             </Grid.Column>
             <Grid.Column xs={6}>
-              <VerifyButton onClick={verifyWithAbuse} variant="secondary" submitting={submitting} />
+              <VerifyButton
+                onClick={verifyWithAbuse}
+                variant="secondary"
+                submitting={verifyEmailLoading}
+              />
             </Grid.Column>
           </Grid>
         </Stack>

--- a/src/pages/domains/components/tests/DomainStatusSection.test.js
+++ b/src/pages/domains/components/tests/DomainStatusSection.test.js
@@ -8,14 +8,12 @@ const mockfunc = jest.fn(() => {
   return Promise.resolve();
 });
 useDomains.mockImplementation(() => {
-  return { updateSendingDomain: mockfunc };
+  return { updateSendingDomain: mockfunc, allowDefault: true, allowSubaccountDefault: true };
 });
 
 describe('DomainStatusSection', () => {
   const defaultProps = {
     id: 'hello-2.com',
-    allowDefault: true,
-    allowSubaccountDefault: true,
     domain: {
       id: 'hello-2.com',
       dkim: {
@@ -43,6 +41,7 @@ describe('DomainStatusSection', () => {
       dkimValue:
         'v=DKIM1; k=rsa; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCpiANdZRxauv72XRP72eLbKav/4ohDpJD9Mye3eh+02++djlfvjfaxdRUVTFd5hkpCPlAHqVIMqyjQwvbCSwmj8ttzVbVfLA18w+nHJP77NihXJ3kbpGqQrXMVAY4vb/DhMWhfBzPctDw6CHrz3aV957DiK5+l0SlwXyIcwa5JvwIDAQAB',
     },
+    isTracking: false,
   };
   const subject = () => shallow(<DomainStatusSection {...defaultProps} />);
 

--- a/src/reducers/trackingDomains.js
+++ b/src/reducers/trackingDomains.js
@@ -46,16 +46,25 @@ export default (state = initialState, { type, payload, meta }) => {
       return { ...state, updating: false };
 
     case 'VERIFY_TRACKING_DOMAIN_PENDING':
-      return { ...state, verifying: [...state.verifying, meta.domain] };
+      return {
+        ...state,
+        verifying: [...state.verifying, meta.domain],
+        verifyingTrackingPending: true,
+      };
 
     case 'VERIFY_TRACKING_DOMAIN_FAIL':
-      return { ...state, verifying: state.verifying.filter(domain => domain !== meta.domain) };
+      return {
+        ...state,
+        verifying: state.verifying.filter(domain => domain !== meta.domain),
+        verifyingTrackingPending: false,
+      };
 
     case 'VERIFY_TRACKING_DOMAIN_SUCCESS':
       return {
         ...state,
         verifying: state.verifying.filter(domain => domain !== meta.domain),
         list: state.list.map(d => (d.domain === meta.domain ? { ...d, status: payload } : d)),
+        verifyingTrackingPending: false,
       };
 
     default:


### PR DESCRIPTION
FE-1187 - Add the Sending/Bounce Verification Page

### What Changed
 - Added the Sending/Bounce Verification Page
 - Updated the condition for showing the sending and bounce section on details page of completely verified domain
 - Reduced prop drilling happening in DomainDetailsPage
 - Added the pending state to all the verification pages
 - Added cypress tests for Sending/Bounce Verification Page

### How To Test
 - Create Sending Domain from /domains/create
 - Select 'Strict Alignment' from Domain Alignment Modal to get to Sending/Bounce Verification Page.
 - Check if it matches mocks - https://sparkpost.invisionapp.com/console/share/CF19LDYPB2/478945612

### To Do
- [ ] Address feedback
- [x] Change the base of branch to master before merging
