### PR TITLE
FE-1245 - Removed the "Authenticate for SPF" section from domain details page and verification page for bounce and sending/bounce

### DIFF
--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -381,28 +381,6 @@ describe('The domains details page', () => {
           ).should('be.visible');
         });
 
-        it('renders correct sections for unverified spf domains', () => {
-          cy.stubRequest({
-            url: '/api/v1/sending-domains/bounce.spappteam.com',
-            fixture: 'sending-domains/200.get.unverified-spf.json',
-            requestAlias: 'unverifiedSpfDomains',
-          });
-
-          cy.visit(`${SENDING_BOUNCE_DETAILS_URL}/bounce.spappteam.com`);
-          cy.wait(['@unverifiedSpfDomains']);
-          cy.wait('@accountDomainsReq');
-
-          cy.findByRole('heading', { name: 'Domain Status' }).should('be.visible');
-          cy.findByRole('heading', { name: 'Link Tracking Domain' }).should('be.visible');
-          cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');
-          cy.findByRole('heading', { name: 'Sending' }).should('not.be.visible');
-          cy.findByRole('heading', { name: 'Bounce' }).should('be.visible');
-          cy.findByRole('button', { name: 'Authenticate for SPF' }).should('be.visible');
-          cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
-          cy.findByRole('heading', { name: 'Email Verification' }).should('not.be.visible');
-          cy.findByRole('heading', { name: 'Sending and Bounce' }).should('not.be.visible');
-        });
-
         it('renders correct sections for completely verified domains', () => {
           cy.stubRequest({
             url: '/api/v1/sending-domains/bounce2.spappteam.com',
@@ -419,7 +397,6 @@ describe('The domains details page', () => {
           cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');
           cy.findByRole('heading', { name: 'Sending' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'Bounce' }).should('not.be.visible');
-          cy.findByRole('button', { name: 'Authenticate for SPF' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'DNS Verification' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'Email Verification' }).should('not.be.visible');
         });
@@ -438,7 +415,6 @@ describe('The domains details page', () => {
           cy.findByRole('heading', { name: 'Sending' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'Bounce' }).should('be.visible');
           cy.findByRole('button', { name: 'Verify Domain' }).should('be.visible');
-          cy.findByRole('button', { name: 'Authenticate for SPF' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
           cy.findByRole('heading', { name: 'Email Verification' }).should('be.visible');
         });

--- a/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
@@ -50,7 +50,6 @@ describe('The verify sending/bounce domain page', () => {
         cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
         cy.findByRole('heading', { name: 'Add DKIM Record' }).should('be.visible');
         cy.findByRole('heading', { name: 'Add Bounce Record' }).should('be.visible');
-        cy.findByRole('heading', { name: 'Add SPF Record' }).should('be.visible');
         cy.findByRole('button', { name: 'Authenticate Domain' }).should('be.visible');
       });
 
@@ -82,8 +81,6 @@ describe('The verify sending/bounce domain page', () => {
         ).should('be.visible');
         cy.findByRole('heading', { name: 'TXT record for DKIM' }).should('be.visible');
         cy.findByRole('heading', { name: 'CNAME record for Bounce' }).should('be.visible');
-        cy.findByRole('heading', { name: 'Add SPF Record' }).should('be.visible');
-        cy.findByRole('button', { name: 'Authenticate for SPF' }).should('be.visible');
       });
 
       it('Authenticate Domain submit button is disabled until the user selects the confirmation checkbox', () => {

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -104,8 +104,7 @@ function DetailsPage(props) {
 
   const resolvedStatus = isTracking ? domain.status : resolveStatus(domain.status);
   const readyFor = isTracking ? {} : resolveReadyFor(domain.status);
-  const displaySendingAndBounceSection =
-    readyFor.dkim && readyFor.bounce && domain.status.spf_status === 'valid';
+  const displaySendingAndBounceSection = readyFor.dkim && readyFor.bounce;
 
   return (
     <Domains.Container>

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -35,10 +35,6 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
 
   const readyFor = resolveReadyFor(domain.status);
 
-  const getButtonText = () => {
-    if (!readyFor.dkim || !readyFor.bounce) return 'Authenticate Domain';
-  };
-
   const onSubmit = () => {
     if (!readyFor.bounce) {
       const type = watchVerificationType.toLowerCase();
@@ -212,7 +208,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                   loading={verifyBounceLoading || verifyDkimLoading}
                   disabled={!watch('addToDns')}
                 >
-                  {getButtonText()}
+                  Authenticate Domain
                 </Button>
               </Panel.Section>
             )}

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -120,7 +120,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
               </Panel.Section>
             ) : (
               <Panel.Section>
-                'Below is the records for this domain at your DNS provider'
+                Below is the records for this domain at your DNS provider
               </Panel.Section>
             )}
 

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Box, Layout, Stack, Text } from 'src/components/matchbox';
-import { Button, Checkbox, Panel, Tag } from 'src/components/matchbox';
+import { Layout, Stack, Text } from 'src/components/matchbox';
+import { Button, Checkbox, Panel } from 'src/components/matchbox';
 import { useForm } from 'react-hook-form';
 import LineBreak from 'src/components/lineBreak';
 import { Bold, SubduedText } from 'src/components/text';
@@ -13,10 +13,6 @@ import { Send } from '@sparkpost/matchbox-icons';
 import styled from 'styled-components';
 import { EXTERNAL_LINKS } from '../constants';
 
-const StyledBox = styled(Box)`
-  float: right;
-`;
-
 const PlaneIcon = styled(Send)`
   transform: translate(0, -25%) rotate(-45deg);
 `;
@@ -24,7 +20,6 @@ const PlaneIcon = styled(Send)`
 export default function SendingAndBounceDomainSection({ domain, isSectionVisible }) {
   const { id, status, subaccount_id } = domain;
   const {
-    getDomain,
     verifyDkim,
     verify,
     showAlert,
@@ -42,7 +37,6 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
 
   const getButtonText = () => {
     if (!readyFor.dkim || !readyFor.bounce) return 'Authenticate Domain';
-    if (status.spf_status !== 'valid') return 'Authenticate for SPF';
   };
 
   const onSubmit = () => {
@@ -64,21 +58,6 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
         }
       });
     }
-
-    if (status.spf_status !== 'valid')
-      getDomain(id).then(result => {
-        if (result.status.spf_status === 'valid') {
-          showAlert({
-            type: 'success',
-            message: `You have successfully authenticated SPF`,
-          });
-        } else {
-          showAlert({
-            type: 'error',
-            message: `SPF authentication failed`,
-          });
-        }
-      });
 
     if (!readyFor.dkim) {
       const { id, subaccount_id: subaccount } = domain;
@@ -213,38 +192,6 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                 )}
               </Stack>
             </Panel.Section>
-            <Panel.Section>
-              <Stack>
-                <Box>
-                  {status.spf_status !== 'valid' ? (
-                    <Box>
-                      <Box display="inline">
-                        <Text as="span" fontSize="300" fontWeight="semibold" role="heading">
-                          Add SPF Record{' '}
-                        </Text>
-                        <Tag color="green" ml="400">
-                          Recommended
-                        </Tag>
-                      </Box>
-
-                      <StyledBox>
-                        <Text as="span" fontSize="200" color="gray.700" fontWeight="400">
-                          Optional
-                        </Text>
-                      </StyledBox>
-                    </Box>
-                  ) : (
-                    'TXT record for SPF'
-                  )}
-                </Box>
-                <CopyField label="Hostname" value={id} hideCopy={status.spf_status === 'valid'} />
-                <CopyField
-                  label="Value"
-                  value="v=spf1 mx a ~all"
-                  hideCopy={status.spf_status === 'valid'}
-                />
-              </Stack>
-            </Panel.Section>
             {(!readyFor.bounce || !readyFor.dkim) && (
               <Panel.Section>
                 <Checkbox
@@ -256,7 +203,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                 />
               </Panel.Section>
             )}
-            {(!readyFor.bounce || !readyFor.dkim || status.spf_status !== 'valid') && (
+            {(!readyFor.bounce || !readyFor.dkim) && (
               <Panel.Section>
                 <Button
                   variant="primary"

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Banner, Box, Button, Layout, Stack, Select, Tag, Text } from 'src/components/matchbox';
+import React from 'react';
+import { Button, Layout, Stack, Select, Text } from 'src/components/matchbox';
 import { Checkbox, Panel } from 'src/components/matchbox';
 import { SubduedText } from 'src/components/text';
 import { Send } from '@sparkpost/matchbox-icons';
@@ -17,26 +17,14 @@ const PlaneIcon = styled(Send)`
   transform: translate(0, -25%) rotate(-45deg);
 `;
 
-const StyledBox = styled(Box)`
-  float: right;
-`;
-
 export default function SetupBounceDomainSection({ domain, isSectionVisible, title }) {
   const { id, status, subaccount_id } = domain;
-  const {
-    getDomain,
-    verify,
-    showAlert,
-    userName,
-    isByoipAccount,
-    verifyBounceLoading,
-  } = useDomains();
+  const { verify, showAlert, userName, isByoipAccount, verifyBounceLoading } = useDomains();
   const readyFor = resolveReadyFor(status);
   const initVerificationType = isByoipAccount && status.mx_status === 'valid' ? 'MX' : 'CNAME';
   const bounceDomainsConfig = getConfig('bounceDomains');
   const { control, handleSubmit, watch, register } = useForm();
   const watchVerificationType = watch('verificationType', initVerificationType);
-  const [warningBanner, toggleBanner] = useState(true);
 
   const onSubmit = () => {
     if (!readyFor.bounce) {
@@ -57,19 +45,6 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
         }
       });
     }
-    return getDomain(id).then(result => {
-      if (result.status.spf_status === 'valid') {
-        showAlert({
-          type: 'success',
-          message: `You have successfully autheticated SPF`,
-        });
-      } else {
-        showAlert({
-          type: 'error',
-          message: `SPF autheticated failed`,
-        });
-      }
-    });
   };
   if (!isSectionVisible) {
     return null;
@@ -81,25 +56,17 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
         <Stack>
           {!readyFor.bounce && (
             <SubduedText fontSize="200">
-              Once the CNAME record is added to the DNS provider settings, the domain will also be
-              setup for Bounce, resulting in Strict Alignment.
+              Adding the CNAME record in your DNS provider settings will set this domain up for
+              Bounce as well resulting in SPF (sender policy framework) authentication which is a
+              sending best practice.
             </SubduedText>
           )}
-
-          {domain.status.spf_status !== 'valid' && readyFor.bounce && warningBanner && (
-            <Banner status="warning" size="small" onDismiss={() => toggleBanner(false)}>
-              <Text fontWeight="normal" maxWidth="100">
-                This domain is not SPF authenticated.
-              </Text>
-            </Banner>
-          )}
-
-          {domain.status.spf_status !== 'valid' && (
+          {!readyFor.bounce && (
             <SubduedText fontSize="200">
-              SPF (Sender Policy Framework) is an email authentication method to determine if a
-              bounce domain is allowed to be used with in given sending IP. SPF failures can cause
-              mail to be rejected at some providers. To ensure they pass all SPF checks, publishing
-              SparkPost CNAME in DNS is required for all bounce domains.
+              SPF is an email authentication method used to determine if a bounce domain is allowed
+              to be used with a given sending IP. SPF failures can cause mail to be rejected at some
+              providers, so SparkPost requires our CNAME record to be published in DNS for all
+              bounce domains to ensure that they pass SPF checks.
             </SubduedText>
           )}
 
@@ -127,7 +94,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
               provider.
               <Panel.Action>
                 <ExternalLink
-                  to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
+                  to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                   icon={PlaneIcon}
                 >
                   Forward to Colleague
@@ -207,76 +174,17 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                 {/*API doesn't support it; Do we want to store this in ui option*/}
               </Stack>
             </Panel.Section>
-            <Panel.Section>
-              <Stack>
-                {domain.status.spf_status !== 'valid' && (
-                  <Box>
-                    <Box display="inline">
-                      <Text as="span" fontSize="300" fontWeight="semibold" role="heading">
-                        Add SPF Record{' '}
-                      </Text>
-                      <Tag color="green" ml="400">
-                        Recommended
-                      </Tag>
-                    </Box>
+            {!readyFor.bounce && (
+              <Panel.Section>
+                <Checkbox
+                  name="ack-checkbox-bounce"
+                  label={`The ${watchVerificationType} record has been added to the DNS provider`}
+                  disabled={verifyBounceLoading}
+                  ref={register({ required: true })}
+                />
+              </Panel.Section>
+            )}
 
-                    <StyledBox>
-                      <Text as="span" fontSize="200" color="gray.700" fontWeight="400">
-                        Optional
-                      </Text>
-                    </StyledBox>
-                  </Box>
-                )}
-                {domain.status.spf_status !== 'valid' && (
-                  <>
-                    <Text as="label" fontWeight="500" fontSize="200">
-                      Type
-                    </Text>
-                    <Text as="p">TXT</Text>
-                  </>
-                )}
-                <CopyField
-                  label="Hostname"
-                  value={id}
-                  hideCopy={domain.status.spf_status === 'valid'}
-                />
-                <CopyField
-                  label="Value"
-                  value="v=spf1 mx a ~all"
-                  hideCopy={domain.status.spf_status === 'valid'}
-                />
-              </Stack>
-            </Panel.Section>
-            {(!readyFor.bounce || domain.status.spf_status !== 'valid') && (
-              <Panel.Section>
-                {readyFor.bounce && domain.status.spf_status !== 'valid' ? (
-                  <Checkbox
-                    name="ack-checkbox-bounce"
-                    label="The TXT record has been added to the DNS provider"
-                    disabled={verifyBounceLoading}
-                    ref={register({ required: true })}
-                  />
-                ) : (
-                  <Checkbox
-                    name="ack-checkbox-bounce"
-                    label={`The ${watchVerificationType} record has been added to the DNS provider`}
-                    disabled={verifyBounceLoading}
-                    ref={register({ required: true })}
-                  />
-                )}
-              </Panel.Section>
-            )}
-            {readyFor.bounce && domain.status.spf_status !== 'valid' && (
-              <Panel.Section>
-                <Button
-                  variant="primary"
-                  type="submit"
-                  disabled={!Boolean(watch('ack-checkbox-bounce'))}
-                >
-                  Authenticate for SPF
-                </Button>
-              </Panel.Section>
-            )}
             {!readyFor.bounce && (
               <Panel.Section>
                 <Button

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -27,24 +27,22 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
   const watchVerificationType = watch('verificationType', initVerificationType);
 
   const onSubmit = () => {
-    if (!readyFor.bounce) {
-      const type = watchVerificationType.toLowerCase();
+    const type = watchVerificationType.toLowerCase();
 
-      return verify({ id, subaccount: subaccount_id, type }).then(result => {
-        if (result[`${type}_status`] === 'valid') {
-          showAlert({
-            type: 'success',
-            message: `You have successfully verified ${type} record of ${id}`,
-          });
-        } else {
-          showAlert({
-            type: 'error',
-            message: `Unable to verify ${type} record of ${id}`,
-            details: result.dns[`${type}_error`],
-          });
-        }
-      });
-    }
+    return verify({ id, subaccount: subaccount_id, type }).then(result => {
+      if (result[`${type}_status`] === 'valid') {
+        showAlert({
+          type: 'success',
+          message: `You have successfully verified ${type} record of ${id}`,
+        });
+      } else {
+        showAlert({
+          type: 'error',
+          message: `Unable to verify ${type} record of ${id}`,
+          details: result.dns[`${type}_error`],
+        });
+      }
+    });
   };
   if (!isSectionVisible) {
     return null;


### PR DESCRIPTION
FE-1245 - Removed the "Authenticate for SPF" section from domain details page and verification page for bounce and sending/bounce

### What Changed
 - Removed the "Authenticate for bounce" section from
      - Unverified domain details page - domains/details/sending-bounce/test.123.900
      - Verification pages 
             - Sending/Bounce = domains/details/test.123.900/verify-sending-bounce
             - Bounce = http://localhost:3100/domains/details/test.123.900/verify-bounce
       - Copy in the left Panel for Bounce is also updated to match - https://sparkpost.invisionapp.com/console/share/CS1SX9XT3H/478945608

### How To Test
 - Verify the Authentication for SPF section is gone, and rest of functionality still works correctly

### To Do
- [ ] Address feedback
