### PR TITLE
SA-1850 - (UI) Compare By - Delays Report

### DIFF
--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -149,7 +149,8 @@ export function ReportBuilder({
 
   const tabs = useMemo(() => {
     /**
-     * Loop through active comparisons and add rendered tabs depending on the metrics selected by the end user
+     * For each type of relevant metrics that could render a tab,
+     * loop through active comparisons and add rendered tabs depending on the metrics selected by the end user
      */
     function getComparisonTabs() {
       let comparisonTabs = [];

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -32,6 +32,7 @@ import {
 
 import {
   BounceReasonTab,
+  DelayReasonsComparisonTab,
   BounceReasonComparisonTab,
   DelayReasonsTab,
   LinksTab,
@@ -147,44 +148,49 @@ export function ReportBuilder({
   const hasLinksTab = hasLinksMetrics && !hasActiveComparisons;
 
   const tabs = useMemo(() => {
+    /**
+     * Loop through active comparisons and add rendered tabs depending on the metrics selected by the end user
+     */
     function getComparisonTabs() {
+      let comparisonTabs = [];
+
       if (hasBounceMetrics) {
-        return reportOptions.comparisons.map(comparison => {
-          return {
+        reportOptions.comparisons.forEach(comparison => {
+          comparisonTabs.push({
             content: `Bounce Reason ${comparison.value}`,
             onClick: () => setShowTable(false),
-          };
+          });
         });
       }
 
       if (hasRejectionMetrics) {
-        return reportOptions.comparisons.map(comparison => {
-          return {
+        reportOptions.comparisons.forEach(comparison => {
+          comparisonTabs.push({
             content: `Rejection Reason ${comparison.value}`,
             onClick: () => setShowTable(false),
-          };
+          });
         });
       }
 
       if (hasDelayMetrics) {
-        return reportOptions.comparisons.map(comparison => {
-          return {
+        reportOptions.comparisons.forEach(comparison => {
+          comparisonTabs.push({
             content: `Delay Reason ${comparison.value}`,
             onClick: () => setShowTable(false),
-          };
+          });
         });
       }
 
       if (hasLinksMetrics) {
-        return reportOptions.comparisons.map(comparison => {
-          return {
+        reportOptions.comparisons.forEach(comparison => {
+          comparisonTabs.push({
             content: `Links ${comparison.value}`,
             onClick: () => setShowTable(false),
-          };
+          });
         });
       }
 
-      return [];
+      return comparisonTabs;
     }
 
     return [
@@ -301,6 +307,16 @@ export function ReportBuilder({
                   return (
                     <Tabs.Item key={`tab-bounce-${comparison.value}-${index}`}>
                       <BounceReasonComparisonTab comparison={comparison} />
+                    </Tabs.Item>
+                  );
+                })}
+
+              {hasDelayMetrics &&
+                hasActiveComparisons &&
+                reportOptions.comparisons.map((comparison, index) => {
+                  return (
+                    <Tabs.Item key={`tab-delay-${comparison.value}-${index}`}>
+                      <DelayReasonsComparisonTab comparison={comparison} />
                     </Tabs.Item>
                   );
                 })}

--- a/src/pages/reportBuilder/components/tables/BounceReasonTable.js
+++ b/src/pages/reportBuilder/components/tables/BounceReasonTable.js
@@ -31,7 +31,7 @@ const columns = [
   { label: 'Domain', minWidth: '90px', sortKey: 'domain' },
 ];
 
-export default function BounceReasonTable({ aggregates, reasons = [], tableLoading }) {
+export default function BounceReasonTable({ aggregates, reasons = [], loading }) {
   const getRowData = useCallback(
     item => {
       const { reason, domain, bounce_category_name, bounce_class_name, count_bounce } = item;
@@ -49,7 +49,7 @@ export default function BounceReasonTable({ aggregates, reasons = [], tableLoadi
     [aggregates],
   );
 
-  if (tableLoading) {
+  if (loading) {
     return <LoadingWrapper />;
   }
 

--- a/src/pages/reportBuilder/components/tables/DelayReasonTable.js
+++ b/src/pages/reportBuilder/components/tables/DelayReasonTable.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { LongTextContainer, Percent, TableCollection } from 'src/components';
+import { safeRate } from 'src/helpers/math';
+import {
+  EmptyWrapper,
+  FilterBoxWrapper,
+  LoadingWrapper,
+  TableCollectionBody,
+  TableWrapper,
+} from '../Wrappers';
+
+const filterBoxConfig = {
+  show: true,
+  itemToStringKeys: ['domain', 'reason'],
+  exampleModifiers: ['domain', 'reason'],
+  matchThreshold: 5,
+  label: 'Filter',
+  wrapper: FilterBoxWrapper,
+};
+
+const columns = [
+  { label: 'Total Delays', sortKey: 'count_delayed' },
+  { label: 'Delayed First Attempt (%)', sortKey: 'count_delayed_first' },
+  { label: 'Reason', sortKey: 'reason', width: '45%' },
+  { label: 'Domain', sortKey: 'domain' },
+];
+
+export default function DelayReasonTable({ reasons, totalAccepted, loading }) {
+  const getRowData = rowData => {
+    const { reason, domain, count_delayed, count_delayed_first } = rowData;
+
+    return [
+      count_delayed,
+      <span>
+        {count_delayed_first} (<Percent value={safeRate(count_delayed_first, totalAccepted)} />)
+      </span>,
+      <LongTextContainer text={reason} />,
+      domain,
+    ];
+  };
+
+  if (loading) {
+    return <LoadingWrapper />;
+  }
+
+  if (!reasons.length) {
+    return <EmptyWrapper message="No delay reasons to report" />;
+  }
+  return (
+    <TableCollection
+      columns={columns}
+      rows={reasons}
+      getRowData={getRowData}
+      pagination
+      defaultSortColumn="count_delayed"
+      defaultSortDirection="desc"
+      wrapperComponent={TableWrapper}
+      filterBox={filterBoxConfig}
+    >
+      {props => <TableCollectionBody {...props} />}
+    </TableCollection>
+  );
+}

--- a/src/pages/reportBuilder/components/tables/index.js
+++ b/src/pages/reportBuilder/components/tables/index.js
@@ -1,1 +1,2 @@
 export { default as BounceReasonTable } from './BounceReasonTable';
+export { default as DelayReasonTable } from './DelayReasonTable';

--- a/src/pages/reportBuilder/components/tabs/BounceReasonComparisonTab.js
+++ b/src/pages/reportBuilder/components/tabs/BounceReasonComparisonTab.js
@@ -11,7 +11,7 @@ import { useReportBuilderContext } from '../../context/ReportBuilderContext';
 import { TAB_LOADING_HEIGHT } from '../../constants';
 
 export default function BounceReasonComparisonTab({ comparison }) {
-  const { aggregatesQuery, bounceReasonsQuery, isPending, isError } = useQueryWithComparison(
+  const { aggregatesQuery, bounceReasonsQuery, isPending, isError } = useQueriesWithComparison(
     comparison,
   );
 
@@ -46,10 +46,9 @@ export default function BounceReasonComparisonTab({ comparison }) {
  *
  * @param {Object} comparison - passed in comparison set by the user via the "Compare By" feature
  */
-function useQueryWithComparison(comparison) {
+function useQueriesWithComparison(comparison) {
   const { state: reportOptions } = useReportBuilderContext();
   // I borrowed this logic from `src/actions/bounceReport`
-  // But does the comparison value influence which metrics are valid for this request?
   const deliverabilityMetrics = getMetricsFromKeys([
     'count_bounce',
     'count_inband_bounce',

--- a/src/pages/reportBuilder/components/tabs/BounceReasonComparisonTab.js
+++ b/src/pages/reportBuilder/components/tabs/BounceReasonComparisonTab.js
@@ -39,7 +39,7 @@ export default function BounceReasonComparisonTab({ comparison }) {
     bounceReport: { aggregates: aggregatesQuery.data[0] },
   });
 
-  return <BounceReasonTable reasons={reasons} aggregates={aggregates} tableLoading={false} />;
+  return <BounceReasonTable reasons={reasons} aggregates={aggregates} loading={false} />;
 }
 
 /**

--- a/src/pages/reportBuilder/components/tabs/BounceReasonTab.js
+++ b/src/pages/reportBuilder/components/tabs/BounceReasonTab.js
@@ -14,9 +14,7 @@ export function BounceReasonsTab({ aggregates, reasons, refreshBounceReport, tab
     }
   }, [refreshBounceReport, reportOptions]);
 
-  return (
-    <BounceReasonTable aggregates={aggregates} reasons={reasons} tableLoading={tableLoading} />
-  );
+  return <BounceReasonTable aggregates={aggregates} reasons={reasons} loading={tableLoading} />;
 }
 
 const mapDispatchToProps = {

--- a/src/pages/reportBuilder/components/tabs/DelayReasonsComparisonTab.js
+++ b/src/pages/reportBuilder/components/tabs/DelayReasonsComparisonTab.js
@@ -9,7 +9,7 @@ import { TAB_LOADING_HEIGHT } from '../../constants';
 import { DelayReasonTable } from '../tables';
 
 export default function DelayReasonComparisonTab({ comparison }) {
-  const { aggregatesQuery, delayReasonsQuery, isPending, isError } = useQueryWithComparison(
+  const { aggregatesQuery, delayReasonsQuery, isPending, isError } = useQueriesWithComparison(
     comparison,
   );
 
@@ -41,7 +41,7 @@ export default function DelayReasonComparisonTab({ comparison }) {
  *
  * @param {Object} comparison - passed in comparison set by the user via the "Compare By" feature
  */
-function useQueryWithComparison(comparison) {
+function useQueriesWithComparison(comparison) {
   const { state: reportOptions } = useReportBuilderContext();
   const deliverabilityMetrics = getMetricsFromKeys([
     'count_accepted',

--- a/src/pages/reportBuilder/components/tabs/DelayReasonsComparisonTab.js
+++ b/src/pages/reportBuilder/components/tabs/DelayReasonsComparisonTab.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function DelayReasonComparisonTab() {
+  return <h1>Delay Reason!</h1>;
+}

--- a/src/pages/reportBuilder/components/tabs/DelayReasonsComparisonTab.js
+++ b/src/pages/reportBuilder/components/tabs/DelayReasonsComparisonTab.js
@@ -1,5 +1,72 @@
 import React from 'react';
+import { usePrepareReportBuilderQuery, useSparkPostQuery } from 'src/hooks';
+import { getDelayReasonByDomain, getDeliverability } from 'src/helpers/api/metrics';
+import { ApiErrorBanner, Loading } from 'src/components';
+import { Panel } from 'src/components/matchbox';
+import { getMetricsFromKeys, getFilterByComparison } from 'src/helpers/metrics';
+import { useReportBuilderContext } from '../../context/ReportBuilderContext';
+import { TAB_LOADING_HEIGHT } from '../../constants';
+import { DelayReasonTable } from '../tables';
 
-export default function DelayReasonComparisonTab() {
-  return <h1>Delay Reason!</h1>;
+export default function DelayReasonComparisonTab({ comparison }) {
+  const { aggregatesQuery, delayReasonsQuery, isPending, isError } = useQueryWithComparison(
+    comparison,
+  );
+
+  function handleReload() {
+    aggregatesQuery.refetch();
+    delayReasonsQuery.refetch();
+  }
+
+  if (isPending) {
+    return <Loading minHeight={TAB_LOADING_HEIGHT} />;
+  }
+
+  if (isError) {
+    return (
+      <Panel.Section>
+        <ApiErrorBanner reload={handleReload} status="muted" />
+      </Panel.Section>
+    );
+  }
+
+  const reasons = delayReasonsQuery.data;
+  const totalAccepted = aggregatesQuery.data ? aggregatesQuery.data.count_accepted : 1;
+
+  return <DelayReasonTable reasons={reasons} totalAccepted={totalAccepted} loading={false} />;
+}
+
+/**
+ * Prepares request parameters using common hooks, then leverages helper functions to determine which `metrics` are passed as arguments to each request.
+ *
+ * @param {Object} comparison - passed in comparison set by the user via the "Compare By" feature
+ */
+function useQueryWithComparison(comparison) {
+  const { state: reportOptions } = useReportBuilderContext();
+  const deliverabilityMetrics = getMetricsFromKeys([
+    'count_accepted',
+    'count_delayed',
+    'count_delayed_first',
+  ]);
+  const existingFilters = reportOptions.filters ? reportOptions.filters : [];
+  const comparisonFilter = getFilterByComparison(comparison);
+  const aggregatesParams = usePrepareReportBuilderQuery({
+    ...reportOptions,
+    filters: [...existingFilters, comparisonFilter],
+    metrics: deliverabilityMetrics,
+  });
+  const delayReasonsParams = usePrepareReportBuilderQuery({
+    ...reportOptions,
+    filters: [...existingFilters, comparisonFilter],
+    metrics: reportOptions.metrics,
+  });
+  const delayReasonsQuery = useSparkPostQuery(() => getDelayReasonByDomain(delayReasonsParams));
+  const aggregatesQuery = useSparkPostQuery(() => getDeliverability(aggregatesParams));
+
+  return {
+    aggregatesQuery,
+    delayReasonsQuery,
+    isPending: aggregatesQuery.status === 'loading' || delayReasonsQuery.status === 'loading',
+    isError: aggregatesQuery.status === 'error' || delayReasonsQuery.status === 'error',
+  };
 }

--- a/src/pages/reportBuilder/components/tabs/DelayReasonsTab.js
+++ b/src/pages/reportBuilder/components/tabs/DelayReasonsTab.js
@@ -1,36 +1,11 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { LongTextContainer, Percent, TableCollection } from 'src/components';
 import { refreshDelayReportV2 as refreshDelayReport } from 'src/actions/delayReport';
-import { safeRate } from 'src/helpers/math';
-import {
-  EmptyWrapper,
-  FilterBoxWrapper,
-  LoadingWrapper,
-  TableCollectionBody,
-  TableWrapper,
-} from '../Wrappers';
 import { useReportBuilderContext } from '../../context/ReportBuilderContext';
+import { DelayReasonTable } from '../tables';
 
-const filterBoxConfig = {
-  show: true,
-  itemToStringKeys: ['domain', 'reason'],
-  exampleModifiers: ['domain', 'reason'],
-  matchThreshold: 5,
-  label: 'Filter',
-  wrapper: FilterBoxWrapper,
-};
-
-const columns = [
-  { label: 'Total Delays', sortKey: 'count_delayed' },
-  { label: 'Delayed First Attempt (%)', sortKey: 'count_delayed_first' },
-  { label: 'Reason', sortKey: 'reason', width: '45%' },
-  { label: 'Domain', sortKey: 'domain' },
-];
-
-export function DelayReasonsTab(props) {
+export function DelayReasonsTab({ reasons, totalAccepted, refreshDelayReport, tableLoading }) {
   const { state: reportOptions } = useReportBuilderContext();
-  const { loading, reasons, totalAccepted, refreshDelayReport } = props;
 
   useEffect(() => {
     if (reportOptions.to && reportOptions.from) {
@@ -38,45 +13,15 @@ export function DelayReasonsTab(props) {
     }
   }, [refreshDelayReport, reportOptions]);
 
-  const getRowData = rowData => {
-    const { reason, domain, count_delayed, count_delayed_first } = rowData;
-    return [
-      count_delayed,
-      <span>
-        {count_delayed_first} (<Percent value={safeRate(count_delayed_first, totalAccepted)} />)
-      </span>,
-      <LongTextContainer text={reason} />,
-      domain,
-    ];
-  };
-
-  if (loading) {
-    return <LoadingWrapper />;
-  }
-
-  if (!reasons.length) {
-    return <EmptyWrapper message="No delay reasons to report" />;
-  }
   return (
-    <TableCollection
-      columns={columns}
-      rows={reasons}
-      getRowData={getRowData}
-      pagination
-      defaultSortColumn="count_delayed"
-      defaultSortDirection="desc"
-      wrapperComponent={TableWrapper}
-      filterBox={filterBoxConfig}
-    >
-      {props => <TableCollectionBody {...props} />}
-    </TableCollection>
+    <DelayReasonTable reasons={reasons} totalAccepted={totalAccepted} loading={tableLoading} />
   );
 }
 
 const mapStateToProps = state => {
   const { aggregates } = state.delayReport;
   return {
-    loading: state.delayReport.aggregatesLoading || state.delayReport.reasonsLoading,
+    tableLoading: state.delayReport.aggregatesLoading || state.delayReport.reasonsLoading,
     reasons: state.delayReport.reasons,
     totalAccepted: aggregates ? aggregates.count_accepted : 1,
   };

--- a/src/pages/reportBuilder/components/tabs/DelayReasonsTab.js
+++ b/src/pages/reportBuilder/components/tabs/DelayReasonsTab.js
@@ -20,6 +20,7 @@ export function DelayReasonsTab({ reasons, totalAccepted, refreshDelayReport, ta
 
 const mapStateToProps = state => {
   const { aggregates } = state.delayReport;
+
   return {
     tableLoading: state.delayReport.aggregatesLoading || state.delayReport.reasonsLoading,
     reasons: state.delayReport.reasons,

--- a/src/pages/reportBuilder/components/tabs/index.js
+++ b/src/pages/reportBuilder/components/tabs/index.js
@@ -1,5 +1,6 @@
 export { default as BounceReasonTab } from './BounceReasonTab';
 export { default as BounceReasonComparisonTab } from './BounceReasonComparisonTab';
 export { default as DelayReasonsTab } from './DelayReasonsTab';
+export { default as DelayReasonsComparisonTab } from './DelayReasonsComparisonTab';
 export { default as LinksTab } from './LinksTab';
 export { default as RejectionReasonsTab } from './RejectionReasonsTab';

--- a/src/pages/reportBuilder/constants/index.js
+++ b/src/pages/reportBuilder/constants/index.js
@@ -82,3 +82,5 @@ export const GROUP_BY_CONFIG = {
     keyName: 'ip_pool',
   },
 };
+
+export const TAB_LOADING_HEIGHT = '300px';


### PR DESCRIPTION
[SA-1850](https://sparkpost.atlassian.net/browse/SA-1850)

### What Changed

- Extracts delay reasons table as a component and refactors existing delay reasons tab
- Adds new `DelayReasonsComparisonTab` component that renders when relevant delay reason metrics are selected _and_ comparisons are applied
- Cleaned up existing tests by adding missing `cy.wait()` actions and using more re-usable functions

### How To Test

1. With the compare by feature flag enabled, go to `/signals/analytics`
2. Add delay reason metrics ("Accepted", "Delayed", "Delayed 1st Attempt")
3. Add two valid comparisons
4. Verify that a new delay reason tab renders for each item being compared and that the default "Delay Reason" tab does _not_ render
5. Additionally, add some bounce reason metrics ("Bounces", for example) and verify that bounce reason tabs render for each comparison as well as delay reason tabs

### To Do

- [ ] Incorporate feedback