### PR TITLE
FE-1252 - Subaccounts Empty State and Info Banner

### DIFF
--- a/cypress/fixtures/users/200.get.subaccount-banner-dismissed.json
+++ b/cypress/fixtures/users/200.get.subaccount-banner-dismissed.json
@@ -1,0 +1,39 @@
+{
+  "results": {
+    "username": "mockuser",
+    "first_name": "UpdateAppTest",
+    "last_name": "TeamName",
+    "email": "mockuser@example.com",
+    "customer": 107,
+    "cookie_consent": "2018-03-28T18:12:32.615Z",
+    "tfa_enabled": false,
+    "tou_auto_accept": false,
+    "is_sso": false,
+    "email_verified": true,
+    "access_level": "admin",
+    "options": {
+      "ui": {
+        "isHibanaBannerVisible": false,
+        "isHibanaEnabled": true,
+        "onboardingV2": {
+          "subaccountsBannerDismissed": true
+        }
+      }
+    },
+    "created": "2015-07-29T17:59:48.477Z",
+    "updated": "2019-12-13T16:34:20.358Z",
+    "has_subaccounts": true,
+    "tokens": [],
+    "tou": {
+      "state": "accepted",
+      "updated_date": "2014-10-15T00:00+00:00",
+      "must_accept_date": null
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "/api/v1/users/appteam"
+    }
+  ]
+}

--- a/cypress/tests/integration/subaccounts/listPage.spec.js
+++ b/cypress/tests/integration/subaccounts/listPage.spec.js
@@ -1,3 +1,4 @@
+import { CREATE_SUBACCOUNT } from 'src/constants';
 import { IS_HIBANA_ENABLED, USERNAME } from 'cypress/constants';
 const SUBACCOUNT_API_URL = '/api/v1/subaccounts';
 const PAGE_URL = '/account/subaccounts';
