### PR TITLE
FE-1361 - Hide upgrade link for manually billed subscriptions

### DIFF
--- a/cypress/tests/integration/dashboard/dashboardPage.spec.js
+++ b/cypress/tests/integration/dashboard/dashboardPage.spec.js
@@ -594,9 +594,7 @@ describe('the dashboard page', () => {
       '@dataGetTimeSeries',
       '@dataGetDeliverability',
     ]);
-    cy.get('a')
-      .contains('Upgrade')
-      .should('not.exist');
+    cy.findByRole('link', { name: 'Upgrade' }).should('not.exist');
   });
 
   describe('sidebar', () => {

--- a/cypress/tests/integration/dashboard/dashboardPage.spec.js
+++ b/cypress/tests/integration/dashboard/dashboardPage.spec.js
@@ -560,6 +560,45 @@ describe('the dashboard page', () => {
     cy.findByDataId('validations-usage-section').should('not.exist');
   });
 
+  it('does not render the "Upgrade" link for manually billed customers', () => {
+    stubAccountsReq();
+    stubAlertsReq();
+    stubUsageReq({ fixture: 'usage/200.get.messaging.json' });
+    stubReportsRequest();
+    stubSubscription({ fixture: 'billing/subscription/200.get.manually-billed.json' });
+    cy.stubRequest({
+      url: '/api/v1/subaccounts',
+      fixture: 'subaccounts/200.get.json',
+      requestAlias: 'subaccountsReq',
+    });
+    cy.stubRequest({
+      method: 'GET',
+      url: '/api/v1/metrics/deliverability**/**',
+      fixture: 'metrics/deliverability/200.get.json',
+      requestAlias: 'dataGetDeliverability',
+    });
+    cy.stubRequest({
+      method: 'GET',
+      url: '/api/v1/metrics/deliverability/time-series**/**',
+      fixture: 'metrics/deliverability/time-series/200.get.json',
+      requestAlias: 'dataGetTimeSeries',
+    });
+    cy.visit(PAGE_URL);
+    cy.wait([
+      '@accountReq',
+      '@alertsReq',
+      '@usageReq',
+      '@getReports',
+      '@getSubscription',
+      '@subaccountsReq',
+      '@dataGetTimeSeries',
+      '@dataGetDeliverability',
+    ]);
+    cy.get('a')
+      .contains('Upgrade')
+      .should('not.exist');
+  });
+
   describe('sidebar', () => {
     it("renders the user's email address and role  in the account details section", () => {
       commonBeforeSteps();
@@ -650,6 +689,17 @@ function commonBeforeSteps() {
 
   cy.visit(PAGE_URL);
   cy.wait(['@accountReq', '@usageReq', '@alertsReq']);
+}
+
+function stubSubscription({
+  fixture = 'billing/subscription/200.get.json',
+  requestAlias = 'getSubscription',
+}) {
+  cy.stubRequest({
+    url: '/api/v1/billing/subscription',
+    fixture,
+    requestAlias,
+  });
 }
 
 function stubAccountsReq({ fixture = 'account/200.get.dashboard-v2.json' } = {}) {

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 import { ROLES } from 'src/constants';
 import hasGrants from 'src/helpers/conditions/hasGrants';
 import { hasRole, isAdmin } from 'src/helpers/conditions/user';
+import { isManuallyBilled } from 'src/selectors/accountBillingInfo';
+import { getSubscription } from 'src/actions/billing';
 import { fetch as getAccount, getUsage } from 'src/actions/account';
 import { listAlerts } from 'src/actions/alerts';
 import { selectRecentlyTriggeredAlerts } from 'src/selectors/alerts';
@@ -93,13 +95,14 @@ function mapStateToProps(state) {
     validationsThisMonth: selectMonthlyRecipientValidationUsage(state),
     endOfBillingPeriod: selectEndOfBillingPeriod(state),
     pending: isPending,
-    hasUpgradeLink: hasGrants('account/manage')(state),
+    hasUpgradeLink: hasGrants('account/manage')(state) && !isManuallyBilled(state),
     hasUsageSection: isAdmin(state),
     reports: state.reports.list,
   };
 }
 
 const mapDispatchToProps = {
+  getSubscription,
   getAccount,
   getReports,
   listAlerts,

--- a/src/pages/dashboardV2/DashboardPageV2.container.js
+++ b/src/pages/dashboardV2/DashboardPageV2.container.js
@@ -4,7 +4,6 @@ import { ROLES } from 'src/constants';
 import hasGrants from 'src/helpers/conditions/hasGrants';
 import { hasRole, isAdmin } from 'src/helpers/conditions/user';
 import { isManuallyBilled } from 'src/selectors/accountBillingInfo';
-import { getSubscription } from 'src/actions/billing';
 import { fetch as getAccount, getUsage } from 'src/actions/account';
 import { listAlerts } from 'src/actions/alerts';
 import { selectRecentlyTriggeredAlerts } from 'src/selectors/alerts';
@@ -102,7 +101,6 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  getSubscription,
   getAccount,
   getReports,
   listAlerts,

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -52,6 +52,7 @@ export default function DashboardPageV2() {
     canViewUsage,
     canManageSendingDomains,
     canManageApiKeys,
+    getSubscription,
     getAccount,
     getReports,
     listAlerts,
@@ -79,6 +80,7 @@ export default function DashboardPageV2() {
   }, [onboarding]);
 
   useEffect(() => {
+    getSubscription();
     getAccount();
     listAlerts();
     if (canViewUsage) getUsage();
@@ -216,6 +218,7 @@ export default function DashboardPageV2() {
                   </Columns>
                 </Dashboard.Panel>
               )}
+
               {onboarding === 'addSending' && (
                 <Dashboard.Panel>
                   <Columns>

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -52,7 +52,6 @@ export default function DashboardPageV2() {
     canViewUsage,
     canManageSendingDomains,
     canManageApiKeys,
-    getSubscription,
     getAccount,
     getReports,
     listAlerts,
@@ -80,7 +79,6 @@ export default function DashboardPageV2() {
   }, [onboarding]);
 
   useEffect(() => {
-    getSubscription();
     getAccount();
     listAlerts();
     if (canViewUsage) getUsage();

--- a/src/pages/dashboardV2/components/Sidebar.js
+++ b/src/pages/dashboardV2/components/Sidebar.js
@@ -68,7 +68,7 @@ function BillingUsage() {
 
               {hasUpgradeLink && (
                 <UpgradeLink to="/account/billing/plan">
-                  Upgrade&nbsp;
+                  <span>Upgrade&nbsp;</span>
                   <UpgradeIcon size={16} />
                 </UpgradeLink>
               )}


### PR DESCRIPTION
### What Changed
- Used the account condition `isManuallyBilled` to determine `hasUpgradeLink`.
- When an account/user has a billing/subscription return type `manual` - hasUpgradeLink is set to false.
- a.k.a. Upgrade link hidden for manually billed customers.

### How To Test
- Have to have a manually billed account/user subscription type. I don't know how to actually set that or log in with that. I mocked the state using Cypress. 
- Log into a manually billed account then go to dashboard and verify no Upgrade link on the right sidebar.

### To Do
- [ ] Feedback
- [ ] Find or create manually billed account for staging and prod testing.
