### PR TITLE
FE-1337 - Fix custom relativeRange reports on dashboard v2

### DIFF
--- a/src/hooks/usePinnedRport/usePinnedReport.js
+++ b/src/hooks/usePinnedRport/usePinnedReport.js
@@ -35,10 +35,11 @@ export default function usePinnedReport(onboarding) {
   const reportOptionsWithDates = reportOptions => {
     const { relativeRange, precision } = reportOptions;
     const { from, to } = getRelativeDates(relativeRange, { precision });
+    // Note: when relativeRange is set to custom, getRelativeDates won't produce from and to, so reportOptions goes last in the return struct
     return {
+      from,
+      to,
       ...reportOptions,
-      from: relativeRange === 'custom' ? reportOptions.from : from,
-      to: relativeRange === 'custom' ? reportOptions.to : to,
     };
   };
 

--- a/src/hooks/usePinnedRport/usePinnedReport.js
+++ b/src/hooks/usePinnedRport/usePinnedReport.js
@@ -34,18 +34,12 @@ export default function usePinnedReport(onboarding) {
 
   const reportOptionsWithDates = reportOptions => {
     const { relativeRange, precision } = reportOptions;
-    if (relativeRange === 'custom') {
-      return {
-        ...reportOptions,
-      };
-    } else {
-      const { from, to } = getRelativeDates(relativeRange, { precision });
-      return {
-        ...reportOptions,
-        from,
-        to,
-      };
-    }
+    const { from, to } = getRelativeDates(relativeRange, { precision });
+    return {
+      ...reportOptions,
+      from: relativeRange === 'custom' ? reportOptions.from : from,
+      to: relativeRange === 'custom' ? reportOptions.to : to,
+    };
   };
 
   pinnedReport.loading = subaccountsLoading || reportsLoading;

--- a/src/hooks/usePinnedRport/usePinnedReport.js
+++ b/src/hooks/usePinnedRport/usePinnedReport.js
@@ -34,12 +34,18 @@ export default function usePinnedReport(onboarding) {
 
   const reportOptionsWithDates = reportOptions => {
     const { relativeRange, precision } = reportOptions;
-    const { from, to } = getRelativeDates(relativeRange, { precision });
-    return {
-      ...reportOptions,
-      from,
-      to,
-    };
+    if (relativeRange === 'custom') {
+      return {
+        ...reportOptions,
+      };
+    } else {
+      const { from, to } = getRelativeDates(relativeRange, { precision });
+      return {
+        ...reportOptions,
+        from,
+        to,
+      };
+    }
   };
 
   pinnedReport.loading = subaccountsLoading || reportsLoading;
@@ -48,7 +54,6 @@ export default function usePinnedReport(onboarding) {
   const summaryReportOptions = parseSearch(summaryReportQueryString);
 
   const report = _.find(reports, { id: pinnedReportId });
-
   if (report) {
     const options = parseSearch(report.query_string);
     pinnedReport.name = report.name;

--- a/src/hooks/usePinnedRport/usePinnedReport.js
+++ b/src/hooks/usePinnedRport/usePinnedReport.js
@@ -35,11 +35,10 @@ export default function usePinnedReport(onboarding) {
   const reportOptionsWithDates = reportOptions => {
     const { relativeRange, precision } = reportOptions;
     const { from, to } = getRelativeDates(relativeRange, { precision });
-    // Note: when relativeRange is set to custom, getRelativeDates won't produce from and to, so reportOptions goes last in the return struct
     return {
-      from,
-      to,
       ...reportOptions,
+      from: relativeRange === 'custom' ? reportOptions.from : from,
+      to: relativeRange === 'custom' ? reportOptions.to : to,
     };
   };
 


### PR DESCRIPTION
### What Changed
- Custom relativeRange reports were calling into `getRelativeDates` and that function wasn't returning from and to information. That was resulting in the response from `reportOptionsWithDates` to not have from and to, and as a result the pinnedReport `pinnedReport` object used in DashboardPageV2.js had no from and to information. 
- This PR ensures that custom relativeRange reports have their from and to properties set for displaying on the dashboard. 

### How To Test
- Go to the /dashboard page and change reports to and from custom and non custom date range reports. Use the summary report too - and check to make sure the to and from dates used/showing are correct for the custom saved range. 

### To Do
- [x] Test (need to make sure the exact change I made is the best one I could have made, I have a feeling `getRelativeDates` could also be updated instead, to return the to and from datapoints, instead of setting a condition like I have here.)
- [x] Feedback
