### PR TITLE
SA-1763: Subaccounts are called on mounting report builder

### DIFF
--- a/cypress/fixtures/metrics/deliverability/subaccount/200.get.json
+++ b/cypress/fixtures/metrics/deliverability/subaccount/200.get.json
@@ -5,14 +5,14 @@
       "count_rendered": 200,
       "count_accepted": 300,
       "count_bounce": 400,
-      "subaccount_id": 1
+      "subaccount_id": 101
     },
     {
       "count_targeted": 500,
       "count_rendered": 600,
       "count_accepted": 700,
       "count_bounce": 800,
-      "subaccount_id": 2
+      "subaccount_id": 102
     },
     {
       "count_targeted": 900,

--- a/cypress/tests/integration/signals-analytics/analytics-report/analyticsReportBreakdownTable.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/analyticsReportBreakdownTable.spec.js
@@ -209,12 +209,14 @@ if (IS_HIBANA_ENABLED) {
 
     it('renders data broken down by "Subaccount"', () => {
       cy.clock(STABLE_UNIX_DATE);
+
       cy.stubRequest({
         url: '/api/v1/metrics/deliverability/subaccount**/*',
         fixture: 'metrics/deliverability/subaccount/200.get.json',
         requestAlias: 'getSubaccount',
       });
-
+      cy.visit(PAGE_URL);
+      cy.wait('@getSubaccountList');
       cy.findByLabelText('Break Down By')
         .scrollIntoView()
         .select('Subaccount', { force: true });
@@ -245,7 +247,7 @@ if (IS_HIBANA_ENABLED) {
 
       verifyRow({
         rowIndex: 2,
-        firstCell: 'Subaccount 2',
+        firstCell: 'Fake Subaccount 2 (ID 102)',
         secondCell: '500',
         thirdCell: '600',
         fourthCell: '700',
@@ -254,7 +256,7 @@ if (IS_HIBANA_ENABLED) {
 
       verifyRow({
         rowIndex: 3,
-        firstCell: 'Subaccount 1',
+        firstCell: 'Fake Subaccount 1 (ID 101)',
         secondCell: '100',
         thirdCell: '200',
         fourthCell: '300',

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -93,10 +93,8 @@ export function ReportBuilder({
   }, [getSubscription]);
 
   useEffect(() => {
-    if (isComparatorsEnabled) {
-      getSubaccountsList();
-    }
-  }, [isComparatorsEnabled, getSubaccountsList]);
+    getSubaccountsList();
+  }, [getSubaccountsList]);
 
   useEffect(() => {
     if (isSavedReportsEnabled) {

--- a/src/pages/reportBuilder/components/ReportTable.js
+++ b/src/pages/reportBuilder/components/ReportTable.js
@@ -128,16 +128,16 @@ export const ReportTable = props => {
 
   return (
     <>
-      <Panel.LEGACY marginBottom="-1px">
-        <Panel.LEGACY.Section>
+      <Panel marginBottom="-1px">
+        <Panel.Section>
           <GroupByOption
             _getTableData={_getTableData}
             groupBy={groupBy}
             hasSubaccounts={hasSubaccounts}
             tableLoading={tableLoading}
           />
-        </Panel.LEGACY.Section>
-      </Panel.LEGACY>
+        </Panel.Section>
+      </Panel>
       <div data-id="summary-table">{renderTable()}</div>
     </>
   );

--- a/src/pages/reportBuilder/components/ReportTable.js
+++ b/src/pages/reportBuilder/components/ReportTable.js
@@ -16,7 +16,7 @@ import styles from './ReportTable.module.scss';
 
 const tableWrapper = props => {
   return (
-    <Panel.LEGACY borderTop="0">
+    <Panel.LEGACY>
       <Table freezeFirstColumn>{props.children}</Table>
     </Panel.LEGACY>
   );


### PR DESCRIPTION
### What Changed
 - Subaccounts called on mounting report builder
 - Subaccounts are no longer feature flagged behind additional comparators
 - Subaccounts called once

### How To Test
 - On any account (with or without account ui feature flag `allow_report_filters_v2`), subaccounts API call should be made
 - Click on Group By selector (bottom of page)
 - Select subaaccounts
 - Subaccount names should populate (if available)

### To Do
- [ ] Address feedback
