### PR TITLE
SA-1894: Add active comparisons to save report modal

### DIFF
--- a/cypress/fixtures/reports/200.get.json
+++ b/cypress/fixtures/reports/200.get.json
@@ -47,6 +47,18 @@
       "name": "My new report",
       "query_string": "from=2020-09-18T15%3A00%3A00Z&to=2020-09-25T15%3A08%3A36Z&range=7days&timezone=America%2FNew_York&precision=hour&filters=Campaign%3ABlack%20Friday&metrics=count_bounce&report=0e860570-c1a8-47cf-9c39-1ffee38dd982",
       "subaccount_id": 0
+    },
+    {
+      "created": "2020-09-22T19:55:34.215Z",
+      "creator": "mockuser",
+      "current_user_can_edit": true,
+      "description": "Here is a description",
+      "id": "0e860570-c1a8-47cf-9c39-1ffee38dd983",
+      "is_editable": false,
+      "modified": "2020-10-08T19:39:53.830Z",
+      "name": "Comparison Report",
+      "query_string": "range=7days&comparisons[0][type]=Subaccount&comparisons[0][value]=Fake Subaccount 3 (ID 103)&comparisons[0][id]=103&comparisons[1][type]=Subaccount&comparisons[1][value]=Fake Subaccount 1 (ID 101)&comparisons[1][id]=101",
+      "subaccount_id": 0
     }
   ]
 }

