### PR TITLE
FE-1211 - [Dashboard] Verify Sending Domain Onboarding

### DIFF
--- a/cypress/fixtures/sending-domains/200.get.multiple-unverified-sending.json
+++ b/cypress/fixtures/sending-domains/200.get.multiple-unverified-sending.json
@@ -1,0 +1,38 @@
+{
+  "results": [
+    {
+      "creation_time": "2017-08-03T22:25:37+00:00",
+      "shared_with_subaccounts": false,
+      "status": {
+        "mx_status": "unverified",
+        "spf_status": "unverified",
+        "cname_status": "unverified",
+        "ownership_verified": false,
+        "abuse_at_status": "unverified",
+        "compliance_status": "pending",
+        "verification_mailbox_status": "unverified",
+        "dkim_status": "unverified",
+        "postmaster_at_status": "unverified"
+      },
+      "domain": "sparkspam.com",
+      "is_default_bounce_domain": true
+    },
+    {
+      "creation_time": "2017-08-03T22:25:37+00:00",
+      "shared_with_subaccounts": false,
+      "status": {
+        "mx_status": "unverified",
+        "spf_status": "unverified",
+        "cname_status": "unverified",
+        "ownership_verified": false,
+        "abuse_at_status": "unverified",
+        "compliance_status": "pending",
+        "verification_mailbox_status": "unverified",
+        "dkim_status": "unverified",
+        "postmaster_at_status": "unverified"
+      },
+      "domain": "other.sparkspam.com",
+      "is_default_bounce_domain": true
+    }
+  ]
+}

--- a/cypress/fixtures/sending-domains/200.get.unverified-sending.json
+++ b/cypress/fixtures/sending-domains/200.get.unverified-sending.json
@@ -1,0 +1,21 @@
+{
+  "results": [
+    {
+      "creation_time": "2017-08-03T22:25:37+00:00",
+      "shared_with_subaccounts": false,
+      "status": {
+        "mx_status": "unverified",
+        "spf_status": "unverified",
+        "cname_status": "unverified",
+        "ownership_verified": false,
+        "abuse_at_status": "unverified",
+        "compliance_status": "pending",
+        "verification_mailbox_status": "unverified",
+        "dkim_status": "unverified",
+        "postmaster_at_status": "unverified"
+      },
+      "domain": "sparkspam.com",
+      "is_default_bounce_domain": true
+    }
+  ]
+}

--- a/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
+++ b/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
@@ -35,10 +35,67 @@ describe('Version 2 of the dashboard page', () => {
         .should('not.be.disabled');
     });
 
-    it.skip('onboarding step two', () => {
-      // TODO: FE-1211, FE-1213
+    it('onboarding step two - one unverified sending domain', () => {
+      stubAccountsReq({ fixture: 'account/200.get.has-dashboard-v2.json' });
+      stubUsageReq({ fixture: 'usage/200.get.no-last-sent.json' });
+      cy.stubRequest({
+        url: '/api/v1/sending-domains**',
+        fixture: 'sending-domains/200.get.unverified-sending.json',
+        requestAlias: 'sendingDomains',
+      });
+      cy.visit(PAGE_URL);
+      cy.wait(['@accountReq', '@usageReq', '@sendingDomains']);
+
+      cy.title().should('include', 'Dashboard');
+
+      cy.findByRole('heading', { name: 'Get Started!' }).should('be.visible');
+
+      cy.findAllByText('Once a sending domain has been added, it needs to be').should('be.visible');
+      cy.findAllByText('verified.').should('be.visible');
+      cy.findAllByText(
+        'Follow the instructions on the domain details page to configure your',
+      ).should('be.visible');
+      cy.findAllByText('DNS settings.').should('be.visible');
+
+      cy.get('[data-id="onboarding-verify-sending-button"]')
+        .should('be.visible')
+        .should('not.be.disabled')
+        .should('have.attr', 'href')
+        .and('include', '/details/sending-bounce/sparkspam.com');
+      cy.get('[data-id="onboarding-verify-sending-button"]').contains('Verify Sending Domain');
     });
 
+    it('onboarding step two - more than one unverified sending domain', () => {
+      stubAccountsReq({ fixture: 'account/200.get.has-dashboard-v2.json' });
+      stubUsageReq({ fixture: 'usage/200.get.no-last-sent.json' });
+      cy.stubRequest({
+        url: '/api/v1/sending-domains**',
+        fixture: 'sending-domains/200.get.multiple-unverified-sending.json',
+        requestAlias: 'sendingDomains',
+      });
+      cy.visit(PAGE_URL);
+      cy.wait(['@accountReq', '@usageReq', '@sendingDomains']);
+
+      cy.title().should('include', 'Dashboard');
+
+      cy.findByRole('heading', { name: 'Get Started!' }).should('be.visible');
+
+      cy.findAllByText('Once a sending domain has been added, it needs to be').should('be.visible');
+      cy.findAllByText('verified.').should('be.visible');
+      cy.findAllByText(
+        'Follow the instructions on the domain details page to configure your',
+      ).should('be.visible');
+      cy.findAllByText('DNS settings.').should('be.visible');
+
+      cy.get('[data-id="onboarding-verify-sending-button"]')
+        .should('be.visible')
+        .should('not.be.disabled')
+        .should('have.attr', 'href')
+        .and('include', '/domains/list/sending');
+      cy.get('[data-id="onboarding-verify-sending-button"]').contains('Verify Sending Domain');
+    });
+
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip('onboarding step three', () => {
       // TODO: FE-1213, FE-1213
     });
@@ -86,7 +143,7 @@ describe('Version 2 of the dashboard page', () => {
       });
     });
 
