### PR TITLE
FE-1334: Add the functionality on new domain pages to verify domain through url

### DIFF
--- a/cypress/fixtures/sending-domains/200.get.multiple-results.json
+++ b/cypress/fixtures/sending-domains/200.get.multiple-results.json
@@ -48,7 +48,7 @@
         "dkim_status": "invalid",
         "postmaster_at_status": "unverified"
       },
-      "domain": "failed-verification.com",
+      "domain": "fake1.domain.com",
       "is_default_bounce_domain": false
     },
     {

--- a/cypress/fixtures/sending-domains/200.get.paginated-results.json
+++ b/cypress/fixtures/sending-domains/200.get.paginated-results.json
@@ -48,7 +48,7 @@
         "dkim_status": "invalid",
         "postmaster_at_status": "unverified"
       },
-      "domain": "failed-verification.com",
+      "domain": "fake1.domain.com",
       "is_default_bounce_domain": false
     },
     {

--- a/cypress/fixtures/sending-domains/verify/200.post-abusetoken.json
+++ b/cypress/fixtures/sending-domains/verify/200.post-abusetoken.json
@@ -1,0 +1,17 @@
+{
+  "results": {
+    "mx_status": "unverified",
+    "spf_status": "unverified",
+    "dns": {
+      "dkim_record": "v=DKIM1; k=rsa; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCo7qGacXAjV3kl/nOeCkXBGFfhYiKQ0PUFuQPJpn3Me8oawfTpJvAM+5tlCMk/w8B1dpPqcXpbaSXE2EaRnPa6ECb2lavRgcQ3ZO8InD1J+j9p6WP2v9TrUj3r/yD5eOYDcHz2vrP3AErqu5LkLRGki2JCIc1EPIRbGuynR+aafQIDAQAB"
+    },
+    "ownership_verified": true,
+    "cname_status": "valid",
+    "abuse_at_status": "valid",
+    "dkim_status": "valid",
+    "compliance_status": "valid",
+    "verification_mailbox_status": "valid",
+    "verification_mailbox": "me",
+    "postmaster_at_status": "unverified"
+  }
+}

--- a/cypress/tests/integration/configuration/domains/listPage.spec.js
+++ b/cypress/tests/integration/configuration/domains/listPage.spec.js
@@ -68,22 +68,20 @@ describe('The domains list page', () => {
       stubSendingDomains({ fixture: 'sending-domains/200.get.paginated-results.json' });
       stubSubaccounts();
       cy.stubRequest({
-        url: '/api/v1/sending-domains/failed-verification.com/verify',
+        url: '/api/v1/sending-domains/fake1.domain.com/verify',
         method: 'POST',
         fixture: 'sending-domains/verify/200.post-abusetoken.json',
         requestAlias: 'sendingDomainVerifyReq',
       });
       cy.stubRequest({
-        url: '/api/v1/sending-domains/failed-verification.com',
+        url: '/api/v1/sending-domains/fake1.domain.com',
         fixture: 'sending-domains/200.get.all-verified.json',
         requestAlias: 'sendingDomainsReq',
       });
-      cy.visit(
-        `${PAGE_URL}/list/sending?token=faketoken&domain=failed-verification.com&mailbox=abuse`,
-      );
+      cy.visit(`${PAGE_URL}/list/sending?token=faketoken&domain=fake1.domain.com&mailbox=abuse`);
 
-      cy.wait(['@sendingDomainsReq', '@subaccountsReq', '@sendingDomainsReq']);
-      cy.findByText('failed-verification.com has been verified').should('be.visible');
+      cy.wait(['@sendingDomainsReq', '@subaccountsReq', '@sendingDomainVerifyReq']);
+      cy.findByText('fake1.domain.com has been verified').should('be.visible');
       cy.findByRole('heading', { name: 'Domain Details' }).should('be.visible');
     });
 
@@ -91,17 +89,15 @@ describe('The domains list page', () => {
       stubSendingDomains({ fixture: 'sending-domains/200.get.paginated-results.json' });
       stubSubaccounts();
       cy.stubRequest({
-        url: '/api/v1/sending-domains/failed-verification.com/verify',
+        url: '/api/v1/sending-domains/fake1.domain.com/verify',
         method: 'POST',
         fixture: 'sending-domains/verify/200.post.json',
         requestAlias: 'sendingDomainVerifyReq',
       });
-      cy.visit(
-        `${PAGE_URL}/list/sending?token=faketoken&domain=failed-verification.com&mailbox=abuse`,
-      );
+      cy.visit(`${PAGE_URL}/list/sending?token=faketoken&domain=fake1.domain.com&mailbox=abuse`);
 
       cy.wait(['@sendingDomainsReq', '@subaccountsReq']);
-      cy.findByText('Unable to verify failed-verification.com').should('be.visible');
+      cy.findByText('Unable to verify fake1.domain.com').should('be.visible');
       cy.findByRole('heading', { name: 'Domains' }).should('be.visible');
     });
     /**
@@ -169,7 +165,7 @@ describe('The domains list page', () => {
         });
         verifyTableRow({
           rowIndex: 4,
-          domainName: 'failed-verification.com',
+          domainName: 'fake1.domain.com',
           creationDate: 'Aug 3, 2017',
           subaccount: 'Assignment: Primary Account',
           statusTags: ['Unverified'],
@@ -437,7 +433,7 @@ describe('The domains list page', () => {
         });
         verifyTableRow({
           rowIndex: 3,
-          domainName: 'failed-verification.com',
+          domainName: 'fake1.domain.com',
           creationDate: 'Aug 3, 2017',
           statusTags: ['Unverified'],
         });
@@ -485,7 +481,7 @@ describe('The domains list page', () => {
         });
         verifyTableRow({
           rowIndex: 3,
-          domainName: 'failed-verification.com',
+          domainName: 'fake1.domain.com',
           creationDate: 'Aug 3, 2017',
           statusTags: ['Unverified'],
         });
@@ -547,7 +543,7 @@ describe('The domains list page', () => {
         });
         verifyTableRow({
           rowIndex: 4,
-          domainName: 'failed-verification.com',
+          domainName: 'fake1.domain.com',
           creationDate: 'Aug 3, 2017',
           statusTags: ['Unverified'],
         });
@@ -581,7 +577,7 @@ describe('The domains list page', () => {
         });
         verifyTableRow({
           rowIndex: 2,
-          domainName: 'failed-verification.com',
+          domainName: 'fake1.domain.com',
           creationDate: 'Aug 3, 2017',
           statusTags: ['Unverified'],
         });
@@ -675,7 +671,7 @@ describe('The domains list page', () => {
         });
         verifyTableRow({
           rowIndex: 3,
-          domainName: 'failed-verification.com',
+          domainName: 'fake1.domain.com',
           creationDate: 'Aug 3, 2017',
           statusTags: ['Unverified'],
         });

--- a/src/pages/domains/DetailsPage.js
+++ b/src/pages/domains/DetailsPage.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Page, Banner, Button, Box } from 'src/components/matchbox';
-import { useRouteMatch, useParams, useLocation } from 'react-router-dom';
+import { useRouteMatch, useParams } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { get as getDomain, clearSendingDomain } from 'src/actions/sendingDomains';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
@@ -18,8 +18,6 @@ import _ from 'lodash';
 import styled from 'styled-components';
 import Domains from './components';
 import { DETAILS_BASE_URL, EXTERNAL_LINKS } from './constants';
-import qs from 'query-string';
-import { VerifyToken } from './components/VerifyToken';
 
 const StyledBox = styled(Box)`
   max-width: 600px;
@@ -55,8 +53,6 @@ function DetailsPage(props) {
 
     return history.push('/domains/list/sending');
   };
-
-  const queryParams = qs.parse(useLocation().search);
 
   useEffect(() => {
     if (!isTracking) getDomain(id);
@@ -174,14 +170,6 @@ function DetailsPage(props) {
             </Banner.Actions>
           </Banner>
         )}
-        <VerifyToken
-          domain={domain}
-          id={id}
-          isTracking={isTracking}
-          queryParams={queryParams}
-          sendingDomainsGetError={sendingDomainsGetError}
-          sendingDomainsPending={sendingDomainsPending}
-        />
         <Domains.DomainStatusSection domain={domain} id={id} isTracking={isTracking} />
 
         <Domains.SetupForSending

--- a/src/pages/domains/ListPage.js
+++ b/src/pages/domains/ListPage.js
@@ -9,10 +9,11 @@ import { SENDING_DOMAINS_URL, BOUNCE_DOMAINS_URL, TRACKING_DOMAINS_URL } from '.
 import BounceDomainsEmptyState from './components/BounceDomainsEmptyState';
 import SendingDomainsEmptyState from './components/SendingDomainsEmptyState';
 import TrackingDomainsEmptyState from './components/TrackingDomainsEmptyState';
-
 import SendingDomainInfoBanner from './components/SendingDomainInfoBanner.js';
 import BounceDomainInfoBanner from './components/BounceDomainInfoBanner.js';
 import TrackingDomainInfoBanner from './components/TrackingDomainInfoBanner';
+import { VerifyToken } from './components/VerifyToken';
+import qs from 'query-string';
 
 function DomainTabPages() {
   const {
@@ -167,7 +168,7 @@ function DomainTabPages() {
       return 'tracking';
     }
   };
-
+  const queryParams = qs.parse(useLocation().search);
   return (
     <Page
       title="Domains"
@@ -184,6 +185,13 @@ function DomainTabPages() {
       }}
       loading={listPending && isFirstRender}
     >
+      <VerifyToken
+        isTracking={matchesTrackingTab}
+        sendingDomainsListError={sendingDomainsListError}
+        domains={sendingDomains}
+        loading={listPending}
+        queryParams={queryParams}
+      />
       <Stack>
         <Tabs selected={tabIndex} tabs={TABS} />
         <div>

--- a/src/pages/domains/ListPage.js
+++ b/src/pages/domains/ListPage.js
@@ -169,7 +169,7 @@ function DomainTabPages() {
       return 'tracking';
     }
   };
-  const queryParams = qs.parse(useLocation().search);
+  const [queryParams] = useState(qs.parse(useLocation().search));
   return (
     <Page
       title="Domains"

--- a/src/pages/domains/ListPage.js
+++ b/src/pages/domains/ListPage.js
@@ -29,6 +29,7 @@ function DomainTabPages() {
     hasSubaccounts,
     subaccounts,
     listSubaccounts,
+    verifyTokenLoading,
   } = useDomains();
   const [isFirstRender, setIsFirstRender] = useState(true);
   const history = useHistory();
@@ -189,7 +190,7 @@ function DomainTabPages() {
         isTracking={matchesTrackingTab}
         sendingDomainsListError={sendingDomainsListError}
         domains={sendingDomains}
-        loading={listPending}
+        loading={listPending || verifyTokenLoading}
         queryParams={queryParams}
       />
       <Stack>

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -64,8 +64,10 @@ function mapStateToProps(state) {
     verifyEmailLoading: state.sendingDomains.verifyEmailLoading,
     verifyBounceLoading: state.sendingDomains.verifyBounceLoading,
     verifyingTrackingPending: state.trackingDomains.verifyingTrackingPending,
+    verifyTokenError: state.sendingDomains.verifyTokenError,
     trackingDomainCname: selectTrackingDomainCname(state),
     isEmptyStateEnabled: isAccountUiOptionSet('allow_empty_states')(state),
+    verifyTokenLoading: state.sendingDomains.verifyTokenLoading,
   };
 }
 

--- a/src/pages/domains/components/Container.js
+++ b/src/pages/domains/components/Container.js
@@ -11,6 +11,9 @@ import {
   verifyMailbox,
   verifyAbuse,
   verifyPostmaster,
+  verifyMailboxToken,
+  verifyAbuseToken,
+  verifyPostmasterToken,
 } from 'src/actions/sendingDomains';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
 import { showAlert } from 'src/actions/globalAlert';
@@ -48,6 +51,8 @@ function mapStateToProps(state) {
     updateTrackingPending: state.trackingDomains.updating,
     hasSubaccounts: hasSubaccounts(state),
     subaccounts: state.subaccounts.list,
+    subaccountsPending: state.subaccounts.listLoading,
+    tokenStatus: state.sendingDomains.verifyTokenStatus,
     trackingDomains: selectTrackingDomainsRows(state),
     trackingDomainsListError: state.trackingDomains.error,
     userName: state.currentUser.username,
@@ -82,6 +87,9 @@ const mapDispatchToProps = {
   updateTrackingDomain,
   deleteTrackingDomain,
   verifyTrackingDomain,
+  verifyMailboxToken,
+  verifyAbuseToken,
+  verifyPostmasterToken,
 };
 
 export default connect(

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -107,6 +107,15 @@ const initFiltersForSending = {
       return val === 'true' || val === 'false' || typeof val === 'boolean';
     },
   },
+  domain: {
+    defaultValue: undefined,
+  },
+  token: {
+    defaultValue: undefined,
+  },
+  mailbox: {
+    defaultValue: undefined,
+  },
 };
 
 const options = [

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -107,15 +107,6 @@ const initFiltersForSending = {
       return val === 'true' || val === 'false' || typeof val === 'boolean';
     },
   },
-  domain: {
-    defaultValue: undefined,
-  },
-  token: {
-    defaultValue: undefined,
-  },
-  mailbox: {
-    defaultValue: undefined,
-  },
 };
 
 const options = [

--- a/src/pages/domains/components/VerifyToken.js
+++ b/src/pages/domains/components/VerifyToken.js
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import useDomains from '../hooks/useDomains';
+import { usePrevious } from 'src/hooks';
+
+export function VerifyToken({
+  isTracking,
+  domain,
+  id,
+  queryParams,
+  sendingDomainsGetError,
+  sendingDomainsPending,
+}) {
+  const {
+    showAlert,
+    verifyMailboxToken,
+    verifyAbuseToken,
+    verifyPostmasterToken,
+    tokenStatus,
+    subaccountsPending,
+  } = useDomains();
+  const prevTokenStatus = usePrevious(tokenStatus);
+  useEffect(() => {
+    if (
+      !isTracking &&
+      !sendingDomainsGetError &&
+      !sendingDomainsPending &&
+      !subaccountsPending &&
+      domain.id === id
+    ) {
+      function verifyDomain({ mailbox, token }) {
+        if (mailbox && domain && token) {
+          const subaccount = !isNaN(parseInt(domain.subaccount_id))
+            ? domain.subaccount_id
+            : undefined;
+          let verifyAction = verifyMailboxToken;
+
+          if (mailbox === 'abuse') {
+            verifyAction = verifyAbuseToken;
+          }
+
+          if (mailbox === 'postmaster') {
+            verifyAction = verifyPostmasterToken;
+          }
+
+          return verifyAction({ id, token, subaccount });
+        }
+      }
+
+      verifyDomain(queryParams);
+    }
+  }, [
+    domain,
+    id,
+    isTracking,
+    queryParams,
+    sendingDomainsGetError,
+    sendingDomainsPending,
+    subaccountsPending,
+    verifyAbuseToken,
+    verifyMailboxToken,
+    verifyPostmasterToken,
+  ]);
+
+  useEffect(() => {
+    // Api returns a 200 even if domain has not been verified
+    // Manually check if this domain has been verified
+    if (prevTokenStatus !== tokenStatus && !prevTokenStatus && tokenStatus) {
+      if (tokenStatus[`${tokenStatus.type}_status`] !== 'valid') {
+        showAlert({ type: 'error', message: `Unable to verify ${tokenStatus.domain}` });
+      } else {
+        showAlert({ type: 'success', message: `${tokenStatus.domain} has been verified` });
+      }
+    }
+  }, [id, prevTokenStatus, showAlert, tokenStatus]);
+
+  return <></>;
+}

--- a/src/pages/domains/components/VerifyToken.js
+++ b/src/pages/domains/components/VerifyToken.js
@@ -4,8 +4,6 @@ import { usePrevious } from 'src/hooks';
 
 export function VerifyToken({
   isTracking,
-  domain,
-  id,
   queryParams,
   sendingDomainsGetError,
   sendingDomainsPending,
@@ -20,14 +18,8 @@ export function VerifyToken({
   } = useDomains();
   const prevTokenStatus = usePrevious(tokenStatus);
   useEffect(() => {
-    if (
-      !isTracking &&
-      !sendingDomainsGetError &&
-      !sendingDomainsPending &&
-      !subaccountsPending &&
-      domain.id === id
-    ) {
-      function verifyDomain({ mailbox, token }) {
+    if (!isTracking && !sendingDomainsGetError && !sendingDomainsPending && !subaccountsPending) {
+      function verifyDomain({ domain, mailbox, token }) {
         if (mailbox && domain && token) {
           const subaccount = !isNaN(parseInt(domain.subaccount_id))
             ? domain.subaccount_id
@@ -42,15 +34,13 @@ export function VerifyToken({
             verifyAction = verifyPostmasterToken;
           }
 
-          return verifyAction({ id, token, subaccount });
+          return verifyAction({ id: domain.id, token, subaccount });
         }
       }
 
       verifyDomain(queryParams);
     }
   }, [
-    domain,
-    id,
     isTracking,
     queryParams,
     sendingDomainsGetError,
@@ -71,7 +61,7 @@ export function VerifyToken({
         showAlert({ type: 'success', message: `${tokenStatus.domain} has been verified` });
       }
     }
-  }, [id, prevTokenStatus, showAlert, tokenStatus]);
+  }, [prevTokenStatus, showAlert, tokenStatus]);
 
   return <></>;
 }

--- a/src/pages/domains/components/VerifyToken.js
+++ b/src/pages/domains/components/VerifyToken.js
@@ -9,7 +9,7 @@ export function VerifyToken({
   isTracking,
   queryParams,
   sendingDomainsListError,
-  listPending,
+  loading,
 }) {
   const history = useHistory();
   const {
@@ -18,11 +18,18 @@ export function VerifyToken({
     verifyPostmasterToken,
     showAlert,
     tokenStatus,
+    verifyTokenError,
   } = useDomains();
   const prevTokenStatus = usePrevious(tokenStatus);
 
   useEffect(() => {
-    if (!isTracking && !sendingDomainsListError && !listPending) {
+    if (
+      !isTracking &&
+      !sendingDomainsListError &&
+      !loading &&
+      !verifyTokenError &&
+      !tokenStatus?.type
+    ) {
       function verifyDomain({ mailbox, domain, token }) {
         // Find the domain to inject subaccount
         const sendingDomain = _.find(domains, { domainName: domain });
@@ -50,18 +57,20 @@ export function VerifyToken({
   }, [
     domains,
     isTracking,
-    listPending,
+    loading,
     queryParams,
     sendingDomainsListError,
+    tokenStatus,
     verifyAbuseToken,
     verifyMailboxToken,
     verifyPostmasterToken,
+    verifyTokenError,
   ]);
 
   useEffect(() => {
     // Api returns a 200 even if domain has not been verified
     // Manually check if this domain has been verified
-    if (prevTokenStatus !== tokenStatus && !prevTokenStatus && tokenStatus) {
+    if (!prevTokenStatus && tokenStatus) {
       if (tokenStatus[`${tokenStatus.type}_status`] !== 'valid') {
         showAlert({ type: 'error', message: `Unable to verify ${tokenStatus.domain}` });
       } else {

--- a/src/pages/sendingDomains/components/VerifyToken.js
+++ b/src/pages/sendingDomains/components/VerifyToken.js
@@ -2,7 +2,11 @@ import React, { Component } from 'react'; // eslint-disable-line no-unused-vars
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import qs from 'query-string';
-import { verifyMailboxToken, verifyAbuseToken, verifyPostmasterToken } from 'src/actions/sendingDomains';
+import {
+  verifyMailboxToken,
+  verifyAbuseToken,
+  verifyPostmasterToken,
+} from 'src/actions/sendingDomains';
 import { showAlert } from 'src/actions/globalAlert';
 import _ from 'lodash';
 
@@ -20,7 +24,9 @@ export class VerifyToken extends Component {
     const sendingDomain = _.find(domains, { domain });
 
     if (sendingDomain && mailbox && domain && token) {
-      const subaccount = !isNaN(parseInt(sendingDomain.subaccount_id)) ? sendingDomain.subaccount_id : undefined;
+      const subaccount = !isNaN(parseInt(sendingDomain.subaccount_id))
+        ? sendingDomain.subaccount_id
+        : undefined;
       let verifyAction = verifyMailboxToken;
 
       if (mailbox === 'abuse') {
@@ -55,10 +61,15 @@ export class VerifyToken extends Component {
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   domains: state.sendingDomains.list,
-  tokenStatus: state.sendingDomains.verifyTokenStatus
+  tokenStatus: state.sendingDomains.verifyTokenStatus,
 });
 
-const mapDispatchToProps = { showAlert, verifyMailboxToken, verifyAbuseToken, verifyPostmasterToken };
+const mapDispatchToProps = {
+  showAlert,
+  verifyMailboxToken,
+  verifyAbuseToken,
+  verifyPostmasterToken,
+};
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(VerifyToken));

--- a/src/reducers/sendingDomains.js
+++ b/src/reducers/sendingDomains.js
@@ -50,7 +50,7 @@ export default (state = initialState, { type, payload, meta }) => {
       return { ...state, getError: payload, getLoading: false };
 
     case 'CLEAR_SENDING_DOMAIN':
-      return { ...state, ...initialDomainState, verifyTokenStatus: null };
+      return { ...state, ...initialDomainState };
 
     case 'VERIFY_SENDING_DOMAIN_CNAME_PENDING':
     case 'VERIFY_SENDING_DOMAIN_MX_PENDING':
@@ -104,7 +104,7 @@ export default (state = initialState, { type, payload, meta }) => {
     case 'VERIFY_TOKEN_PENDING':
       return {
         ...state,
-        verifyTokenLoading: false,
+        verifyTokenLoading: true,
         verifyTokenStatus: null,
         verifyTokenError: null,
       };

--- a/src/reducers/sendingDomains.js
+++ b/src/reducers/sendingDomains.js
@@ -50,7 +50,7 @@ export default (state = initialState, { type, payload, meta }) => {
       return { ...state, getError: payload, getLoading: false };
 
     case 'CLEAR_SENDING_DOMAIN':
-      return { ...state, ...initialDomainState };
+      return { ...state, ...initialDomainState, verifyTokenStatus: null };
 
     case 'VERIFY_SENDING_DOMAIN_CNAME_PENDING':
     case 'VERIFY_SENDING_DOMAIN_MX_PENDING':


### PR DESCRIPTION
FE-1334: Add the functionality on new domain pages to verify domain through url

### What Changed

- Added VerifyToken component on Domains list page
- Whenever domain/list/sending?domain={{domain}}&token={{token}}&mailbox={{mailbox}} is loaded, verify action will trigger on page load
      - if the domain is verified then it would redirect to domain details page with a success alert
      - if domain is not verified then it would stay on the list page with unsuccessful alert
      
      
### How To Test

- Load http://localhost:3100/domains/list/sending?domain=unverified.com&mailbox=abuse&token=akaka url, you should see a unsuccessful alert
- From appteam staging send yourself a email from here 
<img width="1478" alt="Screen Shot 2021-01-13 at 5 01 50 PM" src="https://user-images.githubusercontent.com/4179337/104515641-1b4cd000-55c1-11eb-9713-20259b41d79e.png">
     - use the token and mailboax in the link and navigate to http://localhost:3100/domains/list/sending?domain={{domain}}&mailbox={{mailbox}}&token={{token}}

### To Do

- [ ] Address feedback
