### PR TITLE
[FE-1352] Do not show empty state when allow_ingest_events  is enabled

### DIFF
--- a/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/reportPage.spec.js
@@ -63,6 +63,19 @@ describe('Analytics Report', () => {
     });
     cy.findByRole('heading', { name: 'Example Analytics' }).should('be.visible');
   });
+  it('should not render the Empty State when allow_events_ingest is enabled for the account', () => {
+    commonBeforeSteps();
+    stubAccountsReq();
+    stubSendingDomains();
+    cy.visit(PAGE_URL);
+    cy.wait(['@sendingDomainsReq']);
+    cy.findByRole('heading', { name: 'Analytics Report' }).should('be.visible');
+    cy.findAllByText(
+      "Build and save custom reports with SparkPost's easy to use dashboard. Apply unlimited metrics across delivery and deliverability data. To learn how to unlock the full potential of SparkPost's Analytics Report, visit the documentation link below.",
+    ).should('not.exist');
+    cy.findByRole('button', { name: 'Add Sending Domain' }).should('not.exist');
+    cy.findByRole('heading', { name: 'Example Analytics' }).should('not.exist');
+  });
 
   it('does not render the banner when the banner has been dismissed', () => {
     commonBeforeSteps();
@@ -374,5 +387,13 @@ function stubSendingDomains({
     fixture,
     requestAlias,
     statusCode,
+  });
+}
+
+function stubAccountsReq({ fixture = 'account/200.get.has-integration-page.json' } = {}) {
+  cy.stubRequest({
+    url: '/api/v1/account**',
+    fixture: fixture,
+    requestAlias: 'accountReq',
   });
 }

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-is-first-render-empty-state-loading */
 import React, { useState, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -50,6 +51,7 @@ import { PRESET_REPORT_CONFIGS } from './constants';
 import { TrackingEngagementTab, InvestigatingProblemsTab } from './components/EmptyTabs';
 import { InfoBanner } from './components';
 import { Heading } from 'src/components/text';
+import { hasAccountOptionEnabled } from 'src/helpers/conditions/account';
 
 // Enable for EMPTY_STATE_TABS when SD is released
 // {
@@ -78,9 +80,10 @@ export function ReportBuilder({
   listSendingDomains,
   sendingDomains,
   sendingDomainsListLoading,
+  ingestEventsAllowed,
 }) {
   const history = useHistory();
-  const showReportBuilderEmptyState = sendingDomains.length === 0;
+  const showReportBuilderEmptyState = sendingDomains.length === 0 && !ingestEventsAllowed;
   const [isFirstRender, setIsFirstRender] = useState(true);
   const [showTable, setShowTable] = useState(true); // TODO: Incorporate in to the context reducer due to state interaction
   const [selectedReport, setReport] = useState(null); // TODO: Incorporate in to the context reducer due to state interaction
@@ -470,6 +473,7 @@ const mapStateToProps = state => ({
   subscription: state.billing.subscription,
   sendingDomains: selectVerifiedDomains(state),
   sendingDomainsListLoading: state.sendingDomains.listLoading,
+  ingestEventsAllowed: hasAccountOptionEnabled('allow_events_ingest')(state),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
Note: Give your PR a short title. Something like "_TICKET NUMBER: feature description_" is good.

### What Changed

- Do not show empty states for customers when allow_ingest_events is enabled

### How To Test

- Enable allow_ingest_events Account option for a new account and check if you can see the empty state on Report builder page.
- Check if this solution works for all the roles.

### To Do

- [ ] Address feedback
