### PR TITLE
FE-1269 - Create Empty State for Analytics Report 

### DIFF
--- a/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
@@ -37,6 +37,20 @@ if (IS_HIBANA_ENABLED) {
       cy.findByLabelText('Break Down By').should('be.visible');
     });
 
+    it('should render the Empty State when there are no sending domains', () => {
+      commonBeforeSteps();
+      stubAccountsReq();
+      stubSendingDomains();
+      cy.visit(PAGE_URL);
+      cy.wait(['@accountReq', '@sendingDomainsReq']);
+      cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
+      cy.findAllByText(
+        "Build and save custom reports with SparkPost's easy to use dashboard. Apply unlimited metrics across delivery and deliverability data. To learn how to unlock the full potential of SparkPost's Analytics Report, visit the documentation link below.",
+      ).should('be.visible');
+      cy.findByRole('button', { name: 'Add Sending Domain' }).should('be.visible');
+      cy.findByRole('link', { name: 'Analytics Documentation' }).should('be.visible');
+    });
+
     it('should render error state for charts', () => {
       commonBeforeSteps();
       cy.stubRequest({
@@ -293,4 +307,25 @@ if (IS_HIBANA_ENABLED) {
 
 function getFirstRemoveButton() {
   return cy.findAllByRole('button', { name: 'Remove' }).eq(0);
+}
+
+function stubSendingDomains({
+  fixture = '200.get.no-results.json',
+  requestAlias = 'sendingDomainsReq',
+  statusCode = 200,
+} = {}) {
+  cy.stubRequest({
+    url: '/api/v1/sending-domains',
+    fixture,
+    requestAlias,
+    statusCode,
+  });
+}
+
+function stubAccountsReq({ fixture = 'account/200.get.has-empty-states.json' } = {}) {
+  cy.stubRequest({
+    url: '/api/v1/account**',
+    fixture: fixture,
+    requestAlias: 'accountReq',
+  });
 }

--- a/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
@@ -37,7 +37,7 @@ if (IS_HIBANA_ENABLED) {
       cy.findByLabelText('Break Down By').should('be.visible');
     });
 
-    it('should render the Empty State when there are no sending domains', () => {
+    it('should render the Empty State when there are no sending domains and allow_empty_state is enabled', () => {
       commonBeforeSteps();
       stubAccountsReq();
       stubSendingDomains();
@@ -48,7 +48,11 @@ if (IS_HIBANA_ENABLED) {
         "Build and save custom reports with SparkPost's easy to use dashboard. Apply unlimited metrics across delivery and deliverability data. To learn how to unlock the full potential of SparkPost's Analytics Report, visit the documentation link below.",
       ).should('be.visible');
       cy.findByRole('button', { name: 'Add Sending Domain' }).should('be.visible');
-      cy.findByRole('link', { name: 'Analytics Documentation' }).should('be.visible');
+      cy.verifyLink({
+        content: 'Analytics Documentation',
+        href: 'https://www.sparkpost.com/docs/reporting/signals-analytics/#',
+      });
+      cy.findByRole('heading', { name: 'Example Analytics' }).should('be.visible');
     });
 
     it('should render error state for charts', () => {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -77,6 +77,7 @@ export const LINKS = {
     'https://developers.sparkpost.com/api/transmissions/#transmissions-post-send-an-a-b-test',
   API_KEYS_GUIDE: 'https://www.sparkpost.com/docs/getting-started/create-api-keys/',
   SNIPPETS_DOCS: 'https://developers.sparkpost.com/api/template-language/#header-snippets',
+  ANALYTICS_DOCS: 'https://www.sparkpost.com/docs/reporting/signals-analytics/#',
 };
 
 export const ENTERPRISE_PLAN_CODES = ['ent1'];

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -24,6 +24,7 @@ import {
 import { parseSearchNew as parseSearch } from 'src/helpers/reports';
 import { getFormattedDateRangeForAggregateData } from 'src/helpers/date';
 import { selectVerifiedDomains } from 'src/selectors/sendingDomains';
+import { isAccountUiOptionSet } from 'src/helpers/conditions/account';
 import {
   Charts,
   ReportOptions,
@@ -57,6 +58,7 @@ export function ReportBuilder({
   subaccountsReady,
   listSendingDomains,
   sendingDomains,
+  isEmptyStateEnabled,
 }) {
   const [showTable, setShowTable] = useState(true); // TODO: Incorporate in to the context reducer due to state interaction
   const [selectedReport, setReport] = useState(null); // TODO: Incorporate in to the context reducer due to state interaction
@@ -261,7 +263,7 @@ export function ReportBuilder({
         </Box>
       }
       empty={{
-        show: sendingDomains.length === 0,
+        show: sendingDomains.length === 0 && isEmptyStateEnabled,
       }}
       hibanaEmptyStateComponent={ReportBuilderEmptyState}
     >
@@ -386,6 +388,7 @@ const mapStateToProps = state => ({
   subaccountsReady: state.subaccounts.ready,
   subscription: state.billing.subscription,
   sendingDomains: selectVerifiedDomains(state),
+  isEmptyStateEnabled: isAccountUiOptionSet('allow_empty_states')(state),
 });
 
 const mapDispatchToProps = {

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { Error } from '@sparkpost/matchbox-icons';
 import { refreshReportBuilder } from 'src/actions/summaryChart';
 import { getSubscription } from 'src/actions/billing';
+import { list as listSendingDomains } from 'src/actions/sendingDomains';
 import { list as getSubaccountsList } from 'src/actions/subaccounts';
 import { getReports } from 'src/actions/reports';
 import {
@@ -22,12 +23,14 @@ import {
 } from 'src/config/metrics';
 import { parseSearchNew as parseSearch } from 'src/helpers/reports';
 import { getFormattedDateRangeForAggregateData } from 'src/helpers/date';
+import { selectVerifiedDomains } from 'src/selectors/sendingDomains';
 import {
   Charts,
   ReportOptions,
   GroupByTable,
   SaveReportModal,
   CompareByGroupByTable,
+  ReportBuilderEmptyState,
 } from './components';
 import {
   BounceReasonTab,
@@ -52,6 +55,8 @@ export function ReportBuilder({
   getReports,
   getSubaccountsList,
   subaccountsReady,
+  listSendingDomains,
+  sendingDomains,
 }) {
   const [showTable, setShowTable] = useState(true); // TODO: Incorporate in to the context reducer due to state interaction
   const [selectedReport, setReport] = useState(null); // TODO: Incorporate in to the context reducer due to state interaction
@@ -65,6 +70,10 @@ export function ReportBuilder({
   const isEmpty = useMemo(() => {
     return !Boolean(reportOptions.metrics && reportOptions.metrics.length);
   }, [reportOptions.metrics]);
+
+  useEffect(() => {
+    listSendingDomains();
+  }, [listSendingDomains]);
 
   useEffect(() => {
     if (reportOptions.isReady && !isEmpty) {
@@ -251,6 +260,10 @@ export function ReportBuilder({
           </Button>
         </Box>
       }
+      empty={{
+        show: sendingDomains.length === 0,
+      }}
+      hibanaEmptyStateComponent={ReportBuilderEmptyState}
     >
       <Panel>
         <ReportOptions
@@ -372,6 +385,7 @@ const mapStateToProps = state => ({
   reportsStatus: state.reports.status,
   subaccountsReady: state.subaccounts.ready,
   subscription: state.billing.subscription,
+  sendingDomains: selectVerifiedDomains(state),
 });
 
 const mapDispatchToProps = {
@@ -379,6 +393,7 @@ const mapDispatchToProps = {
   getSubscription,
   getReports,
   getSubaccountsList,
+  listSendingDomains,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ReportBuilder);

--- a/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
+++ b/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { EmptyState, Tabs } from 'src/components/matchbox';
+import { Rocket } from '@sparkpost/matchbox-icons';
 import AnalyticsWebp from '@sparkpost/matchbox-media/images/Analytics.webp';
 import { Page } from 'src/components/matchbox';
 import { useHistory } from 'react-router-dom';
 import { LINKS } from 'src/constants';
+import { Heading } from 'src/components/text';
 
 export default function ReportBuilderEmptyState() {
   const history = useHistory();
@@ -26,6 +28,7 @@ export default function ReportBuilderEmptyState() {
           Analytics Documentation
         </EmptyState.Action>
       </EmptyState>
+      <Heading as="h2">Example Analytics</Heading>
       <Tabs
         keyboardActivation="auto"
         mb="800"
@@ -38,6 +41,14 @@ export default function ReportBuilderEmptyState() {
           },
           {
             content: 'Investigating Problems',
+            onClick: function noRefCheck() {},
+          },
+          {
+            content: (
+              <>
+                Deliverability Metrics <Rocket color="#fa6423" size="25" />
+              </>
+            ),
             onClick: function noRefCheck() {},
           },
         ]}

--- a/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
+++ b/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
@@ -6,6 +6,7 @@ import { Page } from 'src/components/matchbox';
 import { useHistory } from 'react-router-dom';
 import { LINKS } from 'src/constants';
 import { Heading } from 'src/components/text';
+import { tokens } from '@sparkpost/design-tokens-hibana';
 
 export default function ReportBuilderEmptyState() {
   const history = useHistory();
@@ -46,7 +47,7 @@ export default function ReportBuilderEmptyState() {
           {
             content: (
               <>
-                Deliverability Metrics <Rocket color="#fa6423" size="25" />
+                Deliverability Metrics <Rocket color={tokens.color_brand_orange} size="25" />
               </>
             ),
             onClick: function noRefCheck() {},

--- a/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
+++ b/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { EmptyState, Tabs } from 'src/components/matchbox';
+import { EmptyState, Stack, Tabs } from 'src/components/matchbox';
 import { Rocket } from '@sparkpost/matchbox-icons';
 import AnalyticsWebp from '@sparkpost/matchbox-media/images/Analytics.webp';
 import { Page } from 'src/components/matchbox';
 import { useHistory } from 'react-router-dom';
 import { LINKS } from 'src/constants';
-import { Heading } from 'src/components/text';
+import { Heading, Bold } from 'src/components/text';
 import { tokens } from '@sparkpost/design-tokens-hibana';
 
 export default function ReportBuilderEmptyState() {
@@ -15,11 +15,14 @@ export default function ReportBuilderEmptyState() {
       <EmptyState>
         <EmptyState.Header>Analytics Report</EmptyState.Header>
         <EmptyState.Content>
-          <p>
-            Build and save custom reports with SparkPost's easy to use dashboard. Apply unlimited
-            metrics across delivery and deliverability data. To learn how to unlock the full
-            potential of SparkPost's Analytics Report, visit the documentation link below.
-          </p>
+          <Stack>
+            <p>
+              Build and save custom reports with SparkPost's easy to use dashboard. Apply unlimited
+              metrics across delivery and deliverability data. To learn how to unlock the full
+              potential of SparkPost's Analytics Report, visit the documentation link below.
+            </p>
+            <Bold>A sending domain is required to start generating analytics.</Bold>
+          </Stack>
         </EmptyState.Content>
         <EmptyState.Image src={AnalyticsWebp} />
         <EmptyState.Action onClick={() => history.push('/domains/create')}>

--- a/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
+++ b/src/pages/reportBuilder/components/ReportBuilderEmptyState.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { EmptyState, Tabs } from 'src/components/matchbox';
+import AnalyticsWebp from '@sparkpost/matchbox-media/images/Analytics.webp';
+import { Page } from 'src/components/matchbox';
+import { useHistory } from 'react-router-dom';
+import { LINKS } from 'src/constants';
+
+export default function ReportBuilderEmptyState() {
+  const history = useHistory();
+  return (
+    <Page>
+      <EmptyState>
+        <EmptyState.Header>Analytics Report</EmptyState.Header>
+        <EmptyState.Content>
+          <p>
+            Build and save custom reports with SparkPost's easy to use dashboard. Apply unlimited
+            metrics across delivery and deliverability data. To learn how to unlock the full
+            potential of SparkPost's Analytics Report, visit the documentation link below.
+          </p>
+        </EmptyState.Content>
+        <EmptyState.Image src={AnalyticsWebp} />
+        <EmptyState.Action onClick={() => history.push('/domains/create')}>
+          Add Sending Domain
+        </EmptyState.Action>
+        <EmptyState.Action variant="outline" to={LINKS.ANALYTICS_DOCS} external>
+          Analytics Documentation
+        </EmptyState.Action>
+      </EmptyState>
+      <Tabs
+        keyboardActivation="auto"
+        mb="800"
+        onSelect={function noRefCheck() {}}
+        selected={0}
+        tabs={[
+          {
+            content: 'Tracking Engagement',
+            onClick: function noRefCheck() {},
+          },
+          {
+            content: 'Investigating Problems',
+            onClick: function noRefCheck() {},
+          },
+        ]}
+      />
+    </Page>
+  );
+}

--- a/src/pages/reportBuilder/components/index.js
+++ b/src/pages/reportBuilder/components/index.js
@@ -8,3 +8,4 @@ export { default as ReportOptions } from './ReportOptions';
 export { default as SaveReportModal } from './SavedReportsSection/SaveReportModal';
 export { default as GroupByTable } from './GroupByTable/GroupByTable';
 export { default as CompareByGroupByTable } from './GroupByTable/CompareByGroupByTable';
+export { default as ReportBuilderEmptyState } from './ReportBuilderEmptyState';


### PR DESCRIPTION
FE-1269 - Create Empty State for Analytics Report 

### What Changed

-  Empty state should show up on Analytics Report when user has no sending domain.
-  Added the three Tabs  as in the mock (with placeholder components)

mocks - https://sparkpost.invisionapp.com/console/Empty-States-ckcno05yk00tf011ij29ebpmx/ckevla6xu04f301yh7ymqfocx/play#project_console
### How To Test

- Enable "allow_empty_states" feature flag and check the Analytics page when you have no sending domain, you should see the Empty state as in the mock, with three placeholder tabs
- When "allow_empty_states" feature flag is not enabled the Analytics Page should appear as it is now.

### To Do

- [ ] Address feedback
