### PR TITLE
SA-1805 - (UI) Advanced comparators error with less than 3 character values

### DIFF
--- a/cypress/tests/integration/signals-analytics/analytics-report/filtersForm.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/filtersForm.spec.js
@@ -30,7 +30,7 @@ if (IS_HIBANA_ENABLED) {
       });
     });
 
-    it('clears current filter values when the user swaps between "compare by" values', () => {
+    it('validates the user\'s entry performing a "contains" or "does not contain" filter', () => {
       navigateToForm();
 
       cy.findByLabelText(TYPE_LABEL).select('Sending Domain');
@@ -41,6 +41,30 @@ if (IS_HIBANA_ENABLED) {
       cy.findByLabelText(COMPARE_BY_LABEL).select('does not contain');
       cy.findByText('hello.com').should('not.be.visible');
       cy.findByText('world.org').should('not.be.visible');
+    });
+
+    it('clears current filter values when the user swaps between "compare by" values', () => {
+      navigateToForm();
+
+      cy.findByLabelText(TYPE_LABEL).select('Sending Domain');
+      cy.findByLabelText(COMPARE_BY_LABEL).select('contains');
+      cy.findByLabelText('Sending Domain').type('hello.com ');
+      cy.findByText('hello.com').should('be.visible');
+
+      // Verify that the error renders until the user resolves the length bug
+      cy.findByLabelText('Sending Domain').type('h ');
+      cy.findByText('3 or more characters required').should('be.visible');
+      cy.findByLabelText('Sending Domain').type('e');
+      cy.findByText('3 or more characters required').should('be.visible');
+      cy.findByLabelText('Sending Domain').type('l');
+      cy.findByText('3 or more characters required').should('not.be.visible');
+      cy.findByLabelText('Sending Domain').clear();
+
+      // The error is removed when the user deletes all of their entry
+      cy.findByLabelText('Sending Domain').type('he ');
+      cy.findByText('3 or more characters required').should('be.visible');
+      cy.findByLabelText('Sending Domain').clear();
+      cy.findByText('3 or more characters required').should('not.be.visible');
     });
 
     it('only renders the "is equal to" and "is not equal to" comparison options when the user selects the "Subaccount" filter type', () => {

--- a/cypress/tests/integration/signals-analytics/analytics-report/filtersForm.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/filtersForm.spec.js
@@ -30,7 +30,7 @@ if (IS_HIBANA_ENABLED) {
       });
     });
 
-    it('validates the user\'s entry performing a "contains" or "does not contain" filter', () => {
+    it('clears current filter values when the user swaps between "compare by" values', () => {
       navigateToForm();
 
       cy.findByLabelText(TYPE_LABEL).select('Sending Domain');
@@ -43,7 +43,7 @@ if (IS_HIBANA_ENABLED) {
       cy.findByText('world.org').should('not.be.visible');
     });
 
-    it('clears current filter values when the user swaps between "compare by" values', () => {
+    it('validates the user\'s entry performing a "contains" or "does not contain" filter', () => {
       navigateToForm();
 
       cy.findByLabelText(TYPE_LABEL).select('Sending Domain');

--- a/cypress/tests/integration/signals-analytics/analytics-report/filtersForm.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/filtersForm.spec.js
@@ -51,7 +51,7 @@ if (IS_HIBANA_ENABLED) {
       cy.findByLabelText('Sending Domain').type('hello.com ');
       cy.findByText('hello.com').should('be.visible');
 
-      // Verify that the error renders until the user resolves the length bug
+      // The error renders until the user resolves the length bug on change
       cy.findByLabelText('Sending Domain').type('h ');
       cy.findByText('3 or more characters required').should('be.visible');
       cy.findByLabelText('Sending Domain').type('e');
@@ -65,6 +65,18 @@ if (IS_HIBANA_ENABLED) {
       cy.findByText('3 or more characters required').should('be.visible');
       cy.findByLabelText('Sending Domain').clear();
       cy.findByText('3 or more characters required').should('not.be.visible');
+
+      // The error also renders on blur when the user's entry violates the requirements
+      cy.findByLabelText('Sending Domain')
+        .type('he')
+        .blur();
+      cy.findByText('3 or more characters required').should('be.visible');
+      cy.findByLabelText('Sending Domain').type('l');
+      cy.findByText('3 or more characters required').should('not.be.visible');
+      cy.findByLabelText('Sending Domain')
+        .type('lo.net')
+        .blur();
+      cy.findByText('hello.net').should('be.visible');
     });
 
     it('only renders the "is equal to" and "is not equal to" comparison options when the user selects the "Subaccount" filter type', () => {
@@ -110,7 +122,7 @@ if (IS_HIBANA_ENABLED) {
         // Verifying remove button rendering within the first group
         cy.findByLabelText(TYPE_LABEL).select('Campaign');
         cy.findByLabelText(COMPARE_BY_LABEL).select('does not contain');
-        cy.findByLabelText('Campaign').type('my-campaign is the best ');
+        cy.findByLabelText('Campaign').type('my-campaign will work well ');
         cy.findByRole('button', { name: 'Add And Filter' }).click();
         getGroupingByIndex(0).within(() => {
           cy.findAllByRole('button', { name: 'Remove Filter' }).should('have.length', 2);
@@ -131,7 +143,7 @@ if (IS_HIBANA_ENABLED) {
         getGroupingByIndex(1).within(() => {
           cy.findByLabelText(TYPE_LABEL).select('Template');
           cy.findByLabelText(COMPARE_BY_LABEL).select('contains');
-          cy.findByLabelText('Template').type('this is a template ');
+          cy.findByLabelText('Template').type('my favorite template ');
         });
         cy.findByRole('button', { name: 'Add And Grouping' }).click();
         getGroupingByIndex(2).within(() => {

--- a/src/hooks/useMultiEntry/useMultiEntry.js
+++ b/src/hooks/useMultiEntry/useMultiEntry.js
@@ -69,6 +69,8 @@ const defaultInitialState = {
 export default function useMultiEntry(initialState) {
   const prevInitialState = usePrevious(initialState);
   const [state, dispatch] = useReducer(reducer, { ...defaultInitialState, ...initialState });
+  const hasMinLengthError = value =>
+    state.minLength && value.length > 0 && value.length < state.minLength;
 
   // If the initial state updates (i.e., through an external source of state),
   // update the value list accordingly
@@ -84,7 +86,7 @@ export default function useMultiEntry(initialState) {
       e.preventDefault();
 
       // Configurable min length returns an error when attempting to update valueList before meeting the requirement
-      if (state.minLength && e.target.value.length < state.minLength) {
+      if (hasMinLengthError(e.target.value)) {
         return dispatch({
           type: 'ERROR',
           error: `${state.minLength} or more characters required`,
@@ -104,6 +106,14 @@ export default function useMultiEntry(initialState) {
   }
 
   function handleBlur(e) {
+    // Configurable min length returns an error when attempting to update valueList before meeting the requirement
+    if (hasMinLengthError(e.target.value)) {
+      return dispatch({
+        type: 'ERROR',
+        error: `${state.minLength} or more characters required`,
+      });
+    }
+
     return dispatch({ type: 'UPDATE_VALUES', value: e.target.value });
   }
 

--- a/src/hooks/useMultiEntry/useMultiEntry.js
+++ b/src/hooks/useMultiEntry/useMultiEntry.js
@@ -13,10 +13,18 @@ function reducer(state, action) {
       if (action.value.includes(' ')) {
         const additionalValues = action.value.split(' ');
 
-        return { ...state, value: '', valueList: [...state.valueList, ...additionalValues] };
+        return {
+          ...state,
+          value: '',
+          valueList: [...state.valueList, ...additionalValues],
+        };
       }
 
-      return { ...state, value: '', valueList: [...state.valueList, action.value] };
+      return {
+        ...state,
+        value: '',
+        valueList: [...state.valueList, action.value],
+      };
 
     case 'SET_VALUE_LIST': {
       return { ...state, valueList: action.valueList };
@@ -31,18 +39,19 @@ function reducer(state, action) {
       return { ...state, valueList };
     }
 
-    case 'REMOVE_LAST_VALUE': {
-      const valueList = state.valueList.filter(
-        (_value, index) => index + 1 !== state.valueList.length,
-      );
-
-      return {
-        ...state,
-        valueList,
-      };
+    case 'ERROR': {
+      return { ...state, error: action.error };
     }
 
     case 'VALUE_CHANGE': {
+      // Remove the minimum length error as the user's entry changes, but only when the problem is fixed
+      if (
+        state.minLength &&
+        (action.value.length === 0 || action.value.length >= state.minLength)
+      ) {
+        return { ...state, value: action.value, error: undefined };
+      }
+
       return { ...state, value: action.value };
     }
 
@@ -54,6 +63,7 @@ function reducer(state, action) {
 const defaultInitialState = {
   value: '',
   valueList: [],
+  error: undefined, // TODO: If other error scenarios are introduced, this should be an object that contains each type of error
 };
 
 export default function useMultiEntry(initialState) {
@@ -72,6 +82,14 @@ export default function useMultiEntry(initialState) {
     // Spacebar or enter key
     if (e.keyCode === 32 || e.keyCode === 13) {
       e.preventDefault();
+
+      // Configurable min length returns an error when attempting to update valueList before meeting the requirement
+      if (state.minLength && e.target.value.length < state.minLength) {
+        return dispatch({
+          type: 'ERROR',
+          error: `${state.minLength} or more characters required`,
+        });
+      }
 
       return dispatch({ type: 'UPDATE_VALUES', value: e.target.value });
     }
@@ -92,6 +110,8 @@ export default function useMultiEntry(initialState) {
   return {
     value: state.value,
     valueList: state.valueList,
+    minLength: state.minLength,
+    error: state.error,
     handleKeyDown,
     handleBlur,
     handleChange,

--- a/src/hooks/useMultiEntry/useMultiEntry.test.js
+++ b/src/hooks/useMultiEntry/useMultiEntry.test.js
@@ -6,7 +6,7 @@ import { ComboBoxTextField } from 'src/components/matchbox';
 import TestApp from 'src/__testHelpers__/TestApp';
 
 function UseMultiEntryDemo(props) {
-  const { initialValue = '', initialValueList = [] } = props;
+  const { initialValue = '', initialValueList = [], minLength } = props;
   const {
     value,
     valueList,
@@ -14,7 +14,8 @@ function UseMultiEntryDemo(props) {
     handleChange,
     handleBlur,
     handleRemove,
-  } = useMultiEntry({ value: initialValue, valueList: initialValueList });
+    error,
+  } = useMultiEntry({ value: initialValue, valueList: initialValueList, minLength });
 
   return (
     <TestApp isHibanaEnabled={true}>
@@ -27,6 +28,7 @@ function UseMultiEntryDemo(props) {
         label="Filters"
         value={value}
         selectedItems={valueList}
+        error={error}
         itemToString={value => value}
       />
     </TestApp>
@@ -158,5 +160,25 @@ describe('useMultiEntry', () => {
     userEvent.click(removeButtons[0]);
 
     expect(screen.queryByText('again')).not.toBeInTheDocument();
+  });
+
+  it('renders an error when the user violates the passed in minLength as the user types', () => {
+    render(<UseMultiEntryDemo minLength={3} />);
+    userEvent.type(getComboBox(), 'h{space}');
+    expect(screen.getByText('3 or more characters required')).toBeInTheDocument();
+    userEvent.type(getComboBox(), 'e{enter}');
+    expect(screen.getByText('3 or more characters required')).toBeInTheDocument();
+    userEvent.type(getComboBox(), 'l'); // The user has typed `hel` by this point
+    expect(screen.queryByText('3 or more characters required')).not.toBeInTheDocument();
+  });
+
+  it('renders an error when the user violates the passed in minLength when the user blurs the field', () => {
+    render(<UseMultiEntryDemo minLength={3} />);
+    userEvent.type(getComboBox(), 'he');
+    userEvent.tab();
+    expect(screen.getByText('3 or more characters required')).toBeInTheDocument();
+    userEvent.type(getComboBox(), 'l');
+    userEvent.tab();
+    expect(screen.queryByText('3 or more characters required')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
+++ b/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
@@ -211,6 +211,7 @@ function FiltersForm({
                                         onKeyDown={props.handleKeyDown}
                                         onChange={props.handleChange}
                                         value={props.value}
+                                        error={props.error}
                                         selectedItems={props.valueList}
                                         itemToString={item => (item ? item : '')}
                                       />

--- a/src/pages/reportBuilder/components/FiltersForm/components.js
+++ b/src/pages/reportBuilder/components/FiltersForm/components.js
@@ -72,11 +72,12 @@ export function MultiEntryController({
   const {
     value,
     valueList,
+    error,
     handleKeyDown,
     handleChange,
     handleBlur,
     handleRemove,
-  } = useMultiEntry({ valueList: initialValueList });
+  } = useMultiEntry({ valueList: initialValueList, minLength: 3 });
 
   useEffect(() => {
     setFilterValues({
@@ -90,6 +91,7 @@ export function MultiEntryController({
     id,
     value,
     valueList,
+    error,
     handleKeyDown,
     handleChange,
     handleBlur,


### PR DESCRIPTION
[SA-1805](https://sparkpost.atlassian.net/browse/SA-1805)

### What Changed
- Adds new `error` and `minLength` properties to the `useMultiEntry` hook state
- Adds `minLength` of `3` to the `MultiEntryController` used in the `FiltersForm`
- Adds supporting integration and unit tests

### How To Test
- With Hibana enabled and the `allow_report_filters_v2` feature flag enabled, go to `/signals/analytics`
- Click on "Add Filters" and change the compare by value to "contains" or "does not contain"
- type 1 or 2 characters and try adding the tag to the field with the space key, enter key, or by blurring the field
- An error should render!
- The error should be removed when: the user clears their entry entirely _or_ the user enters 3 or more characters

### To Do
- [ ] Incorporate feedback
