### PR TITLE
[FE-1244] Fixed the links to domains in Hibana

### DIFF
--- a/src/context/HibanaContext.js
+++ b/src/context/HibanaContext.js
@@ -6,7 +6,7 @@ import { isUserUiOptionSet } from 'src/helpers/conditions/user';
 import { selectCondition } from 'src/selectors/accessConditionState';
 import { segmentTrack, SEGMENT_EVENTS } from '../helpers/segment';
 
-const HibanaStateContext = createContext();
+export const HibanaStateContext = createContext();
 
 function Provider(props) {
   const { children, ...rest } = props;
@@ -40,16 +40,11 @@ const mapDispatchToProps = {
   showAlert,
 };
 
+export const HibanaProvider = connect(mapStateToProps, mapDispatchToProps)(Provider);
+
 export function useHibana() {
   const context = useContext(HibanaStateContext);
-
   if (context === undefined) throw new Error('useHibana must be used within a HibanaProvider');
 
   return [context];
-}
-
-export const HibanaProvider = connect(mapStateToProps, mapDispatchToProps)(Provider);
-
-export function HibanaConsumer({ children }) {
-  return <HibanaStateContext.Consumer>{children}</HibanaStateContext.Consumer>;
 }

--- a/src/pages/dashboard/components/GettingStartedGuide.js
+++ b/src/pages/dashboard/components/GettingStartedGuide.js
@@ -3,6 +3,7 @@ import { Expandable, Panel } from 'src/components/matchbox';
 import { GUIDE_IDS } from 'src/constants';
 import ShowMeSparkpostStep from './ShowMeSparkpostStep';
 import LetsCodeStep from './LetsCodeStep';
+import { useHibana } from 'src/context/HibanaContext';
 
 export const GuideContext = createContext();
 export const useGuideContext = () => useContext(GuideContext);
@@ -32,6 +33,8 @@ export const GettingStartedGuide = ({
     }
   };
 
+  const [{ isHibanaEnabled }] = useHibana();
+
   const handleAction = action => {
     switch (action) {
       case 'Send Test Email':
@@ -57,7 +60,8 @@ export const GettingStartedGuide = ({
         history.push('/account/api-keys');
         break;
       case 'Add Sending Domain':
-        history.push(`/account/sending-domains`, { triggerGuide: true });
+        if (!isHibanaEnabled) history.push(`/account/sending-domains`, { triggerGuide: true });
+        else history.push(`/domains/create`);
         break;
       default:
         break;

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -20,15 +20,68 @@ const defaultProps = {
 };
 
 describe('GettingStartedGuide full', () => {
-  const subject = (props, renderFn = render) =>
+  const hibanaOnSubject = (props, renderFn = render) =>
+    renderFn(
+      <TestApp isHibanaEnabled={true}>
+        <GettingStartedGuide {...defaultProps} {...props} />
+      </TestApp>,
+    );
+
+  it('should navigate to /domains/create Add Sending Domain is clicked - hibana', () => {
+    const { queryByText } = hibanaOnSubject({ onboarding: { active_step: "Let's Code" } });
+    userEvent.click(queryByText('Add Sending Domain'));
+    expect(defaultProps.history.push).toHaveBeenCalledWith(`/domains/create`);
+  });
+
+  const hibanaOffSubject = (props, renderFn = render) =>
     renderFn(
       <TestApp>
         <GettingStartedGuide {...defaultProps} {...props} />
       </TestApp>,
     );
 
+  it('should render ShowMeSparkpostStep inside "Start Sending with SparkPost" Expandable and this Expandable is open by default', () => {
+    const { queryByText, queryAllByTestId } = hibanaOffSubject({
+      onboarding: { active_step: 'Show Me SparkPost' },
+    });
+
+    const expandables = queryAllByTestId('expandable-toggle');
+    expect(expandables[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(expandables.length).toEqual(2);
+    expect(queryByText('SparkPost Analytics')).toBeInTheDocument();
+    expect(queryByText('Start Sending with SparkPost')).toBeInTheDocument();
+    expect(queryByText('Send a Test Email')).toBeInTheDocument(); // ShowMeSparkpostStep
+    expect(queryByText('Send a test email using our starter template.')).toBeInTheDocument(); // ShowMeSparkpostStep
+  });
+
+  it('should render LetsCodeStep inside SparkPost Analytics Expandable', () => {
+    const { queryByText, queryAllByTestId } = hibanaOffSubject({
+      onboarding: { active_step: "Let's Code" },
+    });
+    const expandables = queryAllByTestId('expandable-toggle');
+    expect(expandables[1]).toHaveAttribute('aria-expanded', 'false');
+    expect(expandables.length).toEqual(2);
+    expect(queryByText('SparkPost Analytics')).toBeInTheDocument();
+    expect(queryByText('Start Sending with SparkPost')).toBeInTheDocument();
+    expect(
+      queryByText("You'll need to add a sending domain in order to start sending emails."),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render the "Start Sending with SparkPost" Expandable when user does not have grants to manageKeys or manageSendingDomains', () => {
+    const { queryByText, queryAllByTestId } = hibanaOffSubject({
+      canManageKeys: false,
+      canManageSendingDomains: false,
+      onboarding: { active_step: "Let's Code" },
+    });
+    const expandables = queryAllByTestId('expandable-toggle');
+    expect(expandables.length).toEqual(1);
+    expect(queryByText('SparkPost Analytics')).toBeInTheDocument();
+    expect(queryByText('Start Sending with SparkPost')).not.toBeInTheDocument();
+  });
+
   it('should navigate to templates page when Send a Test Email button is clicked', () => {
-    const { queryByText } = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
+    const { queryByText } = hibanaOffSubject({ onboarding: { active_step: 'Show Me SparkPost' } });
     userEvent.click(queryByText('Send Test Email'));
     expect(defaultProps.history.push).toHaveBeenCalledWith(
       `/templates?appcue=${GUIDE_IDS.SEND_TEST_EMAIL}`,
@@ -36,7 +89,7 @@ describe('GettingStartedGuide full', () => {
   });
 
   it('should navigate to summary report when Explore Analytics button is clicked', () => {
-    const { getAllByText } = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
+    const { getAllByText } = hibanaOffSubject({ onboarding: { active_step: 'Show Me SparkPost' } });
     userEvent.click(getAllByText('Explore Analytics')[1]);
 
     expect(defaultProps.history.push).toHaveBeenCalledWith(`/reports/summary`, {
@@ -45,7 +98,7 @@ describe('GettingStartedGuide full', () => {
   });
 
   it('should navigate to events page when Check Out Events button is clicked', () => {
-    const { getAllByText } = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
+    const { getAllByText } = hibanaOffSubject({ onboarding: { active_step: 'Show Me SparkPost' } });
     userEvent.click(getAllByText('Check Out Events')[1]);
 
     expect(defaultProps.history.push).toHaveBeenCalledWith(`/reports/message-events`, {
@@ -54,7 +107,7 @@ describe('GettingStartedGuide full', () => {
   });
 
   it('should navigate to users page when Invite a Collaborator is clicked', () => {
-    const { queryByText } = subject({ onboarding: { active_step: 'Show Me SparkPost' } });
+    const { queryByText } = hibanaOffSubject({ onboarding: { active_step: 'Show Me SparkPost' } });
     userEvent.click(queryByText('Invite a Collaborator'));
     expect(defaultProps.history.push).toHaveBeenCalledWith(`/account/users`);
     expect(defaultProps.setAccountOption).toHaveBeenCalledWith('onboarding', {
@@ -63,7 +116,7 @@ describe('GettingStartedGuide full', () => {
   });
 
   it('should have an external link to developer docs', () => {
-    const { queryByText } = subject({ onboarding: { active_step: "Let's Code" } });
+    const { queryByText } = hibanaOffSubject({ onboarding: { active_step: "Let's Code" } });
     userEvent.click(queryByText('View Developer Docs'));
     expect(defaultProps.setAccountOption).toHaveBeenCalledWith('onboarding', {
       view_developer_docs_completed: true,
@@ -71,7 +124,7 @@ describe('GettingStartedGuide full', () => {
   });
 
   it("should route to API key page from Let's Code list", () => {
-    const { queryByText } = subject({
+    const { queryByText } = hibanaOffSubject({
       onboarding: { active_step: "Let's Code" },
       hasApiKeysForSending: true,
     });
@@ -80,7 +133,7 @@ describe('GettingStartedGuide full', () => {
   });
 
   it('should navigate to sending domains page when Add Sending Domain is clicked', () => {
-    const { queryByText } = subject({ onboarding: { active_step: "Let's Code" } });
+    const { queryByText } = hibanaOffSubject({ onboarding: { active_step: "Let's Code" } });
     userEvent.click(queryByText('Add Sending Domain'));
     expect(defaultProps.history.push).toHaveBeenCalledWith(`/account/sending-domains`, {
       triggerGuide: true,

--- a/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
+++ b/src/pages/dashboard/components/tests/GettingStartedGuide.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TestApp from 'src/__testHelpers__/TestApp';
@@ -19,31 +18,6 @@ const defaultProps = {
   canManageSendingDomains: true,
   canManageUsers: true,
 };
-
-describe('GettingStartedGuide shallow', () => {
-  beforeEach(() => {
-    jest.mock('src/context/HibanaContext');
-  });
-
-  const subject = props => shallow(<GettingStartedGuide {...defaultProps} {...props} />);
-  const wrapper = subject();
-
-  it('should render ShowMeSparkpostStep inside "Start Sending with SparkPost" Expandable and this Expandable is open by default', () => {
-    expect(wrapper.find('Expandable')).toHaveTextContent('Start Sending with SparkPost');
-    expect(wrapper.find('Expandable').find('ShowMeSparkpostStep')).toHaveLength(1);
-    expect(wrapper.find('Expandable').first()).toHaveProp('defaultOpen');
-  });
-
-  it('should render LetsCodeStep inside SparkPost Analytics Expandable', () => {
-    expect(wrapper.find('Expandable')).toHaveTextContent('SparkPost Analytics');
-    expect(wrapper.find('Expandable').find('LetsCodeStep')).toHaveLength(1);
-  });
-
-  it('should not render the "Start Sending with SparkPost" Expandable when user does not have grants to manageKeys or manageSendingDomains', () => {
-    const wrapper = subject({ canManageKeys: false, canManageSendingDomains: false });
-    expect(wrapper.find({ title: 'Start Sending with SparkPost' })).not.toExist();
-  });
-});
 
 describe('GettingStartedGuide full', () => {
   const subject = (props, renderFn = render) =>

--- a/src/pages/subaccounts/components/SendingDomainsTab.js
+++ b/src/pages/subaccounts/components/SendingDomainsTab.js
@@ -7,6 +7,7 @@ import { Button, Panel, Stack } from 'src/components/matchbox';
 import { Loading } from 'src/components';
 import { TableCollection, DomainStatusCell, StatusTooltipHeader } from 'src/components';
 import { selectSendingDomainsForSubaccount } from 'src/selectors/sendingDomains';
+import { HibanaConsumer } from 'src/context/HibanaContext';
 
 const StyledPanelContent = styled.div`
   text-align: center;
@@ -17,56 +18,23 @@ const columns = [
   { label: <StatusTooltipHeader />, width: '40%' },
 ];
 
-export const getRowData = row => [
-  <PageLink to={`/account/sending-domains/edit/${row.domain}`}>{row.domain}</PageLink>,
+export const getRowData = (row, isHibanaEnabled) => [
+  <PageLink
+    to={
+      isHibanaEnabled
+        ? `/domains/details/sending-bounce/${row.domain}`
+        : `/account/sending-domains/edit/${row.domain}`
+    }
+  >
+    {row.domain}
+  </PageLink>,
   <DomainStatusCell domain={row} />,
 ];
 
+const getToLink = (value = {}) =>
+  value.isHibanaEnabled ? '/domains/list/sending' : '/account/sending-domains';
+
 export class SendingDomainsTab extends Component {
-  renderCollection() {
-    const { domains } = this.props;
-
-    return (
-      <>
-        <Panel.LEGACY marginBottom="0" borderBottom="0">
-          <Panel.LEGACY.Section>
-            <p>Sending Domains assigned to this subaccount.</p>
-          </Panel.LEGACY.Section>
-        </Panel.LEGACY>
-
-        <TableCollection
-          columns={columns}
-          getRowData={getRowData}
-          pagination={true}
-          rows={domains}
-        />
-      </>
-    );
-  }
-
-  renderEmpty() {
-    return (
-      <Panel.LEGACY>
-        <Panel.LEGACY.Section>
-          <StyledPanelContent>
-            <Stack>
-              <p>
-                This subaccount has no sending domains assigned to it. You can assign an existing
-                one, or create a new one.
-              </p>
-
-              <div>
-                <PageLink as={Button} variant="secondary" to="/account/sending-domains">
-                  Manage Sending Domains
-                </PageLink>
-              </div>
-            </Stack>
-          </StyledPanelContent>
-        </Panel.LEGACY.Section>
-      </Panel.LEGACY>
-    );
-  }
-
   render() {
     const { loading } = this.props;
 
@@ -76,7 +44,48 @@ export class SendingDomainsTab extends Component {
 
     const showEmpty = this.props.domains.length === 0;
 
-    return <>{showEmpty ? this.renderEmpty() : this.renderCollection()}</>;
+    return (
+      <HibanaConsumer>
+        {value => (
+          <>
+            {showEmpty ? (
+              <Panel.LEGACY>
+                <Panel.LEGACY.Section>
+                  <StyledPanelContent>
+                    <Stack>
+                      <p>
+                        This subaccount has no sending domains assigned to it. You can assign an
+                        existing one, or create a new one.
+                      </p>
+
+                      <div>
+                        <PageLink as={Button} variant="secondary" to={getToLink(value)}>
+                          Manage Sending Domains
+                        </PageLink>
+                      </div>
+                    </Stack>
+                  </StyledPanelContent>
+                </Panel.LEGACY.Section>
+              </Panel.LEGACY>
+            ) : (
+              <>
+                <Panel.LEGACY marginBottom="0" borderBottom="0">
+                  <Panel.LEGACY.Section>
+                    <p>Sending Domains assigned to this subaccount.</p>
+                  </Panel.LEGACY.Section>
+                </Panel.LEGACY>
+                <TableCollection
+                  columns={columns}
+                  getRowData={row => getRowData(row, value.isHibanaEnabled)}
+                  pagination={true}
+                  rows={this.props.domains}
+                />{' '}
+              </>
+            )}
+          </>
+        )}
+      </HibanaConsumer>
+    );
   }
 }
 

--- a/src/pages/subaccounts/components/SendingDomainsTab.js
+++ b/src/pages/subaccounts/components/SendingDomainsTab.js
@@ -7,7 +7,7 @@ import { Button, Panel, Stack } from 'src/components/matchbox';
 import { Loading } from 'src/components';
 import { TableCollection, DomainStatusCell, StatusTooltipHeader } from 'src/components';
 import { selectSendingDomainsForSubaccount } from 'src/selectors/sendingDomains';
-import { HibanaConsumer } from 'src/context/HibanaContext';
+import { HibanaStateContext } from 'src/context/HibanaContext';
 
 const StyledPanelContent = styled.div`
   text-align: center;
@@ -43,9 +43,8 @@ export class SendingDomainsTab extends Component {
     }
 
     const showEmpty = this.props.domains.length === 0;
-
     return (
-      <HibanaConsumer>
+      <HibanaStateContext.Consumer>
         {value => (
           <>
             {showEmpty ? (
@@ -57,7 +56,6 @@ export class SendingDomainsTab extends Component {
                         This subaccount has no sending domains assigned to it. You can assign an
                         existing one, or create a new one.
                       </p>
-
                       <div>
                         <PageLink as={Button} variant="secondary" to={getToLink(value)}>
                           Manage Sending Domains
@@ -84,7 +82,7 @@ export class SendingDomainsTab extends Component {
             )}
           </>
         )}
-      </HibanaConsumer>
+      </HibanaStateContext.Consumer>
     );
   }
 }

--- a/src/pages/subaccounts/components/test/SendingDomainsTab.test.js
+++ b/src/pages/subaccounts/components/test/SendingDomainsTab.test.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { SendingDomainsTab, getRowData } from '../SendingDomainsTab';
-import { HibanaConsumer } from 'src/context/HibanaContext';
+import { HibanaStateContext } from 'src/context/HibanaContext';
+
+const mockConsumer = jest.fn();
 
 describe('SendingDomainsTab', () => {
+  beforeEach(() => {
+    mockConsumer.mockReset();
+  });
+
   const defaultProps = {
     domains: [
       {
@@ -16,29 +22,29 @@ describe('SendingDomainsTab', () => {
     loading: false,
   };
 
-  const subject = props =>
-    shallow(<SendingDomainsTab {...defaultProps} {...props} />, {
-      context: { isHibanaEnabled: false },
-    });
+  const subject = props => shallow(<SendingDomainsTab {...defaultProps} {...props} />);
+
   it('should load domains in tab', () => {
+    mockConsumer.mockReturnValue({ isHibanaEnabled: false });
     const wrapper = subject()
-      .find(HibanaConsumer)
-      .renderProp('children')();
+      .find(HibanaStateContext.Consumer)
+      .renderProp('children')(mockConsumer());
     expect(wrapper).toHaveTextContent('Sending Domains assigned to this subaccount.');
     expect(wrapper.find('TableCollection')).toHaveProp('rows', defaultProps.domains);
   });
 
   it('should show panel loading while loading domains', () => {
+    mockConsumer.mockReturnValue({ isHibanaEnabled: false });
     const wrapper = subject({ loading: true });
-
     expect(wrapper.find('Loading')).toExist();
     expect(wrapper.find('TableCollection')).not.toExist();
   });
 
   it('should show empty message when 0 domains exist', () => {
+    mockConsumer.mockReturnValue({ isHibanaEnabled: false });
     const wrapper = subject({ domains: [] })
-      .find(HibanaConsumer)
-      .renderProp('children')();
+      .find(HibanaStateContext.Consumer)
+      .renderProp('children')(mockConsumer());
 
     expect(wrapper).toHaveTextContent(
       'This subaccount has no sending domains assigned to it. You can assign an existing one, or create a new one.',
@@ -46,7 +52,17 @@ describe('SendingDomainsTab', () => {
     expect(wrapper.find('PageLink')).toHaveProp('to', '/account/sending-domains');
   });
 
-  it('getRowData', () => {
-    expect(getRowData({ domain: 'foo.com' })).toMatchSnapshot();
+  it('should show a link to /domains/list/sending when hibana is enabled', () => {
+    mockConsumer.mockReturnValue({ isHibanaEnabled: true });
+    const wrapper = subject({ domains: [] }).renderProp('children')(mockConsumer());
+    expect(wrapper.find('PageLink')).toHaveProp('to', '/domains/list/sending');
+  });
+
+  it('snapshots getRowData without hibana', () => {
+    expect(getRowData({ domain: 'foo.com' }, false)).toMatchSnapshot();
+  });
+
+  it('snapshots getRowData with hibana', () => {
+    expect(getRowData({ domain: 'foo.com' }, true)).toMatchSnapshot();
   });
 });

--- a/src/pages/subaccounts/components/test/SendingDomainsTab.test.js
+++ b/src/pages/subaccounts/components/test/SendingDomainsTab.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { SendingDomainsTab, getRowData } from '../SendingDomainsTab';
+import { HibanaConsumer } from 'src/context/HibanaContext';
 
 describe('SendingDomainsTab', () => {
   const defaultProps = {
@@ -15,11 +16,14 @@ describe('SendingDomainsTab', () => {
     loading: false,
   };
 
-  const subject = props => shallow(<SendingDomainsTab {...defaultProps} {...props} />);
-
+  const subject = props =>
+    shallow(<SendingDomainsTab {...defaultProps} {...props} />, {
+      context: { isHibanaEnabled: false },
+    });
   it('should load domains in tab', () => {
-    const wrapper = subject();
-
+    const wrapper = subject()
+      .find(HibanaConsumer)
+      .renderProp('children')();
     expect(wrapper).toHaveTextContent('Sending Domains assigned to this subaccount.');
     expect(wrapper.find('TableCollection')).toHaveProp('rows', defaultProps.domains);
   });
@@ -32,7 +36,9 @@ describe('SendingDomainsTab', () => {
   });
 
   it('should show empty message when 0 domains exist', () => {
-    const wrapper = subject({ domains: [] });
+    const wrapper = subject({ domains: [] })
+      .find(HibanaConsumer)
+      .renderProp('children')();
 
     expect(wrapper).toHaveTextContent(
       'This subaccount has no sending domains assigned to it. You can assign an existing one, or create a new one.',

--- a/src/pages/subaccounts/components/test/__snapshots__/SendingDomainsTab.test.js.snap
+++ b/src/pages/subaccounts/components/test/__snapshots__/SendingDomainsTab.test.js.snap
@@ -1,6 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SendingDomainsTab getRowData 1`] = `
+exports[`SendingDomainsTab snapshots getRowData with hibana 1`] = `
+Array [
+  <PageLink
+    to="/domains/details/sending-bounce/foo.com"
+  >
+    foo.com
+  </PageLink>,
+  <DomainStatusCell
+    domain={
+      Object {
+        "domain": "foo.com",
+      }
+    }
+  />,
+]
+`;
+
+exports[`SendingDomainsTab snapshots getRowData without hibana 1`] = `
 Array [
   <PageLink
     to="/account/sending-domains/edit/foo.com"


### PR DESCRIPTION
FE-1244 - Redirection to account/sending-domains from /account/subaccounts and Add a Sending Domain step on Dashboard should be replaced with correct domain pages in Hibana


### What Changed

- In Hibana redirect to /domains/list/sending instead of account/sending-domains from /account/subaccounts page
- In Hibana redirect to /domains/create instead of account/sending-domains/create Add a Sending Domain step on old 
Dashboard page

### How To Test
 - Check if the links redirect to correct pages in Hibana and in OG

### To Do
- [ ] Address feedback
