### PR TITLE
[FE-1197] UX Feedback for Domain Details Pages - Part 3

### DIFF
--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -163,10 +163,10 @@ describe('The domains details page', () => {
         cy.findByRole('heading', { name: 'Domain Status' }).should('be.visible');
         cy.findByRole('heading', { name: 'Link Tracking Domain' }).should('be.visible');
         cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');
-        cy.findByRole('heading', { name: 'Sending' }).should('be.visible');
+        cy.findByRole('heading', { name: 'Sending' }).should('not.be.visible');
         cy.findByRole('heading', { name: 'Bounce' }).should('be.visible');
         cy.findByRole('button', { name: 'Authenticate for SPF' }).should('be.visible');
-        cy.findByRole('heading', { name: 'DNS Verification' }).should('not.be.visible');
+        cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
         cy.findByRole('heading', { name: 'Email Verification' }).should('not.be.visible');
         cy.findByRole('heading', { name: 'Sending and Bounce' }).should('not.be.visible');
       });

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Page, Banner, Button } from 'src/components/matchbox';
+import { Page, Banner, Button, Box } from 'src/components/matchbox';
 import { get as getDomain } from 'src/actions/sendingDomains';
 import Domains from './components';
 import { connect } from 'react-redux';
@@ -12,7 +12,11 @@ import { listTrackingDomains } from 'src/actions/trackingDomains';
 import _ from 'lodash';
 import { TranslatableText } from 'src/components/text';
 import { EXTERNAL_LINKS } from './constants';
+import styled from 'styled-components';
 
