### PR TITLE
FE-1338 - Report Builder Info Banner

### DIFF
--- a/cypress/fixtures/users/200.get.report-builder-banner-dismissed.json
+++ b/cypress/fixtures/users/200.get.report-builder-banner-dismissed.json
@@ -1,0 +1,39 @@
+{
+  "results": {
+    "username": "mockuser",
+    "first_name": "UpdateAppTest",
+    "last_name": "TeamName",
+    "email": "mockuser@example.com",
+    "customer": 107,
+    "cookie_consent": "2018-03-28T18:12:32.615Z",
+    "tfa_enabled": false,
+    "tou_auto_accept": false,
+    "is_sso": false,
+    "email_verified": true,
+    "access_level": "admin",
+    "options": {
+      "ui": {
+        "isHibanaBannerVisible": false,
+        "isHibanaEnabled": true,
+        "onboardingV2": {
+          "reportBuilderBannerDismissed": true
+        }
+      }
+    },
+    "created": "2015-07-29T17:59:48.477Z",
+    "updated": "2019-12-13T16:34:20.358Z",
+    "has_subaccounts": true,
+    "tokens": [],
+    "tou": {
+      "state": "accepted",
+      "updated_date": "2014-10-15T00:00+00:00",
+      "must_accept_date": null
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "/api/v1/users/appteam"
+    }
+  ]
+}

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -49,6 +49,7 @@ import {
 import { useReportBuilderContext } from './context/ReportBuilderContext';
 import { PRESET_REPORT_CONFIGS } from './constants';
 import { TrackingEngagementTab, InvestigatingProblemsTab } from './components/EmptyTabs';
+import { InfoBanner } from './components';
 import { Heading } from 'src/components/text';
 
 // Enable for EMPTY_STATE_TABS when SD is released
@@ -342,6 +343,8 @@ export function ReportBuilder({
           {/* {selectedEmptyStateTab === 2 && <DeliverabilityMetricsTab />} */}
         </>
       )}
+
+      {!showReportBuilderEmptyState && <InfoBanner />}
 
       {/* NON-EMPTY STATE */}
       {!showReportBuilderEmptyState && (

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -97,6 +97,7 @@ export function ReportBuilder({
     return !Boolean(reportOptions.metrics && reportOptions.metrics.length);
   }, [reportOptions.metrics]);
 
+  const showInfoBanner = !showReportBuilderEmptyState && isEmptyStateEnabled;
   const emptyStateUrlHash = location.hash.replace('#', '');
   let emptyStateTabFromUrl;
 
@@ -344,7 +345,7 @@ export function ReportBuilder({
         </>
       )}
 
-      {!showReportBuilderEmptyState && <InfoBanner />}
+      {showInfoBanner && <InfoBanner />}
 
       {/* NON-EMPTY STATE */}
       {!showReportBuilderEmptyState && (

--- a/src/pages/reportBuilder/components/InfoBanner.js
+++ b/src/pages/reportBuilder/components/InfoBanner.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Banner, Picture } from 'src/components/matchbox';
+import AnalyticsJpg from '@sparkpost/matchbox-media/images/Analytics.jpg';
+import AnalyticsWebp from '@sparkpost/matchbox-media/images/Analytics.webp';
+import { updateUserUIOptions } from 'src/actions/currentUser';
+import { isUserUiOptionSet } from 'src/helpers/conditions/user';
+import { LINKS } from 'src/constants';
+
+export default function InfoBanner() {
+  const [dismissed, setDismissed] = useState(
+    useSelector(state => isUserUiOptionSet('onboardingV2.reportBuilderBannerDismissed')(state)),
+  );
+  const dispatch = useDispatch();
+  const handleDismiss = () => {
+    setDismissed(true);
+    dispatch(updateUserUIOptions({ onboardingV2: { reportBuilderBannerDismissed: true } }));
+  };
+  if (dismissed) return null;
+
+  return (
+    <Banner
+      onDismiss={handleDismiss}
+      size="large"
+      status="muted"
+      title="All the Metrics in One Place"
+      mb="600"
+    >
+      <p>
+        Build and save custom reports with SparkPost's easy to use dashboard. Apply unlimited
+        metrics across delivery and deliverability data. To learn how to unlock the full potential
+        of SparkPost's Analytics Report, visit the documentation below.
+      </p>
+      {/* TODO: VIEW SEEDLIST TO LINK */}
+      <Banner.Action color="blue" to="/inbox-placement/seedlist">
+        View Seedlist
+      </Banner.Action>
+      <Banner.Action color="blue" to={LINKS.ANALYTICS_DOCS} external variant="outline">
+        Analytics Documentation
+      </Banner.Action>
+      <Banner.Media>
+        <Picture seeThrough>
+          <Picture.Image alt="" src={AnalyticsJpg}>
+            <source srcSet={AnalyticsWebp} type="image/webp"></source>
+          </Picture.Image>
+        </Picture>
+      </Banner.Media>
+    </Banner>
+  );
+}

--- a/src/pages/reportBuilder/components/InfoBanner.js
+++ b/src/pages/reportBuilder/components/InfoBanner.js
@@ -31,10 +31,10 @@ export default function InfoBanner() {
         metrics across delivery and deliverability data. To learn how to unlock the full potential
         of SparkPost's Analytics Report, visit the documentation below.
       </p>
-      {/* TODO: VIEW SEEDLIST TO LINK */}
-      <Banner.Action color="blue" to="/inbox-placement/seedlist">
+      {/* TODO: Show View Seedlist button when Signals Deliverability is live and the route is available */}
+      {/* <Banner.Action color="blue" to="/inbox-placement/seedlist">
         View Seedlist
-      </Banner.Action>
+      </Banner.Action> */}
       <Banner.Action color="blue" to={LINKS.ANALYTICS_DOCS} external variant="outline">
         Analytics Documentation
       </Banner.Action>

--- a/src/pages/reportBuilder/components/index.js
+++ b/src/pages/reportBuilder/components/index.js
@@ -1,6 +1,7 @@
 export { default as ActiveComparisons } from './ActiveComparisons';
 export { default as ActiveMetrics } from './ActiveMetrics';
 export { default as Charts } from './Charts';
+export { default as InfoBanner } from './InfoBanner';
 export { default as CompareByForm } from './CompareByForm';
 export { default as FiltersForm } from './FiltersForm';
 export { default as MetricsDrawer } from './MetricsDrawer';

--- a/src/pages/reportBuilder/context/ReportBuilderContext.js
+++ b/src/pages/reportBuilder/context/ReportBuilderContext.js
@@ -212,7 +212,7 @@ const ReportOptionsContextProvider = props => {
     [dispatch],
   );
 
-  //Not currently used but I am leaving them here for now.
+  // Not currently used but I am leaving them here for now.
   const setFilters = useCallback(
     payload => {
       return dispatch({
@@ -223,7 +223,7 @@ const ReportOptionsContextProvider = props => {
     [dispatch],
   );
 
-  //Not currently used but I am leaving them here for now.
+  // Not currently used but I am leaving them here for now.
   const clearFilters = useCallback(() => {
     return dispatch({
       type: 'CLEAR_FILTERS',


### PR DESCRIPTION
Branched from [FE-1270](github.com/SparkPost/2web2ui/pull/2005)

### What Changed
- Info banner for report builder doc and seedlist buttons was added at the top of the page

### How To Test
- On an account that hasn't dismissed the banner yet, go to the report builder page with at least one verified sending domain.
- The info banner should show at the top of the page until the user dismisses it.
- 

### Questions
- What's the link for the view seedlist button?
- When should that view seedlist button show? Always?

### To Do
- [x] Cypress test coverage
- [x] Feedback 
