### PR TITLE
SA-2055: Performance improvements on typeahead

### DIFF
--- a/cypress/tests/integration/signals-analytics/analytics-report/compareBy.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/compareBy.spec.js
@@ -231,17 +231,21 @@ describe('Analytics Report - Compare By', () => {
             .click();
           cy.findAllByLabelText('Subaccount')
             .eq(index + 2)
+            .scrollIntoView()
             .type('Fake Subaccount');
           cy.findByText(`Fake Subaccount ${index + 3} (ID 10${index + 3})`)
             .scrollIntoView()
-
             .should('be.visible')
             .click();
         });
 
-      cy.findByRole('button', { name: 'Add Subaccount' }).click();
+      cy.findByRole('button', { name: 'Add Subaccount' })
+        .scrollIntoView()
+        .click();
       cy.findAllByLabelText('Subaccount')
         .eq(9)
+        .scrollIntoView()
+
         .scrollIntoView()
 
         .type('Fake Subaccount');
@@ -251,11 +255,15 @@ describe('Analytics Report - Compare By', () => {
         .should('be.visible')
         .click();
 
-      cy.findByText('Limit on number of comparisons reached').should('be.visible');
+      cy.findByText('Limit on number of comparisons reached')
+        .scrollIntoView()
+        .should('be.visible');
       cy.findByRole('button', { name: 'Add Subaccount' }).should('not.exist');
 
       cy.findAllByRole('button', { name: 'Remove Filter' })
         .eq(8)
+        .scrollIntoView()
+
         .should('be.visible')
         .click();
 

--- a/cypress/tests/integration/signals-analytics/analytics-report/compareBy.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/compareBy.spec.js
@@ -226,11 +226,15 @@ describe('Analytics Report - Compare By', () => {
       Array(7)
         .fill()
         .forEach((_item, index) => {
-          cy.findByRole('button', { name: 'Add Subaccount' }).click();
+          cy.findByRole('button', { name: 'Add Subaccount' })
+            .scrollIntoView()
+            .click();
           cy.findAllByLabelText('Subaccount')
             .eq(index + 2)
             .type('Fake Subaccount');
           cy.findByText(`Fake Subaccount ${index + 3} (ID 10${index + 3})`)
+            .scrollIntoView()
+
             .should('be.visible')
             .click();
         });
@@ -238,8 +242,12 @@ describe('Analytics Report - Compare By', () => {
       cy.findByRole('button', { name: 'Add Subaccount' }).click();
       cy.findAllByLabelText('Subaccount')
         .eq(9)
+        .scrollIntoView()
+
         .type('Fake Subaccount');
       cy.findByText(`Fake Subaccount 10 (ID 110)`)
+        .scrollIntoView()
+
         .should('be.visible')
         .click();
 

--- a/cypress/tests/integration/signals-analytics/analytics-report/compareBy.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/compareBy.spec.js
@@ -215,7 +215,7 @@ describe('Analytics Report - Compare By', () => {
         .type('Fake Subaccount');
       cy.findByText('Fake Subaccount 1 (ID 101)')
         .should('be.visible')
-        .click();
+        .click({ force: true });
       cy.findAllByLabelText('Subaccount')
         .eq(1)
         .type('Fake Subaccount');
@@ -228,7 +228,7 @@ describe('Analytics Report - Compare By', () => {
         .forEach((_item, index) => {
           cy.findByRole('button', { name: 'Add Subaccount' })
             .scrollIntoView()
-            .click();
+            .click({ force: true });
           cy.findAllByLabelText('Subaccount')
             .eq(index + 2)
             .scrollIntoView()
@@ -241,17 +241,14 @@ describe('Analytics Report - Compare By', () => {
 
       cy.findByRole('button', { name: 'Add Subaccount' })
         .scrollIntoView()
-        .click();
+        .click({ force: true });
       cy.findAllByLabelText('Subaccount')
         .eq(9)
         .scrollIntoView()
-
-        .scrollIntoView()
-
         .type('Fake Subaccount');
+
       cy.findByText(`Fake Subaccount 10 (ID 110)`)
         .scrollIntoView()
-
         .should('be.visible')
         .click();
 
@@ -263,9 +260,8 @@ describe('Analytics Report - Compare By', () => {
       cy.findAllByRole('button', { name: 'Remove Filter' })
         .eq(8)
         .scrollIntoView()
-
         .should('be.visible')
-        .click();
+        .click({ force: true });
 
       cy.findByText('Limit on number of comparisons reached').should('not.exist');
     });

--- a/src/components/typeahead/AsyncComboBoxTypeahead.js
+++ b/src/components/typeahead/AsyncComboBoxTypeahead.js
@@ -42,7 +42,7 @@ export const ComboBoxTypeahead = ({
   useEffect(() => {
     onInputChange(debouncedValue);
   }, [onInputChange, debouncedValue]);
-  const [debounceInputChange] = useDebouncedCallback(setDebouncedValue, 300);
+  const [debounceInputChange] = useDebouncedCallback(setDebouncedValue, 500);
 
   useEffect(() => {
     debounceInputChange(inputValue);

--- a/src/helpers/api/domains.js
+++ b/src/helpers/api/domains.js
@@ -1,7 +1,6 @@
-export function getSendingDomains(params) {
+export function getSendingDomains() {
   return {
     method: 'GET',
     url: '/v1/sending-domains',
-    params,
   };
 }

--- a/src/helpers/api/domains.js
+++ b/src/helpers/api/domains.js
@@ -1,0 +1,7 @@
+export function getSendingDomains(params) {
+  return {
+    method: 'GET',
+    url: '/v1/sending-domains',
+    params,
+  };
+}

--- a/src/helpers/api/metrics.js
+++ b/src/helpers/api/metrics.js
@@ -25,6 +25,14 @@ export function getSendingIps(params) {
   };
 }
 
+export function getIpPools(params) {
+  return {
+    method: 'GET',
+    url: `${METRICS_BASE_URL}/ip-pools`,
+    params: { ...params, rollup: true },
+  };
+}
+
 export function getTemplates(params) {
   return {
     method: 'GET',

--- a/src/helpers/api/selectors/metrics.js
+++ b/src/helpers/api/selectors/metrics.js
@@ -1,0 +1,42 @@
+export const selectRecipientDomains = ({ domains = [] } = {}) =>
+  domains.map(value => ({
+    type: 'Recipient Domain',
+    value,
+  }));
+
+export const selectSubaccounts = (subaccounts = []) =>
+  subaccounts.map(({ name, id }) => ({
+    type: 'Subaccount',
+    value: `${name} (ID ${id})`,
+    id,
+  }));
+
+export const selectSendingDomains = (sendingDomains = []) =>
+  sendingDomains.map(({ domain }) => ({
+    type: 'Sending Domain',
+    value: domain,
+  }));
+
+export const selectCampaigns = ({ campaigns = [] } = {}) =>
+  campaigns.map(value => ({
+    type: 'Campaign',
+    value,
+  }));
+
+export const selectSendingIps = ({ sendingIps = [] } = {}) =>
+  sendingIps.map(value => ({
+    type: 'Sending IP',
+    value,
+  }));
+
+export const selectIpPools = ({ ipPools = [] } = {}) =>
+  ipPools.map(value => ({
+    type: 'IP Pool',
+    value,
+  }));
+
+export const selectTemplates = ({ templates = [] } = {}) =>
+  templates.map(value => ({
+    type: 'Template',
+    value,
+  }));

--- a/src/helpers/api/subaccounts.js
+++ b/src/helpers/api/subaccounts.js
@@ -1,0 +1,7 @@
+export function getSubaccounts(params) {
+  return {
+    method: 'GET',
+    url: '/v1/subaccounts',
+    params: { ...params },
+  };
+}

--- a/src/helpers/api/subaccounts.js
+++ b/src/helpers/api/subaccounts.js
@@ -1,7 +1,6 @@
-export function getSubaccounts(params) {
+export function getSubaccounts() {
   return {
     method: 'GET',
     url: '/v1/subaccounts',
-    params: { ...params },
   };
 }

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -1,5 +1,4 @@
 import React, { useReducer } from 'react';
-import { connect } from 'react-redux';
 import {
   Banner,
   Box,
@@ -13,15 +12,24 @@ import { REPORT_BUILDER_FILTER_KEY_MAP } from 'src/constants';
 import { Add, Close } from '@sparkpost/matchbox-icons';
 import { TranslatableText, Comparison } from 'src/components/text';
 import {
-  fetchMetricsDomains,
-  fetchMetricsCampaigns,
-  fetchMetricsSendingIps,
-  fetchMetricsIpPools,
-  fetchMetricsTemplates,
-} from 'src/actions/metrics';
-import { list as listSubaccounts } from 'src/actions/subaccounts';
-import { list as listSendingDomains } from 'src/actions/sendingDomains';
-import { selectCacheReportBuilder } from 'src/selectors/reportFilterTypeaheadCache';
+  getDomains,
+  getCampaigns,
+  getSendingIps,
+  getTemplates,
+  getIpPools,
+} from 'src/helpers/api/metrics';
+import { getSendingDomains } from 'src/helpers/api/domains';
+import { getSubaccounts } from 'src/helpers/api/subaccounts';
+import {
+  selectRecipientDomains,
+  selectCampaigns,
+  selectIpPools,
+  selectSendingDomains,
+  selectSendingIps,
+  selectSubaccounts,
+  selectTemplates,
+} from 'src/helpers/api/selectors/metrics';
+
 import { useReportBuilderContext } from '../../context/ReportBuilderContext';
 import { getQueryFromOptionsV2 } from 'src/helpers/metrics';
 import Typeahead from './Typeahead';
@@ -101,18 +109,7 @@ const getInitialState = comparisons => {
   };
 };
 
-function CompareByForm({
-  // reportOptions,
-  fetchMetricsDomains,
-  fetchMetricsCampaigns,
-  fetchMetricsSendingIps,
-  fetchMetricsIpPools,
-  fetchMetricsTemplates,
-  listSubaccounts,
-  listSendingDomains,
-  typeaheadCache,
-  handleSubmit,
-}) {
+function CompareByForm({ handleSubmit }) {
   const { state: reportOptions } = useReportBuilderContext();
   const { comparisons, to, from } = reportOptions;
   const [state, dispatch] = useReducer(reducer, getInitialState(comparisons));
@@ -143,42 +140,50 @@ function CompareByForm({
     {
       label: 'Recipient Domain',
       value: 'domains',
-      action: fetchMetricsDomains,
+      action: getDomains,
+      selector: selectRecipientDomains,
     },
     {
       label: 'Sending IP',
       value: 'sending_ips',
-      action: fetchMetricsSendingIps,
+      action: getSendingIps,
+      selector: selectSendingIps,
     },
     {
       label: 'IP Pool',
       value: 'ip_pools',
-      action: fetchMetricsIpPools,
+      action: getIpPools,
+      selector: selectIpPools,
     },
     {
       label: 'Campaign',
       value: 'campaigns',
-      action: fetchMetricsCampaigns,
+      action: getCampaigns,
+      selector: selectCampaigns,
     },
     {
       label: 'Template',
       value: 'templates',
-      action: fetchMetricsTemplates,
+      action: getTemplates,
+      selector: selectTemplates,
     },
     {
       label: 'Sending Domain',
       value: 'sending_domains',
-      action: listSendingDomains,
+      action: getSendingDomains,
+      selector: selectSendingDomains,
     },
     {
       label: 'Subaccount',
       value: 'subaccounts',
-      action: listSubaccounts,
+      action: getSubaccounts,
+      selector: selectSubaccounts,
     },
   ];
 
   const filterConfig = FILTER_TYPES.find(item => item.value === filterType);
   const filterAction = filterConfig?.action;
+  const filterSelector = filterConfig?.selector;
   const filterLabel = filterConfig?.label;
 
   const areInputsFilled = filters.every(filter => filter !== null);
@@ -200,11 +205,6 @@ function CompareByForm({
           />
           {filterType &&
             filters.map((filter, index) => {
-              const filteredTypeaheadResults = typeaheadCache[filterLabel]?.filter(
-                typeaheadItem => {
-                  return !filters.some(filter => typeaheadItem.value === filter?.value);
-                },
-              );
               return (
                 <Box key={`filter-typeahead-${index}`} position="relative">
                   {index > 0 && filter && filters.length > 2 ? (
@@ -219,13 +219,13 @@ function CompareByForm({
                       <Typeahead
                         id={`typeahead-${index}`}
                         lookaheadRequest={filterAction}
+                        selector={filterSelector}
                         lookaheadOptions={getQueryFromOptionsV2({ to, from })}
                         label={filterLabel}
                         labelHidden
                         dispatch={dispatch}
                         itemToString={item => (item?.value ? item.value : '')}
                         selectedItem={filter}
-                        results={filteredTypeaheadResults}
                         onChange={value => {
                           dispatch({ type: 'SET_FILTER', index, value });
                         }}
@@ -293,12 +293,4 @@ function CompareByForm({
   );
 }
 
-export default connect(state => ({ typeaheadCache: selectCacheReportBuilder(state) }), {
-  fetchMetricsDomains,
-  fetchMetricsCampaigns,
-  fetchMetricsSendingIps,
-  fetchMetricsIpPools,
-  fetchMetricsTemplates,
-  listSubaccounts,
-  listSendingDomains,
-})(CompareByForm);
+export default CompareByForm;

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -23,6 +23,7 @@ import { list as listSubaccounts } from 'src/actions/subaccounts';
 import { list as listSendingDomains } from 'src/actions/sendingDomains';
 import { selectCacheReportBuilder } from 'src/selectors/reportFilterTypeaheadCache';
 import { useReportBuilderContext } from '../../context/ReportBuilderContext';
+import { getQueryFromOptionsV2 } from 'src/helpers/metrics';
 import Typeahead from './Typeahead';
 import styled from 'styled-components';
 
@@ -113,7 +114,7 @@ function CompareByForm({
   handleSubmit,
 }) {
   const { state: reportOptions } = useReportBuilderContext();
-  const { comparisons } = reportOptions;
+  const { comparisons, to, from } = reportOptions;
   const [state, dispatch] = useReducer(reducer, getInitialState(comparisons));
   const { filters, filterType, hasMinComparisonsError, hasMaxComparisonsError } = state;
 
@@ -218,6 +219,7 @@ function CompareByForm({
                       <Typeahead
                         id={`typeahead-${index}`}
                         lookaheadRequest={filterAction}
+                        lookaheadOptions={getQueryFromOptionsV2({ to, from })}
                         label={filterLabel}
                         labelHidden
                         dispatch={dispatch}

--- a/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
+++ b/src/pages/reportBuilder/components/CompareByForm/CompareByForm.js
@@ -187,7 +187,7 @@ function CompareByForm({ handleSubmit }) {
   const filterLabel = filterConfig?.label;
 
   const areInputsFilled = filters.every(filter => filter !== null);
-
+  const { to: formattedTo, from: formattedFrom } = getQueryFromOptionsV2({ to, from });
   return (
     <form onSubmit={handleFormSubmit}>
       <Box padding="500" paddingBottom="8rem">
@@ -220,7 +220,7 @@ function CompareByForm({ handleSubmit }) {
                         id={`typeahead-${index}`}
                         lookaheadRequest={filterAction}
                         selector={filterSelector}
-                        lookaheadOptions={getQueryFromOptionsV2({ to, from })}
+                        lookaheadOptions={{ to: formattedTo, from: formattedFrom }}
                         label={filterLabel}
                         labelHidden
                         dispatch={dispatch}

--- a/src/pages/reportBuilder/components/CompareByForm/Typeahead.js
+++ b/src/pages/reportBuilder/components/CompareByForm/Typeahead.js
@@ -238,7 +238,7 @@ const AsyncTypeaheadReducer = (state, action) => {
   }
 };
 
-function Typeahead({ id, onChange, lookaheadRequest, results = [], ...rest }) {
+function Typeahead({ id, onChange, lookaheadRequest, results = [], lookaheadOptions, ...rest }) {
   const [state, dispatch] = useReducer(AsyncTypeaheadReducer, initState);
   const { omitResults, loading, inputValue } = state;
 
@@ -254,6 +254,7 @@ function Typeahead({ id, onChange, lookaheadRequest, results = [], ...rest }) {
 
       dispatch({ type: 'SET_LOADING' });
       const options = {
+        ...lookaheadOptions,
         match: pattern,
         limit: METRICS_API_LIMIT,
       };
@@ -261,7 +262,7 @@ function Typeahead({ id, onChange, lookaheadRequest, results = [], ...rest }) {
         dispatch({ type: 'SET_READY' });
       });
     },
-    [lookaheadRequest, dispatch],
+    [lookaheadRequest, lookaheadOptions],
   );
 
   const filteredResults = useMemo(() => {

--- a/src/pages/reportBuilder/components/CompareByForm/Typeahead.js
+++ b/src/pages/reportBuilder/components/CompareByForm/Typeahead.js
@@ -228,7 +228,7 @@ function Typeahead({ id, onChange, lookaheadRequest, lookaheadOptions, selector,
         match: inputValue,
         limit: METRICS_API_LIMIT,
       }),
-    { enabled: inputValue && inputValue.length >= 3 },
+    { enabled: inputValue && inputValue.length >= 3, refetchOnWindowFocus: false },
   );
   const results = selector(data);
 

--- a/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
+++ b/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
@@ -147,6 +147,8 @@ function FiltersForm({ handleSubmit }) {
     };
   });
 
+  const { to: formattedTo, from: formattedFrom } = getQueryFromOptionsV2({ to, from });
+
   return (
     <form onSubmit={handleFormSubmit}>
       <Box padding="500" paddingBottom="8rem">
@@ -219,7 +221,7 @@ function FiltersForm({ handleSubmit }) {
                                 <Typeahead
                                   id={`typeahead-${groupingIndex}-${filterIndex}`}
                                   lookaheadRequest={filterRequest}
-                                  lookaheadOptions={getQueryFromOptionsV2({ to, from })}
+                                  lookaheadOptions={{ to: formattedTo, from: formattedFrom }}
                                   selector={filterSelector}
                                   itemToString={item => (item?.value ? item.value : '')}
                                   groupingIndex={groupingIndex}

--- a/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
+++ b/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
@@ -36,6 +36,7 @@ import {
   TypeSelect,
 } from './components';
 import useFiltersForm from './useFiltersForm';
+import { getQueryFromOptionsV2 } from 'src/helpers/metrics';
 
 const FILTER_VALUE_PLACEHOLDER_TEXT = 'e.g. resource_01 or resource_02';
 
@@ -66,7 +67,7 @@ function FiltersForm({
   } = actions;
   const groupings = getGroupingFields(state.groupings);
   const { state: reportOptions } = useReportBuilderContext();
-  const { filters } = reportOptions;
+  const { filters, to, from } = reportOptions;
 
   function handleFormSubmit(e) {
     e.preventDefault(); // Prevents page refresh
@@ -212,6 +213,7 @@ function FiltersForm({
                                 <Typeahead
                                   id={`typeahead-${groupingIndex}-${filterIndex}`}
                                   lookaheadRequest={filterRequest}
+                                  lookaheadOptions={getQueryFromOptionsV2({ to, from })}
                                   itemToString={item => (item?.value ? item.value : '')}
                                   groupingIndex={groupingIndex}
                                   filterType={filter.type}

--- a/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
+++ b/src/pages/reportBuilder/components/FiltersForm/FiltersForm.js
@@ -1,16 +1,24 @@
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
 import _ from 'lodash';
+
 import {
-  fetchMetricsDomains,
-  fetchMetricsCampaigns,
-  fetchMetricsSendingIps,
-  fetchMetricsIpPools,
-  fetchMetricsTemplates,
-} from 'src/actions/metrics';
-import { list as listSubaccounts } from 'src/actions/subaccounts';
-import { list as listSendingDomains } from 'src/actions/sendingDomains';
-import { selectCacheReportBuilder } from 'src/selectors/reportFilterTypeaheadCache';
+  getDomains,
+  getCampaigns,
+  getSendingIps,
+  getTemplates,
+  getIpPools,
+} from 'src/helpers/api/metrics';
+import { getSendingDomains } from 'src/helpers/api/domains';
+import { getSubaccounts } from 'src/helpers/api/subaccounts';
+import {
+  selectRecipientDomains,
+  selectCampaigns,
+  selectIpPools,
+  selectSendingDomains,
+  selectSendingIps,
+  selectSubaccounts,
+  selectTemplates,
+} from 'src/helpers/api/selectors/metrics';
 import { RadioButtonGroup } from 'src/components';
 import {
   Button,
@@ -40,17 +48,7 @@ import { getQueryFromOptionsV2 } from 'src/helpers/metrics';
 
 const FILTER_VALUE_PLACEHOLDER_TEXT = 'e.g. resource_01 or resource_02';
 
-function FiltersForm({
-  handleSubmit,
-  fetchMetricsDomains,
-  listSubaccounts,
-  fetchMetricsCampaigns,
-  fetchMetricsTemplates,
-  listSendingDomains,
-  fetchMetricsIpPools,
-  fetchMetricsSendingIps,
-  typeaheadCache,
-}) {
+function FiltersForm({ handleSubmit }) {
   const { state, actions } = useFiltersForm();
   const { status } = state;
   const {
@@ -100,37 +98,44 @@ function FiltersForm({
     {
       label: 'Recipient Domain',
       value: 'domains',
-      action: fetchMetricsDomains,
+      action: getDomains,
+      selector: selectRecipientDomains,
     },
     {
       label: 'Sending IP',
       value: 'sending_ips',
-      action: fetchMetricsSendingIps,
+      action: getSendingIps,
+      selector: selectSendingIps,
     },
     {
       label: 'IP Pool',
       value: 'ip_pools',
-      action: fetchMetricsIpPools,
+      action: getIpPools,
+      selector: selectIpPools,
     },
     {
       label: 'Campaign',
       value: 'campaigns',
-      action: fetchMetricsCampaigns,
+      action: getCampaigns,
+      selector: selectCampaigns,
     },
     {
       label: 'Template',
       value: 'templates',
-      action: fetchMetricsTemplates,
+      action: getTemplates,
+      selector: selectTemplates,
     },
     {
       label: 'Sending Domain',
       value: 'sending_domains',
-      action: listSendingDomains,
+      action: getSendingDomains,
+      selector: selectSendingDomains,
     },
     {
       label: 'Subaccount',
       value: 'subaccounts',
-      action: listSubaccounts,
+      action: getSubaccounts,
+      selector: selectSubaccounts,
     },
   ];
 
@@ -155,6 +160,7 @@ function FiltersForm({
                       const filterConfig = FILTERS.find(item => item.value === filter.type); // Find the matching configuration entry
                       const filterRequest = filterConfig?.action;
                       const filterLabel = filterConfig?.label;
+                      const filterSelector = filterConfig?.selector;
                       const filterValue = filterConfig?.value;
 
                       return (
@@ -214,6 +220,7 @@ function FiltersForm({
                                   id={`typeahead-${groupingIndex}-${filterIndex}`}
                                   lookaheadRequest={filterRequest}
                                   lookaheadOptions={getQueryFromOptionsV2({ to, from })}
+                                  selector={filterSelector}
                                   itemToString={item => (item?.value ? item.value : '')}
                                   groupingIndex={groupingIndex}
                                   filterType={filter.type}
@@ -222,7 +229,6 @@ function FiltersForm({
                                   value={filter.values}
                                   type={filterLabel}
                                   label={filterLabel}
-                                  results={typeaheadCache[filterLabel]}
                                   placeholder={FILTER_VALUE_PLACEHOLDER_TEXT}
                                 />
                               ) : null}
@@ -364,12 +370,4 @@ function FiltersForm({
   );
 }
 
-export default connect(state => ({ typeaheadCache: selectCacheReportBuilder(state) }), {
-  fetchMetricsDomains,
-  fetchMetricsCampaigns,
-  fetchMetricsSendingIps,
-  fetchMetricsIpPools,
-  fetchMetricsTemplates,
-  listSubaccounts,
-  listSendingDomains,
-})(FiltersForm);
+export default FiltersForm;

--- a/src/pages/reportBuilder/components/Typeahead.js
+++ b/src/pages/reportBuilder/components/Typeahead.js
@@ -17,6 +17,7 @@ function Typeahead(props) {
     setFilterValues,
     index,
     lookaheadRequest,
+    lookaheadOptions = {},
     value,
     results = [],
     itemToString,
@@ -49,7 +50,9 @@ function Typeahead(props) {
 
       setOmitResults(false);
       setLoading(true);
+
       const options = {
+        ...lookaheadOptions,
         match: pattern,
         limit: METRICS_API_LIMIT,
       };
@@ -57,7 +60,7 @@ function Typeahead(props) {
         setLoading(false);
       });
     },
-    [setLoading, setOmitResults, lookaheadRequest, setInputValue],
+    [setLoading, setOmitResults, lookaheadRequest, setInputValue, lookaheadOptions],
   );
 
   const filteredResults = useMemo(() => {

--- a/src/pages/reportBuilder/components/Typeahead.js
+++ b/src/pages/reportBuilder/components/Typeahead.js
@@ -36,7 +36,7 @@ function Typeahead(props) {
         match: inputValue,
         limit: METRICS_API_LIMIT,
       }),
-    { enabled: inputValue && inputValue.length >= 3 },
+    { enabled: inputValue && inputValue.length >= 3, refetchOnWindowFocus: false },
   );
   const results = selector(data);
 


### PR DESCRIPTION
### What Changed

- Typeahead now passes to/from dates
- Typeahead now uses react-query to help with caching
- Typeahead now has debounce of 500ms

### How To Test

- Go to report builder
- Verify that typeaheads pass in proper params in filters form
- Verify that typeahesds pass in proper params in compare by
- Verify that typeaheads have longer debounce time

### To Do

- [ ] Address feedback