+const StyledBox = styled(Box)`
+  max-width: 600px;
+`;
 function DetailsPage(props) {
   const {
     trackingDomainList,
@@ -31,6 +35,14 @@ function DetailsPage(props) {
     readyFor.dkim && readyFor.bounce && domain.status.spf_status === 'valid';
   const isTracking = Boolean(_.find(trackingDomainList, ['domain', match.params.id.toLowerCase()]));
 
+  const handleAllDomains = () => {
+    if (isTracking) return history.push('/domains/list/tracking');
+
+    if (readyFor.bounce) return history.push('/domains/list/bounce');
+
+    return history.push('/domains/list/sending');
+  };
+
   useEffect(() => {
     getDomain(match.params.id);
   }, [getDomain, match.params.id]);
@@ -48,10 +60,7 @@ function DetailsPage(props) {
         title="Domain Details"
         breadcrumbAction={{
           content: 'All Domains',
-          onClick: () =>
-            isTracking
-              ? history.push('/domains/list/tracking')
-              : history.push('/domains/list/sending'),
+          onClick: handleAllDomains,
         }}
       >
         {resolvedStatus === 'unverified' && warningBanner && !isTracking && (
@@ -73,7 +82,12 @@ function DetailsPage(props) {
         )}
         {resolvedStatus === 'blocked' && (
           <Banner status="danger" title="This domain has been blocked by SparkPost" mb="500">
-            ??
+            <StyledBox>
+              If your domain’s status is “Blocked”, it’s generally because your domain is already in
+              use by another SparkPost account, your domain has been previously blocked for sending
+              abusive traffic through our service or another provider, or because one or more of our
+              requirements are not met.
+            </StyledBox>
             <Banner.Actions>
               <SupportTicketLink as={Button}>Create Support ticket</SupportTicketLink>
               <ExternalLink to={EXTERNAL_LINKS.BLOCKED_DOMAIN_DOCUMENTATION}>
@@ -87,7 +101,6 @@ function DetailsPage(props) {
 
         <Domains.SetupForSending
           domain={domain}
-          resolvedStatus={resolvedStatus}
           isSectionVisible={
             resolvedStatus !== 'blocked' && !isTracking && !displaySendingAndBounceSection
           }

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -26,6 +26,7 @@ import {
   selectTrackingDomainsRows,
   selectTrackingDomainsOptions,
 } from 'src/selectors/trackingDomains';
+import { selectTrackingDomainCname } from 'src/selectors/account';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 import { DomainsProvider } from '../context/DomainsContext';
 import { selectCondition } from 'src/selectors/accessConditionState';
@@ -62,6 +63,7 @@ function mapStateToProps(state) {
     verifyEmailLoading: state.sendingDomains.verifyEmailLoading,
     verifyBounceLoading: state.sendingDomains.verifyBounceLoading,
     verifyingTrackingPending: state.trackingDomains.verifyingTrackingPending,
+    trackingDomainCname: selectTrackingDomainCname(state),
   };
 }
 

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -19,8 +19,9 @@ const Field = ({ verified, label, value }) => {
   return <TextField label={label} value={value} readOnly />;
 };
 
-export default function SetupForSending({ domain, resolvedStatus, isSectionVisible }) {
+export default function SetupForSending({ domain, isSectionVisible }) {
   const { verifyDkim, showAlert, userName, verifyDkimLoading } = useDomains();
+  const readyFor = resolveReadyFor(domain.status);
 
   const handleVerifyDkim = () => {
     const { id, subaccount_id: subaccount } = domain;
@@ -48,9 +49,9 @@ export default function SetupForSending({ domain, resolvedStatus, isSectionVisib
     <Layout>
       <Layout.Section annotated>
         <Layout.SectionTitle as="h2">
-          {resolvedStatus === 'unverified' ? 'DNS Verification' : 'Sending'}
+          {!readyFor.dkim ? 'DNS Verification' : 'Sending'}
         </Layout.SectionTitle>
-        {resolvedStatus === 'unverified' && (
+        {!readyFor.dkim && (
           <>
             <Tag color="green" mb="200">
               Recommended
@@ -73,7 +74,7 @@ export default function SetupForSending({ domain, resolvedStatus, isSectionVisib
       </Layout.Section>
       <Layout.Section>
         <Panel>
-          {resolvedStatus !== 'verified' ? (
+          {!readyFor.dkim ? (
             <Panel.Section>
               Add these{' '}
               <Text as="span" fontWeight="semibold">
@@ -101,7 +102,7 @@ export default function SetupForSending({ domain, resolvedStatus, isSectionVisib
           )}
           <Panel.Section>
             <Stack>
-              {resolvedStatus !== 'verified' && (
+              {!readyFor.dkim && (
                 <>
                   <Text as="label" fontWeight="500" fontSize="200">
                     Type
@@ -109,17 +110,9 @@ export default function SetupForSending({ domain, resolvedStatus, isSectionVisib
                   <Text as="p">TXT</Text>
                 </>
               )}
-              <Field
-                label="Hostname"
-                value={domain.dkimHostname}
-                verified={resolvedStatus === 'verified'}
-              />
-              <Field
-                label="Value"
-                value={domain.dkimValue}
-                verified={resolvedStatus === 'verified'}
-              />
-              {resolvedStatus !== 'verified' && (
+              <Field label="Hostname" value={domain.dkimHostname} verified={readyFor.dkim} />
+              <Field label="Value" value={domain.dkimValue} verified={readyFor.dkim} />
+              {!readyFor.dkim && (
                 <Checkbox
                   id="add-txt-to-godaddy"
                   label={<>The TXT record has been added to the DNS provider</>}
@@ -128,7 +121,7 @@ export default function SetupForSending({ domain, resolvedStatus, isSectionVisib
               {/*API doesn't support it; Do we want to store this in ui option*/}
             </Stack>
           </Panel.Section>
-          {resolvedStatus !== 'verified' && (
+          {!readyFor.dkim && (
             <Panel.Section>
               <Button variant="primary" onClick={handleVerifyDkim} loading={verifyDkimLoading}>
                 Verify Domain

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -15,7 +15,12 @@ const Field = ({ verified, label, value }) => {
 };
 
 export default function TrackingDnsSection({ id, isSectionVisible, title }) {
-  const { trackingDomains, verifyTrackingDomain, verifyingTrackingPending } = useDomains();
+  const {
+    trackingDomainCname,
+    trackingDomains,
+    verifyTrackingDomain,
+    verifyingTrackingPending,
+  } = useDomains();
   let trackingDomain = _.find(trackingDomains, ['domainName', id.toLowerCase()]) || {};
   const { unverified } = trackingDomain;
 
@@ -77,7 +82,7 @@ export default function TrackingDnsSection({ id, isSectionVisible, title }) {
                 </>
               )}
               <Field label="Hostname" value={trackingDomain.domainName} verified={!unverified} />
-              <Field label="Value" value="placeholder" verified={!unverified} />
+              <Field label="Value" value={trackingDomainCname} verified={!unverified} />
             </Stack>
           </Panel.Section>
           {unverified && (


### PR DESCRIPTION
[FE-1197] UX Feedback for Domain Details Pages - Part 3

### What Changed

- [x] For tracking Domain Detail Page - update the placeholder value to be spgo.io etc use the the same values that we have in the unverified tracking domains banner

- [x] Blocked Domain Banner sub-text should be updated from placeholder to “If your domain’s status is “Blocked”, it’s generally because your domain is already in use by another SparkPost account, your domain has been previously blocked for sending abusive traffic through our service or another provider, or because one or more of our requirements are not met.”

- [x] If set up for sending means they just did the email verification not the sending DKIM verification.. So on that detail page the version to copy and paste the Hostname and value should appear with the details about DKIM information

- [x] The back buttons from bounce domain pages should redirect to /domains/list/bounce

### How To Test
 - Verify if the above changes look good
### To Do
- [ ] Address feedback


[FE-1197]: https://sparkpost.atlassian.net/browse/FE-1197