### PR TITLE
FE-1226 - Domain list page - status filter "or" logic

### DIFF
--- a/cypress/tests/integration/domains/listPage.spec.js
+++ b/cypress/tests/integration/domains/listPage.spec.js
@@ -488,16 +488,20 @@ describe('The domains list page', () => {
 
         cy.findByRole('button', { name: 'Domain Status' }).click();
 
-        cy.findByLabelText('Blocked').check({ force: true });
         verifyTableRow({
-          rowIndex: 0,
+          rowIndex: 1,
           domainName: 'blocked.com',
           creationDate: 'Aug 6, 2017',
           statusTags: ['Blocked'],
         });
         cy.findByLabelText('Blocked').uncheck({ force: true });
+        verifyTableRow({
+          rowIndex: 1,
+          domainName: 'spf-valid.com',
+          creationDate: 'Aug 5, 2017',
+          statusTags: ['Sending', 'SPF Valid'],
+        });
 
-        cy.findByLabelText('Unverified').check({ force: true });
         verifyTableRow({
           rowIndex: 0,
           domainName: 'with-a-subaccount.com',
@@ -505,45 +509,64 @@ describe('The domains list page', () => {
           statusTags: ['Unverified'],
         });
         verifyTableRow({
-          rowIndex: 1,
+          rowIndex: 3,
           domainName: 'failed-verification.com',
           creationDate: 'Aug 3, 2017',
           statusTags: ['Unverified'],
         });
         cy.findByLabelText('Unverified').uncheck({ force: true });
-
-        cy.findByLabelText('SPF Valid').check({ force: true });
         verifyTableRow({
           rowIndex: 0,
-          domainName: 'blocked.com',
-          creationDate: 'Aug 6, 2017',
-          statusTags: ['Blocked'],
-        });
-        verifyTableRow({
-          rowIndex: 1,
           domainName: 'spf-valid.com',
           creationDate: 'Aug 5, 2017',
-          statusTags: ['SPF Valid'],
+          statusTags: ['Sending', 'SPF Valid'],
         });
-        cy.findByLabelText('SPF Valid').uncheck({ force: true });
-
-        cy.findByLabelText('Bounce').check({ force: true });
         verifyTableRow({
-          rowIndex: 0,
+          rowIndex: 3,
           domainName: 'default-bounce.com',
           creationDate: 'Aug 1, 2017',
           statusTags: ['Sending', 'Bounce'],
         });
-        cy.findByLabelText('Bounce').uncheck({ force: true });
 
-        cy.findByLabelText('DKIM Signing').check({ force: true });
+        cy.findByLabelText('SPF Valid').uncheck({ force: true });
         verifyTableRow({
           rowIndex: 0,
           domainName: 'dkim-signing.com',
           creationDate: 'Aug 4, 2017',
           statusTags: ['Sending', 'DKIM Signing'],
         });
+
+        cy.findByLabelText('Bounce').uncheck({ force: true });
+        verifyTableRow({
+          rowIndex: 0,
+          domainName: 'dkim-signing.com',
+          creationDate: 'Aug 4, 2017',
+          statusTags: ['Sending', 'DKIM Signing'],
+        });
+        verifyTableRow({
+          rowIndex: 1,
+          domainName: 'ready-for-sending.com',
+          creationDate: 'Aug 2, 2017',
+          statusTags: ['Sending'],
+        });
+        cy.get('tbody tr')
+          .eq(2)
+          .should('not.exist');
+
         cy.findByLabelText('DKIM Signing').uncheck({ force: true });
+        verifyTableRow({
+          rowIndex: 0,
+          domainName: 'ready-for-sending.com',
+          creationDate: 'Aug 2, 2017',
+          statusTags: ['Sending'],
+        });
+        cy.get('tbody tr')
+          .eq(1)
+          .should('not.exist');
+
+        cy.findByLabelText('Sending Domain').uncheck({ force: true });
+
+        cy.findByText('There is no data to display').should('be.visible');
       });
     });
 
