### PR TITLE
AC-1838: Update UI to use dedicated ip limits from api instead of value in config

### DIFF
--- a/cypress/fixtures/billing/subscription/200.get.premier-plan-with-dedicatedip-override.json
+++ b/cypress/fixtures/billing/subscription/200.get.premier-plan-with-dedicatedip-override.json
@@ -32,10 +32,10 @@
         "plan": "ip-0519",
         "product": "dedicated_ip",
         "quantity": 1,
-        "limit": 4,
+        "limit": 14,
         "price": 20,
         "volume": 1,
-        "billing_period": "month"
+        "billing_period": "quarter"
       },
       {
         "plan": "reports",

--- a/cypress/tests/integration/accounts/billing/billingPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/billingPage.spec.js
@@ -125,7 +125,7 @@ describe('Billing Page', () => {
     cy.findByText('Dedicated IPs').should('not.exist');
   });
 
-  it.skip('renders the manually billed transition banner when the user\'s subscription type is not "active", "inactive", or "none"', () => {
+  it('renders the manually billed transition banner when the user\'s subscription type is not "active", "inactive", or "none"', () => {
     cy.stubRequest({
       url: `${BILLING_API_BASE_URL}/subscription`,
       fixture: 'billing/subscription/200.get.manually-billed.json',
@@ -179,6 +179,18 @@ describe('Billing Page', () => {
     cy.findByLabelText('Country').should('be.visible');
     cy.findByLabelText('State').should('be.visible');
     cy.findByLabelText('Zip Code').should('be.visible');
+  });
+
+  it(" 'Add Dedicated Ip' button is not disabled if the limit on the subscription is more that the quantity of dedicated Ips", () => {
+    cy.stubRequest({
+      url: `${BILLING_API_BASE_URL}/subscription`,
+      fixture: 'billing/subscription/200.get.premier-plan-with-dedicatedip-override.json',
+      requestAlias: 'dedicatedIpOverrideRequest',
+    });
+    cy.visit(PAGE_URL);
+    cy.wait('@dedicatedIpOverrideRequest');
+    cy.findByText('2 for $20.00 per quarter').should('be.visible');
+    cy.findByRole('button', { name: 'Add Dedicated IPs' }).should('not.be.disabled');
   });
 
   describe('the dedicated IPs modal', () => {
@@ -272,6 +284,19 @@ describe('Billing Page', () => {
       assignToExistingIpPool();
 
       cy.findByText('Successfully added 1 dedicated IPs!').should('be.visible');
+    });
+    it(' Renders the modal correctly when limit on the subscription is more that the quantity of dedicated Ips', () => {
+      cy.stubRequest({
+        url: `${BILLING_API_BASE_URL}/subscription`,
+        fixture: 'billing/subscription/200.get.premier-plan-with-dedicatedip-override.json',
+        requestAlias: 'dedicatedIpOverrideRequest',
+      });
+      cy.visit(PAGE_URL);
+      cy.wait('@dedicatedIpOverrideRequest');
+      cy.findByRole('button', { name: 'Add Dedicated IPs' }).click();
+      cy.findByText(
+        'You can add up to 14 total dedicated IPs to your plan for $20.00 per quarter each.',
+      ).should('be.visible');
     });
   });
 

--- a/cypress/tests/integration/accounts/billing/billingPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/billingPage.spec.js
@@ -47,6 +47,17 @@ function getBillingSubscription({
   });
 }
 
+function getInvoices({
+  fixture = 'billing/invoices/200.get.json',
+  requestAlias = 'invoicesReq',
+} = {}) {
+  cy.stubRequest({
+    url: `${BILLING_API_BASE_URL}/invoices`,
+    fixture: fixture,
+    requestAlias: requestAlias,
+  });
+}
+
 describe('Billing Page', () => {
   beforeEach(() => {
     cy.stubAuth();
@@ -56,10 +67,7 @@ describe('Billing Page', () => {
     getBillingPlans();
     getBillingBundles();
     getSendingIps();
-    cy.stubRequest({
-      url: `${BILLING_API_BASE_URL}/invoices`,
-      fixture: 'billing/invoices/200.get.json',
-    });
+    getInvoices();
 
     cy.stubRequest({
       url: '/api/v1/usage',

--- a/cypress/tests/integration/accounts/billing/billingPage.spec.js
+++ b/cypress/tests/integration/accounts/billing/billingPage.spec.js
@@ -219,7 +219,7 @@ describe('Billing Page', () => {
     });
     cy.visit(PAGE_URL);
     cy.wait('@dedicatedIpOverrideRequest');
-    cy.findByText('2 for $20.00 per quarter').should('be.visible');
+    cy.findByRole('heading', { name: '2 for $20.00 per quarter' }).should('be.visible');
     cy.findByRole('button', { name: 'Add Dedicated IPs' }).should('not.be.disabled');
   });
 
@@ -328,7 +328,7 @@ describe('Billing Page', () => {
       cy.visit(PAGE_URL);
       cy.wait('@dedicatedIpOverrideRequest');
       cy.findByRole('button', { name: 'Add Dedicated IPs' }).click();
-      cy.findByText(
+      cy.contains(
         'You can add up to 14 total dedicated IPs to your plan for $20.00 per quarter each.',
       ).should('be.visible');
     });

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -133,11 +133,6 @@ const config = identifier => ({
     localpart: 'sandbox',
     domain: 'sparkpostbox.com',
   },
-  sendingIps: {
-    maxPerAccount: 4,
-    pricePerIp: 20.0,
-    awsPricePerIp: 0.028,
-  },
   splashPage: '/reports/summary',
   summaryChart: {
     defaultMetrics: ['count_targeted', 'count_rendered', 'count_accepted', 'count_bounce'],

--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -114,6 +114,9 @@ export default class BillingSummary extends Component {
       ?.limit;
     const priceOfEachDedicatedIp = _.find(billingSubscription.products, { product: 'dedicated_ip' })
       ?.price;
+    const billingPeriodOfDedicatedIp = _.find(billingSubscription.products, {
+      product: 'dedicated_ip',
+    })?.billing_period;
     // This is an extreme case to support manually billed accounts while transitioning to self serve
     const isTransitioningToSelfServe =
       billing !== null && !billing.credit_card && subscription.type === 'default';
@@ -149,6 +152,7 @@ export default class BillingSummary extends Component {
             isTransitioningToSelfServe={isTransitioningToSelfServe}
             limitOnDedicatedIps={limitOnDedicatedIps}
             priceOfEachDedicatedIp={priceOfEachDedicatedIp}
+            billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
           />
           {rvUsage && this.renderRecipientValidationSection({ rvUsage })}
         </Panel.LEGACY>
@@ -168,6 +172,7 @@ export default class BillingSummary extends Component {
               onClose={this.handleModal}
               limitOnDedicatedIps={limitOnDedicatedIps}
               priceOfEachDedicatedIp={priceOfEachDedicatedIp}
+              billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
             />
           )}
         </Modal.LEGACY>

--- a/src/pages/billing/components/BillingSummary.js
+++ b/src/pages/billing/components/BillingSummary.js
@@ -110,13 +110,8 @@ export default class BillingSummary extends Component {
     } = this.props;
     const { rvUsage, pending_cancellation, subscription, billing = {} } = account;
     const { show } = this.state;
-    const limitOnDedicatedIps = _.find(billingSubscription.products, { product: 'dedicated_ip' })
-      ?.limit;
-    const priceOfEachDedicatedIp = _.find(billingSubscription.products, { product: 'dedicated_ip' })
-      ?.price;
-    const billingPeriodOfDedicatedIp = _.find(billingSubscription.products, {
-      product: 'dedicated_ip',
-    })?.billing_period;
+    const dedicatedIpProduct =
+      billingSubscription.products.find(({ product }) => product === 'dedicated_ip') || {};
     // This is an extreme case to support manually billed accounts while transitioning to self serve
     const isTransitioningToSelfServe =
       billing !== null && !billing.credit_card && subscription.type === 'default';
@@ -150,9 +145,9 @@ export default class BillingSummary extends Component {
             canPurchaseIps={this.props.canPurchaseIps}
             onClick={this.handleIpModal}
             isTransitioningToSelfServe={isTransitioningToSelfServe}
-            limitOnDedicatedIps={limitOnDedicatedIps}
-            priceOfEachDedicatedIp={priceOfEachDedicatedIp}
-            billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
+            limitOnDedicatedIps={dedicatedIpProduct.limit}
+            priceOfEachDedicatedIp={dedicatedIpProduct.price}
+            billingPeriodOfDedicatedIp={dedicatedIpProduct.billing_period}
           />
           {rvUsage && this.renderRecipientValidationSection({ rvUsage })}
         </Panel.LEGACY>
@@ -170,9 +165,9 @@ export default class BillingSummary extends Component {
           {show === IP_MODAL && (
             <AddIps
               onClose={this.handleModal}
-              limitOnDedicatedIps={limitOnDedicatedIps}
-              priceOfEachDedicatedIp={priceOfEachDedicatedIp}
-              billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
+              limitOnDedicatedIps={dedicatedIpProduct.limit}
+              priceOfEachDedicatedIp={dedicatedIpProduct.price}
+              billingPeriodOfDedicatedIp={dedicatedIpProduct.billing_period}
             />
           )}
         </Modal.LEGACY>

--- a/src/pages/billing/components/DedicatedIpCost.js
+++ b/src/pages/billing/components/DedicatedIpCost.js
@@ -1,7 +1,4 @@
-import config from 'src/config';
-
-export default function DedicatedIpCost({ quantity, isAWSAccount }) {
-  return isAWSAccount
-    ? `$${(config.sendingIps.awsPricePerIp * quantity).toFixed(3)} per hour`
-    : `$${(config.sendingIps.pricePerIp * quantity).toFixed(2)} per month`;
+//TODO: need to update the props everywhere this is used
+export default function DedicatedIpCost({ priceOfEachDedicatedIp, quantity }) {
+  return `$${(priceOfEachDedicatedIp * quantity).toFixed(2)} per month`;
 }

--- a/src/pages/billing/components/DedicatedIpCost.js
+++ b/src/pages/billing/components/DedicatedIpCost.js
@@ -1,4 +1,8 @@
 //TODO: need to update the props everywhere this is used
-export default function DedicatedIpCost({ priceOfEachDedicatedIp, quantity }) {
-  return `$${(priceOfEachDedicatedIp * quantity).toFixed(2)} per month`;
+export default function DedicatedIpCost({
+  priceOfEachDedicatedIp,
+  quantity,
+  billingPeriodOfDedicatedIp,
+}) {
+  return `$${(priceOfEachDedicatedIp * quantity).toFixed(2)} per ${billingPeriodOfDedicatedIp}`;
 }

--- a/src/pages/billing/components/DedicatedIpSummarySection.js
+++ b/src/pages/billing/components/DedicatedIpSummarySection.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Panel } from 'src/components/matchbox';
 
-import config from 'src/config';
 import { LabelledValue } from 'src/components';
 import { PageLink } from 'src/components/links';
 import DedicatedIpCost from './DedicatedIpCost';
+import _ from 'lodash';
 
 function noop() {}
 
@@ -12,11 +12,12 @@ export default function DedicatedIpSummarySection({
   count = 0,
   plan = {},
   onClick = noop,
-  isAWSAccount,
   isTransitioningToSelfServe,
   canPurchaseIps,
+  limitOnDedicatedIps,
+  priceOfEachDedicatedIp,
 }) {
-  const hasReachedMax = count >= config.sendingIps.maxPerAccount;
+  const hasReachedMax = count >= limitOnDedicatedIps;
   const disabledPurchaseIP = hasReachedMax || plan.isFree;
 
   // There are some paid accounts that do not allow dedicated IPs
@@ -47,13 +48,13 @@ export default function DedicatedIpSummarySection({
 
   // Decrement count if plan includes one free IP
   const billableCount = count > 0 && plan.includesIp ? count - 1 : count;
-
   const summary =
     count === 0 ? (
       <h6>0</h6>
     ) : (
       <h6>
-        {count} for <DedicatedIpCost quantity={billableCount} isAWSAccount={isAWSAccount} />
+        {count} for{' '}
+        <DedicatedIpCost quantity={billableCount} priceOfEachDedicatedIp={priceOfEachDedicatedIp} />
       </h6>
     );
 

--- a/src/pages/billing/components/DedicatedIpSummarySection.js
+++ b/src/pages/billing/components/DedicatedIpSummarySection.js
@@ -3,8 +3,8 @@ import { Panel } from 'src/components/matchbox';
 
 import { LabelledValue } from 'src/components';
 import { PageLink } from 'src/components/links';
+import { TranslatableText } from 'src/components/text';
 import DedicatedIpCost from './DedicatedIpCost';
-import _ from 'lodash';
 
 function noop() {}
 
@@ -53,14 +53,17 @@ export default function DedicatedIpSummarySection({
     count === 0 ? (
       <h6>0</h6>
     ) : (
-      <h6>
-        {count} for{' '}
-        <DedicatedIpCost
-          quantity={billableCount}
-          priceOfEachDedicatedIp={priceOfEachDedicatedIp}
-          billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
-        />
-      </h6>
+      <>
+        <h6>
+          <TranslatableText>{count} </TranslatableText> for{' '}
+          <DedicatedIpCost
+            quantity={billableCount}
+            priceOfEachDedicatedIp={priceOfEachDedicatedIp}
+            billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
+          />
+        </h6>
+        {plan.includesIp && <p>Your plan includes one free dedicated IP address.</p>}
+      </>
     );
 
   return (

--- a/src/pages/billing/components/DedicatedIpSummarySection.js
+++ b/src/pages/billing/components/DedicatedIpSummarySection.js
@@ -16,6 +16,7 @@ export default function DedicatedIpSummarySection({
   canPurchaseIps,
   limitOnDedicatedIps,
   priceOfEachDedicatedIp,
+  billingPeriodOfDedicatedIp,
 }) {
   const hasReachedMax = count >= limitOnDedicatedIps;
   const disabledPurchaseIP = hasReachedMax || plan.isFree;
@@ -54,7 +55,11 @@ export default function DedicatedIpSummarySection({
     ) : (
       <h6>
         {count} for{' '}
-        <DedicatedIpCost quantity={billableCount} priceOfEachDedicatedIp={priceOfEachDedicatedIp} />
+        <DedicatedIpCost
+          quantity={billableCount}
+          priceOfEachDedicatedIp={priceOfEachDedicatedIp}
+          billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
+        />
       </h6>
     );
 

--- a/src/pages/billing/components/ManuallyBilledOrAwsBanner.js
+++ b/src/pages/billing/components/ManuallyBilledOrAwsBanner.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Banner, Box, Button } from 'src/components/matchbox';
+import { Banner, Button } from 'src/components/matchbox';
 import { PageLink, SupportTicketLink } from 'src/components/links';
 
 /**
@@ -48,9 +48,7 @@ const ManuallyBilledOrAwsBanner = ({
           {<SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>}.
         </p>
 
-        <Box marginTop="400">
-          <p>Enable automatic billing to self-manage your plan and add-ons.</p>
-        </Box>
+        <p>Enable automatic billing to self-manage your plan and add-ons.</p>
 
         <Banner.Actions>
           <PageLink as={Button} to="/account/billing/enable-automatic">

--- a/src/pages/billing/components/ManuallyBilledOrAwsBanner.js
+++ b/src/pages/billing/components/ManuallyBilledOrAwsBanner.js
@@ -40,24 +40,32 @@ const ManuallyBilledOrAwsBanner = ({
     );
   }
 
+  if (onZuoraPlan)
+    return (
+      <Banner status="info" title={title}>
+        <p>
+          To make changes to your plan or billing information, please{' '}
+          {<SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>}.
+        </p>
+
+        <Box marginTop="400">
+          <p>Enable automatic billing to self-manage your plan and add-ons.</p>
+        </Box>
+
+        <Banner.Actions>
+          <PageLink as={Button} to="/account/billing/enable-automatic">
+            Enable Automatic Billing
+          </PageLink>
+        </Banner.Actions>
+      </Banner>
+    );
+
   return (
     <Banner status="info" title={title}>
       <p>
         To make changes to your plan or billing information, please{' '}
         {<SupportTicketLink issueId="general_issue">submit a support ticket</SupportTicketLink>}.
       </p>
-
-      {onZuoraPlan && (
-        <Box marginTop="400">
-          <p>Enable automatic billing to self-manage your plan and add-ons.</p>
-
-          <Banner.Actions>
-            <PageLink as={Button} to="/account/billing/enable-automatic">
-              Enable Automatic Billing
-            </PageLink>
-          </Banner.Actions>
-        </Box>
-      )}
     </Banner>
   );
 };

--- a/src/pages/billing/components/tests/BillingSummary.test.js
+++ b/src/pages/billing/components/tests/BillingSummary.test.js
@@ -30,6 +30,27 @@ describe('Component: Billing Summary', () => {
       currentPlan: {
         isFree: true,
       },
+      subscription: {
+        bill_cycle_day: 5,
+        pending_downgrades: [],
+        products: [
+          {
+            plan: '100K-premier-0519',
+            product: 'messaging',
+          },
+
+          {
+            plan: 'ip-0519',
+            product: 'dedicated_ip',
+            quantity: 1,
+            limit: 14,
+            price: 20,
+            volume: 1,
+            billing_period: 'quarter',
+          },
+        ],
+        type: 'active',
+      },
       canChangePlan: true,
       canUpdateBillingInfo: true,
       canPurchaseIps: true,

--- a/src/pages/billing/components/tests/DedicatedIpCost.test.js
+++ b/src/pages/billing/components/tests/DedicatedIpCost.test.js
@@ -2,29 +2,17 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import DedicatedIpCost from '../DedicatedIpCost';
 
-jest.mock('src/config', () => ({
-  sendingIps: {
-    awsPricePerIp: 0.01,
-    pricePerIp: 20
-  }
-}));
-
 describe('Component: Dedicated IP Cost', () => {
   let wrapper;
   beforeEach(() => {
     const props = {
+      priceOfEachDedicatedIp: 20,
       quantity: 2,
-      isAWSAccount: false
+      billingPeriodOfDedicatedIp: 'month',
     };
-    wrapper = shallow(<DedicatedIpCost {...props}/>);
+    wrapper = shallow(<DedicatedIpCost {...props} />);
   });
-  it('should render an AWS price', () => {
-    wrapper.setProps({ isAWSAccount: true });
-    expect(wrapper.text()).toEqual('$0.020 per hour');
-  });
-
   it('should render a regular price', () => {
     expect(wrapper.text()).toEqual('$40.00 per month');
   });
-
 });

--- a/src/pages/billing/components/tests/DedicatedIpSummarySection.test.js
+++ b/src/pages/billing/components/tests/DedicatedIpSummarySection.test.js
@@ -10,29 +10,25 @@ const TEST_CASES = {
     count: 0,
     canPurchaseIps: true,
     plan: { includesIp: true },
-    isAWSAccount: false,
+    limitOnDedicatedIps: 4,
+    priceOfEachDedicatedIp: 20,
+    billingPeriodOfDedicatedIp: 'month',
   },
   'renders count and zero cost': {
     count: 1,
     canPurchaseIps: true,
     plan: { includesIp: true },
-    isAWSAccount: false,
+    limitOnDedicatedIps: 4,
+    priceOfEachDedicatedIp: 20,
+    billingPeriodOfDedicatedIp: 'month',
   },
   'renders disabled add button, count, cost, and max plan notice': {
     count: 4, // configuration default
     canPurchaseIps: true,
     plan: {},
-    isAWSAccount: false,
-  },
-  'renders count and cost for aws customers': {
-    count: 2,
-    plan: {},
-    isAWSAccount: true,
-  },
-  'renders count and cost for aws customers with free ip': {
-    count: 3,
-    plan: { includesIp: true },
-    isAWSAccount: true,
+    limitOnDedicatedIps: 4,
+    priceOfEachDedicatedIp: 20,
+    billingPeriodOfDedicatedIp: 'month',
   },
 };
 

--- a/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/BillingSummary.test.js.snap
@@ -20,6 +20,28 @@ exports[`Component: Billing Summary should render correctly for a paid plan 1`] 
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -70,15 +92,18 @@ exports[`Component: Billing Summary should render correctly for a paid plan 1`] 
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={true}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": false,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -184,6 +209,28 @@ exports[`Component: Billing Summary should render correctly for a standard free 
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -234,15 +281,18 @@ exports[`Component: Billing Summary should render correctly for a standard free 
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={false}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -308,6 +358,28 @@ exports[`Component: Billing Summary should render correctly if you can't buy IPs
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -358,15 +430,18 @@ exports[`Component: Billing Summary should render correctly if you can't buy IPs
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={false}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -472,6 +547,28 @@ exports[`Component: Billing Summary should render correctly if you can't change 
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -513,15 +610,18 @@ exports[`Component: Billing Summary should render correctly if you can't change 
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={true}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -627,6 +727,28 @@ exports[`Component: Billing Summary should render correctly if you can't update 
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -677,15 +799,18 @@ exports[`Component: Billing Summary should render correctly if you can't update 
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={true}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -751,6 +876,28 @@ exports[`Component: Billing Summary should render with IP modal open 1`] = `
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -801,15 +948,18 @@ exports[`Component: Billing Summary should render with IP modal open 1`] = `
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={true}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -888,7 +1038,10 @@ exports[`Component: Billing Summary should render with IP modal open 1`] = `
     open={true}
   >
     <AddIpsForm
+      billingPeriodOfDedicatedIp="quarter"
+      limitOnDedicatedIps={14}
       onClose={[Function]}
+      priceOfEachDedicatedIp={20}
     />
   </Modal.LEGACY>
   <RecipientValidationModalWrapper
@@ -917,6 +1070,28 @@ exports[`Component: Billing Summary should render with the billing contact modal
         "subscription": Object {
           "plan_volume": 15000,
         },
+      }
+    }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
       }
     }
   />
@@ -969,15 +1144,18 @@ exports[`Component: Billing Summary should render with the billing contact modal
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={true}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -1087,6 +1265,28 @@ exports[`Component: Billing Summary should render with the payment info modal op
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -1137,15 +1337,18 @@ exports[`Component: Billing Summary should render with the payment info modal op
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={true}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue
@@ -1255,6 +1458,28 @@ exports[`Component: Billing Summary should show the invoice history if there are
         },
       }
     }
+    subscription={
+      Object {
+        "bill_cycle_day": 5,
+        "pending_downgrades": Array [],
+        "products": Array [
+          Object {
+            "plan": "100K-premier-0519",
+            "product": "messaging",
+          },
+          Object {
+            "billing_period": "quarter",
+            "limit": 14,
+            "plan": "ip-0519",
+            "price": 20,
+            "product": "dedicated_ip",
+            "quantity": 1,
+            "volume": 1,
+          },
+        ],
+        "type": "active",
+      }
+    }
   />
   <FreePlanWarningBanner
     account={
@@ -1305,15 +1530,18 @@ exports[`Component: Billing Summary should show the invoice history if there are
       </LabelledValue>
     </Panel.LEGACY.Section>
     <DedicatedIpSummarySection
+      billingPeriodOfDedicatedIp="quarter"
       canPurchaseIps={true}
       count={0}
       isTransitioningToSelfServe={false}
+      limitOnDedicatedIps={14}
       onClick={[Function]}
       plan={
         Object {
           "isFree": true,
         }
       }
+      priceOfEachDedicatedIp={20}
     />
     <Panel.LEGACY.Section>
       <LabelledValue

--- a/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
@@ -25,7 +25,10 @@ exports[`DedicatedIpSummarySection renders count and zero cost 1`] = `
     label="Dedicated IPs"
   >
     <h6>
-      1
+      <TranslatableText>
+        1
+         
+      </TranslatableText>
        for
        
       <DedicatedIpCost
@@ -34,6 +37,9 @@ exports[`DedicatedIpSummarySection renders count and zero cost 1`] = `
         quantity={0}
       />
     </h6>
+    <p>
+      Your plan includes one free dedicated IP address.
+    </p>
   </LabelledValue>
 </Panel.LEGACY.Section>
 `;
@@ -63,7 +69,10 @@ exports[`DedicatedIpSummarySection renders disabled add button, count, cost, and
     label="Dedicated IPs"
   >
     <h6>
-      4
+      <TranslatableText>
+        4
+         
+      </TranslatableText>
        for
        
       <DedicatedIpCost

--- a/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/DedicatedIpSummarySection.test.js.snap
@@ -1,77 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DedicatedIpSummarySection renders count and cost for aws customers 1`] = `
-<Panel.LEGACY.Section
-  actions={
-    Array [
-      Object {
-        "Component": [Function],
-        "color": "orange",
-        "content": "Manage Your IPs",
-        "to": "/account/ip-pools",
-        "visible": true,
-      },
-      Object {
-        "Component": [Function],
-        "color": "orange",
-        "content": "Upgrade Now",
-        "to": "/account/billing/plan",
-        "visible": true,
-      },
-    ]
-  }
->
-  <LabelledValue
-    label="Dedicated IPs"
-  >
-    <h6>
-      2
-       for 
-      <DedicatedIpCost
-        isAWSAccount={true}
-        quantity={2}
-      />
-    </h6>
-  </LabelledValue>
-</Panel.LEGACY.Section>
-`;
-
-exports[`DedicatedIpSummarySection renders count and cost for aws customers with free ip 1`] = `
-<Panel.LEGACY.Section
-  actions={
-    Array [
-      Object {
-        "Component": [Function],
-        "color": "orange",
-        "content": "Manage Your IPs",
-        "to": "/account/ip-pools",
-        "visible": true,
-      },
-      Object {
-        "Component": [Function],
-        "color": "orange",
-        "content": "Upgrade Now",
-        "to": "/account/billing/plan",
-        "visible": true,
-      },
-    ]
-  }
->
-  <LabelledValue
-    label="Dedicated IPs"
-  >
-    <h6>
-      3
-       for 
-      <DedicatedIpCost
-        isAWSAccount={true}
-        quantity={2}
-      />
-    </h6>
-  </LabelledValue>
-</Panel.LEGACY.Section>
-`;
-
 exports[`DedicatedIpSummarySection renders count and zero cost 1`] = `
 <Panel.LEGACY.Section
   actions={
@@ -98,9 +26,11 @@ exports[`DedicatedIpSummarySection renders count and zero cost 1`] = `
   >
     <h6>
       1
-       for 
+       for
+       
       <DedicatedIpCost
-        isAWSAccount={false}
+        billingPeriodOfDedicatedIp="month"
+        priceOfEachDedicatedIp={20}
         quantity={0}
       />
     </h6>
@@ -108,9 +38,7 @@ exports[`DedicatedIpSummarySection renders count and zero cost 1`] = `
 </Panel.LEGACY.Section>
 `;
 
-exports[
-  `DedicatedIpSummarySection renders disabled add button, count, cost, and max plan notice 1`
-] = `
+exports[`DedicatedIpSummarySection renders disabled add button, count, cost, and max plan notice 1`] = `
 <Panel.LEGACY.Section
   actions={
     Array [
@@ -136,9 +64,11 @@ exports[
   >
     <h6>
       4
-       for 
+       for
+       
       <DedicatedIpCost
-        isAWSAccount={false}
+        billingPeriodOfDedicatedIp="month"
+        priceOfEachDedicatedIp={20}
         quantity={4}
       />
     </h6>

--- a/src/pages/billing/components/tests/__snapshots__/ManuallyBilledOrAwsBanner.test.js.snap
+++ b/src/pages/billing/components/tests/__snapshots__/ManuallyBilledOrAwsBanner.test.js.snap
@@ -17,21 +17,17 @@ exports[`ManuallyBilledBanner renders banner 1`] = `
     </Component>
     .
   </p>
-  <Box
-    marginTop="400"
-  >
-    <p>
-      Enable automatic billing to self-manage your plan and add-ons.
-    </p>
-    <Banner.Actions>
-      <PageLink
-        as={[Function]}
-        to="/account/billing/enable-automatic"
-      >
-        Enable Automatic Billing
-      </PageLink>
-    </Banner.Actions>
-  </Box>
+  <p>
+    Enable automatic billing to self-manage your plan and add-ons.
+  </p>
+  <Banner.Actions>
+    <PageLink
+      as={[Function]}
+      to="/account/billing/enable-automatic"
+    >
+      Enable Automatic Billing
+    </PageLink>
+  </Banner.Actions>
 </Banner>
 `;
 
@@ -52,21 +48,17 @@ exports[`ManuallyBilledBanner with custom subscription and plan in Zuora 1`] = `
     </Component>
     .
   </p>
-  <Box
-    marginTop="400"
-  >
-    <p>
-      Enable automatic billing to self-manage your plan and add-ons.
-    </p>
-    <Banner.Actions>
-      <PageLink
-        as={[Function]}
-        to="/account/billing/enable-automatic"
-      >
-        Enable Automatic Billing
-      </PageLink>
-    </Banner.Actions>
-  </Box>
+  <p>
+    Enable automatic billing to self-manage your plan and add-ons.
+  </p>
+  <Banner.Actions>
+    <PageLink
+      as={[Function]}
+      to="/account/billing/enable-automatic"
+    >
+      Enable Automatic Billing
+    </PageLink>
+  </Banner.Actions>
 </Banner>
 `;
 

--- a/src/pages/billing/forms/AddIps.js
+++ b/src/pages/billing/forms/AddIps.js
@@ -13,6 +13,7 @@ import { required, integer, minNumber, maxNumber } from 'src/helpers/validation'
 import * as conversions from 'src/helpers/conversionTracking';
 import { getCurrentAccountPlan } from 'src/selectors/accessConditionState';
 import DedicatedIpCost from '../components/DedicatedIpCost';
+import { TranslatableText } from 'src/components/text';
 import { isAws } from 'src/helpers/conditions/account';
 import { ANALYTICS_ADDON_IP } from 'src/constants';
 import styles from './Forms.module.scss';
@@ -125,7 +126,8 @@ export class AddIps extends Component {
                     <span>You cannot currently add any more IPs</span>
                   ) : (
                     <span>
-                      You can add up to {limitOnDedicatedIps} total dedicated IPs to your plan for{' '}
+                      You can add up to <TranslatableText>{limitOnDedicatedIps}</TranslatableText>{' '}
+                      total dedicated IPs to your plan for{' '}
                       <DedicatedIpCost
                         priceOfEachDedicatedIp={priceOfEachDedicatedIp}
                         quantity="1"

--- a/src/pages/billing/forms/AddIps.js
+++ b/src/pages/billing/forms/AddIps.js
@@ -79,6 +79,7 @@ export class AddIps extends Component {
       submitting,
       limitOnDedicatedIps,
       priceOfEachDedicatedIp,
+      billingPeriodOfDedicatedIp,
     } = this.props;
     const remainingCount =
       limitOnDedicatedIps - Math.min(this.props.sendingIps.length, limitOnDedicatedIps);
@@ -128,6 +129,7 @@ export class AddIps extends Component {
                       <DedicatedIpCost
                         priceOfEachDedicatedIp={priceOfEachDedicatedIp}
                         quantity="1"
+                        billingPeriodOfDedicatedIp={billingPeriodOfDedicatedIp}
                       />{' '}
                       each.
                     </span>

--- a/src/pages/billing/forms/AddIps.js
+++ b/src/pages/billing/forms/AddIps.js
@@ -7,7 +7,6 @@ import { addDedicatedIps } from 'src/actions/billing';
 import { showAlert } from 'src/actions/globalAlert';
 import { createPool } from 'src/actions/ipPools';
 import { ButtonWrapper, TextFieldWrapper } from 'src/components';
-import config from 'src/config';
 import IpPoolSelect from './fields/IpPoolSelect';
 import ErrorTracker from 'src/helpers/errorTracker';
 import { required, integer, minNumber, maxNumber } from 'src/helpers/validation';
@@ -72,9 +71,17 @@ export class AddIps extends Component {
   };
 
   render() {
-    const { currentPlan, error, handleSubmit, onClose, submitting } = this.props;
-    const { maxPerAccount } = config.sendingIps;
-    const remainingCount = maxPerAccount - Math.min(this.props.sendingIps.length, maxPerAccount);
+    const {
+      currentPlan,
+      error,
+      handleSubmit,
+      onClose,
+      submitting,
+      limitOnDedicatedIps,
+      priceOfEachDedicatedIp,
+    } = this.props;
+    const remainingCount =
+      limitOnDedicatedIps - Math.min(this.props.sendingIps.length, limitOnDedicatedIps);
 
     // This form should not be rendered if the account has no remaining IP addresses
     const isDisabled = submitting || remainingCount === 0;
@@ -117,8 +124,12 @@ export class AddIps extends Component {
                     <span>You cannot currently add any more IPs</span>
                   ) : (
                     <span>
-                      You can add up to {maxPerAccount} total dedicated IPs to your plan for{' '}
-                      <DedicatedIpCost plan={currentPlan} quantity="1" /> each.
+                      You can add up to {limitOnDedicatedIps} total dedicated IPs to your plan for{' '}
+                      <DedicatedIpCost
+                        priceOfEachDedicatedIp={priceOfEachDedicatedIp}
+                        quantity="1"
+                      />{' '}
+                      each.
                     </span>
                   )
                 }

--- a/src/pages/billing/forms/tests/AddIps.test.js
+++ b/src/pages/billing/forms/tests/AddIps.test.js
@@ -20,7 +20,10 @@ describe('AddIps', () => {
       currentPlan: plan,
       sendingIps: [],
       handleSubmit: jest.fn(),
-      account: {}
+      account: {},
+      limitOnDedicatedIps: 4,
+      priceOfEachDedicatedIp: 20,
+      billingPeriodOfDedicatedIp: 'month',
     };
 
     isAws.mockImplementation(() => false);
@@ -52,7 +55,7 @@ describe('AddIps', () => {
       additionalProps = {
         showAlert: jest.fn(),
         onClose: jest.fn(),
-        addDedicatedIps: jest.fn(() => Promise.resolve())
+        addDedicatedIps: jest.fn(() => Promise.resolve()),
       };
       wrapper.setProps(additionalProps);
     });
@@ -62,7 +65,7 @@ describe('AddIps', () => {
       expect(instance.props.addDedicatedIps).toHaveBeenCalledWith({
         ip_pool: 'pool_name',
         isAwsAccount: false,
-        quantity: 2
+        quantity: 2,
       });
       expect(additionalProps.showAlert).toHaveBeenCalledTimes(1);
       expect(additionalProps.onClose).toHaveBeenCalledTimes(1);
@@ -74,13 +77,15 @@ describe('AddIps', () => {
       expect(instance.props.addDedicatedIps).toHaveBeenCalledWith({
         ip_pool: 'pool_name',
         isAwsAccount: true,
-        quantity: 1
+        quantity: 1,
       });
     });
 
     it('throws on error', async () => {
       additionalProps.addDedicatedIps.mockReturnValue(Promise.reject());
-      await expect(instance.onSubmit({ ipPool: 'pool name', quantity: 1 })).rejects.toThrowError(SubmissionError);
+      await expect(instance.onSubmit({ ipPool: 'pool name', quantity: 1 })).rejects.toThrowError(
+        SubmissionError,
+      );
       expect(additionalProps.showAlert).toHaveBeenCalledTimes(0);
       expect(additionalProps.onClose).toHaveBeenCalledTimes(0);
     });
@@ -90,5 +95,4 @@ describe('AddIps', () => {
       expect(conversions.trackAddonPurchase).toHaveBeenCalledWith(constants.ANALYTICS_ADDON_IP);
     });
   });
-
 });

--- a/src/pages/billing/forms/tests/__snapshots__/AddIps.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/AddIps.test.js.snap
@@ -107,10 +107,12 @@ exports[`AddIps renders correctly with default props 1`] = `
                total dedicated IPs to your plan for
                
               <DedicatedIpCost
-                plan={Object {}}
+                billingPeriodOfDedicatedIp="month"
+                priceOfEachDedicatedIp={20}
                 quantity="1"
               />
-               each.
+               
+              each.
             </span>
           }
           label="Quantity"
@@ -193,14 +195,12 @@ exports[`AddIps renders free ip elements when included in plan 1`] = `
                total dedicated IPs to your plan for
                
               <DedicatedIpCost
-                plan={
-                  Object {
-                    "includesIp": true,
-                  }
-                }
+                billingPeriodOfDedicatedIp="month"
+                priceOfEachDedicatedIp={20}
                 quantity="1"
               />
-               each.
+               
+              each.
             </span>
           }
           label="Quantity"

--- a/src/pages/billing/forms/tests/__snapshots__/AddIps.test.js.snap
+++ b/src/pages/billing/forms/tests/__snapshots__/AddIps.test.js.snap
@@ -103,8 +103,11 @@ exports[`AddIps renders correctly with default props 1`] = `
           helpText={
             <span>
               You can add up to 
-              4
-               total dedicated IPs to your plan for
+              <TranslatableText>
+                4
+              </TranslatableText>
+               
+              total dedicated IPs to your plan for
                
               <DedicatedIpCost
                 billingPeriodOfDedicatedIp="month"
@@ -191,8 +194,11 @@ exports[`AddIps renders free ip elements when included in plan 1`] = `
           helpText={
             <span>
               You can add up to 
-              4
-               total dedicated IPs to your plan for
+              <TranslatableText>
+                4
+              </TranslatableText>
+               
+              total dedicated IPs to your plan for
                
               <DedicatedIpCost
                 billingPeriodOfDedicatedIp="month"


### PR DESCRIPTION
AC-1838: Update UI to use dedicated ip limits from api instead of value in config

### What Changed

- DedicatedIpSection and AddIps form on billing page now uses limits, quantity, price and billing_period from GET /billing/subscription
- removed the isAwsAccount from the DedicatedIpCost since billing page isn't visible to them anyways (they just see a banner)
- Added cypress tests for the case where user has higher limit on subscription for dedicated ip

### How To Test

- Run the added cypress tests 
- Limit override can be set for a account using PUT /billing/subscription/control/product/dedicated_ip - https://github.com/SparkPost/sparkpost-admin-api-documentation/blob/master/services/billing_api.md#subscription-product---[…]oncontrolproductproduct
- Check that the Add Dedicated Ips is not disabled for user who haven't yet reached the limit on subscription.

### To Do

- [ ] Address feedback
