### PR TITLE
[FE-1203] UX Feedback for Domain Detail Pages Part - 1

### DIFF
--- a/src/components/toggleBlock/ToggleBlock.js
+++ b/src/components/toggleBlock/ToggleBlock.js
@@ -25,12 +25,15 @@ function OGToggleBlock({ input, label, helpText, ...rest }) {
 }
 
 function HibanaToggleBlock(props) {
-  const { input, label, helpText, ...rest } = props;
+  /* variant prop helps adjusting the spacing between toggle and label text*/
+  const { input, label, helpText, variant, ...rest } = props;
+  const columns = variant === 'dense' ? 4 : 8;
+  const justifyContent = variant === 'dense' ? 'flex-start' : 'flex-end';
 
   return (
     <Box data-id="toggle-block">
       <Grid middle="xs">
-        <Grid.Column xs={8}>
+        <Grid.Column xs={columns}>
           {/* actual label for ScreenReaders made available via the `Toggle` component */}
           <div aria-hidden="true">
             <Label label={label} fontSize="200" />
@@ -38,7 +41,7 @@ function HibanaToggleBlock(props) {
         </Grid.Column>
 
         <Grid.Column xs={4}>
-          <Box display="flex" alignItems="center" justifyContent="flex-end">
+          <Box display="flex" alignItems="center" justifyContent={justifyContent}>
             <Toggle
               id={input.name}
               label={label}

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Page, Banner, Button, Box } from 'src/components/matchbox';
-import { get as getDomain } from 'src/actions/sendingDomains';
+import { get as getDomain, clearSendingDomain } from 'src/actions/sendingDomains';
 import Domains from './components';
 import { connect } from 'react-redux';
 import { selectDomain } from 'src/selectors/sendingDomains';
@@ -27,6 +27,7 @@ function DetailsPage(props) {
     domain,
     getDomain,
     listTrackingDomains,
+    clearSendingDomain,
   } = props;
   const resolvedStatus = resolveStatus(domain.status);
   const [warningBanner, toggleBanner] = useState(true);
@@ -45,7 +46,11 @@ function DetailsPage(props) {
 
   useEffect(() => {
     getDomain(match.params.id);
-  }, [getDomain, match.params.id]);
+    return () => {
+      //reset the domain
+      clearSendingDomain();
+    };
+  }, [clearSendingDomain, getDomain, match.params.id]);
   useEffect(() => {
     listTrackingDomains();
   }, [listTrackingDomains]);
@@ -150,5 +155,5 @@ export default connect(
     sendingDomainsPending: state.sendingDomains.getLoading,
     trackingDomainListPending: state.trackingDomains.listLoading,
   }),
