### PR TITLE
SA-1893: Compare by filters limited to 10 filters

### DIFF
--- a/cypress/fixtures/subaccounts/200.get.many.json
+++ b/cypress/fixtures/subaccounts/200.get.many.json
@@ -1,0 +1,74 @@
+{
+  "results": [
+    {
+      "customer_id": 123,
+      "id": 101,
+      "name": "Fake Subaccount 1",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 102,
+      "name": "Fake Subaccount 2",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 103,
+      "name": "Fake Subaccount 3",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 104,
+      "name": "Fake Subaccount 4",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 105,
+      "name": "Fake Subaccount 5",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 106,
+      "name": "Fake Subaccount 6",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 107,
+      "name": "Fake Subaccount 7",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 108,
+      "name": "Fake Subaccount 8",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 109,
+      "name": "Fake Subaccount 9",
+      "compliance_status": "active",
+      "status": "active"
+    },
+    {
+      "customer_id": 123,
+      "id": 110,
+      "name": "Fake Subaccount 10",
+      "compliance_status": "active",
+      "status": "active"
+    }
+  ]
+}

--- a/cypress/tests/integration/signals-analytics/analytics-report/reportCompareBy.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/reportCompareBy.spec.js
@@ -250,6 +250,7 @@ if (IS_HIBANA_ENABLED) {
           .click();
 
         cy.findByText('Limit on number of comparisons reached').should('exist');
+        cy.findByRole('button', { name: 'Add Subaccount' }).should('not.exist');
 
         cy.findAllByRole('button', { name: 'Remove Filter' })
           .eq(8)

--- a/cypress/tests/integration/signals-analytics/analytics-report/reportCompareBy.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/reportCompareBy.spec.js
@@ -249,7 +249,7 @@ if (IS_HIBANA_ENABLED) {
           .should('be.visible')
           .click();
 
-        cy.findByText('Limit on number of comparisons reached').should('exist');
+        cy.findByText('Limit on number of comparisons reached').should('be.visible');
         cy.findByRole('button', { name: 'Add Subaccount' }).should('not.exist');
 
         cy.findAllByRole('button', { name: 'Remove Filter' })

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -92,7 +92,10 @@ const getInitialState = comparisons => {
     return initialState;
   }
 
-  return { filterType: REPORT_BUILDER_FILTER_KEY_MAP[comparisons[0].type], filters: comparisons };
+  return {
+    filterType: REPORT_BUILDER_FILTER_KEY_MAP[comparisons[0].type],
+    filters: [...comparisons],
+  };
 };
 
 function CompareByForm({

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -175,11 +175,6 @@ function CompareByForm({
     <form onSubmit={handleFormSubmit}>
       <Box padding="500" paddingBottom="8rem">
         <Stack>
-          {error && (
-            <Banner size="small" status={errorStatus}>
-              {error}
-            </Banner>
-          )}
           <Select
             placeholder="Select Resource"
             placeholderValue="Select Resource"
@@ -244,6 +239,11 @@ function CompareByForm({
                 <Button.Icon as={Add} />
               </Button>
             </Box>
+          )}
+          {error && (
+            <Banner size="small" status={errorStatus}>
+              {error}
+            </Banner>
           )}
         </Stack>
       </Box>


### PR DESCRIPTION
### What Changed

- Added comparison limit of 10 filters

### How To Test

- On Hibana, with `allow_compare_by` feature flag enabled, go to Report Builder page
- Click on `Add Comparison`
- Select comparison type
- Fill out form, adding up to 10 filters
- Verify that warning appears at top of form

### To Do

- [ ] Address feedback

### Notes
- Just realized that user wouldn't immediately see the warning message. Might be worth thinking about how the message is displayed. 
