### PR TITLE
AC-1851 - Merge account usage into main usage

### DIFF
--- a/cypress/tests/integration/accounts/usage/usagePage.spec.js
+++ b/cypress/tests/integration/accounts/usage/usagePage.spec.js
@@ -4,6 +4,7 @@ describe('The usage page', () => {
   beforeEach(() => {
     cy.stubAuth();
     cy.login({ isStubbed: true });
+
     cy.stubRequest({
       url: `api/v1/billing/subscription`,
       fixture: 'billing/subscription/200.get.json',
@@ -109,6 +110,7 @@ describe('The usage page', () => {
     cy.wait(['@usageReq', '@usageHistoryReq', '@subscriptionReq']);
     cy.findByText('Aug 18th').should('not.exist');
   });
+
   it('renders Usage Page correctly for customers on Annual plans', () => {
     cy.stubRequest({
       url: 'api/v1/account',
@@ -186,9 +188,10 @@ describe('The usage page', () => {
     cy.wait(['@usageReq', '@usageHistoryReq', '@subscriptionReq']);
     cy.get('[data-id="messaging-usage-chart"]').should('be.visible');
   });
+
   it('renders Usage Page correctly for enterprise customers', () => {
     cy.stubRequest({
-      url: 'api/v1/account',
+      url: 'api/v1/account*',
       fixture: 'account/200.get.enterprise-tenant.json',
       requestAlias: 'accountReq',
     });

--- a/src/pages/usage/UsagePage.js
+++ b/src/pages/usage/UsagePage.js
@@ -56,7 +56,7 @@ export default function UsagePage() {
   // Merging data so existing selectors can work together to grab from a common object
   const data = { account, subscription, usage, usageHistory };
 
-  // NOTE: API usage data discrepancy
+  // NOTE: AC-1851 - API usage data discrepancy
   usage.messaging.day = {
     ...account.usage.day,
     ...usage.messaging.day, // Usage second so if the API fixes the response, it'll win out over the account call
@@ -65,7 +65,7 @@ export default function UsagePage() {
     ...account.usage.month,
     ...usage.messaging.month, // Usage second so if the API fixes the response, it'll win out over the account call
   };
-  // NOTE: API usage data discrepancy
+  // NOTE: AC-1851 - API usage data discrepancy
 
   const endOfBillingPeriod = selectEndOfMonthlyUsage(data);
   const startOfBillingPeriod = selectStartOfMonthlyUsage(data);

--- a/src/pages/usage/UsagePage.js
+++ b/src/pages/usage/UsagePage.js
@@ -12,8 +12,8 @@ import { MessagingUsageSection, FeatureUsageSection, RVUsageSection } from './co
 
 export default function UsagePage() {
   // API Requests
-  const { data: account, status: accountStatus, refetch: accountRefetch } = useSparkPostQuery(
-    getAccount,
+  const { data: account, status: accountStatus, refetch: accountRefetch } = useSparkPostQuery(() =>
+    getAccount({ include: 'usage' }),
   );
   const { data: usage, status: usageStatus, refetch: usageRefetch } = useSparkPostQuery(getUsage);
   const {
@@ -55,6 +55,18 @@ export default function UsagePage() {
 
   // Merging data so existing selectors can work together to grab from a common object
   const data = { account, subscription, usage, usageHistory };
+
+  // NOTE: API usage data discrepancy
+  usage.messaging.day = {
+    ...account.usage.day,
+    ...usage.messaging.day, // Usage second so if the API fixes the response, it'll win out over the account call
+  };
+  usage.messaging.month = {
+    ...account.usage.month,
+    ...usage.messaging.month, // Usage second so if the API fixes the response, it'll win out over the account call
+  };
+  // NOTE: API usage data discrepancy
+
   const endOfBillingPeriod = selectEndOfMonthlyUsage(data);
   const startOfBillingPeriod = selectStartOfMonthlyUsage(data);
   const accountSubscription = data.account.subscription;

--- a/src/pages/usage/UsagePage.js
+++ b/src/pages/usage/UsagePage.js
@@ -58,12 +58,12 @@ export default function UsagePage() {
 
   // NOTE: AC-1851 - API usage data discrepancy
   usage.messaging.day = {
-    ...account.usage.day,
-    ...usage.messaging.day, // Usage second so if the API fixes the response, it'll win out over the account call
+    ...account?.usage?.day,
+    ...usage?.messaging?.day, // Usage second so if the API fixes the response, it'll win out over the account call
   };
   usage.messaging.month = {
-    ...account.usage.month,
-    ...usage.messaging.month, // Usage second so if the API fixes the response, it'll win out over the account call
+    ...account?.usage?.month,
+    ...usage?.messaging?.month, // Usage second so if the API fixes the response, it'll win out over the account call
   };
   // NOTE: AC-1851 - API usage data discrepancy
 


### PR DESCRIPTION
### What Changed
- Merged the account usage response into the main usage response to make sure limit data is correctly displaying.

![image](https://user-images.githubusercontent.com/4204806/105875938-08c09680-5fc4-11eb-8335-1c42def1b191.png)

### How To Test
- Go to the `/usage` page and make sure daily and monthly limit data is displaying.
(this data will only show if on accounts that have limits & not on enterprise)

### To Do
- [ ] Feedback

### Relates to
- https://sparkpost.atlassian.net/browse/FE-1249
