### PR TITLE
FE-1364 - change green to darkGray

### DIFF
--- a/src/pages/domains/components/SendingDomainStatusCell.js
+++ b/src/pages/domains/components/SendingDomainStatusCell.js
@@ -37,9 +37,9 @@ export function SendingDomainStatusCell({ domain }) {
         </Tag>
       )}
 
-      {readyFor?.dkim && <Tag color="green">DKIM Signing</Tag>}
+      {readyFor?.dkim && <Tag color="darkGray">DKIM Signing</Tag>}
 
-      {status?.spf_status === 'valid' && <Tag color="green">SPF Valid</Tag>}
+      {status?.spf_status === 'valid' && <Tag color="darkGray">SPF Valid</Tag>}
     </Inline>
   );
 }

--- a/src/pages/domains/components/SendingDomainsTable.js
+++ b/src/pages/domains/components/SendingDomainsTable.js
@@ -109,7 +109,7 @@ function StatusCell({ row }) {
             <TranslatableText>Bounce</TranslatableText>
 
             {defaultBounceDomain && (
-              <Box color="green.700">
+              <Box color="darkGray">
                 <Tooltip content={tooltipContent} id={tooltipId}>
                   <div tabIndex="0" data-id="default-bounce-domain-tooltip">
                     <Bookmark />
@@ -121,9 +121,9 @@ function StatusCell({ row }) {
         </Tag>
       )}
 
-      {readyForDKIM && <Tag color="green">DKIM Signing</Tag>}
+      {readyForDKIM && <Tag color="darkGray">DKIM Signing</Tag>}
 
-      {validSPF && <Tag color="green">SPF Valid</Tag>}
+      {validSPF && <Tag color="darkGray">SPF Valid</Tag>}
     </Inline>
   );
 }

--- a/src/pages/domains/components/SendingDomainsTable.js
+++ b/src/pages/domains/components/SendingDomainsTable.js
@@ -109,7 +109,7 @@ function StatusCell({ row }) {
             <TranslatableText>Bounce</TranslatableText>
 
             {defaultBounceDomain && (
-              <Box color="darkGray">
+              <Box color="green.700">
                 <Tooltip content={tooltipContent} id={tooltipId}>
                   <div tabIndex="0" data-id="default-bounce-domain-tooltip">
                     <Bookmark />

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -45,7 +45,7 @@ export default function SetupForSending({ domain, isSectionVisible }) {
         </Layout.SectionTitle>
         {!readyFor.dkim && (
           <>
-            <Tag color="green" mb="200">
+            <Tag color="darkGray" mb="200">
               Recommended
             </Tag>
             <Stack>


### PR DESCRIPTION
### What Changed
- Change tag color green to darkGray for domain pages

Before: 
![image](https://user-images.githubusercontent.com/4204806/106802823-14960380-6629-11eb-877d-dffbdee1ce6b.png)

After:
![image](https://user-images.githubusercontent.com/4204806/106802840-1c55a800-6629-11eb-83ab-2ed8e069db2c.png)

Before:
![image](https://user-images.githubusercontent.com/4204806/106802863-24154c80-6629-11eb-94b6-f4c92b863019.png)

After:
![image](https://user-images.githubusercontent.com/4204806/106802882-2bd4f100-6629-11eb-95d1-5ee75ce3f7c3.png)

### How To Test
- Go to the domain list and details page and make sure the green tags on stage are now gray locally

### To Do
- [ ] Confirm with UX this is what they want
- [ ] Feedback
