### PR TITLE
FE-1279 - CNAME instead of TXT

### DIFF
--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -74,7 +74,7 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
                     <Text as="label" fontWeight="500" fontSize="200">
                       Type
                     </Text>
-                    <Text as="p">TXT</Text>
+                    <Text as="p">CNAME</Text>
                   </>
                 )}
                 <CopyField label="Hostname" value={domainName} hideCopy={!unverified} />


### PR DESCRIPTION
### What Changed
- display text `TXT` is changed to `CNAME`

![image](https://user-images.githubusercontent.com/4204806/101544337-216ce280-396b-11eb-96b1-cd78efa630fa.png)


### How To Test
- Just need to make sure the value displays correctly on the tracking domain details page: http://localhost:3100/domains/details/tracking/{domain_name}
domain I used: boo-yeah.com

### To Do
- [ ] feedback