-    // TODO: Fix, something is wrong here
+    // TODO: FE-1211 OR FE-1212 Fix, something is wrong here
     it.skip('does not render certain links when grants are not available for a user', () => {
       commonBeforeSteps();
       cy.stubRequest({
@@ -118,7 +175,7 @@ describe('Version 2 of the dashboard page', () => {
       // });
     });
 
-    // TODO: Fix, something is wrong here
+    // TODO: FE-1211 OR FE-1212 Fix, something is wrong here
     it.skip('does not render the "Setup Documentation" or the usage section panel when the user is not an admin, developer, or super user', () => {
       cy.stubRequest({
         url: `/api/v1/users/${Cypress.env('USERNAME')}`,

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -38,6 +38,8 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
+  isAdmin,
+  hasRole,
   getAccount,
   getUsage,
   listAlerts,

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -38,8 +38,6 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  isAdmin,
-  hasRole,
   getAccount,
   getUsage,
   listAlerts,

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -24,6 +24,7 @@ import Dashboard from './components/Dashboard';
 import Sidebar from './components/Sidebar';
 import { LINKS } from 'src/constants';
 import styled from 'styled-components';
+import { resolveStatus } from 'src/helpers/domains';
 
 const OnboardingPicture = styled(Picture.Image)`
   vertical-align: bottom;
@@ -43,8 +44,12 @@ export default function DashboardPageV2() {
   } = useDashboardContext();
 
   // TODO: useReducer instead
-  const [hasSetupDocumentationPanel, setHasSetupDocumentationPanel] = useState();
-  const [addSendingDomainOnboarding, setAddSendingDomainOnboarding] = useState();
+  const [hasSetupDocumentationPanel, setHasSetupDocumentationPanel] = useState(false);
+  const [addSendingDomainOnboarding, setAddSendingDomainOnboarding] = useState(false);
+  const [verifySendingDomainOnboarding, setVerifySendingDomainOnboarding] = useState(false);
+  const [linkForVerifySendingDomainButton, setLinkForVerifySendingDomainButton] = useState(
+    '/domains/list/sending',
+  );
   const [lastUsageDate, setlastUsageDate] = useState(-1);
 
   // TODO: useReducer instead
@@ -57,13 +62,22 @@ export default function DashboardPageV2() {
         sendingDomains.length === 0 &&
         lastUsageDate === null,
     );
-    // TODO: FE-1211
-    /**
-        setVerifySendingDomainOnboarding(
-          !addSendingDomainOnboarding &&
-          verifiedSendingDomains.length === 0 &&
-        )
-     */
+
+    const verifiedSendingDomains = sendingDomains
+      .map(i => {
+        return resolveStatus(i.status) === 'verified' ? i : null;
+      })
+      .filter(Boolean);
+    setVerifySendingDomainOnboarding(
+      !addSendingDomainOnboarding && verifiedSendingDomains.length === 0,
+    );
+
+    if (sendingDomains.length === 1 && verifiedSendingDomains.length === 0) {
+      setLinkForVerifySendingDomainButton(
+        `/domains/details/sending-bounce/${sendingDomains[0].domain}`,
+      );
+    }
+
     // TODO: FE-1212
     /**
         setCreateApiKeyOnboarding(
@@ -116,86 +130,124 @@ export default function DashboardPageV2() {
         <Layout>
           <Layout.Section>
             <Stack>
-              {isAdminOrDev && (
-                <Dashboard.Panel>
-                  <ScreenReaderOnly>
-                    <Heading as="h3">Next Steps</Heading>
-                  </ScreenReaderOnly>
+              <Dashboard.Panel>
+                <ScreenReaderOnly>
+                  <Heading as="h3">Next Steps</Heading>
+                </ScreenReaderOnly>
 
-                  {addSendingDomainOnboarding && (
-                    <Columns>
-                      <Column>
-                        <Panel.Section>
-                          <Panel.Headline>
-                            <TranslatableText>Get Started!</TranslatableText>
-                          </Panel.Headline>
-                          <Text pb="600">
-                            <TranslatableText>At least one </TranslatableText>
-                            <Bold>verified sending domain </Bold>
-                            <TranslatableText>
-                              is required in order to start or enable analytics.
-                            </TranslatableText>
-                          </Text>
-                          <PageLink
-                            variant="primary"
-                            size="default"
-                            color="blue"
-                            to="/domains/list/sending"
-                            as={Button}
-                          >
-                            Add Sending Domain
-                          </PageLink>
-                        </Panel.Section>
-                      </Column>
-                      <Box as={Column} display={['none', 'none', 'block']} width={[0, 0, 0.5]}>
-                        <Box height="100%">
-                          <Picture role="presentation">
-                            <source srcset={SendingMailWebp} type="image/webp" />
-                            <OnboardingPicture alt="" src={SendingMail} seeThrough />
-                          </Picture>
-                        </Box>
+                {addSendingDomainOnboarding && (
+                  <Columns>
+                    <Column>
+                      <Panel.Section>
+                        <Panel.Headline>
+                          <TranslatableText>Get Started!</TranslatableText>
+                        </Panel.Headline>
+                        <Text pb="600">
+                          <TranslatableText>At least one </TranslatableText>
+                          <Bold>verified sending domain </Bold>
+                          <TranslatableText>
+                            is required in order to start or enable analytics.
+                          </TranslatableText>
+                        </Text>
+                        <PageLink
+                          data-id="onboarding-add-sending-button"
+                          variant="primary"
+                          size="default"
+                          color="blue"
+                          to="/domains/list/sending"
+                          as={Button}
+                        >
+                          Add Sending Domain
+                        </PageLink>
+                      </Panel.Section>
+                    </Column>
+                    <Box as={Column} display={['none', 'none', 'block']} width={[0, 0, 0.5]}>
+                      <Box height="100%">
+                        <Picture role="presentation">
+                          <source srcset={SendingMailWebp} type="image/webp" />
+                          <OnboardingPicture alt="" src={SendingMail} seeThrough />
+                        </Picture>
                       </Box>
-                    </Columns>
-                  )}
+                    </Box>
+                  </Columns>
+                )}
 
-                  {/* TODO: FE-1213 will be split out over the rest of them - add conditions here to meet 1213 requirements */}
-                  {/* !verifySendingDomainOnboarding */}
-                  {/* !createApiKeyOnboarding */}
-                  {!addSendingDomainOnboarding && (
-                    <Columns>
-                      <Column>
-                        <Panel.Section>
-                          <Panel.Headline>
-                            <TranslatableText>Start Sending!</TranslatableText>
-                          </Panel.Headline>
-                          <Text pb="600">
-                            Follow the Getting Started documentation to set up sending via API or
-                            SMTP.
-                          </Text>
-                          <ExternalLink
-                            variant="primary"
-                            size="default"
-                            color="blue"
-                            showIcon={false}
-                            to={LINKS.ONBOARDING_SENDING_EMAIL}
-                            as={Button}
-                          >
-                            Getting Started Documentation
-                          </ExternalLink>
-                        </Panel.Section>
-                      </Column>
-                      <Box as={Column} display={['none', 'none', 'block']} width={[0, 0, 0.5]}>
-                        <Box height="100%">
-                          <Picture role="presentation">
-                            <source srcset={ConfigurationWebp} type="image/webp" />
-                            <OnboardingPicture alt="" src={Configuration} seeThrough />
-                          </Picture>
-                        </Box>
+                {!addSendingDomainOnboarding && verifySendingDomainOnboarding && (
+                  <Columns>
+                    <Column>
+                      <Panel.Section>
+                        <Panel.Headline>
+                          <TranslatableText>Get Started!</TranslatableText>
+                        </Panel.Headline>
+                        <Text pb="600">
+                          <TranslatableText>
+                            Once a sending domain has been added, it needs to be
+                          </TranslatableText>
+                          <Bold> verified. </Bold>
+                          <TranslatableText>
+                            Follow the instructions on the domain details page to configure your
+                          </TranslatableText>
+                          <TranslatableText> DNS settings.</TranslatableText>
+                        </Text>
+                        <PageLink
+                          data-id="onboarding-verify-sending-button"
+                          variant="primary"
+                          size="default"
+                          color="blue"
+                          to={linkForVerifySendingDomainButton}
+                          as={Button}
+                        >
+                          Verify Sending Domain
+                        </PageLink>
+                      </Panel.Section>
+                    </Column>
+                    <Box as={Column} display={['none', 'none', 'block']} width={[0, 0, 0.5]}>
+                      <Box height="100%">
+                        <Picture role="presentation">
+                          <source srcset={SendingMailWebp} type="image/webp" />
+                          <OnboardingPicture alt="" src={SendingMail} seeThrough />
+                        </Picture>
                       </Box>
-                    </Columns>
-                  )}
-                </Dashboard.Panel>
-              )}
+                    </Box>
+                  </Columns>
+                )}
+
+                {/* TODO: FE-1213 will be split out over the rest of them - add conditions here to meet 1213 requirements */}
+                {/* !createApiKeyOnboarding */}
+                {!addSendingDomainOnboarding && !verifySendingDomainOnboarding && (
+                  <Columns>
+                    <Column>
+                      <Panel.Section>
+                        <Panel.Headline>
+                          <TranslatableText>Start Sending!</TranslatableText>
+                        </Panel.Headline>
+                        <Text pb="600">
+                          Once a sending domain has been added, it needs to be verified. Follow the
+                          instructions on the domain details page to configure your DNS settings.
+                        </Text>
+                        <ExternalLink
+                          variant="primary"
+                          size="default"
+                          color="blue"
+                          showIcon={false}
+                          to={LINKS.ONBOARDING_SENDING_EMAIL}
+                          as={Button}
+                        >
+                          Getting Started Documentation
+                        </ExternalLink>
+                      </Panel.Section>
+                    </Column>
+                    <Box as={Column} display={['none', 'none', 'block']} width={[0, 0, 0.5]}>
+                      <Box height="100%">
+                        <Picture role="presentation">
+                          <source srcset={ConfigurationWebp} type="image/webp" />
+                          <OnboardingPicture alt="" src={Configuration} seeThrough />
+                        </Picture>
+                      </Box>
+                    </Box>
+                  </Columns>
+                )}
+              </Dashboard.Panel>
 
               <Dashboard.Panel>
                 <Panel.Section>

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -222,8 +222,8 @@ export default function DashboardPageV2() {
                           <TranslatableText>Start Sending!</TranslatableText>
                         </Panel.Headline>
                         <Text pb="600">
-                          Once a sending domain has been added, it needs to be verified. Follow the
-                          instructions on the domain details page to configure your DNS settings.
+                          Follow the Getting Started documentation to set up sending via API or
+                          SMTP.
                         </Text>
                         <ExternalLink
                           variant="primary"


### PR DESCRIPTION
Epic: https://sparkpost.atlassian.net/browse/FE-1185
Task: https://sparkpost.atlassian.net/browse/FE-1211

Branched From: https://github.com/SparkPost/2web2ui/pull/1888
Compare of upstream branch: https://github.com/SparkPost/2web2ui/compare/FE-1209...FE-1211

### What Changed
 - This is the second onboarding step for the new dashboard - Verify Sending Domain

![image](https://user-images.githubusercontent.com/4204806/98742354-eb404100-2373-11eb-9b84-ff7be6e2ca16.png)

Design Mock:
https://sparkpost.invisionapp.com/console/Progressive-Onboarding-ckfe1rusj0cqn0185gnro5f8c/ckfe1s8bf019q010e0xfahnz0/play

### How To Test
 - It's best to use the Cypress integration tests for this. They'll setup the data to meet the conditions. Otherwise you need a fresh account that you can add/remove domains to/from to meet the conditions manually. 

### To Do
- [ ] Feedback
