### PR TITLE
FE-1286 - Show Pinned Report to Reporting and templates user when their last_usage_date!==null

### DIFF
--- a/cypress/fixtures/authenticate/grants/200.get.reporting.json
+++ b/cypress/fixtures/authenticate/grants/200.get.reporting.json
@@ -44,6 +44,9 @@
     },
     {
       "key": "support/manage"
+    },
+    {
+      "key": "usage/view"
     }
   ]
 }

--- a/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
+++ b/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
@@ -77,9 +77,7 @@ describe('Version 2 of the dashboard page', () => {
       cy.findByText('Pinned Report updated').should('be.visible');
     });
 
-    // TODO: I believe this test is catching a bug - the `AggregatedMetrics` component does not make a request for the summary chart data
-    // If it's already available in the Redux store, it will be present, however.
-    it.skip('renders the Analytics Report step with pinned report when last usage date is not null and a pinned report is present in account ui options', () => {
+    it('renders the Analytics Report step with pinned report when last usage date is not null and a pinned report is present in account ui options', () => {
       stubGrantsRequest({ role: 'admin' });
       stubAlertsReq();
       stubAccountsReq();
@@ -436,12 +434,14 @@ describe('Version 2 of the dashboard page', () => {
 
       // step 4 text...
       cy.findByRole('heading', { name: 'Start Sending!' }).should('not.exist');
+
+      //text from default Analytics report step...
       cy.findByText(
         'Follow the Getting Started documentation to set up sending via API or SMTP.',
       ).should('not.exist');
     });
 
-    it('Shows the default "Go To Analytics Report" onboarding step for templates users with last usage date', () => {
+    it('Shows the Pinned Report onboarding step for templates users with last usage date', () => {
       stubGrantsRequest({ role: 'templates' });
       stubAlertsReq();
       stubAccountsReq();
@@ -452,16 +452,11 @@ describe('Version 2 of the dashboard page', () => {
       cy.visit(PAGE_URL);
       cy.wait(['@alertsReq', '@accountReq', '@stubbedUsersRequest', '@usageReq']);
 
-      cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
+      cy.findByRole('heading', { name: 'Summary Report' }).should('be.visible');
 
       cy.findByText('Build custom analytics, track engagement, diagnose errors, and more.').should(
-        'be.visible',
+        'not.exist',
       );
-
-      cy.verifyLink({
-        content: 'Go To Analytics Report',
-        href: '/signals/analytics',
-      });
 
       // step 1 text...
       cy.findAllByText('is required in order to start or enable analytics.').should('not.exist');

--- a/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
+++ b/cypress/tests/integration/dashboardV2/dashboardPageV2.spec.js
@@ -77,6 +77,8 @@ describe('Version 2 of the dashboard page', () => {
       cy.findByText('Pinned Report updated').should('be.visible');
     });
 
+    // TODO: I believe this test is catching a bug - the `AggregatedMetrics` component does not make a request for the summary chart data
+    // If it's already available in the Redux store, it will be present, however.
     it('renders the Analytics Report step with pinned report when last usage date is not null and a pinned report is present in account ui options', () => {
       stubGrantsRequest({ role: 'admin' });
       stubAlertsReq();
@@ -404,11 +406,12 @@ describe('Version 2 of the dashboard page', () => {
       stubGrantsRequest({ role: 'reporting' });
       stubAlertsReq();
       stubAccountsReq();
+      stubUsageReq({ fixture: 'usage/200.get.messaging.no-last-sent.json' });
       // Force not admin here - Our mocked cypress state always has the user as admin
       stubUsersRequest({ access_level: 'reporting' });
 
       cy.visit(PAGE_URL);
-      cy.wait(['@alertsReq', '@accountReq', '@stubbedUsersRequest']);
+      cy.wait(['@alertsReq', '@accountReq', '@stubbedUsersRequest', '@usageReq']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 
@@ -486,44 +489,6 @@ describe('Version 2 of the dashboard page', () => {
 
       cy.visit(PAGE_URL);
       cy.wait(['@alertsReq', '@accountReq', '@stubbedUsersRequest', '@usageReq']);
-
-      cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
-
-      cy.findByText('Build custom analytics, track engagement, diagnose errors, and more.').should(
-        'be.visible',
-      );
-
-      cy.verifyLink({
-        content: 'Go To Analytics Report',
-        href: '/signals/analytics',
-      });
-
-      // step 1 text...
-      cy.findAllByText('is required in order to start or enable analytics.').should('not.exist');
-
-      // step 2 text...
-      cy.findAllByText('Once a sending domain has been added, it needs to be').should('not.exist');
-
-      // step 3 text...
-      cy.findAllByText('Create an API key in order to start sending via API or SMTP.').should(
-        'not.exist',
-      );
-
-      // step 4 text...
-      cy.findByRole('heading', { name: 'Start Sending!' }).should('not.exist');
-      cy.findByText(
-        'Follow the Getting Started documentation to set up sending via API or SMTP.',
-      ).should('not.exist');
-    });
-
-    it('Shows the default "Go To Analytics Report" onboarding step for any user without the sending_domains/manage grant', () => {
-      stubGrantsRequest({ role: 'reporting' });
-      stubAlertsReq();
-      stubAccountsReq();
-      stubUsersRequest({ access_level: 'reporting' });
-
-      cy.visit(PAGE_URL);
-      cy.wait(['@getGrants', '@alertsReq', '@accountReq', '@stubbedUsersRequest']);
 
       cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
 

--- a/src/hooks/usePinnedRport/usePinnedReport.js
+++ b/src/hooks/usePinnedRport/usePinnedReport.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getRelativeDates, getLocalTimezone } from 'src/helpers/date';
 import { parseSearchNew as parseSearch } from 'src/helpers/reports';
@@ -15,11 +15,9 @@ const defaultReportName = 'Summary Report';
 export default function usePinnedReport(onboarding) {
   const pinnedReport = { options: {}, name: '', linkToReportBuilder: '/' };
   const dispatch = useDispatch();
-  const isFirstRender = useRef(true);
 
   useEffect(() => {
     if (onboarding === 'done') {
-      isFirstRender.current = false; //used this to prevent triggering the getAggregateTable action on first render since loading state is false in reducer initially
       dispatch(listSubaccounts());
       dispatch(getReports());
     }
@@ -44,7 +42,7 @@ export default function usePinnedReport(onboarding) {
     };
   };
 
-  pinnedReport.loading = subaccountsLoading || reportsLoading || isFirstRender.current;
+  pinnedReport.loading = subaccountsLoading || reportsLoading;
   let summaryReportQueryString = PRESET_REPORT_CONFIGS.find(x => x.name === defaultReportName)
     .query_string;
   const summaryReportOptions = parseSearch(summaryReportQueryString);

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -38,7 +38,7 @@ function mapStateToProps(state) {
   const canManageSendingDomains = hasGrants('sending_domains/manage')(state);
 
   let onboarding = 'done';
-  if (canViewUsage && lastUsageDate === null && (isAnAdmin || isDev)) {
+  if (lastUsageDate === null && (isAnAdmin || isDev)) {
     let addSendingDomainNeeded;
     let verifySendingNeeded;
     let createApiKeyNeeded;
@@ -60,8 +60,7 @@ function mapStateToProps(state) {
 
     if (!addSendingDomainNeeded && !verifySendingNeeded && !createApiKeyNeeded)
       onboarding = 'startSending';
-  } else if (isTemplatesUser || isReportingUser) {
-    //TODO: revisit this condition if usage/view grant gets added for reporting & subaccount_reporting users
+  } else if (lastUsageDate === null && (isTemplatesUser || isReportingUser)) {
     onboarding = 'analyticsReportPromo';
   }
 


### PR DESCRIPTION
[FE-1286] Show Pinned Report to Reporting and templates user when their last_usage_date!==null

### What Changed

- Updated the condition to show Analytics Promo step for templates and reporting user when last usage date is null
- And show Pinned Report for templates and reporting user when last usage date is not null
- Updated a condition on usePinnedReport which was causing the _skipped_ cypress test to fail
- Updated the usage/view grant in the fixture for reporting users.

### How To Test

- Check /dashboardv2 for reporting and templates user on appteam, it should show pinned report.

### To Do

- [ ] Address feedback


[FE-1286]: https://sparkpost.atlassian.net/browse/FE-1286