### PR TITLE
SA-1892: Added segment to report builder comparison form

### DIFF
--- a/src/helpers/segment.js
+++ b/src/helpers/segment.js
@@ -17,6 +17,7 @@ export const SEGMENT_EVENTS = {
   SENDING_DOMAIN_ADDED: 'Sending Domain Added',
   SENDING_DOMAIN_VERIFIED: 'Sending Domain Verified',
   EMPTY_STATE_LOADED: 'Empty state loaded',
+  REPORT_BUILDER_COMPARISON_ADDED: 'Report Builder Comparison Added',
 };
 
 const UX_EVENTS = [SEGMENT_EVENTS.HIBANA_TOGGLED_ON, SEGMENT_EVENTS.HIBANA_TOGGLED_OFF];

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -26,6 +26,8 @@ import { useReportBuilderContext } from '../../context/ReportBuilderContext';
 import Typeahead from './Typeahead';
 import styled from 'styled-components';
 
+import { segmentTrack, SEGMENT_EVENTS } from 'src/helpers/segment';
+
 const initialState = {
   filters: [null, null],
   filterType: undefined,
@@ -118,6 +120,13 @@ function CompareByForm({
       return dispatch({
         type: 'SET_MIN_COMPARE_ERROR',
         error: 'Select more than one item to compare',
+      });
+    }
+
+    if (formattedFilters.length >= 2) {
+      segmentTrack(SEGMENT_EVENTS.REPORT_BUILDER_COMPARISON_ADDED, {
+        comparisonType: state.filterType,
+        numberOfComparisons: formattedFilters.length,
       });
     }
 

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -54,6 +54,7 @@ const reducer = (state, action) => {
       return {
         ...state,
         filters: [...state.filters, null],
+        formChanged: true,
         hasMaxComparisonsError: Boolean(state.filters.length >= 9), //Will now be 10
       };
     case 'REMOVE_FILTER':
@@ -61,6 +62,7 @@ const reducer = (state, action) => {
         ...state,
         filters: state.filters.filter((_filter, filterIndex) => filterIndex !== action.index),
         hasMaxComparisonsError: false,
+        formChanged: true,
       };
     case 'SET_FILTER':
       const newFilters = state.filters;
@@ -73,11 +75,13 @@ const reducer = (state, action) => {
         hasMaxComparisonsError: false,
         filters: [null, null],
         filterType: action.filterType,
+        formChanged: true,
       };
-    case 'RESET_FORM':
-      return { ...initialState, filters: [null, null], filterType: undefined };
     case 'SET_MIN_COMPARE_ERROR':
-      return { ...state, hasMinComparisonsError: true };
+      return { ...state, hasMinComparisonsError: true, formChanged: true };
+    case 'RESET_FORM':
+      return { ...initialState, filters: [null, null], filterType: undefined, formChanged: true };
+
     default:
       throw new Error(`${action.type} is not supported.`);
   }
@@ -123,12 +127,11 @@ function CompareByForm({
       });
     }
 
-    if (formattedFilters.length >= 2) {
-      segmentTrack(SEGMENT_EVENTS.REPORT_BUILDER_COMPARISON_ADDED, {
-        comparisonType: state.filterType,
-        numberOfComparisons: formattedFilters.length,
-      });
-    }
+    segmentTrack(SEGMENT_EVENTS.REPORT_BUILDER_COMPARISON_ADDED, {
+      formChanged: state.formChanged,
+      comparisonType: state.filterType,
+      numberOfComparisons: formattedFilters.length,
+    });
 
     return handleSubmit({ comparisons: formattedFilters });
   }

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -94,6 +94,7 @@ const getInitialState = comparisons => {
   }
 
   return {
+    ...initialState,
     filterType: REPORT_BUILDER_FILTER_KEY_MAP[comparisons[0].type],
     filters: [...comparisons],
   };

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -33,6 +33,7 @@ const initialState = {
   filterType: undefined,
   hasMinComparisonsError: false,
   hasMaxComparisonsError: false,
+  formChanged: false,
 };
 
 const StyledButton = styled(Button)`


### PR DESCRIPTION
### What Changed

- Added segment tracking event for compare by in report builder

### How To Test
- Go to Comparison form in report builder
- Apply form with no comparisons
- Check that request does not go through with applying
- Apply form with at least 2 comparison
- Check that request goes through with the appropriate data

### To Do

- [ ] Verify data on segment
