### PR TITLE
SA-1770: Fixed filters not properly being pulled from query params

### DIFF
--- a/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
@@ -40,6 +40,21 @@ if (IS_HIBANA_ENABLED) {
       cy.findByLabelText('Break Down By').should('be.visible');
     });
 
+    it('renders the initial page based on query params', () => {
+      cy.visit(`${PAGE_URL}&filters=Recipient Domain%3Atest.com`);
+      cy.withinMainContent(() => {
+        cy.findAllByText('Targeted').should('have.length', 2);
+        cy.findAllByText('Accepted').should('have.length', 2);
+        cy.findAllByText('Bounces').should('have.length', 2);
+      });
+      cy.findByDataId('report-options').within(() => {
+        cy.findByText('Filters').should('be.visible');
+        cy.findByText('Recipient Domain').should('be.visible');
+        cy.findByText('equals').should('be.visible');
+        cy.findByText('test.com').should('be.visible');
+      });
+    });
+
     it('filters by metric', () => {
       // 1. Open the drawer, uncheck default metrics, check all metrics
       cy.findByRole('button', { name: 'Add Metrics' }).click();

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -126,7 +126,7 @@ export function ReportBuilder({
       setReport(report);
       refreshReportOptions({ ...reportOptions, filters: [...reportFilters, ...optionsFilters] });
     } else {
-      refreshReportOptions(options);
+      refreshReportOptions({ ...options, filters: optionsFilters });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSavedReportsEnabled, reportsStatus, reports, subaccountsReady]);

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -102,16 +102,18 @@ export function ReportBuilder({
     }
   }, [isSavedReportsEnabled, getReports]);
 
-  //Initializes the report options with the search
+  //Grabs report options from the URL query params (as well as report ID)
   useEffect(() => {
-    const { report: reportId, filters: optionsFilters = [], ...options } = parseSearch(
+    const { report: reportId, filters: urlFilters = [], ...urlOptions } = parseSearch(
       location.search,
     );
 
+    //Looks for report with report ID
     const allReports = [...reports, ...PRESET_REPORT_CONFIGS];
     const report = allReports.find(({ id }) => id === reportId);
 
-    //Waiting on reports (if enabled) to initialize
+    //Waiting on reports to load (if enabled) to finish initializeing
+    //Waiting on subaccounts (if using comparators) to finish initializing
     if (
       (reportId && isSavedReportsEnabled && reportsStatus !== 'success') ||
       (isComparatorsEnabled && !subaccountsReady) ||
@@ -120,13 +122,14 @@ export function ReportBuilder({
       return;
     }
 
-    // Initializes once it finds relavant report
+    // If report is found from ID, consolidates reportOptions from URL and report
     if (report) {
       const { filters: reportFilters = [], ...reportOptions } = parseSearch(report.query_string);
       setReport(report);
-      refreshReportOptions({ ...reportOptions, filters: [...reportFilters, ...optionsFilters] });
+      refreshReportOptions({ ...reportOptions, filters: [...reportFilters, ...urlFilters] });
     } else {
-      refreshReportOptions({ ...options, filters: optionsFilters });
+      //Initializes w/ just URL options
+      refreshReportOptions({ ...urlOptions, filters: urlFilters });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSavedReportsEnabled, reportsStatus, reports, subaccountsReady]);


### PR DESCRIPTION
### What Changed
 - Filter are properly attached when parsed from URL params

### How To Test
 - Go to report builder
 - Don't select a report
 - Add a filter
 - Copy and paste URL
 - Filter should persist through URL

### To Do
- [ ] Address feedback