--- a/cypress/tests/integration/signals-analytics/analytics-report/savedReports.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/savedReports.spec.js
@@ -208,10 +208,7 @@ if (IS_HIBANA_ENABLED) {
         cy.findByLabelText('Report').focus(); // open typeahead
 
         cy.findListBoxByLabelText('Report').within(() => {
-          cy.findAllByRole('option')
-            .eq(0)
-            .should('have.contain', 'My Bounce Report')
-            .click();
+          cy.findByRole('option', { name: 'My Bounce Report mockuser' }).click();
         });
 
         cy.findByLabelText('Report').should('have.value', 'My Bounce Report');
@@ -221,10 +218,7 @@ if (IS_HIBANA_ENABLED) {
         );
         cy.findByLabelText('Precision').should('have.value', 'hour');
 
-        cy.get('[data-id="metric-tag"]')
-          .should('have.length', 1)
-          .eq(0)
-          .should('have.contain', 'Bounces');
+        cy.get('[data-id="metric-tag"]').should('have.contain', 'Bounces');
       });
 
       it('should edit details of a saved report', () => {
@@ -235,10 +229,7 @@ if (IS_HIBANA_ENABLED) {
         cy.findByRole('button', { name: 'Edit Details' }).should('be.disabled');
 
         cy.findListBoxByLabelText('Report').within(() => {
-          cy.findAllByRole('option')
-            .eq(0)
-            .should('have.contain', 'My Bounce Report')
-            .click();
+          cy.findByRole('option', { name: 'My Bounce Report mockuser' }).click();
         });
 
         cy.findByRole('button', { name: 'Edit Details' }).click();
@@ -254,10 +245,7 @@ if (IS_HIBANA_ENABLED) {
         cy.findByRole('button', { name: 'Save Changes' }).should('be.disabled');
 
         cy.findListBoxByLabelText('Report').within(() => {
-          cy.findAllByRole('option')
-            .eq(2)
-            .should('have.contain', 'Comparison Report')
-            .click();
+          cy.findByRole('option', { name: 'Comparison Report mockuser' }).click();
         });
 
         cy.findByRole('button', { name: 'Save Changes' }).click();

--- a/cypress/tests/integration/signals-analytics/analytics-report/savedReports.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/savedReports.spec.js
@@ -255,18 +255,20 @@ if (IS_HIBANA_ENABLED) {
 
         cy.findListBoxByLabelText('Report').within(() => {
           cy.findAllByRole('option')
-            .eq(0)
-            .should('have.contain', 'My Bounce Report')
+            .eq(2)
+            .should('have.contain', 'Comparison Report')
             .click();
         });
 
         cy.findByRole('button', { name: 'Save Changes' }).click();
-        cy.findByLabelText('Name').should('have.value', 'My Bounce Report');
+        cy.findByLabelText('Name').should('have.value', 'Comparison Report');
         cy.findByLabelText('Description').should('have.value', 'Here is a description');
 
         cy.withinModal(() => {
           cy.findByText('Bounces').should('be.visible');
           cy.findByText('Last 7 Days').should('be.visible');
+          cy.findByText('Fake Subaccount 3 (ID 103)').should('be.visible');
+          cy.findByText('Fake Subaccount 1 (ID 101)').should('be.visible');
         });
       });
 

--- a/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
+++ b/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
@@ -5,6 +5,7 @@ import {
   Button,
   Checkbox,
   Inline,
+  LabelValue,
   Modal,
   Stack,
   Tag,
@@ -120,24 +121,33 @@ export function SaveReportModal(props) {
           {saveQuery && (
             <Stack>
               <Box>
-                <Heading as="h6">Metrics</Heading>
-
-                <ActiveMetrics metrics={reportOptions.metrics} />
+                <LabelValue>
+                  <LabelValue.Label>Metrics</LabelValue.Label>
+                  <LabelValue.Value>
+                    <ActiveMetrics metrics={reportOptions.metrics} />
+                  </LabelValue.Value>
+                </LabelValue>
               </Box>
 
               {hasFilters ? (
                 <Box>
-                  <Heading as="h6">Filters</Heading>
-
-                  <ActiveFilters filters={reportOptions.filters} />
+                  <LabelValue>
+                    <LabelValue.Label>Filters</LabelValue.Label>
+                    <LabelValue.Value>
+                      <ActiveFilters filters={reportOptions.filters} />
+                    </LabelValue.Value>
+                  </LabelValue>
                 </Box>
               ) : null}
 
               {hasComparisons ? (
                 <Box>
-                  <Heading as="h6">Comparisons</Heading>
-
-                  <ActiveComparisons comparisons={reportOptions.comparisons} />
+                  <LabelValue>
+                    <LabelValue.Label>Comparisons</LabelValue.Label>
+                    <LabelValue.Value>
+                      <ActiveComparisons comparisons={reportOptions.comparisons} />
+                    </LabelValue.Value>
+                  </LabelValue>
                 </Box>
               ) : null}
 

--- a/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
+++ b/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
@@ -19,6 +19,7 @@ import { getMetricsFromKeys } from 'src/helpers/metrics';
 import { useReportBuilderContext } from '../../context/ReportBuilderContext';
 import ActiveFilters from 'src/components/reportBuilder/ActiveFilters';
 import { formatDateTime, relativeDateOptionsIndexed } from 'src/helpers/date';
+import ActiveComparisons from '../ActiveComparisons';
 
 const DateRange = ({ to, from, relativeRange }) => {
   if (relativeRange === 'custom') {
@@ -74,6 +75,7 @@ export function SaveReportModal(props) {
   const { search = '' } = useLocation();
   const { state: reportOptions } = useReportBuilderContext();
   const hasFilters = Boolean(reportOptions.filters.length);
+  const hasComparisons = Boolean(reportOptions.comparisons.length);
 
   React.useEffect(() => {
     if (!report) return;
@@ -128,6 +130,14 @@ export function SaveReportModal(props) {
                   <Heading as="h6">Filters</Heading>
 
                   <ActiveFilters filters={reportOptions.filters} />
+                </Box>
+              ) : null}
+
+              {hasComparisons ? (
+                <Box>
+                  <Heading as="h6">Comparisons</Heading>
+
+                  <ActiveComparisons comparisons={reportOptions.comparisons} />
                 </Box>
               ) : null}
 

--- a/src/pages/reportBuilder/components/SavedReportsSection/tests/SaveReportModal.test.js
+++ b/src/pages/reportBuilder/components/SavedReportsSection/tests/SaveReportModal.test.js
@@ -10,7 +10,7 @@ jest.mock('src/context/HibanaContext', () => ({
 }));
 
 jest.mock('src/pages/reportBuilder/context/ReportBuilderContext', () => ({
-  useReportBuilderContext: jest.fn(() => ({ state: { foo: 'bar', filters: [] } })),
+  useReportBuilderContext: jest.fn(() => ({ state: { foo: 'bar', filters: [], comparisons: [] } })),
 }));
 
 const mockOnCancel = jest.fn();


### PR DESCRIPTION
### What Changed

- Active comparisons displayed on save report changes modal

### How To Test

- Go to report builder
- Save a custom report
- Click Add Comparisons and add at least 2 comparison filters (need feature flag `allow_compare_by`)
- Click `Save Changes` to get to save report modal
- Verify that active comparisons are displayed

### To Do

- [ ] Address feedback
