### PR TITLE
Fe 1258 hotfix - fixing tracking domain options for sending domain with subaccounts

### DIFF
--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -22,10 +22,7 @@ import {
   verifyTrackingDomain,
 } from 'src/actions/trackingDomains';
 import { selectSendingDomainsRows, selectBounceDomainsRows } from 'src/selectors/sendingDomains';
-import {
-  selectTrackingDomainsRows,
-  selectTrackingDomainsOptions,
-} from 'src/selectors/trackingDomains';
+import { selectTrackingDomainsRows } from 'src/selectors/trackingDomains';
 import { selectTrackingDomainCname } from 'src/selectors/account';
 import { hasSubaccounts } from 'src/selectors/subaccounts';
 import { DomainsProvider } from '../context/DomainsContext';
@@ -52,7 +49,6 @@ function mapStateToProps(state) {
     hasSubaccounts: hasSubaccounts(state),
     subaccounts: state.subaccounts.list,
     trackingDomains: selectTrackingDomainsRows(state),
-    trackingDomainOptions: selectTrackingDomainsOptions(state),
     trackingDomainsListError: state.trackingDomains.error,
     userName: state.currentUser.username,
     isByoipAccount: selectCondition(hasAccountOptionEnabled('byoip_customer'))(state),

--- a/src/pages/domains/components/LinkTrackingDomainSection.js
+++ b/src/pages/domains/components/LinkTrackingDomainSection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Button, Layout, Stack } from 'src/components/matchbox';
 import { Panel } from 'src/components/matchbox';
 import { SubduedText } from 'src/components/text';
@@ -7,10 +8,11 @@ import { useForm, Controller } from 'react-hook-form';
 import { Select } from 'src/components/matchbox';
 import useDomains from '../hooks/useDomains';
 import { EXTERNAL_LINKS } from '../constants';
+import { selectTrackingDomainsOptions } from 'src/selectors/trackingDomains';
 
-export default function LinkTrackingDomainSection({ domain, isSectionVisible }) {
+function LinkTrackingDomainSection({ domain, isSectionVisible, trackingDomainOptions }) {
   const { control, handleSubmit, watch } = useForm();
-  const { trackingDomainOptions, updateSendingDomain, showAlert } = useDomains();
+  const { updateSendingDomain, showAlert } = useDomains();
 
   const onSubmit = ({ trackingDomain }) => {
     const { id, subaccount_id: subaccount } = domain;
@@ -85,3 +87,10 @@ export default function LinkTrackingDomainSection({ domain, isSectionVisible }) 
     </Layout>
   );
 }
+
+export default connect(
+  (state, props) => ({
+    trackingDomainOptions: selectTrackingDomainsOptions(state, props),
+  }),
+  null,
+)(LinkTrackingDomainSection);


### PR DESCRIPTION
How to test - 

- Check for option in "Link Tracking Domains" section for sending domain with subaccounts and check option in OG theme.
- Check for option in "Link Tracking Domains" section for sending domain without subaccounts and check option in OG theme.