### PR TITLE
FE-1298 - Recommend using a subdomain when creating

### DIFF
--- a/cypress/tests/integration/configuration/domains/createPage.spec.js
+++ b/cypress/tests/integration/configuration/domains/createPage.spec.js
@@ -29,6 +29,15 @@ describe('The domains create page', () => {
       .should('be.checked');
     cy.findByLabelText('Assign to Primary Account').should('be.visible');
     cy.findByLabelText('Assign to Subaccount').should('be.visible');
+
+    cy.get('p')
+      .contains('Using a subdomain is recommended e.g. sub.domain.com')
+      .should('be.visible');
+    cy.get('p')
+      .contains(
+        'It may not be possible to completely configure DNS records using the organizational domain.',
+      )
+      .should('be.visible');
   });
 
   it('creates a new sending domain assigned to all subaccounts', () => {
@@ -191,6 +200,7 @@ describe('The domains create page', () => {
     cy.title().should('include', 'Verify Bounce Domain | Domains');
     cy.findByRole('heading', { name: 'Verify Bounce Domain' }).should('be.visible');
   });
+
   it('creates a new bounce domain for the Assign to Primary Account', () => {
     commonBeforeSteps();
     stubSendingDomainsPostReq();
@@ -218,6 +228,7 @@ describe('The domains create page', () => {
     cy.title().should('include', 'Verify Bounce Domain | Domains');
     cy.findByRole('heading', { name: 'Verify Bounce Domain' }).should('be.visible');
   });
+
   it('creates a new Bounce domain for the assigned subaccount', () => {
     commonBeforeSteps();
     stubSendingDomainsPostReq();
@@ -251,6 +262,7 @@ describe('The domains create page', () => {
     cy.title().should('include', 'Verify Bounce Domain | Domains');
     cy.findByRole('heading', { name: 'Verify Bounce Domain' }).should('be.visible');
   });
+
   it('creates a new tracking domain', () => {
     commonBeforeSteps();
     stubTrackingDomainsPostReq();

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -193,8 +193,8 @@ export default function CreateForm() {
             </Banner>
             <Box mt="400">
               <SubduedText fontSize="200">
-                It may not be possible to completely configure your DNS records if you use your
-                organizational domain.
+                It may not be possible to completely configure DNS records using the organizational
+                domain.
               </SubduedText>
             </Box>
           </Layout.Section>

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -189,7 +189,7 @@ export default function CreateForm() {
           <Layout.Section annotated>
             <Layout.SectionTitle>Domain and Assignment</Layout.SectionTitle>
             <Banner status="warning" size="small">
-              <p>We recommend using a subdomain e.g. sub.domain.com</p>
+              <p>Using a subdomain is recommended e.g. sub.domain.com</p>
             </Banner>
             <Box mt="400">
               <SubduedText fontSize="200">

--- a/src/pages/domains/components/CreateForm.js
+++ b/src/pages/domains/components/CreateForm.js
@@ -5,6 +5,7 @@ import { LINKS } from 'src/constants';
 import { Abbreviation } from 'src/components';
 import {
   Box,
+  Banner,
   Button,
   Layout,
   Panel,
@@ -187,12 +188,15 @@ export default function CreateForm() {
         <Layout>
           <Layout.Section annotated>
             <Layout.SectionTitle>Domain and Assignment</Layout.SectionTitle>
-
-            <SubduedText fontSize="200">
-              We recommend using a subdomain e.g. mail.mydomain.com. Depending on how you want to
-              use your domain, you may not be able to completely configure your DNS records if you
-              use your organizational domain.
-            </SubduedText>
+            <Banner status="warning" size="small">
+              <p>We recommend using a subdomain e.g. sub.domain.com</p>
+            </Banner>
+            <Box mt="400">
+              <SubduedText fontSize="200">
+                It may not be possible to completely configure your DNS records if you use your
+                organizational domain.
+              </SubduedText>
+            </Box>
           </Layout.Section>
 
           <Layout.Section>


### PR DESCRIPTION
### What Changed
- Added a mini banner in the domain and assignment to draw attention to using a subdomain and not a root domain.

### How To Test
- Go to the domain create form/page.
- Look at the left sidebar for the "domain and assignment" section.

### To Do
- [x] Talk with UX about no dismiss action. (no dismiss is fine)
- [x] Talk with UX about pronoun usage. (got updated verbiage from UX after asking)
- [x] Ask UX if the mini banner should always show or only after they select bounce domain to create. (always show banner)
- [ ] Feedback