@@ -52,7 +53,7 @@ describe('The subaccounts list page', () => {
       );
       cy.verifyLink({
         content: 'Create Subaccount',
-        href: '/account/subaccounts/create',
+        href: CREATE_SUBACCOUNT,
       });
       cy.verifyLink({
         content: 'Learn more',
@@ -113,7 +114,7 @@ describe('The subaccounts list page', () => {
       ).should('be.visible');
       cy.verifyLink({
         content: 'Create Subaccount',
-        href: '/account/subaccounts/create',
+        href: CREATE_SUBACCOUNT,
       });
       cy.verifyLink({
         content: 'Subaccounts Documentation',

--- a/cypress/tests/integration/subaccounts/listPage.spec.js
+++ b/cypress/tests/integration/subaccounts/listPage.spec.js
@@ -1,0 +1,61 @@
+import { IS_HIBANA_ENABLED } from 'cypress/constants';
+const SUBACCOUNT_API_URL = '/api/v1/subaccounts';
+const PAGE_URL = '/account/subaccounts';
+
+function stubSubaccount({ fixture = 'subaccounts/200.get.json', statusCode } = {}) {
+  return cy.stubRequest({
+    url: SUBACCOUNT_API_URL,
+    fixture,
+    statusCode,
+    requestAlias: 'subaccounts',
+  });
+}
+
+function stubAccountsReq({ fixture = 'account/200.get.has-empty-states.json' } = {}) {
+  cy.stubRequest({
+    url: '/api/v1/account**',
+    fixture: fixture,
+    requestAlias: 'accountReq',
+  });
+}
+
+describe('The subaccounts list page', () => {
+  beforeEach(() => {
+    cy.stubAuth();
+    cy.login({ isStubbed: true });
+  });
+
+  it('has a relevant page title', () => {
+    stubSubaccount();
+    cy.visit(PAGE_URL);
+    cy.title().should('include', 'Subaccounts');
+  });
+
+  if (IS_HIBANA_ENABLED) {
+    it('does not render the empty state banner when "allow_empty_states" is not set', () => {
+      stubSubaccount({ fixture: '200.get.no-results.json' });
+      cy.visit(PAGE_URL);
+      cy.wait(['@subaccounts']);
+      cy.title().should('include', 'Subaccounts');
+      cy.findByRole('heading', { name: 'Manage your subaccounts' }).should('be.visible');
+    });
+
+    it('renders the empty state banner when "allow_empty_states" is set on the account and banner has not been dismissed', () => {
+      stubSubaccount({ fixture: '200.get.no-results.json' });
+      stubAccountsReq();
+      cy.visit(PAGE_URL);
+      cy.wait(['@subaccounts']);
+      cy.title().should('include', 'Subaccounts');
+      cy.findByRole('heading', { name: 'Subaccounts' }).should('be.visible');
+    });
+
+    it('renders the empty state when there are no subaccounts', () => {
+      stubSubaccount({ fixture: '200.get.no-results.json' });
+      stubAccountsReq();
+      cy.visit(PAGE_URL);
+      cy.wait(['@subaccounts']);
+      cy.title().should('include', 'Subaccounts');
+      cy.findByRole('heading', { name: 'Subaccounts' }).should('be.visible');
+    });
+  }
+});

--- a/cypress/tests/integration/subaccounts/listPage.spec.js
+++ b/cypress/tests/integration/subaccounts/listPage.spec.js
@@ -1,4 +1,4 @@
-import { IS_HIBANA_ENABLED } from 'cypress/constants';
+import { IS_HIBANA_ENABLED, USERNAME } from 'cypress/constants';
 const SUBACCOUNT_API_URL = '/api/v1/subaccounts';
 const PAGE_URL = '/account/subaccounts';
 
@@ -19,6 +19,15 @@ function stubAccountsReq({ fixture = 'account/200.get.has-empty-states.json' } =
   });
 }
 
+// this is an override of the stub set by stubAuth
+function stubUsersRequest() {
+  cy.stubRequest({
+    url: `/api/v1/users/${USERNAME}`,
+    fixture: `users/200.get.subaccount-banner-dismissed.json`,
+    requestAlias: 'stubbedUsersRequest',
+  });
+}
+
 describe('The subaccounts list page', () => {
   beforeEach(() => {
     cy.stubAuth();
@@ -32,13 +41,15 @@ describe('The subaccounts list page', () => {
   });
 
   if (IS_HIBANA_ENABLED) {
-    it('does not render the empty state banner when "allow_empty_states" is not set', () => {
+    it('does not render the empty state when "allow_empty_states" is not set', () => {
       stubSubaccount({ fixture: '200.get.no-results.json' });
       cy.visit(PAGE_URL);
       cy.wait(['@subaccounts']);
       cy.title().should('include', 'Subaccounts');
       cy.findByRole('heading', { name: 'Manage your subaccounts' }).should('be.visible');
-      cy.findByText('Subaccounts are a good way of managing external client accounts.');
+      cy.findByText('Subaccounts are a good way of managing external client accounts.').should(
+        'be.visible',
+      );
       cy.verifyLink({
         content: 'Create Subaccount',
         href: '/account/subaccounts/create',
@@ -47,6 +58,20 @@ describe('The subaccounts list page', () => {
         content: 'Learn more',
         href: 'https://developers.sparkpost.com/api/subaccounts.html',
       });
+    });
+
+    it('does not renders the empty state banner when the banner has been dismissed', () => {
+      stubSubaccount({ fixture: 'subaccounts/200.get.json' });
+      stubAccountsReq();
+      stubUsersRequest(); // override for user ui option to turn off banner
+      cy.visit(PAGE_URL);
+      cy.wait(['@subaccounts']);
+      cy.title().should('include', 'Subaccounts');
+      cy.findByRole('heading', { name: 'Subaccounts' }).should('be.visible');
+      cy.findByRole('heading', { name: 'Organize Sending and Analytics' }).should('not.exist');
+      cy.findByText(
+        'Subaccounts can be used to provision and manage senders separately from each other, and to provide assets and reporting data for each of them.',
+      ).should('not.exist');
     });
 
     it('renders the empty state banner when "allow_empty_states" is set on the account and banner has not been dismissed', () => {
@@ -59,7 +84,7 @@ describe('The subaccounts list page', () => {
       cy.findByRole('heading', { name: 'Organize Sending and Analytics' }).should('be.visible');
       cy.findByText(
         'Subaccounts can be used to provision and manage senders separately from each other, and to provide assets and reporting data for each of them.',
-      );
+      ).should('be.visible');
       cy.verifyLink({
         content: 'Subaccounts Documentation',
         href: 'https://sparkpost.com/docs/user-guide/subaccounts/',
@@ -76,10 +101,16 @@ describe('The subaccounts list page', () => {
       cy.get('p').contains(
         'Subaccounts can be used to provision and manage senders separately from each other, and to provide assets and reporting data for each of them. Subaccounts are great for service providers who send on behalf of others or for businesses that want to separate different streams of traffic.',
       );
-      cy.findByText('Common uses for Subaccounts');
-      cy.findByText('Sending as a service provider for multiple unique customers.');
-      cy.findByText('Keeping unique internal business units independent from one another.');
-      cy.findByText('Tracking mission critical campaign data separate from other mailstreams.');
+      cy.findByText('Common uses for Subaccounts').should('be.visible');
+      cy.findByText('Sending as a service provider for multiple unique customers.').should(
+        'be.visible',
+      );
+      cy.findByText('Keeping unique internal business units independent from one another.').should(
+        'be.visible',
+      );
+      cy.findByText(
+        'Tracking mission critical campaign data separate from other mailstreams.',
+      ).should('be.visible');
       cy.verifyLink({
         content: 'Create Subaccount',
         href: '/account/subaccounts/create',

--- a/cypress/tests/integration/subaccounts/listPage.spec.js
+++ b/cypress/tests/integration/subaccounts/listPage.spec.js
@@ -38,15 +38,32 @@ describe('The subaccounts list page', () => {
       cy.wait(['@subaccounts']);
       cy.title().should('include', 'Subaccounts');
       cy.findByRole('heading', { name: 'Manage your subaccounts' }).should('be.visible');
+      cy.findByText('Subaccounts are a good way of managing external client accounts.');
+      cy.verifyLink({
+        content: 'Create Subaccount',
+        href: '/account/subaccounts/create',
+      });
+      cy.verifyLink({
+        content: 'Learn more',
+        href: 'https://developers.sparkpost.com/api/subaccounts.html',
+      });
     });
 
     it('renders the empty state banner when "allow_empty_states" is set on the account and banner has not been dismissed', () => {
-      stubSubaccount({ fixture: '200.get.no-results.json' });
+      stubSubaccount({ fixture: 'subaccounts/200.get.json' });
       stubAccountsReq();
       cy.visit(PAGE_URL);
       cy.wait(['@subaccounts']);
       cy.title().should('include', 'Subaccounts');
       cy.findByRole('heading', { name: 'Subaccounts' }).should('be.visible');
+      cy.findByRole('heading', { name: 'Organize Sending and Analytics' }).should('be.visible');
+      cy.findByText(
+        'Subaccounts can be used to provision and manage senders separately from each other, and to provide assets and reporting data for each of them.',
+      );
+      cy.verifyLink({
+        content: 'Subaccounts Documentation',
+        href: 'https://sparkpost.com/docs/user-guide/subaccounts/',
+      });
     });
 
     it('renders the empty state when there are no subaccounts', () => {
@@ -56,6 +73,21 @@ describe('The subaccounts list page', () => {
       cy.wait(['@subaccounts']);
       cy.title().should('include', 'Subaccounts');
       cy.findByRole('heading', { name: 'Subaccounts' }).should('be.visible');
+      cy.get('p').contains(
+        'Subaccounts can be used to provision and manage senders separately from each other, and to provide assets and reporting data for each of them. Subaccounts are great for service providers who send on behalf of others or for businesses that want to separate different streams of traffic.',
+      );
+      cy.findByText('Common uses for Subaccounts');
+      cy.findByText('Sending as a service provider for multiple unique customers.');
+      cy.findByText('Keeping unique internal business units independent from one another.');
+      cy.findByText('Tracking mission critical campaign data separate from other mailstreams.');
+      cy.verifyLink({
+        content: 'Create Subaccount',
+        href: '/account/subaccounts/create',
+      });
+      cy.verifyLink({
+        content: 'Subaccounts Documentation',
+        href: 'https://sparkpost.com/docs/user-guide/subaccounts/',
+      });
     });
   }
 });

--- a/src/components/matchbox/Page.js
+++ b/src/components/matchbox/Page.js
@@ -16,7 +16,7 @@ export default function Page({ hibanaEmptyStateComponent: HibanaEmptyStateCompon
   const allowEmptyStates = useSelector(isAccountUiOptionSet('allow_empty_states'));
   const showHibanaEmptyState = allowEmptyStates && HibanaEmptyStateComponent && props.empty?.show;
 
-  // this is to prevent duplicates, but we still have to be careful if this component is unmounted and remounted
+  // IMPORTANT - props.loading needs to have a isFirstRender boolean set from the parent scope - see api-keys/ListPage.js
   React.useEffect(() => {
     if (isHibanaEnabled && showHibanaEmptyState && !props.loading) {
       segmentTrack(SEGMENT_EVENTS.EMPTY_STATE_LOADED, {
@@ -38,5 +38,6 @@ export default function Page({ hibanaEmptyStateComponent: HibanaEmptyStateCompon
 
   return <HibanaPage {...props} />;
 }
+
 OGPage.displayName = 'OGPage';
 HibanaPage.displayName = 'HibanaPage';

--- a/src/config/routes/index.js
+++ b/src/config/routes/index.js
@@ -62,6 +62,7 @@ import App from 'src/components/layout/App';
 import LargeForm from 'src/components/layout/LargeForm';
 
 import {
+  CREATE_SUBACCOUNT,
   AUTH_ROUTE,
   DEFAULT_REDIRECT_ROUTE,
   ENABLE_TFA_AUTH_ROUTE,
@@ -69,6 +70,7 @@ import {
   SSO_AUTH_ROUTE,
   TFA_ROUTE,
 } from 'src/constants';
+
 //route modules
 import { emailRedirects, emailVerificationRedirect } from './emailRoutes';
 import templateRoutes from './templates';
@@ -221,7 +223,7 @@ const appRoutes = [
     category: 'Account',
   },
   {
-    path: '/account/subaccounts/create',
+    path: CREATE_SUBACCOUNT,
     component: subaccounts.CreatePage,
     condition: hasGrants('subaccount/manage', 'api_keys/manage', 'sending_domains/manage'),
     layout: App,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -8,6 +8,7 @@ export const AUTH_ROUTE = '/auth';
 export const TFA_ROUTE = '/auth/tfa';
 export const ENABLE_TFA_AUTH_ROUTE = '/auth/enable-tfa';
 export const SSO_AUTH_ROUTE = '/auth/sso';
+export const CREATE_SUBACCOUNT = '/account/subaccounts/create';
 export const DASHBOARD_ROUTE = '/dashboard';
 export const COOKIE_DOMAIN = '.sparkpost.com';
 

--- a/src/pages/api-keys/ListPage.js
+++ b/src/pages/api-keys/ListPage.js
@@ -38,18 +38,6 @@ export class ListPage extends Component {
     }
   }
 
-  // only want to show the new key after a create
-  componentWillUnmount() {
-    this.props.hideNewApiKey();
-  }
-
-  componentDidMount() {
-    this.props.listApiKeys();
-    if (this.props.hasSubaccounts && this.props.subaccounts.length === 0) {
-      this.props.listSubaccounts();
-    }
-  }
-
   getLabel = ({ canCurrentUserEdit, id, subaccount_id, label }) => {
     if (canCurrentUserEdit) {
       return (

--- a/src/pages/api-keys/ListPage.js
+++ b/src/pages/api-keys/ListPage.js
@@ -38,6 +38,18 @@ export class ListPage extends Component {
     }
   }
 
+  // only want to show the new key after a create
+  componentWillUnmount() {
+    this.props.hideNewApiKey();
+  }
+
+  componentDidMount() {
+    this.props.listApiKeys();
+    if (this.props.hasSubaccounts && this.props.subaccounts.length === 0) {
+      this.props.listSubaccounts();
+    }
+  }
+
   getLabel = ({ canCurrentUserEdit, id, subaccount_id, label }) => {
     if (canCurrentUserEdit) {
       return (

--- a/src/pages/snippets/ListPage.js
+++ b/src/pages/snippets/ListPage.js
@@ -11,6 +11,7 @@ export default class ListPage extends React.Component {
   state = {
     isFirstRender: true, //this is set to display loading on the first render
   };
+
   componentDidMount() {
     this.setState({ isFirstRender: false });
     this.props.getSnippets();

--- a/src/pages/subaccounts/ListPage.js
+++ b/src/pages/subaccounts/ListPage.js
@@ -12,6 +12,7 @@ import InfoBanner from './components/InfoBanner';
 import SubaccountEmptyState from './components/SubaccountEmptyState';
 import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import { useHibana } from 'src/context/HibanaContext';
+import { CREATE_SUBACCOUNT } from 'src/constants';
 
 const columns = [
   { label: 'Name', width: '40%', sortKey: 'name' },
@@ -22,7 +23,7 @@ const columns = [
 const primaryAction = {
   content: 'Create Subaccount',
   Component: PageLink,
-  to: '/account/subaccounts/create',
+  to: CREATE_SUBACCOUNT,
 };
 
 export class ListPage extends Component {

--- a/src/pages/subaccounts/ListPage.js
+++ b/src/pages/subaccounts/ListPage.js
@@ -10,6 +10,8 @@ import getRowData from './helpers/getRowData';
 import { LINKS } from 'src/constants';
 import InfoBanner from './components/InfoBanner';
 import SubaccountEmptyState from './components/SubaccountEmptyState';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
+import { useHibana } from 'src/context/HibanaContext';
 
 const columns = [
   { label: 'Name', width: '40%', sortKey: 'name' },
@@ -101,6 +103,12 @@ const mapStateToProps = state => ({
   subaccounts: selectSubaccounts(state),
   loading: state.subaccounts.listLoading,
   error: state.subaccounts.listError,
+  isEmptyStateEnabled: isAccountUiOptionSet('allow_empty_states')(state),
 });
 
-export default connect(mapStateToProps, { listSubaccounts })(ListPage);
+function ListPageContainer(props) {
+  const [{ isHibanaEnabled }] = useHibana();
+  return <ListPage isHibanaEnabled={isHibanaEnabled} {...props} />;
+}
+
+export default connect(mapStateToProps, { listSubaccounts })(ListPageContainer);

--- a/src/pages/subaccounts/ListPage.js
+++ b/src/pages/subaccounts/ListPage.js
@@ -8,8 +8,8 @@ import { list as listSubaccounts } from 'src/actions/subaccounts';
 import { selectSubaccounts } from 'src/selectors/subaccounts';
 import getRowData from './helpers/getRowData';
 import { LINKS } from 'src/constants';
-
-// const columns = ['Name', 'ID', 'Status', null];
+import InfoBanner from './components/InfoBanner';
+import SubaccountEmptyState from './components/SubaccountEmptyState';
 
 const columns = [
   { label: 'Name', width: '40%', sortKey: 'name' },
@@ -82,7 +82,10 @@ export class ListPage extends Component {
             external: true,
           },
         }}
+        hibanaEmptyStateComponent={SubaccountEmptyState}
+        loading={loading}
       >
+        {this.props.isEmptyStateEnabled && this.props.isHibanaEnabled && <InfoBanner />}
         {error ? this.renderError() : this.renderCollection()}
       </Page>
     );

--- a/src/pages/subaccounts/ListPage.js
+++ b/src/pages/subaccounts/ListPage.js
@@ -24,7 +24,12 @@ const primaryAction = {
 };
 
 export class ListPage extends Component {
+  state = {
+    isFirstRender: true, //this is set to display loading on the first render
+  };
+
   componentDidMount() {
+    this.setState({ isFirstRender: false });
     this.props.listSubaccounts();
   }
 
@@ -83,7 +88,7 @@ export class ListPage extends Component {
           },
         }}
         hibanaEmptyStateComponent={SubaccountEmptyState}
-        loading={loading}
+        loading={loading || this.state.isFirstRender}
       >
         {this.props.isEmptyStateEnabled && this.props.isHibanaEnabled && <InfoBanner />}
         {error ? this.renderError() : this.renderCollection()}

--- a/src/pages/subaccounts/components/InfoBanner.js
+++ b/src/pages/subaccounts/components/InfoBanner.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Banner, Picture } from 'src/components/matchbox';
+import ConfigurationWebp from '@sparkpost/matchbox-media/images/Configuration.webp';
+import { updateUserUIOptions } from 'src/actions/currentUser';
+import { isUserUiOptionSet } from 'src/helpers/conditions/user';
+import { LINKS } from 'src/constants';
+
+export default function InfoBanner() {
+  const [dismiss, setDismiss] = useState(
+    useSelector(state => isUserUiOptionSet('onboardingV2.subaccountsBannerDismissed')(state)),
+  );
+  const dispatch = useDispatch();
+  const handleDismiss = () => {
+    setDismiss(true);
+    dispatch(updateUserUIOptions({ onboardingV2: { subaccountsBannerDismissed: true } }));
+  };
+  if (dismiss) return null;
+
+  return (
+    <Banner
+      onDismiss={handleDismiss}
+      size="large"
+      status="muted"
+      title="Organize Sending and Analytics"
+      backgroundColor="gray.100"
+      borderWidth="100"
+      borderStyle="solid"
+      borderColor="gray.400"
+      mb="600"
+    >
+      <p>
+        Subaccounts can be used to provision and manage senders separately from each other, and to
+        provide assets and reporting data for each of them.
+      </p>
+      <Banner.Action color="blue" to={LINKS.SUBACCOUNTS} external variant="outline">
+        Subaccounts Documentation
+      </Banner.Action>
+      <Banner.Media>
+        <Picture seeThrough>
+          <Picture.Image alt="" src={ConfigurationWebp} />
+        </Picture>
+      </Banner.Media>
+    </Banner>
+  );
+}

--- a/src/pages/subaccounts/components/InfoBanner.js
+++ b/src/pages/subaccounts/components/InfoBanner.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Banner, Picture } from 'src/components/matchbox';
 import ConfigurationWebp from '@sparkpost/matchbox-media/images/Configuration.webp';
+import Configuration from '@sparkpost/matchbox-media/images/Configuration@medium.jpg';
 import { updateUserUIOptions } from 'src/actions/currentUser';
 import { isUserUiOptionSet } from 'src/helpers/conditions/user';
 import { LINKS } from 'src/constants';
@@ -38,7 +39,8 @@ export default function InfoBanner() {
       </Banner.Action>
       <Banner.Media>
         <Picture seeThrough>
-          <Picture.Image alt="" src={ConfigurationWebp} />
+          <source srcset={ConfigurationWebp} type="image/webp" />
+          <Picture.Image alt="" src={Configuration} />
         </Picture>
       </Banner.Media>
     </Banner>

--- a/src/pages/subaccounts/components/SubaccountEmptyState.js
+++ b/src/pages/subaccounts/components/SubaccountEmptyState.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Box, EmptyState } from 'src/components/matchbox';
+import ConfigurationWebp from '@sparkpost/matchbox-media/images/Configuration.webp';
+import Configuration from '@sparkpost/matchbox-media/images/Configuration@medium.jpg';
+import { Page } from 'src/components/matchbox';
+import { PageLink } from 'src/components/links';
+import { Bold, TranslatableText } from 'src/components/text';
+import { CREATE_SUBACCOUNT, LINKS } from 'src/constants';
+
+export default function SubaccountEmptyState() {
+  return (
+    <Page>
+      <EmptyState>
+        <EmptyState.Header>Subaccounts</EmptyState.Header>
+        <EmptyState.Content>
+          <p>
+            <TranslatableText>
+              Subaccounts can be used to provision and manage senders separately from each other,
+              and to provide assets and reporting data for each of them. Subaccounts are great for
+              service providers who send on behalf of others or for businesses that want to separate
+              different streams of traffic.
+            </TranslatableText>
+          </p>
+          <Box mt="400">
+            <Bold>Common uses for Subaccounts</Bold>
+          </Box>
+          <EmptyState.List>
+            <li>
+              <TranslatableText>
+                Sending as a service provider for multiple unique customers.
+              </TranslatableText>
+            </li>
+            <li>
+              <TranslatableText>
+                Keeping unique internal business units independent from one another.
+              </TranslatableText>
+            </li>
+            <li>
+              <TranslatableText>
+                Tracking mission critical campaign data separate from other mailstreams.
+              </TranslatableText>
+            </li>
+          </EmptyState.List>
+        </EmptyState.Content>
+        <EmptyState.Image src={Configuration}>
+          <source srcset={ConfigurationWebp} type="image/webp"></source>
+        </EmptyState.Image>
+        <EmptyState.Action component={PageLink} to={CREATE_SUBACCOUNT}>
+          Create Subaccount
+        </EmptyState.Action>
+        <EmptyState.Action variant="outline" to={LINKS.SUBACCOUNTS} external>
+          Subaccounts Documentation
+        </EmptyState.Action>
+      </EmptyState>
+    </Page>
+  );
+}

--- a/src/pages/subaccounts/index.js
+++ b/src/pages/subaccounts/index.js
@@ -5,5 +5,5 @@ import DetailsPage from './DetailsPage';
 export default {
   ListPage,
   CreatePage,
-  DetailsPage
+  DetailsPage,
 };

--- a/src/pages/subaccounts/tests/__snapshots__/ListPage.test.js.snap
+++ b/src/pages/subaccounts/tests/__snapshots__/ListPage.test.js.snap
@@ -17,6 +17,8 @@ exports[`renders correctly 1`] = `
       "title": "Manage your subaccounts",
     }
   }
+  hibanaEmptyStateComponent={[Function]}
+  loading={false}
   primaryAction={
     Object {
       "Component": [Function],
@@ -108,6 +110,8 @@ exports[`renders empty state 1`] = `
       "title": "Manage your subaccounts",
     }
   }
+  hibanaEmptyStateComponent={[Function]}
+  loading={false}
   primaryAction={
     Object {
       "Component": [Function],
@@ -177,6 +181,8 @@ exports[`renders errors when present 1`] = `
       "title": "Manage your subaccounts",
     }
   }
+  hibanaEmptyStateComponent={[Function]}
+  loading={false}
   primaryAction={
     Object {
       "Component": [Function],


### PR DESCRIPTION
### What Changed
- Adding empty state and banner to subaccount list

### How To Test
- Cypress tests locally are easiest, because the account has to have the usage to create subaccounts for real.
- For non local: Have to have an account that has the ability to have subaccounts and has none yet.
- Check the empty state shows and has the right display text, then create a subaccount and test the banner is visible.
- Then clear the banner and refresh to make sure it doesn't show up again.

### To Do
- [ ] Feedback
- [ ] Update the feature flag confluence page?
