### PR TITLE
FE-1278 - Domain Configuration Feedback

### DIFF
--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -384,10 +384,6 @@ describe('The domains details page', () => {
           cy.visit(`${SENDING_BOUNCE_DETAILS_URL}/hello-world-there.com`);
           cy.wait(['@accountDomainsReq', '@unverifieddkimSendingDomains']);
 
-          // HERE!
-          // cy.get('p').contains('Add these TXT records, Hostnames, and Values for this domain in the settings section of your DNS provider.');
-          // cy.get('p').contains('Add the CNAME record, Hostname and Value for this domain in the settings section of your DNS provider');
-
           cy.findByLabelText('The TXT record has been added to the DNS provider.').check({
             force: true,
           });

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -68,6 +68,25 @@ describe('The domains details page', () => {
               'href',
               'https://www.sparkpost.com/docs/tech-resources/enabling-multiple-custom-tracking-domains/',
             );
+
+          cy.get('p')
+            .contains(
+              'Add the CNAME records, Hostnames, and Values for this domain in the settings section of your DNS provider.',
+            )
+            .should('be.visible');
+
+          cy.findByRole('button', { name: 'Verify Domain' }).click();
+          cy.findAllByText(
+            'Please confirm you have added the records to your DNS provider.',
+          ).should('be.visible');
+
+          cy.findAllByLabelText('The CNAME record has been added to the DNS provider.').click({
+            force: true,
+          });
+
+          cy.findAllByText(
+            'Please confirm you have added the records to your DNS provider.',
+          ).should('not.be.visible');
         });
 
         it('verified Tracking Domain with assigned subaccount functions correctly', () => {
@@ -328,6 +347,11 @@ describe('The domains details page', () => {
 
           cy.visit(`${SENDING_BOUNCE_DETAILS_URL}/hello-world-there.com`);
           cy.wait(['@accountDomainsReq', '@unverifieddkimSendingDomains']);
+
+          // HERE!
+          // cy.get('p').contains('Add these TXT records, Hostnames, and Values for this domain in the settings section of your DNS provider.');
+          // cy.get('p').contains('Add the CNAME record, Hostname and Value for this domain in the settings section of your DNS provider');
+
           cy.findByLabelText('The TXT record has been added to the DNS provider.').check({
             force: true,
           });

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -330,6 +330,42 @@ describe('The domains details page', () => {
           cy.findByRole('heading', { name: 'Link Tracking Domain' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');
           cy.findByRole('button', { name: 'Verify Domain' }).should('be.visible');
+
+          cy.get('p')
+            .contains(
+              'Add these TXT records, Hostnames, and Values for this domain in the settings section of your DNS provider.',
+            )
+            .should('be.visible');
+
+          cy.findByRole('button', { name: 'Verify Domain' }).click();
+
+          cy.findAllByText(
+            'Please confirm you have added the records to your DNS provider.',
+          ).should('be.visible');
+
+          cy.findAllByLabelText('The TXT record has been added to the DNS provider.').click({
+            force: true,
+          });
+
+          cy.findAllByText(
+            'Please confirm you have added the records to your DNS provider.',
+          ).should('not.be.visible');
+
+          cy.get('p')
+            .contains(
+              'Add the CNAME record, Hostname, and Value for this domain in the settings section of your DNS provider.',
+            )
+            .should('be.visible');
+
+          cy.findByRole('button', { name: 'Verify Bounce' }).click();
+
+          cy.findAllByLabelText('The CNAME record has been added to the DNS provider.').click({
+            force: true,
+          });
+
+          cy.findAllByText(
+            'Please confirm you have added the records to your DNS provider.',
+          ).should('not.be.visible');
         });
 
         it('unverified domain renders success message on Verifying Dkim for domain', () => {

--- a/cypress/tests/integration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/domains/detailsPage.spec.js
@@ -50,6 +50,7 @@ describe('The domains details page', () => {
           cy.findByRole('heading', { name: 'Domains' }).should('be.visible');
           cy.url().should('include', '/domains/list');
         });
+
         it('For unverified Tracking Domain sections are rendered correctly along with a unverified banner', () => {
           cy.stubRequest({
             url: '/api/v1/tracking-domains',
@@ -68,6 +69,7 @@ describe('The domains details page', () => {
               'https://www.sparkpost.com/docs/tech-resources/enabling-multiple-custom-tracking-domains/',
             );
         });
+
         it('verified Tracking Domain with assigned subaccount functions correctly', () => {
           let domainName = 'track1.spappteam.com';
           cy.stubRequest({
@@ -326,7 +328,7 @@ describe('The domains details page', () => {
 
           cy.visit(`${SENDING_BOUNCE_DETAILS_URL}/hello-world-there.com`);
           cy.wait(['@accountDomainsReq', '@unverifieddkimSendingDomains']);
-          cy.findByLabelText('The TXT record has been added to the DNS provider').check({
+          cy.findByLabelText('The TXT record has been added to the DNS provider.').check({
             force: true,
           });
           cy.findByRole('button', { name: 'Verify Domain' }).click();
@@ -351,7 +353,7 @@ describe('The domains details page', () => {
           cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');
           cy.findByRole('heading', { name: 'Sending' }).should('be.visible');
           cy.findByRole('heading', { name: 'Bounce' }).should('be.visible');
-          cy.findByRole('button', { name: 'Authenticate for Bounce' }).should('be.visible');
+          cy.findByRole('button', { name: 'Verify Bounce' }).should('be.visible');
           cy.findByRole('heading', { name: 'DNS Verification' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'Email Verification' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'Sending and Bounce' }).should('not.be.visible');
@@ -371,10 +373,10 @@ describe('The domains details page', () => {
           });
           cy.visit(`${SENDING_BOUNCE_DETAILS_URL}/prd2.splango.net`);
           cy.wait(['@unverifiedBounceDomains', '@accountDomainsReq']);
-          cy.findAllByLabelText('The CNAME record has been added to the DNS provider').click({
+          cy.findAllByLabelText('The CNAME record has been added to the DNS provider.').click({
             force: true,
           });
-          cy.findByRole('button', { name: 'Authenticate for Bounce' }).click();
+          cy.findByRole('button', { name: 'Verify Bounce' }).click();
           cy.wait('@verifyDomain');
           cy.findAllByText(
             'You have successfully verified cname record of prd2.splango.net',
@@ -400,6 +402,7 @@ describe('The domains details page', () => {
           cy.findByRole('heading', { name: 'DNS Verification' }).should('not.be.visible');
           cy.findByRole('heading', { name: 'Email Verification' }).should('not.be.visible');
         });
+
         it('renders correct sections for verified bounce domain and unverified sending domain', () => {
           cy.stubRequest({
             url: '/api/v1/sending-domains/bounce2.spappteam.com',
@@ -418,6 +421,7 @@ describe('The domains details page', () => {
           cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
           cy.findByRole('heading', { name: 'Email Verification' }).should('be.visible');
         });
+
         it('renders snackbar after sharing and un-sharing the domain.', () => {
           cy.stubRequest({
             url: '/api/v1/sending-domains/bounce2.spappteam.com',
@@ -450,6 +454,7 @@ describe('The domains details page', () => {
             );
           });
         });
+
         it('delete domain prompts confirmation modal first', () => {
           cy.stubRequest({
             url: '/api/v1/sending-domains/bounce2.spappteam.com',

--- a/cypress/tests/integration/domains/verifyBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifyBounceDomainPage.spec.js
@@ -45,6 +45,13 @@ describe('The verify bounce domain page', () => {
         });
         cy.visit(BASE_URL + 'prd2.splango.net/verify-bounce');
         cy.wait(['@accountDomainsReq', '@unverifiedBounceDomains']);
+
+        cy.verifyLink({
+          content: 'Forward to Colleague',
+          href:
+            'mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(http://localhost:3100/domains/details/prd2.splango.net/verify-bounce)%0D%0A',
+        });
+
         cy.findAllByLabelText('The CNAME record has been added to the DNS provider.').click({
           force: true,
         });

--- a/cypress/tests/integration/domains/verifyBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifyBounceDomainPage.spec.js
@@ -48,8 +48,9 @@ describe('The verify bounce domain page', () => {
 
         cy.verifyLink({
           content: 'Forward to Colleague',
-          href:
-            'mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(http://localhost:3100/domains/details/prd2.splango.net/verify-bounce)%0D%0A',
+          href: `mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${
+            Cypress.config().baseUrl
+          }/domains/details/prd2.splango.net/verify-bounce)%0D%0A`,
         });
 
         cy.findAllByLabelText('The CNAME record has been added to the DNS provider.').click({

--- a/cypress/tests/integration/domains/verifyBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifyBounceDomainPage.spec.js
@@ -17,6 +17,7 @@ describe('The verify bounce domain page', () => {
           requestAlias: 'accountDomainsReq',
         });
       });
+
       it('renders with a relevant page title', () => {
         cy.stubRequest({
           url: '/api/v1/sending-domains/prd2.splango.net',
@@ -30,7 +31,7 @@ describe('The verify bounce domain page', () => {
         cy.findByRole('heading', { name: 'Verify Bounce Domain' }).should('be.visible');
       });
 
-      it('clicking on Authenticate for Bounce, displays a success message', () => {
+      it('clicking on Verify Bounce, displays a success message', () => {
         cy.stubRequest({
           url: '/api/v1/sending-domains/prd2.splango.net',
           fixture: 'sending-domains/200.get.unverified-bounce.json',
@@ -44,14 +45,10 @@ describe('The verify bounce domain page', () => {
         });
         cy.visit(BASE_URL + 'prd2.splango.net/verify-bounce');
         cy.wait(['@accountDomainsReq', '@unverifiedBounceDomains']);
-
-        cy.findByRole('button', { name: 'Authenticate for Bounce' }).should('be.disabled');
-        cy.findAllByLabelText('The CNAME record has been added to the DNS provider').click({
+        cy.findAllByLabelText('The CNAME record has been added to the DNS provider.').click({
           force: true,
         });
-        cy.findByRole('button', { name: 'Authenticate for Bounce' }).should('not.be.disabled');
-        cy.findByRole('button', { name: 'Authenticate for Bounce' }).click();
-
+        cy.findByRole('button', { name: 'Verify Bounce' }).click();
         cy.wait('@verifyDomain');
         cy.findAllByText('You have successfully verified cname record of prd2.splango.net').should(
           'be.visible',

--- a/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
@@ -83,7 +83,7 @@ describe('The verify sending/bounce domain page', () => {
         cy.findByRole('heading', { name: 'CNAME record for Bounce' }).should('be.visible');
       });
 
-      it('Verify Domain submit button is displays an error message until the user selects the confirmation checkbox', () => {
+      it('Verify Domain submit button displays an error message until the user selects the confirmation checkbox', () => {
         cy.stubRequest({
           url: '/api/v1/sending-domains/sending-bounce.net',
           fixture: 'sending-domains/200.get.unverified-dkim-bounce.json',

--- a/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
@@ -71,8 +71,9 @@ describe('The verify sending/bounce domain page', () => {
 
         cy.verifyLink({
           content: 'Forward to Colleague',
-          href:
-            'mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(http://localhost:3100/domains/details/sending-bounce.net/verify-sending-bounce)%0D%0A',
+          href: `mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${
+            Cypress.config().baseUrl
+          }/domains/details/sending-bounce.net/verify-sending-bounce)%0D%0A`,
         });
 
         cy.findByLabelText('The TXT and CNAME records have been added to the DNS provider.').check({

--- a/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
@@ -68,6 +68,13 @@ describe('The verify sending/bounce domain page', () => {
 
         cy.visit('/domains/details/sending-bounce.net/verify-sending-bounce');
         cy.wait(['@accountDomainsReq', '@unverifiedDkimBounce']);
+
+        cy.verifyLink({
+          content: 'Forward to Colleague',
+          href:
+            'mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(http://localhost:3100/domains/details/sending-bounce.net/verify-sending-bounce)%0D%0A',
+        });
+
         cy.findByLabelText('The TXT and CNAME records have been added to the DNS provider.').check({
           force: true,
         });

--- a/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingBounceDomainPage.spec.js
@@ -50,10 +50,10 @@ describe('The verify sending/bounce domain page', () => {
         cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
         cy.findByRole('heading', { name: 'Add DKIM Record' }).should('be.visible');
         cy.findByRole('heading', { name: 'Add Bounce Record' }).should('be.visible');
-        cy.findByRole('button', { name: 'Authenticate Domain' }).should('be.visible');
+        cy.findByRole('button', { name: 'Verify Domain' }).should('be.visible');
       });
 
-      it('clicking on the Authenticate Domain renders success message on succesful verification of dkim and cname of domain and renders correct section titles after', () => {
+      it('clicking on the Verify Domain renders success message on succesful verification of dkim and cname of domain and renders correct section titles after', () => {
         cy.stubRequest({
           url: '/api/v1/sending-domains/sending-bounce.net',
           fixture: 'sending-domains/200.get.unverified-dkim-bounce.json',
@@ -68,10 +68,10 @@ describe('The verify sending/bounce domain page', () => {
 
         cy.visit('/domains/details/sending-bounce.net/verify-sending-bounce');
         cy.wait(['@accountDomainsReq', '@unverifiedDkimBounce']);
-        cy.findByLabelText('The TXT and CNAME records have been added to the DNS provider').check({
+        cy.findByLabelText('The TXT and CNAME records have been added to the DNS provider.').check({
           force: true,
         });
-        cy.findByRole('button', { name: 'Authenticate Domain' }).click();
+        cy.findByRole('button', { name: 'Verify Domain' }).click();
         cy.wait('@verifyDomain');
         cy.findAllByText('You have successfully verified DKIM record of sending-bounce.net').should(
           'be.visible',
@@ -83,7 +83,7 @@ describe('The verify sending/bounce domain page', () => {
         cy.findByRole('heading', { name: 'CNAME record for Bounce' }).should('be.visible');
       });
 
-      it('Authenticate Domain submit button is disabled until the user selects the confirmation checkbox', () => {
+      it('Verify Domain submit button is displays an error message until the user selects the confirmation checkbox', () => {
         cy.stubRequest({
           url: '/api/v1/sending-domains/sending-bounce.net',
           fixture: 'sending-domains/200.get.unverified-dkim-bounce.json',
@@ -93,21 +93,30 @@ describe('The verify sending/bounce domain page', () => {
         cy.visit('/domains/details/sending-bounce.net/verify-sending-bounce');
         cy.wait(['@accountDomainsReq', '@unverifiedDkimBounce']);
 
-        cy.findByRole('button', { name: 'Authenticate Domain' }).should('be.visible');
-        cy.findAllByText('The TXT and CNAME records have been added to the DNS provider').should(
+        cy.findByRole('button', { name: 'Verify Domain' }).should('be.visible');
+
+        cy.findAllByText('The TXT and CNAME records have been added to the DNS provider.').should(
           'be.visible',
         );
-        cy.findAllByText('The TXT and CNAME records have been added to the DNS provider').should(
+        cy.findAllByText('The TXT and CNAME records have been added to the DNS provider.').should(
           'not.be.checked',
         );
-        cy.findByRole('button', { name: 'Authenticate Domain' }).should('be.disabled');
 
-        cy.findByLabelText('The TXT and CNAME records have been added to the DNS provider').check({
+        cy.findByRole('button', { name: 'Verify Domain' }).click({ force: true });
+
+        cy.findAllByText('Please confirm you have added the records to your DNS provider.').should(
+          'be.visible',
+        );
+
+        cy.findByLabelText('The TXT and CNAME records have been added to the DNS provider.').check({
           force: true,
         });
 
-        cy.findByRole('button', { name: 'Authenticate Domain' }).should('not.be.disabled');
-        cy.findByRole('button', { name: 'Authenticate Domain' }).click();
+        cy.findAllByText('Please confirm you have added the records to your DNS provider.').should(
+          'not.be.visible',
+        );
+
+        cy.findByRole('button', { name: 'Verify Domain' }).click();
       });
     });
   }

--- a/cypress/tests/integration/domains/verifySendingDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingDomainPage.spec.js
@@ -51,8 +51,9 @@ describe('The verify sending domain page', () => {
 
         cy.verifyLink({
           content: 'Forward to Colleague',
-          href:
-            'mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(http://localhost:3100/domains/details/hello-world-there.com/verify-sending)%0D%0A',
+          href: `mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${
+            Cypress.config().baseUrl
+          }/domains/details/hello-world-there.com/verify-sending)%0D%0A`,
         });
 
         cy.findAllByText('The TXT record has been added to the DNS provider.').should('be.visible');

--- a/cypress/tests/integration/domains/verifySendingDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingDomainPage.spec.js
@@ -49,6 +49,12 @@ describe('The verify sending domain page', () => {
 
         cy.wait(['@accountDomainsReq', '@unverifieddkimSendingDomains']);
 
+        cy.verifyLink({
+          content: 'Forward to Colleague',
+          href:
+            'mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=mockuser%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(http://localhost:3100/domains/details/hello-world-there.com/verify-sending)%0D%0A',
+        });
+
         cy.findAllByText('The TXT record has been added to the DNS provider.').should('be.visible');
 
         cy.findByLabelText('The TXT record has been added to the DNS provider.').check({

--- a/cypress/tests/integration/domains/verifySendingDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifySendingDomainPage.spec.js
@@ -49,11 +49,9 @@ describe('The verify sending domain page', () => {
 
         cy.wait(['@accountDomainsReq', '@unverifieddkimSendingDomains']);
 
-        cy.findAllByText('The TXT record has been added to the DNS provider').should('be.visible');
+        cy.findAllByText('The TXT record has been added to the DNS provider.').should('be.visible');
 
-        cy.findByRole('button', { name: 'Verify Domain' }).should('be.disabled');
-
-        cy.findByLabelText('The TXT record has been added to the DNS provider').check({
+        cy.findByLabelText('The TXT record has been added to the DNS provider.').check({
           force: true,
         });
 

--- a/cypress/tests/integration/domains/verifyTrackingDomainPage.spec.js
+++ b/cypress/tests/integration/domains/verifyTrackingDomainPage.spec.js
@@ -17,6 +17,7 @@ describe('The verify tracking domain page', () => {
           requestAlias: 'accountDomainsReq',
         });
       });
+
       it('renders with a relevant page title', () => {
         let domainName = 'blah231231231.gmail.com';
         cy.stubRequest({
@@ -32,6 +33,7 @@ describe('The verify tracking domain page', () => {
         cy.title().should('include', 'Verify Tracking Domain');
         cy.findByRole('heading', { name: 'Verify Tracking Domain' }).should('be.visible');
       });
+
       it('redirects to domains list page when domain not found', () => {
         let domainName = 'domain.not.found';
         cy.stubRequest({

--- a/src/components/links/ExternalLink.js
+++ b/src/components/links/ExternalLink.js
@@ -14,15 +14,15 @@ const ExternalLink = ({
   component: _component, // ignore, won't apply external props correctly if set
   showIcon = true,
   icon: Icon = OpenInNew,
+  iconSize = 13,
+  iconMargin = '-0.1em 0 0 0',
   ...props
 }) => {
   const isButton = Component.name === 'Button';
-  let iconSize = 13;
-  let iconMargin = '-0.1em 0 0 0';
 
-  if (isButton) {
+  if (isButton && Number(iconSize) === 13 && iconMargin === '-0.1em 0 0 0') {
     iconSize = 18;
-    iconMargin = '0 0 0 4px';
+    iconMargin = '0 0 0 .25em';
   }
 
   return (

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -115,7 +115,7 @@ export default function CreateForm() {
           </Layout.Section>
 
           <Layout.Section>
-            <Panel>
+            <Panel mb="0">
               <Panel.Section>
                 <RadioCard.Group label="Primary Use for Domain">
                   <RadioCard
@@ -175,7 +175,7 @@ export default function CreateForm() {
           </Layout.Section>
 
           <Layout.Section>
-            <Panel>
+            <Panel mb="0">
               <Panel.Section>
                 <TextField
                   ref={register({ required: 'A valid domain is required.' })}

--- a/src/pages/domains/components/DeleteDomainSection.js
+++ b/src/pages/domains/components/DeleteDomainSection.js
@@ -35,14 +35,13 @@ export default function DeleteDomainSection({ domain, isTracking, id, history })
         <Layout.SectionTitle as="h2">Delete Domain</Layout.SectionTitle>
       </Layout.Section>
       <Layout.Section>
-        <Panel accent="red">
+        <Panel accent="red" mb="0">
           <Panel.Section>
             Deleting a domain is permanent and cannot be undone.{' '}
             <Text as="span" fontWeight="semibold">
               Deletion of the domain affects any transmission that uses this domain.{' '}
             </Text>
           </Panel.Section>
-
           <Panel.Section>
             <Button color="red" outlineBorder size="default" onClick={() => openModal()}>
               Delete Domain

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -170,8 +170,7 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
           {resolvedStatus === 'unverified' && (
             <SubduedText fontSize="200">
               This domain failed authentication. It can take 24 to 48 hours for the DNS record to
-              propogate. For other reasons why this ay have happenedchek out our domain
-              authentication documentation.
+              propogate.
             </SubduedText>
           )}
           {resolvedStatus === 'unverified' && (

--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -89,7 +89,7 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
           </SubduedLink>
         </Layout.Section>
         <Layout.Section>
-          <Panel>
+          <Panel mb="0">
             <Panel.Section>
               <Columns space="100">
                 <Column>
@@ -204,7 +204,7 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
         </Stack>
       </Layout.Section>
       <Layout.Section>
-        <Panel>
+        <Panel mb="0">
           <Panel.Section>
             <Columns space="100">
               <Column>

--- a/src/pages/domains/components/LinkTrackingDomainSection.js
+++ b/src/pages/domains/components/LinkTrackingDomainSection.js
@@ -53,7 +53,7 @@ function LinkTrackingDomainSection({ domain, isSectionVisible, trackingDomainOpt
       </Layout.Section>
       <Layout.Section>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Panel>
+          <Panel mb="0">
             <Panel.Section>
               <Controller
                 name="trackingDomain"

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -106,13 +106,13 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
           <form onSubmit={handleSubmit(onSubmit)} id="sendingbounceForm">
             {!readyFor.dkim || !readyFor.bounce ? (
               <Panel.Section>
-                <p>Add the </p>
+                <p>Add the&nbsp;</p>
                 <Bold>TXT</Bold>
-                <p> and </p>
-                <Bold>{watchVerificationType} </Bold>
+                <p>&nbsp;and&nbsp;</p>
+                <Bold>{watchVerificationType}</Bold>
                 <p>
-                  records, Hostnames and Values for this domain in the settings section of your DNS
-                  Provider
+                  &nbsp;records, Hostnames and Values for this domain in the settings section of
+                  &nbsp;your DNS provider.
                 </p>
                 <Panel.Action>
                   <ExternalLink

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -9,13 +9,9 @@ import getConfig from 'src/helpers/getConfig';
 import useDomains from '../hooks/useDomains';
 import { ExternalLink, SubduedLink } from 'src/components/links';
 import { CopyField } from 'src/components';
-import { Send } from '@sparkpost/matchbox-icons';
-import styled from 'styled-components';
+import { TranslatableText } from 'src/components/text';
+import { Telegram } from '@sparkpost/matchbox-icons';
 import { EXTERNAL_LINKS } from '../constants';
-
-const PlaneIcon = styled(Send)`
-  transform: translate(0, -25%) rotate(-45deg);
-`;
 
 export default function SendingAndBounceDomainSection({ domain, isSectionVisible }) {
   const { id, status, subaccount_id } = domain;
@@ -107,20 +103,24 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
             {!readyFor.dkim || !readyFor.bounce ? (
               <Panel.Section>
                 <p>
-                  <span>Add the&nbsp;</span>
-                  <Bold>TXT</Bold>
-                  <span>&nbsp;and&nbsp;</span>
-                  <Bold>{watchVerificationType}&nbsp;</Bold>
-                  <span>
+                  <TranslatableText>Add the&nbsp;</TranslatableText>
+                  <TranslatableText>
+                    <Bold>TXT</Bold>
+                  </TranslatableText>
+                  <TranslatableText>&nbsp;and&nbsp;</TranslatableText>
+                  <TranslatableText>
+                    <Bold>{watchVerificationType}&nbsp;</Bold>
+                  </TranslatableText>
+                  <TranslatableText>
                     records, Hostnames, and Values for this domain in the settings section of your
                     DNS provider.
-                  </span>
+                  </TranslatableText>
                 </p>
                 <Panel.Action
                   component={ExternalLink}
                   external="true"
                   to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
-                  icon={PlaneIcon}
+                  icon={Telegram}
                   iconMargin="0 0 -.25em .5em"
                   iconSize="18"
                 >

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -121,7 +121,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                   external="true"
                   to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                   icon={Telegram}
-                  iconMargin="0 0 -.25em .5em"
+                  iconMargin="0 0 0 .5em"
                   iconSize="18"
                 >
                   Forward to Colleague

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -116,6 +116,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                 </p>
                 <Panel.Action>
                   <ExternalLink
+                    as={Button}
                     to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                     icon={PlaneIcon}
                   >

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -106,9 +106,14 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
           <form onSubmit={handleSubmit(onSubmit)} id="sendingbounceForm">
             {!readyFor.dkim || !readyFor.bounce ? (
               <Panel.Section>
-                Add the <Bold>TXT</Bold> and <Bold>{watchVerificationType} </Bold>
-                records, Hostnames and Values for this domain in the settings section of your DNS
-                Provider
+                <p>Add the </p>
+                <Bold>TXT</Bold>
+                <p> and </p>
+                <Bold>{watchVerificationType} </Bold>
+                <p>
+                  records, Hostnames and Values for this domain in the settings section of your DNS
+                  Provider
+                </p>
                 <Panel.Action>
                   <ExternalLink
                     to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
@@ -197,6 +202,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                   error={errors.addToDns && 'Adding TXT and CNAME is required'}
                   disabled={verifyBounceLoading || verifyDkimLoading}
                 />
+                <p>Error Message Here?</p>
               </Panel.Section>
             )}
             {(!readyFor.bounce || !readyFor.dkim) && (
@@ -206,9 +212,8 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                   type="submit"
                   name="sendingBounceForm"
                   loading={verifyBounceLoading || verifyDkimLoading}
-                  disabled={!watch('addToDns')}
                 >
-                  Authenticate Domain
+                  Verify Domain
                 </Button>
               </Panel.Section>
             )}

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -109,10 +109,10 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                 <span>Add the&nbsp;</span>
                 <Bold>TXT</Bold>
                 <span>&nbsp;and&nbsp;</span>
-                <Bold>{watchVerificationType}</Bold>
+                <Bold>{watchVerificationType}&nbsp;</Bold>
                 <span>
-                  &nbsp;records, Hostnames, and Values for this domain in the settings section of
-                  &nbsp;your DNS provider.
+                  records, Hostnames, and Values for this domain in the settings section of your DNS
+                  provider.
                 </span>
                 <Panel.Action
                   component={ExternalLink}

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -106,14 +106,16 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
           <form onSubmit={handleSubmit(onSubmit)} id="sendingbounceForm">
             {!readyFor.dkim || !readyFor.bounce ? (
               <Panel.Section>
-                <span>Add the&nbsp;</span>
-                <Bold>TXT</Bold>
-                <span>&nbsp;and&nbsp;</span>
-                <Bold>{watchVerificationType}&nbsp;</Bold>
-                <span>
-                  records, Hostnames, and Values for this domain in the settings section of your DNS
-                  provider.
-                </span>
+                <p>
+                  <span>Add the&nbsp;</span>
+                  <Bold>TXT</Bold>
+                  <span>&nbsp;and&nbsp;</span>
+                  <Bold>{watchVerificationType}&nbsp;</Bold>
+                  <span>
+                    records, Hostnames, and Values for this domain in the settings section of your
+                    DNS provider.
+                  </span>
+                </p>
                 <Panel.Action
                   component={ExternalLink}
                   external="true"

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -106,14 +106,14 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
           <form onSubmit={handleSubmit(onSubmit)} id="sendingbounceForm">
             {!readyFor.dkim || !readyFor.bounce ? (
               <Panel.Section>
-                <p>Add the&nbsp;</p>
+                <span>Add the&nbsp;</span>
                 <Bold>TXT</Bold>
-                <p>&nbsp;and&nbsp;</p>
+                <span>&nbsp;and&nbsp;</span>
                 <Bold>{watchVerificationType}</Bold>
-                <p>
-                  &nbsp;records, Hostnames and Values for this domain in the settings section of
+                <span>
+                  &nbsp;records, Hostnames, and Values for this domain in the settings section of
                   &nbsp;your DNS provider.
-                </p>
+                </span>
                 <Panel.Action>
                   <ExternalLink
                     as={Button}

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -201,10 +201,12 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                   ref={register({ required: true })}
                   name="addToDns"
                   label="The TXT and CNAME records have been added to the DNS provider"
-                  error={errors.addToDns && 'Adding TXT and CNAME is required'}
+                  error={
+                    errors.addToDns &&
+                    'Please confirm you have added the records to your DNS provider.'
+                  }
                   disabled={verifyBounceLoading || verifyDkimLoading}
                 />
-                <p>Error Message Here?</p>
               </Panel.Section>
             )}
             {(!readyFor.bounce || !readyFor.dkim) && (

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -119,7 +119,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                 <Panel.Action
                   component={ExternalLink}
                   external="true"
-                  to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
+                  to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                   icon={Telegram}
                   iconMargin="0 0 0 .5em"
                   iconSize="18"

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -202,7 +202,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                 <Checkbox
                   ref={register({ required: true })}
                   name="addToDns"
-                  label="The TXT and CNAME records have been added to the DNS provider"
+                  label="The TXT and CNAME records have been added to the DNS provider."
                   error={
                     errors.addToDns &&
                     'Please confirm you have added the records to your DNS provider.'

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -114,14 +114,15 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
                   &nbsp;records, Hostnames, and Values for this domain in the settings section of
                   &nbsp;your DNS provider.
                 </span>
-                <Panel.Action>
-                  <ExternalLink
-                    as={Button}
-                    to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending/Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending/bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
-                    icon={PlaneIcon}
-                  >
-                    Forward to Colleague
-                  </ExternalLink>
+                <Panel.Action
+                  component={ExternalLink}
+                  external="true"
+                  to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
+                  icon={PlaneIcon}
+                  iconMargin="0 0 -.25em .5em"
+                  iconSize="18"
+                >
+                  Forward to Colleague
                 </Panel.Action>
               </Panel.Section>
             ) : (

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -102,7 +102,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
         )}
       </Layout.Section>
       <Layout.Section>
-        <Panel>
+        <Panel mb="0">
           <form onSubmit={handleSubmit(onSubmit)} id="sendingbounceForm">
             {!readyFor.dkim || !readyFor.bounce ? (
               <Panel.Section>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -93,8 +93,8 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                 &nbsp;your DNS provider.
               </p>
               <Panel.Action>
-                {/* flat button not link... */}
                 <ExternalLink
+                  as={Button}
                   to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                   icon={PlaneIcon}
                 >

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -81,7 +81,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
         </Stack>
       </Layout.Section>
       <Layout.Section>
-        <Panel>
+        <Panel mb="0">
           {!readyFor.bounce ? (
             <Panel.Section>
               <span>Add the&nbsp;</span>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -89,8 +89,8 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                 CNAME
               </Text>
               <p>
-                &nbsp;record, Hostname and Value for this domain in the settings section of your DNS
-                provider.
+                &nbsp;record, Hostname and Value for this domain in the settings section of
+                &nbsp;your DNS provider.
               </p>
               <Panel.Action>
                 {/* flat button not link... */}
@@ -108,7 +108,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
               <Text as="span" fontWeight="semibold">
                 CNAME
               </Text>
-              <p>&nbsp;record for the Hostname and Value for this domain at your DNS provider</p>
+              <p>&nbsp;record for the Hostname and Value for this domain at your DNS provider.</p>
             </Panel.Section>
           )}
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -1,21 +1,16 @@
 import React from 'react';
 import { Button, Layout, Stack, Select, Text } from 'src/components/matchbox';
 import { Checkbox, Panel } from 'src/components/matchbox';
-import { SubduedText } from 'src/components/text';
-import { Send } from '@sparkpost/matchbox-icons';
+import { SubduedText, TranslatableText } from 'src/components/text';
+import { Telegram } from '@sparkpost/matchbox-icons';
 import { resolveReadyFor } from 'src/helpers/domains';
 import { ExternalLink, PageLink, SubduedLink } from 'src/components/links';
-import styled from 'styled-components';
 import { useForm, Controller } from 'react-hook-form';
 import LineBreak from 'src/components/lineBreak';
 import getConfig from 'src/helpers/getConfig';
 import { CopyField } from 'src/components';
 import useDomains from '../hooks/useDomains';
 import { EXTERNAL_LINKS } from '../constants';
-
-const PlaneIcon = styled(Send)`
-  transform: translate(0, -25%) rotate(-45deg);
-`;
 
 export default function SetupBounceDomainSection({ domain, isSectionVisible, title }) {
   const { id, status, subaccount_id } = domain;
@@ -85,20 +80,20 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
           {!readyFor.bounce ? (
             <Panel.Section>
               <p>
-                <span>Add the&nbsp;</span>
+                <TranslatableText>Add the&nbsp;</TranslatableText>
                 <Text as="span" fontWeight="semibold">
                   CNAME&nbsp;
                 </Text>
-                <span>
+                <TranslatableText>
                   record, Hostname, and Value for this domain in the settings section of your DNS
                   provider.
-                </span>
+                </TranslatableText>
               </p>
               <Panel.Action
                 component={ExternalLink}
                 external="true"
                 to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
-                icon={PlaneIcon}
+                icon={Telegram}
                 iconMargin="0 0 -.25em .5em"
                 iconSize="18"
               >
@@ -108,11 +103,13 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
           ) : (
             <Panel.Section>
               <p>
-                <span>Below is the&nbsp;</span>
+                <TranslatableText>Below is the&nbsp;</TranslatableText>
                 <Text as="span" fontWeight="semibold">
                   CNAME&nbsp;
                 </Text>
-                <span>record for the Hostname and Value for this domain at your DNS provider.</span>
+                <TranslatableText>
+                  record for the Hostname and Value for this domain at your DNS provider.
+                </TranslatableText>
               </p>
             </Panel.Section>
           )}

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -86,11 +86,11 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
             <Panel.Section>
               <span>Add the&nbsp;</span>
               <Text as="span" fontWeight="semibold">
-                CNAME
+                CNAME&nbsp;
               </Text>
               <span>
-                &nbsp;record, Hostname and Value for this domain in the settings section of
-                &nbsp;your DNS provider.
+                record, Hostname and Value for this domain in the settings section of your DNS
+                provider.
               </span>
               <Panel.Action
                 component={ExternalLink}
@@ -107,9 +107,9 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
             <Panel.Section>
               <p>Below is the&nbsp;</p>
               <Text as="span" fontWeight="semibold">
-                CNAME
+                CNAME&nbsp;
               </Text>
-              <p>&nbsp;record for the Hostname and Value for this domain at your DNS provider.</p>
+              <p>record for the Hostname and Value for this domain at your DNS provider.</p>
             </Panel.Section>
           )}
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -84,14 +84,16 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
         <Panel mb="0">
           {!readyFor.bounce ? (
             <Panel.Section>
-              <span>Add the&nbsp;</span>
-              <Text as="span" fontWeight="semibold">
-                CNAME&nbsp;
-              </Text>
-              <span>
-                record, Hostname and Value for this domain in the settings section of your DNS
-                provider.
-              </span>
+              <p>
+                <span>Add the&nbsp;</span>
+                <Text as="span" fontWeight="semibold">
+                  CNAME&nbsp;
+                </Text>
+                <span>
+                  record, Hostname, and Value for this domain in the settings section of your DNS
+                  provider.
+                </span>
+              </p>
               <Panel.Action
                 component={ExternalLink}
                 external="true"

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -23,7 +23,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
   const readyFor = resolveReadyFor(status);
   const initVerificationType = isByoipAccount && status.mx_status === 'valid' ? 'MX' : 'CNAME';
   const bounceDomainsConfig = getConfig('bounceDomains');
-  const { control, handleSubmit, watch, register } = useForm();
+  const { control, handleSubmit, watch, errors, register } = useForm();
   const watchVerificationType = watch('verificationType', initVerificationType);
 
   const onSubmit = () => {
@@ -179,12 +179,15 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
             {!readyFor.bounce && (
               <Panel.Section>
                 <Checkbox
+                  error={
+                    errors['ack-checkbox-bounce'] &&
+                    'Please confirm you have added the records to your DNS provider.'
+                  }
                   name="ack-checkbox-bounce"
                   label={`The ${watchVerificationType} record has been added to the DNS provider`}
                   disabled={verifyBounceLoading}
                   ref={register({ required: true })}
                 />
-                <p>Error message here?</p>
               </Panel.Section>
             )}
 

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -94,7 +94,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                 external="true"
                 to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                 icon={Telegram}
-                iconMargin="0 0 -.25em .5em"
+                iconMargin="0 0 0 .5em"
                 iconSize="18"
               >
                 Forward to Colleague

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -92,14 +92,15 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                 &nbsp;record, Hostname and Value for this domain in the settings section of
                 &nbsp;your DNS provider.
               </span>
-              <Panel.Action>
-                <ExternalLink
-                  as={Button}
-                  to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
-                  icon={PlaneIcon}
-                >
-                  Forward to Colleague
-                </ExternalLink>
+              <Panel.Action
+                component={ExternalLink}
+                external="true"
+                to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
+                icon={PlaneIcon}
+                iconMargin="0 0 -.25em .5em"
+                iconSize="18"
+              >
+                Forward to Colleague
               </Panel.Action>
             </Panel.Section>
           ) : (

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -92,7 +92,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
               <Panel.Action
                 component={ExternalLink}
                 external="true"
-                to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
+                to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                 icon={Telegram}
                 iconMargin="0 0 0 .5em"
                 iconSize="18"

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -184,7 +184,7 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                     'Please confirm you have added the records to your DNS provider.'
                   }
                   name="ack-checkbox-bounce"
-                  label={`The ${watchVerificationType} record has been added to the DNS provider`}
+                  label={`The ${watchVerificationType} record has been added to the DNS provider.`}
                   disabled={verifyBounceLoading}
                   ref={register({ required: true })}
                 />

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -84,13 +84,16 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
         <Panel>
           {!readyFor.bounce ? (
             <Panel.Section>
-              Add the{' '}
+              <p>Add the&nbsp;</p>
               <Text as="span" fontWeight="semibold">
                 CNAME
-              </Text>{' '}
-              record, Hostname and Value for this domain in the settings section of your DNS
-              provider.
+              </Text>
+              <p>
+                &nbsp;record, Hostname and Value for this domain in the settings section of your DNS
+                provider.
+              </p>
               <Panel.Action>
+                {/* flat button not link... */}
                 <ExternalLink
                   to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Bounce%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20bounce%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                   icon={PlaneIcon}
@@ -101,11 +104,11 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
             </Panel.Section>
           ) : (
             <Panel.Section>
-              Below is the{' '}
+              <p>Below is the&nbsp;</p>
               <Text as="span" fontWeight="semibold">
-                CNAME{' '}
+                CNAME
               </Text>
-              record for the Hostname and Value for this domain at your DNS provider
+              <p>&nbsp;record for the Hostname and Value for this domain at your DNS provider</p>
             </Panel.Section>
           )}
           <form onSubmit={handleSubmit(onSubmit)}>
@@ -180,18 +183,14 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                   disabled={verifyBounceLoading}
                   ref={register({ required: true })}
                 />
+                <p>Error message here?</p>
               </Panel.Section>
             )}
 
             {!readyFor.bounce && (
               <Panel.Section>
-                <Button
-                  variant="primary"
-                  type="submit"
-                  disabled={!Boolean(watch('ack-checkbox-bounce'))}
-                  loading={verifyBounceLoading}
-                >
-                  Authenticate for Bounce
+                <Button variant="primary" type="submit" loading={verifyBounceLoading}>
+                  Verify Bounce
                 </Button>
               </Panel.Section>
             )}

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -107,11 +107,13 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
             </Panel.Section>
           ) : (
             <Panel.Section>
-              <p>Below is the&nbsp;</p>
-              <Text as="span" fontWeight="semibold">
-                CNAME&nbsp;
-              </Text>
-              <p>record for the Hostname and Value for this domain at your DNS provider.</p>
+              <p>
+                <span>Below is the&nbsp;</span>
+                <Text as="span" fontWeight="semibold">
+                  CNAME&nbsp;
+                </Text>
+                <span>record for the Hostname and Value for this domain at your DNS provider.</span>
+              </p>
             </Panel.Section>
           )}
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -84,14 +84,14 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
         <Panel>
           {!readyFor.bounce ? (
             <Panel.Section>
-              <p>Add the&nbsp;</p>
+              <span>Add the&nbsp;</span>
               <Text as="span" fontWeight="semibold">
                 CNAME
               </Text>
-              <p>
+              <span>
                 &nbsp;record, Hostname and Value for this domain in the settings section of
                 &nbsp;your DNS provider.
-              </p>
+              </span>
               <Panel.Action>
                 <ExternalLink
                   as={Button}

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -18,7 +18,7 @@ const PlaneIcon = styled(Send)`
 export default function SetupForSending({ domain, isSectionVisible }) {
   const { verifyDkim, showAlert, userName, verifyDkimLoading } = useDomains();
   const readyFor = resolveReadyFor(domain.status);
-  const { handleSubmit, register } = useForm();
+  const { handleSubmit, errors, register } = useForm();
 
   const onSubmit = () => {
     const { id, subaccount_id: subaccount } = domain;
@@ -121,11 +121,14 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                 {!readyFor.dkim && (
                   <>
                     <Checkbox
+                      error={
+                        errors['ack-checkbox-dkim'] &&
+                        'Please confirm you have added the records to your DNS provider.'
+                      }
                       name="ack-checkbox-dkim"
                       ref={register({ required: true })}
                       label={<>The TXT record has been added to the DNS provider</>}
                     />
-                    <p>error message here?</p>
                   </>
                 )}
                 {/*API doesn't support it; Do we want to store this in ui option*/}

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -80,11 +80,11 @@ export default function SetupForSending({ domain, isSectionVisible }) {
               <Panel.Section>
                 <span>Add these&nbsp;</span>
                 <Text as="span" fontWeight="semibold">
-                  TXT
+                  TXT&nbsp;
                 </Text>
                 <span>
-                  &nbsp;records, Hostnames, and Values for this domain in the settings section of
-                  your DNS provider.
+                  records, Hostnames, and Values for this domain in the settings section of your DNS
+                  provider.
                 </span>
                 <Panel.Action
                   component={ExternalLink}
@@ -101,9 +101,9 @@ export default function SetupForSending({ domain, isSectionVisible }) {
               <Panel.Section>
                 <span>Below is the&nbsp;</span>
                 <Text as="span" fontWeight="semibold">
-                  TXT
+                  TXT&nbsp;
                 </Text>
-                <span>&nbsp;record for the Hostname and DKIM value of this domain.</span>
+                <span>record for the Hostname and DKIM value of this domain.</span>
               </Panel.Section>
             )}
             <Panel.Section>
@@ -119,17 +119,15 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                 <CopyField label="Hostname" value={domain.dkimHostname} hideCopy={readyFor.dkim} />
                 <CopyField label="Value" value={domain.dkimValue} hideCopy={readyFor.dkim} />
                 {!readyFor.dkim && (
-                  <>
-                    <Checkbox
-                      error={
-                        errors['ack-checkbox-dkim'] &&
-                        'Please confirm you have added the records to your DNS provider.'
-                      }
-                      name="ack-checkbox-dkim"
-                      ref={register({ required: true })}
-                      label="The TXT record has been added to the DNS provider."
-                    />
-                  </>
+                  <Checkbox
+                    error={
+                      errors['ack-checkbox-dkim'] &&
+                      'Please confirm you have added the records to your DNS provider.'
+                    }
+                    name="ack-checkbox-dkim"
+                    ref={register({ required: true })}
+                    label="The TXT record has been added to the DNS provider."
+                  />
                 )}
               </Stack>
             </Panel.Section>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -78,14 +78,14 @@ export default function SetupForSending({ domain, isSectionVisible }) {
           <Panel>
             {!readyFor.dkim ? (
               <Panel.Section>
-                <p>Add these&nbsp;</p>
+                <span>Add these&nbsp;</span>
                 <Text as="span" fontWeight="semibold">
                   TXT
                 </Text>
-                <p>
-                  &nbsp;records, Hostnames and Values for this domain in the settings section of
+                <span>
+                  &nbsp;records, Hostnames, and Values for this domain in the settings section of
                   your DNS provider.
-                </p>
+                </span>
                 <Panel.Action>
                   <ExternalLink
                     as={Button}
@@ -98,11 +98,11 @@ export default function SetupForSending({ domain, isSectionVisible }) {
               </Panel.Section>
             ) : (
               <Panel.Section>
-                <p>Below is the&nbsp;</p>
+                <span>Below is the&nbsp;</span>
                 <Text as="span" fontWeight="semibold">
                   TXT
                 </Text>
-                <p>&nbsp;record for the Hostname and DKIM value of this domain.</p>
+                <span>&nbsp;record for the Hostname and DKIM value of this domain.</span>
               </Panel.Section>
             )}
             <Panel.Section>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -127,7 +127,7 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                       }
                       name="ack-checkbox-dkim"
                       ref={register({ required: true })}
-                      label={<>The TXT record has been added to the DNS provider</>}
+                      label="The TXT record has been added to the DNS provider."
                     />
                   </>
                 )}

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -87,8 +87,8 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                   your DNS provider.
                 </p>
                 <Panel.Action>
-                  {/* flat button not link... */}
                   <ExternalLink
+                    as={Button}
                     to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                     icon={PlaneIcon}
                   >

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -18,7 +18,7 @@ const PlaneIcon = styled(Send)`
 export default function SetupForSending({ domain, isSectionVisible }) {
   const { verifyDkim, showAlert, userName, verifyDkimLoading } = useDomains();
   const readyFor = resolveReadyFor(domain.status);
-  const { handleSubmit, watch, register } = useForm();
+  const { handleSubmit, register } = useForm();
 
   const onSubmit = () => {
     const { id, subaccount_id: subaccount } = domain;
@@ -78,13 +78,16 @@ export default function SetupForSending({ domain, isSectionVisible }) {
           <Panel>
             {!readyFor.dkim ? (
               <Panel.Section>
-                Add these{' '}
+                <p>Add these&nbsp;</p>
                 <Text as="span" fontWeight="semibold">
                   TXT
-                </Text>{' '}
-                records, Hostnames and Values for this domain in the settings section of your DNS
-                provider.
+                </Text>
+                <p>
+                  &nbsp;records, Hostnames and Values for this domain in the settings section of
+                  your DNS provider.
+                </p>
                 <Panel.Action>
+                  {/* flat button not link... */}
                   <ExternalLink
                     to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                     icon={PlaneIcon}
@@ -95,11 +98,11 @@ export default function SetupForSending({ domain, isSectionVisible }) {
               </Panel.Section>
             ) : (
               <Panel.Section>
-                Below is the{' '}
+                <p>Below is the&nbsp;</p>
                 <Text as="span" fontWeight="semibold">
                   TXT
-                </Text>{' '}
-                record for the Hostname and DKIM value of this domain.
+                </Text>
+                <p>&nbsp;record for the Hostname and DKIM value of this domain.</p>
               </Panel.Section>
             )}
             <Panel.Section>
@@ -115,23 +118,21 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                 <CopyField label="Hostname" value={domain.dkimHostname} hideCopy={readyFor.dkim} />
                 <CopyField label="Value" value={domain.dkimValue} hideCopy={readyFor.dkim} />
                 {!readyFor.dkim && (
-                  <Checkbox
-                    name="ack-checkbox-dkim"
-                    ref={register({ required: true })}
-                    label={<>The TXT record has been added to the DNS provider</>}
-                  />
+                  <>
+                    <Checkbox
+                      name="ack-checkbox-dkim"
+                      ref={register({ required: true })}
+                      label={<>The TXT record has been added to the DNS provider</>}
+                    />
+                    <p>error message here?</p>
+                  </>
                 )}
                 {/*API doesn't support it; Do we want to store this in ui option*/}
               </Stack>
             </Panel.Section>
             {!readyFor.dkim && (
               <Panel.Section>
-                <Button
-                  variant="primary"
-                  loading={verifyDkimLoading}
-                  type="submit"
-                  disabled={!Boolean(watch('ack-checkbox-dkim'))}
-                >
+                <Button variant="primary" loading={verifyDkimLoading} type="submit">
                   Verify Domain
                 </Button>
               </Panel.Section>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -131,7 +131,6 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                     />
                   </>
                 )}
-                {/*API doesn't support it; Do we want to store this in ui option*/}
               </Stack>
             </Panel.Section>
             {!readyFor.dkim && (

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -75,7 +75,7 @@ export default function SetupForSending({ domain, isSectionVisible }) {
       </Layout.Section>
       <Layout.Section>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Panel>
+          <Panel mb="0">
             {!readyFor.dkim ? (
               <Panel.Section>
                 <span>Add these&nbsp;</span>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -88,7 +88,7 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                   external="true"
                   to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
                   icon={Telegram}
-                  iconMargin="0 0 -.25em .5em"
+                  iconMargin="0 0 0 .5em"
                   iconSize="18"
                 >
                   Forward to Colleague

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -1,19 +1,14 @@
 import React from 'react';
 import { Button, Layout, Stack, Tag, Text } from 'src/components/matchbox';
 import { Checkbox, Panel } from 'src/components/matchbox';
-import { SubduedText } from 'src/components/text';
-import { Send } from '@sparkpost/matchbox-icons';
+import { SubduedText, TranslatableText } from 'src/components/text';
+import { Telegram } from '@sparkpost/matchbox-icons';
 import { resolveReadyFor } from 'src/helpers/domains';
 import useDomains from '../hooks/useDomains';
 import { ExternalLink, SubduedLink } from 'src/components/links';
-import styled from 'styled-components';
 import { CopyField } from 'src/components';
 import { useForm } from 'react-hook-form';
 import { EXTERNAL_LINKS } from '../constants';
-
-const PlaneIcon = styled(Send)`
-  transform: translate(0, -25%) rotate(-45deg);
-`;
 
 export default function SetupForSending({ domain, isSectionVisible }) {
   const { verifyDkim, showAlert, userName, verifyDkimLoading } = useDomains();
@@ -79,20 +74,20 @@ export default function SetupForSending({ domain, isSectionVisible }) {
             {!readyFor.dkim ? (
               <Panel.Section>
                 <p>
-                  <span>Add these&nbsp;</span>
+                  <TranslatableText>Add these&nbsp;</TranslatableText>
                   <Text as="span" fontWeight="semibold">
                     TXT&nbsp;
                   </Text>
-                  <span>
+                  <TranslatableText>
                     records, Hostnames, and Values for this domain in the settings section of your
                     DNS provider.
-                  </span>
+                  </TranslatableText>
                 </p>
                 <Panel.Action
                   component={ExternalLink}
                   external="true"
                   to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
-                  icon={PlaneIcon}
+                  icon={Telegram}
                   iconMargin="0 0 -.25em .5em"
                   iconSize="18"
                 >
@@ -102,11 +97,13 @@ export default function SetupForSending({ domain, isSectionVisible }) {
             ) : (
               <Panel.Section>
                 <p>
-                  <span>Below is the&nbsp;</span>
+                  <TranslatableText>Below is the&nbsp;</TranslatableText>
                   <Text as="span" fontWeight="semibold">
                     TXT&nbsp;
                   </Text>
-                  <span>record for the Hostname and DKIM value of this domain.</span>
+                  <TranslatableText>
+                    record for the Hostname and DKIM value of this domain.
+                  </TranslatableText>
                 </p>
               </Panel.Section>
             )}

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -78,14 +78,16 @@ export default function SetupForSending({ domain, isSectionVisible }) {
           <Panel mb="0">
             {!readyFor.dkim ? (
               <Panel.Section>
-                <span>Add these&nbsp;</span>
-                <Text as="span" fontWeight="semibold">
-                  TXT&nbsp;
-                </Text>
-                <span>
-                  records, Hostnames, and Values for this domain in the settings section of your DNS
-                  provider.
-                </span>
+                <p>
+                  <span>Add these&nbsp;</span>
+                  <Text as="span" fontWeight="semibold">
+                    TXT&nbsp;
+                  </Text>
+                  <span>
+                    records, Hostnames, and Values for this domain in the settings section of your
+                    DNS provider.
+                  </span>
+                </p>
                 <Panel.Action
                   component={ExternalLink}
                   external="true"

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -101,11 +101,13 @@ export default function SetupForSending({ domain, isSectionVisible }) {
               </Panel.Section>
             ) : (
               <Panel.Section>
-                <span>Below is the&nbsp;</span>
-                <Text as="span" fontWeight="semibold">
-                  TXT&nbsp;
-                </Text>
-                <span>record for the Hostname and DKIM value of this domain.</span>
+                <p>
+                  <span>Below is the&nbsp;</span>
+                  <Text as="span" fontWeight="semibold">
+                    TXT&nbsp;
+                  </Text>
+                  <span>record for the Hostname and DKIM value of this domain.</span>
+                </p>
               </Panel.Section>
             )}
             <Panel.Section>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -86,14 +86,15 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                   &nbsp;records, Hostnames, and Values for this domain in the settings section of
                   your DNS provider.
                 </span>
-                <Panel.Action>
-                  <ExternalLink
-                    as={Button}
-                    to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
-                    icon={PlaneIcon}
-                  >
-                    Forward to Colleague
-                  </ExternalLink>
+                <Panel.Action
+                  component={ExternalLink}
+                  external="true"
+                  to={`mailto:?subject=Assistance%20Requested%20Verifying%20a%20Sending%20Domain%20on%20SparkPost&body=${userName}%20has%20requested%20your%20assistance%20verifying%20a%20sending%20domain%20with%20SparkPost.%20Follow%20the%20link%20below%20to%20find%20the%20values%20you%E2%80%99ll%20need%20to%20add%20to%20the%20settings%20of%20your%20DNS%20provider.%0D%0A%5BGo%20to%20SparkPost%5D(${window.location})%0D%0A`}
+                  icon={PlaneIcon}
+                  iconMargin="0 0 -.25em .5em"
+                  iconSize="18"
+                >
+                  Forward to Colleague
                 </Panel.Action>
               </Panel.Section>
             ) : (

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -64,11 +64,13 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
               </Panel.Section>
             ) : (
               <Panel.Section>
-                <span>Below is the&nbsp;</span>
-                <Text as="span" fontWeight="semibold">
-                  CNAME&nbsp;
-                </Text>
-                <span>record for this domain at your DNS provider.</span>
+                <p>
+                  <span>Below is the&nbsp;</span>
+                  <Text as="span" fontWeight="semibold">
+                    CNAME&nbsp;
+                  </Text>
+                  <span>record for this domain at your DNS provider.</span>
+                </p>
               </Panel.Section>
             )}
             <Panel.Section>

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -13,7 +13,7 @@ import _ from 'lodash';
 export default function TrackingDnsSection({ domain, isSectionVisible, title }) {
   const { trackingDomainCname, verifyTrackingDomain, verifyingTrackingPending } = useDomains();
   const { unverified, domain: domainName, subaccount_id: subaccountId } = domain;
-  const { handleSubmit, watch, register } = useForm();
+  const { handleSubmit, errors, register } = useForm();
 
   const onSubmit = () => {
     return verifyTrackingDomain({
@@ -51,20 +51,24 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
           <Panel>
             {unverified ? (
               <Panel.Section>
-                Add the{' '}
-                <Text as="span" fontWeight="semibold">
-                  CNAME
-                </Text>{' '}
-                records, Hostnames and Values for this domain in the settings section of your DNS
-                provider.
+                <p>
+                  <span>Add the&nbsp;</span>
+                  <Text as="span" fontWeight="semibold">
+                    CNAME&nbsp;
+                  </Text>
+                  <span>
+                    records, Hostnames, and Values for this domain in the settings section of your
+                    DNS provider.
+                  </span>
+                </p>
               </Panel.Section>
             ) : (
               <Panel.Section>
-                Below is the{' '}
+                <span>Below is the&nbsp;</span>
                 <Text as="span" fontWeight="semibold">
-                  CNAME
-                </Text>{' '}
-                record for this domain at your DNS provider.
+                  CNAME&nbsp;
+                </Text>
+                <span>record for this domain at your DNS provider.</span>
               </Panel.Section>
             )}
             <Panel.Section>
@@ -83,23 +87,22 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
 
               {unverified && (
                 <Checkbox
+                  error={
+                    errors['ack-checkbox-tracking'] &&
+                    'Please confirm you have added the records to your DNS provider.'
+                  }
                   mt="600"
                   mb="100"
                   name="ack-checkbox-tracking"
                   ref={register({ required: true })}
-                  label={<>The CNAME record has been added to the DNS provider.</>}
+                  label="The CNAME record has been added to the DNS provider."
                 />
               )}
             </Panel.Section>
 
             {unverified && (
               <Panel.Section>
-                <Button
-                  variant="primary"
-                  type="submit"
-                  disabled={!Boolean(watch('ack-checkbox-tracking'))}
-                  loading={verifyingTrackingPending}
-                >
+                <Button variant="primary" type="submit" loading={verifyingTrackingPending}>
                   Verify Domain
                 </Button>
               </Panel.Section>

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Layout, Stack, Text } from 'src/components/matchbox';
 import { Panel, Checkbox } from 'src/components/matchbox';
-import { SubduedText } from 'src/components/text';
+import { SubduedText, TranslatableText } from 'src/components/text';
 import { ExternalLink, SubduedLink } from 'src/components/links';
 import useDomains from '../hooks/useDomains';
 import { CopyField } from 'src/components';
@@ -52,24 +52,24 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
             {unverified ? (
               <Panel.Section>
                 <p>
-                  <span>Add the&nbsp;</span>
+                  <TranslatableText>Add the&nbsp;</TranslatableText>
                   <Text as="span" fontWeight="semibold">
                     CNAME&nbsp;
                   </Text>
-                  <span>
+                  <TranslatableText>
                     records, Hostnames, and Values for this domain in the settings section of your
                     DNS provider.
-                  </span>
+                  </TranslatableText>
                 </p>
               </Panel.Section>
             ) : (
               <Panel.Section>
                 <p>
-                  <span>Below is the&nbsp;</span>
+                  <TranslatableText>Below is the&nbsp;</TranslatableText>
                   <Text as="span" fontWeight="semibold">
                     CNAME&nbsp;
                   </Text>
-                  <span>record for this domain at your DNS provider.</span>
+                  <TranslatableText>record for this domain at your DNS provider.</TranslatableText>
                 </p>
               </Panel.Section>
             )}

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -87,7 +87,7 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
                   mb="100"
                   name="ack-checkbox-tracking"
                   ref={register({ required: true })}
-                  label={<>The CNAME record has been added to the DNS provider</>}
+                  label={<>The CNAME record has been added to the DNS provider.</>}
                 />
               )}
             </Panel.Section>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -42,7 +42,7 @@ export default function VerifyEmailSection({ domain, isSectionVisible }) {
         )}
       </Layout.Section>
       <Layout.Section>
-        <Panel>
+        <Panel mb="0">
           <Panel.Section>
             If you don't have access to update your DNS records for this domain, you can click
             "verify sender" to ask SparkPost to send an email to any address on this domain. Once
@@ -50,7 +50,6 @@ export default function VerifyEmailSection({ domain, isSectionVisible }) {
             SparkPost will not be able to DKIM-sign the mail it sends on your behalf, which could
             cause delivebility issues.
           </Panel.Section>
-
           <Panel.Section>
             <Button
               onClick={() => {


### PR DESCRIPTION
### What Changed
- Button labels changed (Authenticate For Bounce -> Verify Bounce, Authenticate Domain -> Verify Domain)
- Buttons not disabled by default - error messages show if clicked
- More Cypress tests added to cover the error/button interaction
- More Cypress tests for the Forward to Colleague anchors/href values
- Adjusted grammar a little (added periods at the end of sentences)
- Removed margin bottom from all the <Panel /> components I could find in the domain details and create pages.
- <ExternalLink /> props adjusted to control icon sizing and spacing directly instead of by `Component.name`
  (component.name === button is still setting icon size and space if the size/margin values are default)
- Placeholder sentence was removed from the "For other reasons why this ay have happenedchek out our domain
              authentication documentation." - had grammar mistakes anyway.
- Bare string formatting was adjusted and to pass linter/prettier rules and tests were added for those.
 

### How To Test
- Load up the domain create and domain details pages
![image](https://user-images.githubusercontent.com/4204806/102234960-6e930c00-3eb7-11eb-9606-e85f19a8083c.png)

(domain details pages have a lot of components/state management that determine what shows and what doesn't - it can get confusing looking through this area because a lot of the code looks the same and is named similar things)
![image](https://user-images.githubusercontent.com/4204806/102235082-94201580-3eb7-11eb-9f80-36478c7aa22a.png)

Attention to detail is the name of the game here. Lots of little things changed. Please reach out if you have any questions or concerns. 

### To Do
- [ ] I might push up a couple more cypress tests - I noticed there was some dynamic text that wasn't being tested. 
- [ ] Talk to the team about doing a review of this domain configuration area to ensure there is no more placeholder/dummy text left over. Also just making sure there are no grammar mistakes. 
- [ ] Feedback

