### PR TITLE
FE-1344 - track onboarding in segment

### DIFF
--- a/src/helpers/segment.js
+++ b/src/helpers/segment.js
@@ -19,6 +19,7 @@ export const SEGMENT_EVENTS = {
   SENDING_DOMAIN_ADDED: 'Sending Domain Added',
   SENDING_DOMAIN_VERIFIED: 'Sending Domain Verified',
   EMPTY_STATE_LOADED: 'Empty state loaded',
+  ONBOARDING: 'Onboarding',
   REPORT_BUILDER_COMPARISON_ADDED: 'Report Builder Comparison Added',
   SCHEDULED_REPORT_CREATED: 'Created Scheduled Report',
 };

--- a/src/helpers/segment.js
+++ b/src/helpers/segment.js
@@ -19,7 +19,7 @@ export const SEGMENT_EVENTS = {
   SENDING_DOMAIN_ADDED: 'Sending Domain Added',
   SENDING_DOMAIN_VERIFIED: 'Sending Domain Verified',
   EMPTY_STATE_LOADED: 'Empty state loaded',
-  ONBOARDING: 'Onboarding',
+  DASHBOARD_ONBOARDING: 'Dashboard Onboarding Loaded',
   REPORT_BUILDER_COMPARISON_ADDED: 'Report Builder Comparison Added',
   SCHEDULED_REPORT_CREATED: 'Created Scheduled Report',
 };

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -22,6 +22,7 @@ import { list as listSendingDomains } from 'src/actions/sendingDomains';
 import { getReports } from 'src/actions/reports';
 import OGDashbaordPage from 'src/pages/dashboard';
 import useHibanaToggle from 'src/hooks/useHibanaToggle';
+import { segmentTrack, SEGMENT_EVENTS } from 'src/helpers/segment';
 
 function mapStateToProps(state) {
   const isAnAdmin = isAdmin(state);
@@ -64,6 +65,12 @@ function mapStateToProps(state) {
       onboarding = 'startSending';
   } else if (lastUsageDate === null && (isTemplatesUser || isReportingUser)) {
     onboarding = 'analyticsReportPromo';
+  }
+
+  if (onboarding !== 'done') {
+    segmentTrack(SEGMENT_EVENTS.ONBOARDING, {
+      onboarding,
+    });
   }
 
   if (onboarding && onboarding === 'verifySending' && sendingDomains.length === 1) {

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -22,7 +22,6 @@ import { list as listSendingDomains } from 'src/actions/sendingDomains';
 import { getReports } from 'src/actions/reports';
 import OGDashbaordPage from 'src/pages/dashboard';
 import useHibanaToggle from 'src/hooks/useHibanaToggle';
-import { segmentTrack, SEGMENT_EVENTS } from 'src/helpers/segment';
 
 function mapStateToProps(state) {
   const isAnAdmin = isAdmin(state);
@@ -65,12 +64,6 @@ function mapStateToProps(state) {
       onboarding = 'startSending';
   } else if (lastUsageDate === null && (isTemplatesUser || isReportingUser)) {
     onboarding = 'analyticsReportPromo';
-  }
-
-  if (onboarding !== 'done') {
-    segmentTrack(SEGMENT_EVENTS.DASHBOARD_ONBOARDING, {
-      onboarding,
-    });
   }
 
   if (onboarding && onboarding === 'verifySending' && sendingDomains.length === 1) {

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -68,7 +68,7 @@ function mapStateToProps(state) {
   }
 
   if (onboarding !== 'done') {
-    segmentTrack(SEGMENT_EVENTS.ONBOARDING, {
+    segmentTrack(SEGMENT_EVENTS.DASHBOARD_ONBOARDING, {
       onboarding,
     });
   }

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -41,6 +41,7 @@ import { _getAggregateDataReportBuilder } from 'src/actions/summaryChart';
 import { usePrevious } from 'src/hooks';
 import { AsyncActionModal } from 'src/components';
 import { ActiveFilters } from 'src/components/reportBuilder';
+import { segmentTrack, SEGMENT_EVENTS } from 'src/helpers/segment';
 
 const OnboardingImg = styled(Picture.Image)`
   vertical-align: bottom;
@@ -70,6 +71,12 @@ export default function DashboardPageV2() {
   const history = useHistory();
 
   useEffect(() => {
+    if (onboarding !== 'done') {
+      segmentTrack(SEGMENT_EVENTS.DASHBOARD_ONBOARDING, {
+        onboarding,
+      });
+    }
+
     getAccount();
     listAlerts();
     if (canViewUsage) getUsage();

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -76,7 +76,9 @@ export default function DashboardPageV2() {
         onboarding,
       });
     }
+  }, [onboarding]);
 
+  useEffect(() => {
     getAccount();
     listAlerts();
     if (canViewUsage) getUsage();
@@ -214,7 +216,6 @@ export default function DashboardPageV2() {
                   </Columns>
                 </Dashboard.Panel>
               )}
-
               {onboarding === 'addSending' && (
                 <Dashboard.Panel>
                   <Columns>


### PR DESCRIPTION
### What Changed
- Tracking onboarding steps in segment as long as it's not set to "done"

### How To Test
- Create a new account and go to the dashboard. 
- Go through each onboarding step manually calling the API to get past the sending domain verification process.
- Make sure calls are going out to segment for each step.

### To Do
- [x] Test
- [x] Feedback