-  { getDomain, listTrackingDomains },
+  { getDomain, listTrackingDomains, clearSendingDomain },
 )(DetailsPage);

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -103,12 +103,12 @@ export default function CreateForm() {
             <Layout.SectionTitle>Domain Type</Layout.SectionTitle>
 
             <Stack>
-              <SubduedText>
+              <SubduedText fontSize="200">
                 Adding a domain is very easy. You&rsquo;ll want to configure at least one domain for
                 each domain type in order to get the most out of our sending and analytics.
               </SubduedText>
 
-              <SubduedLink as={ExternalLink} to={LINKS.SENDING_REQS}>
+              <SubduedLink as={ExternalLink} to={LINKS.SENDING_REQS} fontSize="200">
                 Domains Documentation
               </SubduedLink>
             </Stack>
@@ -167,7 +167,7 @@ export default function CreateForm() {
           <Layout.Section annotated>
             <Layout.SectionTitle>Domain and Assignment</Layout.SectionTitle>
 
-            <SubduedText>
+            <SubduedText fontSize="200">
               We recommend using a subdomain e.g. mail.mydomain.com. Depending on how you want to
               use your domain, you may not be able to completely configure your DNS records if you
               use your organizational domain.

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Layout, Stack, Text } from 'src/components/matchbox';
-import { Box, Checkbox, Columns, Column, Panel, Tooltip } from 'src/components/matchbox';
+import { Checkbox, Columns, Column, Panel, Tooltip } from 'src/components/matchbox';
 import { Heading, SubduedText } from 'src/components/text';
 import { SendingDomainStatusCell as StatusCell } from './SendingDomainStatusCell';
 import TrackingDomainStatusCell from './TrackingDomainStatusCell';
@@ -13,11 +13,6 @@ import { ToggleBlock } from 'src/components';
 import { EXTERNAL_LINKS } from '../constants';
 import { ConfirmationModal } from 'src/components/modals';
 import _ from 'lodash';
-import styled from 'styled-components';
-
-const StyledBox = styled(Box)`
-  max-width: 400px;
-`;
 
 export default function DomainStatusSection({ domain, id, isTracking }) {
   const { closeModal, isModalOpen, openModal } = useModal();
@@ -235,16 +230,15 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
                 </Panel.Section>
               ) : (
                 <Panel.Section>
-                  <StyledBox>
-                    <ToggleBlock
-                      input={{
-                        name: 'share-with-all-subaccounts',
-                        checked: domain.shared_with_subaccounts,
-                        onChange: toggleShareWithSubaccounts,
-                      }}
-                      label="Share this domain with all subaccounts"
-                    />
-                  </StyledBox>
+                  <ToggleBlock
+                    input={{
+                      name: 'share-with-all-subaccounts',
+                      checked: domain.shared_with_subaccounts,
+                      onChange: toggleShareWithSubaccounts,
+                    }}
+                    label="Share this domain with all subaccounts"
+                    variant="dense"
+                  />
                 </Panel.Section>
               )}
               {showDefaultBounceToggle && (

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Layout, Stack, Text } from 'src/components/matchbox';
-import { Checkbox, Columns, Column, Panel } from 'src/components/matchbox';
+import { Box, Checkbox, Columns, Column, Panel, Tooltip } from 'src/components/matchbox';
 import { Heading, SubduedText } from 'src/components/text';
 import { SendingDomainStatusCell as StatusCell } from './SendingDomainStatusCell';
 import TrackingDomainStatusCell from './TrackingDomainStatusCell';
@@ -13,6 +13,11 @@ import { ToggleBlock } from 'src/components';
 import { EXTERNAL_LINKS } from '../constants';
 import { ConfirmationModal } from 'src/components/modals';
 import _ from 'lodash';
+import styled from 'styled-components';
+
+const StyledBox = styled(Box)`
+  max-width: 400px;
+`;
 
 export default function DomainStatusSection({ domain, id, isTracking }) {
   const { closeModal, isModalOpen, openModal } = useModal();
@@ -71,14 +76,14 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
     return (
       <Layout>
         <Layout.Section annotated>
-          <Stack>
-            <Layout.SectionTitle as="h2">Domain Status</Layout.SectionTitle>
-            <Stack>
-              <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.TRACKING_DOMAIN_DOCUMENTATION}>
-                Tracking Domain Documentation
-              </SubduedLink>
-            </Stack>
-          </Stack>
+          <Layout.SectionTitle as="h2">Domain Status</Layout.SectionTitle>
+          <SubduedLink
+            as={ExternalLink}
+            to={EXTERNAL_LINKS.TRACKING_DOMAIN_DOCUMENTATION}
+            fontSize="200"
+          >
+            Tracking Domain Documentation
+          </SubduedLink>
         </Layout.Section>
         <Layout.Section>
           <Panel>
@@ -147,26 +152,38 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
   return (
     <Layout>
       <Layout.Section annotated>
+        <Layout.SectionTitle as="h2">Domain Status</Layout.SectionTitle>
         <Stack>
-          <Layout.SectionTitle as="h2">Domain Status</Layout.SectionTitle>
           {resolvedStatus === 'unverified' && (
-            <SubduedText>
+            <SubduedText fontSize="200">
               This domain failed authentication. It can take 24 to 48 hours for the DNS record to
               propogate. For other reasons why this ay have happenedchek out our domain
               authentication documentation.
             </SubduedText>
           )}
           {resolvedStatus === 'unverified' && (
-            <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.VERIFY_SENDING_DOMAIN_OWNERSHIP}>
+            <SubduedLink
+              as={ExternalLink}
+              to={EXTERNAL_LINKS.VERIFY_SENDING_DOMAIN_OWNERSHIP}
+              fontSize="200"
+            >
               Domain Documentation
             </SubduedLink>
           )}
           {resolvedStatus === 'verified' && (
             <Stack>
-              <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}>
+              <SubduedLink
+                as={ExternalLink}
+                to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}
+                fontSize="200"
+              >
                 Sending Domain Documentation
               </SubduedLink>
-              <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_API_DOCUMENTATION}>
+              <SubduedLink
+                as={ExternalLink}
+                to={EXTERNAL_LINKS.SENDING_DOMAINS_API_DOCUMENTATION}
+                fontSize="200"
+              >
                 Sending Domain API Documentation
               </SubduedLink>
             </Stack>
@@ -218,14 +235,16 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
                 </Panel.Section>
               ) : (
                 <Panel.Section>
-                  <ToggleBlock
-                    input={{
-                      name: 'share-with-all-subaccounts',
-                      checked: domain.shared_with_subaccounts,
-                      onChange: toggleShareWithSubaccounts,
-                    }}
-                    label="Share this domain with all subaccounts"
-                  />
+                  <StyledBox>
+                    <ToggleBlock
+                      input={{
+                        name: 'share-with-all-subaccounts',
+                        checked: domain.shared_with_subaccounts,
+                        onChange: toggleShareWithSubaccounts,
+                      }}
+                      label="Share this domain with all subaccounts"
+                    />
+                  </StyledBox>
                 </Panel.Section>
               )}
               {showDefaultBounceToggle && (
@@ -235,7 +254,16 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
                       id="set-as-default-bounce-domain"
                       label={
                         <>
-                          Set as Default Bounce Domain <Bookmark color="green" />
+                          Set as Default Bounce Domain{' '}
+                          <Tooltip
+                            id="default-bounce-tooltip"
+                            dark
+                            content={`When this is set to "ON", all future transmissions ${
+                              domain.subaccount_id ? 'for this subaccount ' : ''
+                            }will use ${id} as their bounce domain (unless otherwise specified).`}
+                          >
+                            <Bookmark color="green" />
+                          </Tooltip>
                         </>
                       }
                       checked={domain.is_default_bounce_domain}

--- a/src/pages/domains/components/LinkTrackingDomainSection.js
+++ b/src/pages/domains/components/LinkTrackingDomainSection.js
@@ -38,8 +38,12 @@ export default function LinkTrackingDomainSection({ domain, isSectionVisible }) 
       <Layout.Section annotated>
         <Layout.SectionTitle as="h2">Link Tracking Domain</Layout.SectionTitle>
         <Stack>
-          <SubduedText>Assign a tracking domain?</SubduedText>
-          <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.TRACKING_DOMAIN_DOCUMENTATION}>
+          <SubduedText fontSize="200">Assign a tracking domain?</SubduedText>
+          <SubduedLink
+            as={ExternalLink}
+            to={EXTERNAL_LINKS.TRACKING_DOMAIN_DOCUMENTATION}
+            fontSize="200"
+          >
             Tracking Domain Documentation
           </SubduedLink>
         </Stack>

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -116,11 +116,15 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
         </Layout.SectionTitle>
         {(!readyFor.dkim || !readyFor.bounce) && (
           <Stack>
-            <SubduedText>
+            <SubduedText fontSize="200">
               Strict alignment is when the sending and bounce domain being the same value (e.g.
               sending domain = sparkpost.com, and bounce domain = sparkpost.com)
             </SubduedText>
-            <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}>
+            <SubduedLink
+              as={ExternalLink}
+              to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}
+              fontSize="200"
+            >
               Domain Documentation
             </SubduedLink>
           </Stack>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -27,9 +27,8 @@ const PlaneIcon = styled(Send)`
   transform: translate(0, -25%) rotate(-45deg);
 `;
 
-const StyledText = styled(Text)`
+const StyledBox = styled(Box)`
   float: right;
-  color: #c5ced6;
 `;
 
 const Field = ({ verified, label, value }) => {
@@ -95,38 +94,40 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
       <Layout.Section annotated>
         <Layout.SectionTitle as="h2">{title || 'Bounce'}</Layout.SectionTitle>
         <Stack>
-          <SubduedText>
-            <Stack>
-              {readyFor.bounce ? (
-                ''
-              ) : (
-                <>
-                  Once the CNAME record is added to the DNS provider settings, the domain will also
-                  be setup for Bounce, resulting in Strict Alignment.
-                </>
-              )}
-              {domain.status.spf_status !== 'valid' && readyFor.bounce && warningBanner && (
-                <Banner status="warning" size="small" onDismiss={() => toggleBanner(false)}>
-                  <Text fontWeight="normal" maxWidth="100">
-                    This domain is not SPF authenticated.
-                  </Text>
-                </Banner>
-              )}
-              {domain.status.spf_status !== 'valid' && (
-                <>
-                  SPF (Sender Policy Framework) is an email authentication method to determine if a
-                  bounce domain is allowed to be used with in given sending IP. SPF failures can
-                  cause mail to be rejected at some providers. To ensure they pass all SPF checks,
-                  publishing SparkPost CNAME in DNS is required for all bounce domains.
-                </>
-              )}
-            </Stack>
-          </SubduedText>
+          {!readyFor.bounce && (
+            <SubduedText fontSize="200">
+              Once the CNAME record is added to the DNS provider settings, the domain will also be
+              setup for Bounce, resulting in Strict Alignment.
+            </SubduedText>
+          )}
 
-          <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.BOUNCE_DOMAIN_DOCUMENTATION}>
+          {domain.status.spf_status !== 'valid' && readyFor.bounce && warningBanner && (
+            <Banner status="warning" size="small" onDismiss={() => toggleBanner(false)}>
+              <Text fontWeight="normal" maxWidth="100">
+                This domain is not SPF authenticated.
+              </Text>
+            </Banner>
+          )}
+
+          {domain.status.spf_status !== 'valid' && (
+            <SubduedText fontSize="200">
+              SPF (Sender Policy Framework) is an email authentication method to determine if a
+              bounce domain is allowed to be used with in given sending IP. SPF failures can cause
+              mail to be rejected at some providers. To ensure they pass all SPF checks, publishing
+              SparkPost CNAME in DNS is required for all bounce domains.
+            </SubduedText>
+          )}
+
+          <SubduedLink
+            as={ExternalLink}
+            to={EXTERNAL_LINKS.BOUNCE_DOMAIN_DOCUMENTATION}
+            fontSize="200"
+          >
             Bounce Domain Documentation
           </SubduedLink>
-          <PageLink to="/domains/create">Create a seperate bounce subdomain</PageLink>
+          <PageLink to="/domains/create" fontSize="200">
+            Create a seperate bounce subdomain
+          </PageLink>
         </Stack>
       </Layout.Section>
       <Layout.Section>
@@ -226,12 +227,20 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
               <Stack>
                 {domain.status.spf_status !== 'valid' && (
                   <Box>
-                    <Text as="span" fontSize="400" fontWeight="semibold">
-                      Add SPF Record <Tag color="green">Recommended</Tag>
-                    </Text>
-                    <StyledText as="span" fontSize="400" color="gray.400">
-                      Optional
-                    </StyledText>
+                    <Box display="inline">
+                      <Text as="span" fontSize="300" fontWeight="semibold" role="heading">
+                        Add SPF Record{' '}
+                      </Text>
+                      <Tag color="green" ml="400">
+                        Recommended
+                      </Tag>
+                    </Box>
+
+                    <StyledBox>
+                      <Text as="span" fontSize="200" color="gray.700" fontWeight="400">
+                        Optional
+                      </Text>
+                    </StyledBox>
                   </Box>
                 )}
                 {domain.status.spf_status !== 'valid' && (

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -57,7 +57,7 @@ export default function SetupForSending({ domain, isSectionVisible }) {
               Recommended
             </Tag>
             <Stack>
-              <SubduedText>
+              <SubduedText fontSize="200">
                 DKIM (DomainKeys Identified Mail) is an email authentication method that allows a
                 sender to claim responsibility for a message by using digital signatures generated
                 from private and public keys. DKIM failures can cause messages to be rejected, so
@@ -65,7 +65,11 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                 be verified and used, in order to ensure DKIM checks are passed.
               </SubduedText>
 
-              <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}>
+              <SubduedLink
+                as={ExternalLink}
+                to={EXTERNAL_LINKS.SENDING_DOMAINS_DOCUMENTATION}
+                fontSize="200"
+              >
                 Sending Domain Documentation
               </SubduedLink>
             </Stack>

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -36,17 +36,21 @@ export default function TrackingDnsSection({ id, isSectionVisible, title }) {
   return (
     <Layout>
       <Layout.Section annotated>
+        <Layout.SectionTitle as="h2">{title || 'Tracking'} </Layout.SectionTitle>
         <Stack>
-          <Layout.SectionTitle as="h2">{title || 'Tracking'} </Layout.SectionTitle>
           {unverified && (
-            <SubduedText>
+            <SubduedText fontSize="200">
               Tracking domains are used by mail providers to determine where engagement rate (like
               opens and clicks) should be sent. This allows you to measure the health of your email
               campaigns so that your team is able to create content and mailing lists that maximize
               your potential.
             </SubduedText>
           )}
-          <SubduedLink as={ExternalLink} to={EXTERNAL_LINKS.TRACKING_DOMAIN_DOCUMENTATION}>
+          <SubduedLink
+            as={ExternalLink}
+            to={EXTERNAL_LINKS.TRACKING_DOMAIN_DOCUMENTATION}
+            fontSize="200"
+          >
             Tracking Domain Documentation
           </SubduedLink>
         </Stack>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import {
+  Box,
   Grid,
   Button,
   Banner,
@@ -10,6 +11,7 @@ import {
   TextField,
   Text,
 } from 'src/components/matchbox';
+import { Bold } from 'src/components/text';
 import useModal from 'src/hooks/useModal';
 import { useForm, Controller } from 'react-hook-form';
 import useDomains from '../hooks/useDomains';
@@ -113,7 +115,11 @@ function AllowAnyoneAtModal(props) {
                     control={control}
                     rules={{ required: true }}
                     error={errors?.localPart?.type === 'required' ? 'Required' : ''}
-                    connectRight={<strong>{`@${id}`}</strong>}
+                    connectRight={
+                      <Box paddingLeft="200">
+                        <Bold>{`@${id}`}</Bold>
+                      </Box>
+                    }
                   />
                 </div>
               </Grid.Column>


### PR DESCRIPTION
[FE-1203] UX Feedback for Domain Detail Pages Part - 1

### What Changed
- [x] Reset the state for domains when the Domain Details page unmounts.
- [x] Font size should be 200 in Left well MB.
- [x] Vertical spacing in left well title and info copy should be consistent ~ 12px
- [x] In Verify through email Modal - Textfield should not crash into domain
- [x] Toggle should be closer to text in case of "share with all subaccounts". We need to add max-width to this. 
- [x] Remove extra spaces in v=spf1 mx a ~all
- [x] Update text style for Optional - Grey -7 and size is 200
- [x] Wrong text spec in mini banner component MB. Removed the Text in the banner from `<SubduedText>`
- [x] For Sending and Bounce Domain Page - The “Recommended” tag beside the “Add SPF Record” header is too close, per design update it to be 20px distance - use 400 design token

### How To Test
 -  Verify all the above changes look good.

### To Do
- [ ] Address feedback


[FE-1203]: https://sparkpost.atlassian.net/browse/FE-1203