### PR TITLE
[FE-1258] listtracking call for Link tracking domain section

### DIFF
--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -63,13 +63,12 @@ function DetailsPage(props) {
     };
   }, [clearSendingDomain, getDomain, isTracking, match.params.id]);
   useEffect(() => {
-    if (isTracking)
-      listTrackingDomains().then(res => {
-        //this logic redirects to list page when the tracking domain is not found in the list
-        if (!Boolean(_.find(res, ['domain', match.params.id.toLowerCase()]))) {
-          settrackingDomainNotFound(true);
-        }
-      });
+    listTrackingDomains().then(res => {
+      //this logic redirects to list page when the tracking domain is not found in the list
+      if (isTracking && !Boolean(_.find(res, ['domain', match.params.id.toLowerCase()]))) {
+        settrackingDomainNotFound(true);
+      }
+    });
   }, [history, isTracking, listTrackingDomains, match.params.id]);
 
   useEffect(() => {


### PR DESCRIPTION
[FE-1258] - Link tracking domain section not showing subaccount options

### What Changed
 - Added listtracking call for Link tracking domain section
### How To Test
 - Click on a verified sending domain and check the Link Tracking domain section
 - On clicking select their you should see all the available options
 - Double check with old ui in OG theme.

### To Do
- [ ] Address feedback


[FE-1258]: https://sparkpost.atlassian.net/browse/FE-1258