### PR TITLE
SA-1721: Fixed issue with group by in non comparators filters

### DIFF
--- a/src/pages/reportBuilder/components/tests/GroupByOption.test.js
+++ b/src/pages/reportBuilder/components/tests/GroupByOption.test.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import { GroupByOption } from '../GroupByOption';
 import { shallow } from 'enzyme';
+import { dehydrateFilters } from '../../helpers';
 
 jest.mock('../../context/ReportBuilderContext', () => ({
   useReportBuilderContext: jest.fn(() => ({ state: { foo: 'bar', filters: [] } })),
+}));
+
+jest.mock('../../helpers', () => ({
+  dehydrateFilters: jest.fn(),
 }));
 
 describe('Group By Option', () => {
@@ -89,5 +94,15 @@ describe('Group By Option', () => {
       reportOptions: { foo: 'bar', filters: [] },
     });
     expect(wrapper.find('Checkbox')).toBeChecked();
+  });
+
+  it('should dehydrate filters if on new comparators filters', () => {
+    wrapper.setProps({ isComparatorsEnabled: true });
+    expect(wrapper.find('Checkbox')).toBeChecked();
+    wrapper.find('Checkbox').simulate('change');
+    expect(wrapper.find('Checkbox')).not.toBeChecked();
+    wrapper.find('Checkbox').simulate('change');
+    expect(props._getTableData).toHaveBeenCalledTimes(2);
+    expect(dehydrateFilters).toHaveBeenCalled();
   });
 });

--- a/src/pages/reportBuilder/components/tests/ReportTable.test.js
+++ b/src/pages/reportBuilder/components/tests/ReportTable.test.js
@@ -2,18 +2,13 @@ import React from 'react';
 import { render, within } from '@testing-library/react';
 import { ReportTable } from '../ReportTable';
 import { shallow } from 'enzyme';
-import { MemoryRouter } from 'react-router-dom';
+import TestApp from 'src/__testHelpers__/TestApp';
 
 jest.mock('../../context/ReportBuilderContext', () => ({
   useReportBuilderContext: jest.fn(() => [{ foo: 'bar' }]),
 }));
 
 jest.mock('../AddFilterLink', () => jest.fn(({ newFilter }) => <>{newFilter.value}</>));
-
-//Hibana will be enabled in actual component but this should only affect layout
-jest.mock('src/context/HibanaContext', () => ({
-  useHibana: jest.fn().mockReturnValue([{ isHibanaEnabled: false }]),
-}));
 
 describe('Summary Table', () => {
   let wrapper;
@@ -41,9 +36,9 @@ describe('Summary Table', () => {
 
   const subject = (givenProps = {}) =>
     render(
-      <MemoryRouter>
+      <TestApp isHibanaEnabled={true}>
         <ReportTable {...props} {...givenProps} />
-      </MemoryRouter>,
+      </TestApp>,
     );
 
   beforeEach(() => {


### PR DESCRIPTION
### What Changed
 - Fixed group by behavior on non comparators

### How To Test
 - Go to report builder with `allow_report_filters_v2` as `false`
 - Go to group by, select any category
 - Click one filter to add it in
 - Only one row should be visible after
 - Choose another category and then go back to original category
 - Still should only have one role

### To Do
- [ ] Address feedback