@@ -879,38 +902,22 @@ describe('The domains list page', () => {
         cy.wait(['@trackingDomainsReq', '@subaccountsReq']);
 
         cy.findByRole('button', { name: 'Domain Status' }).click();
-        cy.findByLabelText('Tracking Domain').check({ force: true });
+        cy.findByLabelText('Tracking Domain').uncheck({ force: true });
+        verifyTableRow({
+          rowIndex: 0,
+          domainName: 'blocked.com',
+          status: 'Blocked',
+        });
         verifyTableRow({
           rowIndex: 1,
-          domainName: 'verified.com',
-          status: 'Tracking',
-        });
-        verifyTableRow({
-          rowIndex: 0,
-          domainName: 'verified-and-default.com',
-          status: 'Tracking',
-        });
-        verifyTableRow({
-          rowIndex: 2,
-          domainName: 'with-subaccount-assignment.com',
-          status: 'Tracking',
-          subaccount: 'Fake Subaccount 1 (101)',
-        });
-        cy.location().should(loc => {
-          expect(loc.search).to.eq('?verified=true');
-        });
-        cy.findByLabelText('Tracking Domain').uncheck({ force: true });
-        cy.findByLabelText('Unverified').check({ force: true });
-        cy.location().should(loc => {
-          expect(loc.search).to.eq('?unverified=true');
-        });
-        verifyTableRow({
-          rowIndex: 0,
           domainName: 'unverified.com',
           status: 'Unverified',
         });
+        cy.location().should(loc => {
+          expect(loc.search).to.eq('?unverified=true&blocked=true');
+        });
+
         cy.findByLabelText('Unverified').uncheck({ force: true });
-        cy.findByLabelText('Blocked').check({ force: true });
         cy.location().should(loc => {
           expect(loc.search).to.eq('?blocked=true');
         });
@@ -920,6 +927,28 @@ describe('The domains list page', () => {
           status: 'Blocked',
         });
         cy.findByLabelText('Blocked').uncheck({ force: true });
+        cy.findByLabelText('Unverified').check({ force: true });
+
+        cy.location().should(loc => {
+          expect(loc.search).to.eq('?unverified=true');
+        });
+        verifyTableRow({
+          rowIndex: 0,
+          domainName: 'unverified.com',
+          status: 'Unverified',
+        });
+
+        cy.findByLabelText('Unverified').uncheck({ force: true });
+        cy.findByLabelText('Tracking Domain').check({ force: true });
+
+        cy.location().should(loc => {
+          expect(loc.search).to.eq('?verified=true');
+        });
+        verifyTableRow({
+          rowIndex: 1,
+          domainName: 'verified.com',
+          status: 'Tracking',
+        });
       });
 
       it('syncs domain status with query params', () => {

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React, { useEffect, useRef, useReducer } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import { ApiErrorBanner, Empty, Loading } from 'src/components';

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -210,8 +210,11 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
   const firstLoad = useRef(true);
   useEffect(() => {
     if (!listPending) {
-      const statusFilterNames = Object.keys(filters).filter(i => i !== 'domainName');
+      const allStatusFilterNames = Object.keys(filters).filter(i => i !== 'domainName');
       const activeStatusFilters = getActiveStatusFilters(filters);
+      const statusFiltersToApply = !activeStatusFilters.length
+        ? allStatusFilterNames
+        : activeStatusFilters.map(i => i.name);
       const domainNameFilter = filters['domainName'];
 
       if (firstLoad.current) {
@@ -219,9 +222,7 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
 
         filtersStateDispatch({
           type: 'LOAD',
-          names: !activeStatusFilters.length
-            ? statusFilterNames
-            : activeStatusFilters.map(i => i.name),
+          names: statusFiltersToApply,
           domainName: domainNameFilter,
         });
 

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -110,65 +110,37 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
 
   const domains = renderBounceOnly ? bounceDomains : sendingDomains;
 
+  const filter = React.useMemo(() => customDomainStatusFilter, []);
+
   const data = React.useMemo(() => domains, [domains]);
   const columns = React.useMemo(
     () => [
       {
         Header: 'Blocked',
         accessor: 'blocked',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       { Header: 'CreationTime', accessor: 'creationTime' },
       {
         Header: 'DefaultBounceDomain',
         accessor: 'defaultBounceDomain',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       { Header: 'DomainName', accessor: 'domainName' },
       {
         Header: 'ReadyForBounce',
         accessor: 'readyForBounce',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       {
         Header: 'ReadyForDKIM',
         accessor: 'readyForDKIM',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       {
         Header: 'ReadyForSending',
         accessor: 'readyForSending',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       { Header: 'SharedWithSubaccounts', accessor: 'sharedWithSubaccounts', canFilter: false },
       { Header: 'SubaccountId', accessor: 'subaccountId', canFilter: false },
@@ -176,27 +148,15 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
       {
         Header: 'Unverified',
         accessor: 'unverified',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       {
         Header: 'ValidSPF',
         accessor: 'validSPF',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
     ],
-    [],
+    [filter],
   );
   const sortBy = React.useMemo(
     () => [

--- a/src/pages/domains/components/TableFilters.js
+++ b/src/pages/domains/components/TableFilters.js
@@ -50,6 +50,23 @@ export function reducer(state, action) {
       };
     }
 
+    case 'LOAD': {
+      const checkboxes = state.checkboxes.map(filter => {
+        const isChecked = action.names.indexOf(filter.name) >= 0;
+
+        return {
+          ...filter,
+          isChecked: isChecked,
+        };
+      });
+
+      return {
+        ...state,
+        domainName: action.domainName,
+        checkboxes,
+      };
+    }
+
     case 'RESET':
       return action.state;
 

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useReducer } from 'react';
+/* eslint-disable no-unused-vars */
+import React, { useEffect, useRef, useReducer } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import { ApiErrorBanner, Empty, Loading } from 'src/components';
 import { Pagination } from 'src/components/collection';
@@ -9,7 +10,12 @@ import { API_ERROR_MESSAGE } from '../constants';
 import useDomains from '../hooks/useDomains';
 import TableFilters, { reducer as tableFiltersReducer } from './TableFilters';
 import TrackingDomainsTable from './TrackingDomainsTable';
-import getReactTableFilters from '../helpers/getReactTableFilters';
+import {
+  getReactTableFilters,
+  customDomainStatusFilter,
+  getActiveStatusFilters,
+  filterStateToParams,
+} from '../helpers';
 
 const filtersInitialState = {
   domainName: undefined,
@@ -17,17 +23,17 @@ const filtersInitialState = {
     {
       label: 'Tracking Domain',
       name: 'verified',
-      isChecked: false,
+      isChecked: true,
     },
     {
       label: 'Unverified',
       name: 'unverified',
-      isChecked: false,
+      isChecked: true,
     },
     {
       label: 'Blocked',
       name: 'blocked',
-      isChecked: false,
+      isChecked: true,
     },
   ],
 };
@@ -71,14 +77,44 @@ export default function TrackingDomainsTab() {
   const data = React.useMemo(() => trackingDomains, [trackingDomains]);
   const columns = React.useMemo(
     () => [
-      { Header: 'Blocked', accessor: 'blocked' },
+      {
+        Header: 'Blocked',
+        accessor: 'blocked',
+        filter: (rows, columnIds, value) => {
+          const column = columnIds[0];
+          const mappedRows = rows
+            .map(row => (row.values[column] === value ? row : false))
+            .filter(Boolean);
+          return mappedRows;
+        },
+      },
       { Header: 'DefaultTrackingDomain', accessor: 'defaultTrackingDomain' },
       { Header: 'DomainName', accessor: 'domainName' },
       { Header: 'SharedWithSubaccounts', accessor: 'sharedWithSubaccounts' },
       { Header: 'SubaccountId', accessor: 'subaccountId' },
       { Header: 'SubaccountName', accessor: 'subaccountName' },
-      { Header: 'Unverified', accessor: 'unverified' },
-      { Header: 'Verified', accessor: 'verified' },
+      {
+        Header: 'Unverified',
+        accessor: 'unverified',
+        filter: (rows, columnIds, value) => {
+          const column = columnIds[0];
+          const mappedRows = rows
+            .map(row => (row.values[column] === value ? row : false))
+            .filter(Boolean);
+          return mappedRows;
+        },
+      },
+      {
+        Header: 'Verified',
+        accessor: 'verified',
+        filter: (rows, columnIds, value) => {
+          const column = columnIds[0];
+          const mappedRows = rows
+            .map(row => (row.values[column] === value ? row : false))
+            .filter(Boolean);
+          return mappedRows;
+        },
+      },
     ],
     [],
   );
@@ -120,35 +156,34 @@ export default function TrackingDomainsTab() {
     }
   }, [hasSubaccounts, listSubaccounts, subaccounts]);
 
-  // sync the params with filters on page load
-  useEffect(() => {
-    Object.keys(filters).forEach(key => {
-      if (key === 'domainName') {
-        filtersStateDispatch({ type: 'DOMAIN_FILTER_CHANGE', value: filters['domainName'] }); // SET UI INPUT VALUES
-      } else if (filters[key] === 'true') {
-        filtersStateDispatch({ type: 'TOGGLE', name: key }); // SET UI INPUT VALUES
-      }
-    });
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // When filter state updates, update table state and the query parameters
+  const firstLoad = useRef(true);
   useEffect(() => {
     if (!listPending) {
-      const filterStateToParams = () => {
-        let params = {};
-        for (let checkbox of filtersState.checkboxes) {
-          params[checkbox.name] = checkbox.isChecked;
-        }
-        params.domainName = filtersState.domainName;
-        return params;
-      };
-      const filterStateParams = filterStateToParams();
-      updateFilters(filterStateParams);
-      setAllFilters(getReactTableFilters(filterStateParams));
+      const statusFilterNames = Object.keys(filters).filter(i => i !== 'domainName');
+      const activeStatusFilters = getActiveStatusFilters(filters);
+      const domainNameFilter = filters['domainName'];
+
+      if (firstLoad.current) {
+        firstLoad.current = false;
+
+        filtersStateDispatch({
+          type: 'LOAD',
+          names: !activeStatusFilters.length
+            ? statusFilterNames
+            : activeStatusFilters.map(i => i.name),
+          domainName: domainNameFilter,
+        });
+
+        setAllFilters(getReactTableFilters(filterStateToParams(filtersState)));
+
+        return;
+      }
+
+      updateFilters(filterStateToParams(filtersState));
+      setAllFilters(getReactTableFilters(filterStateToParams(filtersState)));
     }
-  }, [filtersState, listPending, setAllFilters, updateFilters]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtersState, listPending]);
 
   if (trackingDomainsListError) {
     return (

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React, { useEffect, useRef, useReducer } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import { ApiErrorBanner, Empty, Loading } from 'src/components';

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -141,8 +141,11 @@ export default function TrackingDomainsTab() {
   const firstLoad = useRef(true);
   useEffect(() => {
     if (!listPending) {
-      const statusFilterNames = Object.keys(filters).filter(i => i !== 'domainName');
+      const allStatusFilterNames = Object.keys(filters).filter(i => i !== 'domainName');
       const activeStatusFilters = getActiveStatusFilters(filters);
+      const statusFiltersToApply = !activeStatusFilters.length
+        ? allStatusFilterNames
+        : activeStatusFilters.map(i => i.name);
       const domainNameFilter = filters['domainName'];
 
       if (firstLoad.current) {
@@ -150,9 +153,7 @@ export default function TrackingDomainsTab() {
 
         filtersStateDispatch({
           type: 'LOAD',
-          names: !activeStatusFilters.length
-            ? statusFilterNames
-            : activeStatusFilters.map(i => i.name),
+          names: statusFiltersToApply,
           domainName: domainNameFilter,
         });
 

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -74,19 +74,14 @@ export default function TrackingDomainsTab() {
   const [filtersState, filtersStateDispatch] = useReducer(tableFiltersReducer, filtersInitialState);
   const { filters, updateFilters } = usePageFilters(initFiltersForTracking);
 
+  const filter = React.useMemo(() => customDomainStatusFilter, []);
   const data = React.useMemo(() => trackingDomains, [trackingDomains]);
   const columns = React.useMemo(
     () => [
       {
         Header: 'Blocked',
         accessor: 'blocked',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       { Header: 'DefaultTrackingDomain', accessor: 'defaultTrackingDomain' },
       { Header: 'DomainName', accessor: 'domainName' },
@@ -96,27 +91,15 @@ export default function TrackingDomainsTab() {
       {
         Header: 'Unverified',
         accessor: 'unverified',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
       {
         Header: 'Verified',
         accessor: 'verified',
-        filter: (rows, columnIds, value) => {
-          const column = columnIds[0];
-          const mappedRows = rows
-            .map(row => (row.values[column] === value ? row : false))
-            .filter(Boolean);
-          return mappedRows;
-        },
+        filter,
       },
     ],
-    [],
+    [filter],
   );
   const sortBy = React.useMemo(() => [{ id: 'domainName', desc: false }], []);
   const tableInstance = useTable(

--- a/src/pages/domains/helpers/customDomainStatusFilter.js
+++ b/src/pages/domains/helpers/customDomainStatusFilter.js
@@ -1,0 +1,11 @@
+const customDomainStatusFilter = function(rows, columnIds, value) {
+  if (!rows || !rows.length) {
+    return rows;
+  }
+
+  const column = columnIds[0];
+  const mappedRows = rows.map(row => (row.values[column] === value ? row : false)).filter(Boolean);
+  return mappedRows;
+};
+
+export default customDomainStatusFilter;

--- a/src/pages/domains/helpers/filterStateToParams.js
+++ b/src/pages/domains/helpers/filterStateToParams.js
@@ -1,0 +1,10 @@
+function filterStateToParams(filtersState) {
+  let params = {};
+  for (let checkbox of filtersState.checkboxes) {
+    params[checkbox.name] = checkbox.isChecked;
+  }
+  params.domainName = filtersState.domainName;
+  return params;
+}
+
+export default filterStateToParams;

--- a/src/pages/domains/helpers/getActiveStatusFilters.js
+++ b/src/pages/domains/helpers/getActiveStatusFilters.js
@@ -1,0 +1,17 @@
+const getActiveStatusFilters = function(filters) {
+  const filterNames = Object.keys(filters);
+  const activeStatusFilters = filterNames
+    .filter(i => i !== 'domainName')
+    .map(key => {
+      if (Boolean(filters[key])) {
+        return { name: key, value: filters[key] };
+      } else {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+  return activeStatusFilters;
+};
+
+export default getActiveStatusFilters;

--- a/src/pages/domains/helpers/getReactTableFilters.js
+++ b/src/pages/domains/helpers/getReactTableFilters.js
@@ -10,8 +10,15 @@ export default params => {
     .map(keyValueArr => {
       // keyValueArr[0] = params key
       // keyValueArr[1] = params value
-      if (!keyValueArr[1]) {
+      if (keyValueArr[1] === true) {
         // if the value of the object key is falsy -> return null so the filter(Boolean removes)
+        return null;
+      }
+
+      if (
+        ('domainName' === keyValueArr[0] && !keyValueArr[1]) ||
+        (typeof keyValueArr[1] === 'string' && keyValueArr[1].length === 0)
+      ) {
         return null;
       }
 

--- a/src/pages/domains/helpers/getReactTableFilters.js
+++ b/src/pages/domains/helpers/getReactTableFilters.js
@@ -3,28 +3,22 @@
  *
  * @param {object} params - The object of key value pairs
  *
- * @returns {array} {id: "keyName", value: true}
+ * @returns {array} {id: "keyName", value: false}
  */
 export default params => {
   return Object.entries(params)
-    .map(keyValueArr => {
-      // keyValueArr[0] = params key
-      // keyValueArr[1] = params value
-      if (keyValueArr[1] === true) {
-        // if the value of the object key is falsy -> return null so the filter(Boolean removes)
+    .map(([key, value]) => {
+      if (value === true) {
         return null;
       }
 
-      if (
-        ('domainName' === keyValueArr[0] && !keyValueArr[1]) ||
-        (typeof keyValueArr[1] === 'string' && keyValueArr[1].length === 0)
-      ) {
+      if (('domainName' === key && !value) || (typeof value === 'string' && value.length === 0)) {
         return null;
       }
 
       return {
-        id: keyValueArr[0],
-        value: keyValueArr[1],
+        id: key,
+        value: value,
       };
     })
     .filter(Boolean);

--- a/src/pages/domains/helpers/index.js
+++ b/src/pages/domains/helpers/index.js
@@ -1,0 +1,11 @@
+import getReactTableFilters from './getReactTableFilters';
+import customDomainStatusFilter from './customDomainStatusFilter';
+import getActiveStatusFilters from './getActiveStatusFilters';
+import filterStateToParams from './filterStateToParams';
+
+export {
+  getReactTableFilters,
+  customDomainStatusFilter,
+  getActiveStatusFilters,
+  filterStateToParams,
+};


### PR DESCRIPTION
### What Changed
 - Reversed the UI logic for domain status filtering

1. **The page url** "http://localhost:3100/domains/list/sending" **automatically selects and updates the url on page load** - "http://localhost:3100/domains/list/sending?readyForSending=true&readyForDKIM=true&readyForBounce=true&validSPF=true&unverified=true&blocked=true"
![image](https://user-images.githubusercontent.com/4204806/98304792-4514c580-1f86-11eb-9400-549dcc720f16.png)

**2. As the user un-checks the status options the URL is updated along with the table.**
![image](https://user-images.githubusercontent.com/4204806/98304885-71304680-1f86-11eb-8272-e7f8c957cf2a.png)

![image](https://user-images.githubusercontent.com/4204806/98304893-77bebe00-1f86-11eb-8fbf-57288e1c5672.png)

**3. Refreshing the page causes the same filter state to load.**

![image](https://user-images.githubusercontent.com/4204806/98305205-0df2e400-1f87-11eb-8a25-251f3452587e.png)


(Sorting and paging are not persistent in the URL ... yet...?)

### How To Test
 - Just have to load up the domain list pages and try to break the filtering/sorting/paging in any way possible. 
http://localhost:3100/domains/list/sending
http://localhost:3100/domains/list/bounce
http://localhost:3100/domains/list/tracking


### To Do
- [x] Fix tests (unit/integration)
- [ ] Ask UX the question at the end of the description.
- [ ] Feedback / Review

Question for UX:
![image](https://user-images.githubusercontent.com/4204806/98305025-af2d6a80-1f86-11eb-92bb-8a5ba4b05213.png)

**Should the bounce tab have all the same filter options as the sending tab?**