### PR TITLE
SA-1897: Strip report ID when saving a report from an existing report

### DIFF
--- a/src/pages/reportBuilder/components/ReportOptions.js
+++ b/src/pages/reportBuilder/components/ReportOptions.js
@@ -54,7 +54,7 @@ export function ReportOptions(props) {
       const { filters } = reportOptions;
 
       if (Boolean(filters.length)) {
-        update.query_filters = encodeURI(JSON.stringify(dehydrateFilters(filters)));
+        update.query_filters = JSON.stringify(dehydrateFilters(filters));
       }
 
       updateFilters({ ...update, report: selectedReport?.id }, { arrayFormat: 'indices' });

--- a/src/pages/reportBuilder/components/ReportOptions.js
+++ b/src/pages/reportBuilder/components/ReportOptions.js
@@ -53,7 +53,10 @@ export function ReportOptions(props) {
       const { filters: selectedFilters, ...update } = selectSummaryChartSearchOptions;
       const { filters } = reportOptions;
 
-      update.query_filters = encodeURI(JSON.stringify(dehydrateFilters(filters)));
+      if (Boolean(filters.length)) {
+        update.query_filters = encodeURI(JSON.stringify(dehydrateFilters(filters)));
+      }
+
       updateFilters({ ...update, report: selectedReport?.id }, { arrayFormat: 'indices' });
     }
   }, [

--- a/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
+++ b/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
@@ -88,10 +88,10 @@ export function SaveReportModal(props) {
   }, [report, reset]);
 
   const onSubmit = data => {
-    const { filters: selectedFilters, ...update } = selectSummaryChartSearchOptions;
-
-    if (Boolean(selectedFilters.length)) {
-      update.query_filters = encodeURI(JSON.stringify(dehydrateFilters(selectedFilters)));
+    const { filters: _selectedFilters, ...update } = selectSummaryChartSearchOptions;
+    const { filters } = reportOptions;
+    if (Boolean(filters.length)) {
+      update.query_filters = JSON.stringify(dehydrateFilters(filters));
     }
 
     const query_string = qs.stringify(update, { arrayFormat: 'indices' });

--- a/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
+++ b/src/pages/reportBuilder/components/SavedReportsSection/SaveReportModal.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import qs from 'qs';
+
 import {
   Box,
   Button,
@@ -13,7 +15,6 @@ import {
 } from 'src/components/matchbox';
 import { useForm } from 'react-hook-form';
 import { Heading } from 'src/components/text';
-import { useLocation } from 'react-router-dom';
 import { createReport, updateReport, getReports } from 'src/actions/reports';
 import { showAlert } from 'src/actions/globalAlert';
 import { getMetricsFromKeys } from 'src/helpers/metrics';
@@ -21,6 +22,7 @@ import { useReportBuilderContext } from '../../context/ReportBuilderContext';
 import ActiveFilters from 'src/components/reportBuilder/ActiveFilters';
 import { formatDateTime, relativeDateOptionsIndexed } from 'src/helpers/date';
 import ActiveComparisons from '../ActiveComparisons';
+import { dehydrateFilters } from '../../helpers';
 
 const DateRange = ({ to, from, relativeRange }) => {
   if (relativeRange === 'custom') {
@@ -73,8 +75,9 @@ export function SaveReportModal(props) {
       is_editable: false,
     },
   });
-  const { search = '' } = useLocation();
-  const { state: reportOptions } = useReportBuilderContext();
+  const { state: reportOptions, selectors } = useReportBuilderContext();
+  const { selectSummaryChartSearchOptions } = selectors;
+
   const hasFilters = Boolean(reportOptions.filters.length);
   const hasComparisons = Boolean(reportOptions.comparisons.length);
 
@@ -85,8 +88,13 @@ export function SaveReportModal(props) {
   }, [report, reset]);
 
   const onSubmit = data => {
-    const query_string = search.charAt(0) === '?' ? search.substring(1) : search;
+    const { filters: selectedFilters, ...update } = selectSummaryChartSearchOptions;
 
+    if (Boolean(selectedFilters.length)) {
+      update.query_filters = encodeURI(JSON.stringify(dehydrateFilters(selectedFilters)));
+    }
+
+    const query_string = qs.stringify(update, { arrayFormat: 'indices' });
     if (saveQuery || create) {
       data.query_string = query_string;
     }

--- a/src/pages/reportBuilder/components/SavedReportsSection/tests/SaveReportModal.test.js
+++ b/src/pages/reportBuilder/components/SavedReportsSection/tests/SaveReportModal.test.js
@@ -10,7 +10,10 @@ jest.mock('src/context/HibanaContext', () => ({
 }));
 
 jest.mock('src/pages/reportBuilder/context/ReportBuilderContext', () => ({
-  useReportBuilderContext: jest.fn(() => ({ state: { foo: 'bar', filters: [], comparisons: [] } })),
+  useReportBuilderContext: jest.fn(() => ({
+    state: { foo: 'bar', filters: [], comparisons: [] },
+    selectors: { selectSummaryChartSearchOptions: { filters: [] } },
+  })),
 }));
 
 const mockOnCancel = jest.fn();


### PR DESCRIPTION
### What Changed

- Report params generated again instead of pulling straight from URL
- Report ID no longer attached to saving report (to avoid having a report point to another report

### How To Test

- Go to report builder
- Select a report
- Save a new report
- Save under a new name
- Verify that report id is not attached

### To Do

- [ ] Address feedback
