### PR TITLE
FE-1257 - DashboardV2 Onboarding Grant Check

### DIFF
--- a/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
+++ b/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
@@ -297,14 +297,10 @@ describe('Version 2 of the dashboard page', () => {
       stubAlertsReq();
       stubAccountsReq();
       // Force not admin here - Our mocked cypress state always has the user as admin
-      cy.stubRequest({
-        url: `/api/v1/users/${Cypress.env('USERNAME')}`,
-        fixture: 'users/200.get.reporting.json',
-        requestAlias: 'userReq',
-      });
+      stubUsersRequest({ access_level: 'reporting' });
 
       cy.visit(PAGE_URL);
-      cy.wait(['@alertsReq', '@accountReq', '@userReq']);
+      cy.wait(['@alertsReq', '@accountReq', '@getUsers']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 
@@ -343,9 +339,10 @@ describe('Version 2 of the dashboard page', () => {
       stubGrantsRequest({ role: 'reporting' });
       stubAlertsReq();
       stubAccountsReq();
+      stubUsersRequest({ access_level: 'reporting' });
 
       cy.visit(PAGE_URL);
-      cy.wait(['@getGrants', '@alertsReq', '@accountReq']);
+      cy.wait(['@getGrants', '@alertsReq', '@accountReq', '@getUsers']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 
@@ -402,16 +399,12 @@ describe('Version 2 of the dashboard page', () => {
       stubUsageReq({ fixture: 'usage/200.get.messaging.json' });
       stubSendingDomains({ fixture: 'sending-domains/200.get.json' });
       stubApiKeyReq({ fixture: 'api-keys/200.get.json' });
-      cy.stubRequest({
-        url: `/api/v1/users/${Cypress.env('USERNAME')}`,
-        fixture: 'users/200.get.reporting.json',
-        requestAlias: 'userReq',
-      });
+      stubUsersRequest({ access_level: 'reporting' });
       cy.visit(PAGE_URL);
       cy.wait([
         '@accountReq',
         '@alertsReq',
-        '@userReq',
+        '@getUsers',
         '@usageReq',
         '@sendingDomainsReq',
         '@apiKeysReq',
@@ -577,5 +570,13 @@ function stubGrantsRequest({ role }) {
     url: '/api/v1/authenticate/grants*',
     fixture: `authenticate/grants/200.get.${role}.json`,
     requestAlias: 'getGrants',
+  });
+}
+
+function stubUsersRequest({ access_level }) {
+  cy.stubRequest({
+    url: '/api/v1/users/appteam',
+    fixture: `users/200.get.${access_level}.json`,
+    requestAlias: 'getUsers',
   });
 }

--- a/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
+++ b/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
@@ -53,15 +53,10 @@ describe('Version 2 of the dashboard page', () => {
       stubAlertsReq();
       stubAccountsReq();
       stubUsageReq({ fixture: 'usage/200.get.messaging.no-last-sent.json' });
-      // Force not admin here - Our mocked cypress state always has the user as admin
-      cy.stubRequest({
-        url: `/api/v1/users/${Cypress.env('USERNAME')}`,
-        fixture: 'users/200.get.reporting.json',
-        requestAlias: 'userReq',
-      });
+      stubUsersRequest({ access_level: 'reporting' });
 
       cy.visit(PAGE_URL);
-      cy.wait(['@alertsReq', '@accountReq', '@usageReq', '@userReq']);
+      cy.wait(['@alertsReq', '@accountReq', '@usageReq', '@getUsers']);
 
       cy.findByRole('heading', { name: 'Helpful Shortcuts' }).should('be.visible');
 

--- a/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
+++ b/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
@@ -53,7 +53,7 @@ describe('Version 2 of the dashboard page', () => {
       stubAlertsReq();
       stubAccountsReq();
       stubUsageReq({ fixture: 'usage/200.get.messaging.no-last-sent.json' });
-      // FORCE NOT ADMIN HERE
+      // Force not admin here - Our mocked cypress state always has the user as admin
       cy.stubRequest({
         url: `/api/v1/users/${Cypress.env('USERNAME')}`,
         fixture: 'users/200.get.reporting.json',
@@ -296,10 +296,7 @@ describe('Version 2 of the dashboard page', () => {
       stubGrantsRequest({ role: 'reporting' });
       stubAlertsReq();
       stubAccountsReq();
-      stubUsageReq({ fixture: 'usage/200.get.messaging.no-last-sent.json' });
-      stubSendingDomains({ fixture: '/200.get.no-results.json' });
-      stubApiKeyReq({ fixture: '/200.get.no-results.json' });
-      // Force not admin here
+      // Force not admin here - Our mocked cypress state always has the user as admin
       cy.stubRequest({
         url: `/api/v1/users/${Cypress.env('USERNAME')}`,
         fixture: 'users/200.get.reporting.json',
@@ -307,14 +304,7 @@ describe('Version 2 of the dashboard page', () => {
       });
 
       cy.visit(PAGE_URL);
-      cy.wait([
-        '@alertsReq',
-        '@accountReq',
-        '@usageReq',
-        '@sendingDomainsReq',
-        '@apiKeysReq',
-        '@userReq',
-      ]);
+      cy.wait(['@alertsReq', '@accountReq', '@userReq']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 
@@ -350,22 +340,12 @@ describe('Version 2 of the dashboard page', () => {
     });
 
     it('Shows the default "Go To Analytics Report" onboarding step for any user without the sending_domains/manage grant', () => {
-      stubGrantsRequest({ role: 'reporting' }); // canManageSendingDomains = false
+      stubGrantsRequest({ role: 'reporting' });
       stubAlertsReq();
       stubAccountsReq();
-      stubUsageReq({ fixture: 'usage/200.get.messaging.no-last-sent.json' });
-      stubSendingDomains({ fixture: '/200.get.no-results.json' });
-      stubApiKeyReq({ fixture: '/200.get.no-results.json' });
 
       cy.visit(PAGE_URL);
-      cy.wait([
-        '@getGrants',
-        '@alertsReq',
-        '@accountReq',
-        '@usageReq',
-        '@sendingDomainsReq',
-        '@apiKeysReq',
-      ]);
+      cy.wait(['@getGrants', '@alertsReq', '@accountReq']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 

--- a/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
+++ b/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
@@ -56,7 +56,8 @@ describe('Version 2 of the dashboard page', () => {
       stubUsersRequest({ access_level: 'reporting' });
 
       cy.visit(PAGE_URL);
-      cy.wait(['@alertsReq', '@accountReq', '@usageReq', '@getUsers']);
+
+      cy.wait(['@alertsReq', '@accountReq', '@usageReq', '@stubbedUsersRequest']);
 
       cy.findByRole('heading', { name: 'Helpful Shortcuts' }).should('be.visible');
 
@@ -295,7 +296,7 @@ describe('Version 2 of the dashboard page', () => {
       stubUsersRequest({ access_level: 'reporting' });
 
       cy.visit(PAGE_URL);
-      cy.wait(['@alertsReq', '@accountReq', '@getUsers']);
+      cy.wait(['@alertsReq', '@accountReq', '@stubbedUsersRequest']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 
@@ -337,7 +338,7 @@ describe('Version 2 of the dashboard page', () => {
       stubUsersRequest({ access_level: 'reporting' });
 
       cy.visit(PAGE_URL);
-      cy.wait(['@getGrants', '@alertsReq', '@accountReq', '@getUsers']);
+      cy.wait(['@getGrants', '@alertsReq', '@accountReq', '@stubbedUsersRequest']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 
@@ -399,7 +400,7 @@ describe('Version 2 of the dashboard page', () => {
       cy.wait([
         '@accountReq',
         '@alertsReq',
-        '@getUsers',
+        '@stubbedUsersRequest',
         '@usageReq',
         '@sendingDomainsReq',
         '@apiKeysReq',
@@ -568,10 +569,11 @@ function stubGrantsRequest({ role }) {
   });
 }
 
+// this is an override of the stub set by stubAuth
 function stubUsersRequest({ access_level }) {
   cy.stubRequest({
-    url: '/api/v1/users/appteam',
+    url: `/api/v1/users/${Cypress.env('USERNAME')}`,
     fixture: `users/200.get.${access_level}.json`,
-    requestAlias: 'getUsers',
+    requestAlias: 'stubbedUsersRequest',
   });
 }

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -27,8 +27,6 @@ function mapStateToProps(state) {
   // TODO: https://sparkpost.atlassian.net/browse/FE-1249 - rvUsage rename
   let lastUsageDate = state?.account?.rvUsage?.messaging?.last_usage_date;
 
-  // let onboarding = state?.onboarding;
-  // TODO: Move onboarding to a higher state/provider where it can be pulled into any area of the app
   const sendingDomains = state.sendingDomains.list;
   const verifiedDomains = selectVerifiedDomains(state);
   const apiKeysForSending = selectApiKeysForSending(state);
@@ -51,7 +49,7 @@ function mapStateToProps(state) {
 
     if (!addSendingDomainNeeded && !verifySendingNeeded && !createApiKeyNeeded)
       onboarding = 'startSending';
-  } else if (lastUsageDate === null) {
+  } else if (!canViewUsage || (canViewUsage && lastUsageDate === null)) {
     onboarding = 'fallback';
   } else {
     onboarding = 'done';

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -36,7 +36,7 @@ function mapStateToProps(state) {
   const canManageApiKeys = hasGrants('api_keys/manage')(state);
   const canManageSendingDomains = hasGrants('sending_domains/manage')(state);
 
-  let onboarding = 'done';
+  let onboarding;
   if (canViewUsage && lastUsageDate === null) {
     if (isAnAdmin || isDev) {
       let addSendingDomainNeeded;

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -36,7 +36,7 @@ function mapStateToProps(state) {
   const canManageApiKeys = hasGrants('api_keys/manage')(state);
   const canManageSendingDomains = hasGrants('sending_domains/manage')(state);
 
-  let onboarding;
+  let onboarding = 'done';
   if (canViewUsage && lastUsageDate === null) {
     if (isAnAdmin || isDev) {
       let addSendingDomainNeeded;

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -27,6 +27,7 @@ function mapStateToProps(state) {
   // TODO: https://sparkpost.atlassian.net/browse/FE-1249 - rvUsage rename
   let lastUsageDate = state?.account?.rvUsage?.messaging?.last_usage_date;
 
+  // let onboarding = state?.onboarding;
   // TODO: Move onboarding to a higher state/provider where it can be pulled into any area of the app
   const sendingDomains = state.sendingDomains.list;
   const verifiedDomains = selectVerifiedDomains(state);
@@ -56,7 +57,7 @@ function mapStateToProps(state) {
     onboarding = 'done';
   }
 
-  if (onboarding && sendingDomains.length === 1 && onboarding === 'verifySending') {
+  if (onboarding && onboarding === 'verifySending' && sendingDomains.length === 1) {
     verifySendingLink = `/domains/details/sending-bounce/${sendingDomains[0].domain}`;
   }
 

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -49,10 +49,8 @@ function mapStateToProps(state) {
 
     if (!addSendingDomainNeeded && !verifySendingNeeded && !createApiKeyNeeded)
       onboarding = 'startSending';
-  } else if (!canViewUsage || (canViewUsage && lastUsageDate === null)) {
-    onboarding = 'fallback';
   } else {
-    onboarding = 'done';
+    onboarding = 'fallback';
   }
 
   if (onboarding && onboarding === 'verifySending' && sendingDomains.length === 1) {

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -24,6 +24,8 @@ function mapStateToProps(state) {
   const sendingDomains = state.sendingDomains.list;
   const verifiedDomains = selectVerifiedDomains(state);
   const apiKeysForSending = selectApiKeysForSending(state);
+  const canViewUsage = hasGrants('usage/view')(state);
+  const canManageApiKeys = hasGrants('api_keys/manage')(state);
   const canManageSendingDomains = hasGrants('sending_domains/manage')(state);
   const isAnAdmin = isAdmin(state);
   const isDev = hasRole(ROLES.DEVELOPER)(state);
@@ -32,8 +34,8 @@ function mapStateToProps(state) {
   let lastUsageDate = state?.account?.rvUsage?.messaging?.last_usage_date;
   let onboarding;
 
-  if (lastUsageDate === null) {
-    const addSendingDomainNeeded = (isAnAdmin || isDev) && sendingDomains.length === 0;
+  if (canManageSendingDomains && canManageApiKeys && canViewUsage && lastUsageDate === null) {
+    const addSendingDomainNeeded = sendingDomains.length === 0;
     if (addSendingDomainNeeded) onboarding = 'addSending';
 
     if (sendingDomains.length === 1 && verifiedDomains.length === 0) {
@@ -50,8 +52,8 @@ function mapStateToProps(state) {
 
     if (!addSendingDomainNeeded && !verifySendingNeeded && !createApiKeyNeeded)
       onboarding = 'startSending';
-
-    if (!canManageSendingDomains || (!isAnAdmin && !isDev)) onboarding = 'fallback';
+  } else {
+    onboarding = 'fallback';
   }
 
   const isPending =
@@ -64,7 +66,9 @@ function mapStateToProps(state) {
   return {
     verifySendingLink,
     onboarding,
+    canViewUsage,
     canManageSendingDomains,
+    canManageApiKeys,
     isAnAdmin,
     isDev,
     currentUser: state.currentUser,

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -36,7 +36,7 @@ function mapStateToProps(state) {
   const canManageApiKeys = hasGrants('api_keys/manage')(state);
   const canManageSendingDomains = hasGrants('sending_domains/manage')(state);
 
-  let onboarding;
+  let onboarding = 'done';
   if (canViewUsage && lastUsageDate === null) {
     if (isAnAdmin || isDev) {
       let addSendingDomainNeeded;
@@ -52,22 +52,20 @@ function mapStateToProps(state) {
       }
 
       // TODO: Has d12y + free sending, "no";
+      // TODO: Has d12y + free sending, "yes";
       if (!addSendingDomainNeeded && !verifySendingNeeded && canManageApiKeys) {
         createApiKeyNeeded = !verifySendingNeeded && apiKeysForSending.length === 0;
         if (createApiKeyNeeded) onboarding = 'createApiKey';
-      } else {
-        // TODO: Has d12y + free sending, "yes" -> onboarding = 'analyticsReportPromo';
       }
 
       if (!addSendingDomainNeeded && !verifySendingNeeded && !createApiKeyNeeded)
         onboarding = 'startSending';
     }
-
+  } else {
     if (isTemplatesUser || isReportingUser) {
+      //TODO: revisit this condition if usage/view grant gets added for reporting & subaccount_reporting users
       onboarding = 'analyticsReportPromo';
     }
-  } else {
-    onboarding = 'done';
   }
 
   if (onboarding && onboarding === 'verifySending' && sendingDomains.length === 1) {

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -50,8 +50,10 @@ function mapStateToProps(state) {
 
     if (!addSendingDomainNeeded && !verifySendingNeeded && !createApiKeyNeeded)
       onboarding = 'startSending';
-  } else {
+  } else if (lastUsageDate === null) {
     onboarding = 'fallback';
+  } else {
+    onboarding = 'done';
   }
 
   if (onboarding && sendingDomains.length === 1 && onboarding === 'verifySending') {

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -31,6 +31,9 @@ const OnboardingPicture = styled(Picture.Image)`
 
 export default function DashboardPageV2() {
   const {
+    canViewUsage,
+    canManageSendingDomains,
+    canManageApiKeys,
     getAccount,
     listAlerts,
     getUsage,
@@ -48,9 +51,9 @@ export default function DashboardPageV2() {
   useEffect(() => {
     getAccount();
     listAlerts();
-    getUsage();
-    listSendingDomains();
-    listApiKeys();
+    if (canViewUsage) getUsage();
+    if (canManageSendingDomains) listSendingDomains();
+    if (canManageApiKeys) listApiKeys();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -153,11 +156,10 @@ export default function DashboardPageV2() {
                               <Abbreviation title="Application Programming Interface">
                                 API&nbsp;
                               </Abbreviation>
-                              <TranslatableText>key in order to start sending via</TranslatableText>
-                              <Abbreviation title="Application Programming Interface">
-                                &nbsp;API&nbsp;
-                              </Abbreviation>
-                              <TranslatableText>or</TranslatableText>
+                              <TranslatableText>
+                                key in order to start sending via API
+                              </TranslatableText>
+                              <TranslatableText>&nbsp;or</TranslatableText>
                               <Abbreviation title="Simple Mail Transfer Protocol">
                                 &nbsp;SMTP.
                               </Abbreviation>

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -76,7 +76,7 @@ export default function DashboardPageV2() {
         <Layout>
           <Layout.Section>
             <Stack>
-              {onboarding !== 'fallback' && onboarding !== undefined && (
+              {onboarding !== 'analyticsReportPromo' && onboarding !== undefined && (
                 <Dashboard.Panel>
                   {onboarding === 'addSending' && (
                     <Columns>
@@ -227,7 +227,7 @@ export default function DashboardPageV2() {
                   )}
                 </Dashboard.Panel>
               )}
-              {onboarding === 'fallback' && (
+              {onboarding === 'analyticsReportPromo' && (
                 <Dashboard.Panel>
                   <Columns>
                     <Column>


### PR DESCRIPTION
### What Changed
 - Added grant checks around the dynamic onboarding states. Set fallback as the else if the needed grants are not met.
 - Removed the extra <Abbr> element

Follow on to: https://github.com/SparkPost/2web2ui/pull/1899
(in that pr I added an extra abbr and didnt set the right grant checks - this fixes that)

**Note**: At some point I think it'd be good to move the onboarding logic/string to be on the main app state where any component/state could pick up on it and react to the users onboarding state. 

### How To Test
 - Load up a user of each type and check to see the onboarding states are correct.
admin and dev will see the individual onboarding steps based on sending domain and api key data. 
reporting and templates will _currently_ always see the analytics promo until a future ticket changes that. 

### To Do
- [x] Review Feedback
