### PR TITLE
FE-1340 - No domain status filters selected by default

### DIFF
--- a/src/pages/domains/components/DomainStatusSection.js
+++ b/src/pages/domains/components/DomainStatusSection.js
@@ -77,10 +77,10 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
     const isDefault = domain.defaultTrackingDomain;
     const domainStatus = {
       blocked: domain.blocked,
-      defaultTrackingDomain: domain.defaultTrackingDomain,
       unverified: domain.unverified,
       verified: domain.verified,
     };
+    const rowValues = { DomainStatus: domainStatus, defaultTrackingDomain: isDefault };
 
     return (
       <Layout>
@@ -108,7 +108,7 @@ export default function DomainStatusSection({ domain, id, isTracking }) {
                   <LabelValue orientation="vertical">
                     <LabelValue.Label>Status</LabelValue.Label>
                     <LabelValue.Value>
-                      <TrackingDomainStatusCell domainStatus={domainStatus} />
+                      <TrackingDomainStatusCell row={rowValues} />
                     </LabelValue.Value>
                   </LabelValue>
                 </Column>

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -221,7 +221,7 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
 
     // NOTE: Handles tab changes, ignores page load
 
-    if (renderBounceOnly === true) {
+    if (Boolean(renderBounceOnly)) {
       filtersInitialState.checkboxes.map(checkbox => {
         checkbox.isChecked = false;
         return checkbox;
@@ -237,9 +237,7 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
         unverified: flattenedFilters['unverified'],
         validSPF: flattenedFilters['validSPF'],
       };
-      if (!renderBounceOnly) {
-        domainStatusValues['readyForBounce'] = flattenedFilters['readyForBounce'];
-      }
+      domainStatusValues['readyForBounce'] = flattenedFilters['readyForBounce'];
       const reactTableFilters = getReactTableFilters({
         domainName: flattenedFilters['domainName'],
         DomainStatus: domainStatusValues, // NOTE: DomainStatus is the Header Key for react-table (needs to match)

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -62,6 +62,7 @@ const filtersInitialState = {
   ],
 };
 
+// For URL params
 const initFiltersForSending = {
   domainName: { defaultValue: undefined },
   readyForSending: {
@@ -186,6 +187,25 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
     [],
   );
 
+  const flattenedFilters = filterStateToParams(filtersState);
+
+  const domainStatusValues = {
+    blocked: flattenedFilters['blocked'],
+    readyForDKIM: flattenedFilters['readyForDKIM'],
+    readyForSending: flattenedFilters['readyForSending'],
+    unverified: flattenedFilters['unverified'],
+    validSPF: flattenedFilters['validSPF'],
+  };
+
+  if (!renderBounceOnly) {
+    domainStatusValues['readyForBounce'] = flattenedFilters['readyForBounce'];
+  }
+
+  const reactTableFilters = getReactTableFilters({
+    domainName: flattenedFilters['domainName'],
+    DomainStatus: domainStatusValues, // NOTE: DomainStatus is the Header Key for react-table (needs to match)
+  });
+
   const tableInstance = useTable(
     {
       columns,
@@ -194,7 +214,7 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
       initialState: {
         pageIndex: DEFAULT_CURRENT_PAGE - 1, // react-table takes a 0 base pageIndex
         pageSize: DEFAULT_PER_PAGE,
-        filters: [],
+        filters: reactTableFilters,
         sortBy: [
           {
             id: 'creationTime',

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -223,7 +223,6 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
     };
 
     if (!renderBounceOnly) {
-      // domainStatusValues['defaultBounceDomain'] = flattenedFilters['defaultBounceDomain'];
       domainStatusValues['readyForBounce'] = flattenedFilters['readyForBounce'];
     }
 

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -160,6 +160,7 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
       { Header: 'SharedWithSubaccounts', accessor: 'sharedWithSubaccounts', canFilter: false },
       { Header: 'SubaccountId', accessor: 'subaccountId', canFilter: false },
       { Header: 'SubaccountName', accessor: 'subaccountName', canFilter: false },
+      { Header: 'DefaultBounceDomain', accessor: 'defaultBounceDomain', canFilter: false },
       {
         Header: 'DomainStatus',
         accessor: row => ({

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -270,7 +270,7 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
 
   // synce query params -> page state on page load, and handle tab switching (sending and bounce)
   useEffect(() => {
-    if (!rows || (rows && rows.length === 0) || listPending) {
+    if (!rows || rows.length === 0 || listPending) {
       return;
     }
 

--- a/src/pages/domains/components/SendingDomainsTable.js
+++ b/src/pages/domains/components/SendingDomainsTable.js
@@ -39,7 +39,7 @@ export default function SendingDomainsTable({ tableInstance }) {
                 <MainCell row={row.values} />
               </Table.Cell>
               <Table.Cell>
-                <StatusCell row={row.values} />
+                <StatusCell row={row?.values} />
               </Table.Cell>
             </Table.Row>
           );
@@ -83,13 +83,13 @@ function MainCell({ row }) {
 function StatusCell({ row }) {
   const {
     blocked,
-    defaultBounceDomain,
     readyForBounce,
     readyForDKIM,
     readyForSending,
     validSPF,
     unverified,
   } = row.DomainStatus;
+  const { defaultBounceDomain } = row;
   const { subaccountId } = row;
 
   const tooltipId = useUniqueId('default-bounce-domain');

--- a/src/pages/domains/components/TableFilters.js
+++ b/src/pages/domains/components/TableFilters.js
@@ -177,7 +177,7 @@ function StatusPopover({ checkboxes, onCheckboxChange, disabled, domainType }) {
             {/* This content is purely visual and is not exposed to screen readers, rather, "Domain Status" is always exposed for those users */}
             <StatusPopoverContent aria-hidden="true">
               {/* Render the checked filters that visually replace the button's content */}
-              {!hasCheckedCheckboxes && 'None'}
+              {!hasCheckedCheckboxes && 'All'}
               {hasCheckedCheckboxes && allCheckboxesChecked && 'All'}
               {hasCheckedCheckboxes && !allCheckboxesChecked && activeStatusLabels}
             </StatusPopoverContent>

--- a/src/pages/domains/components/TrackingDomainStatusCell.js
+++ b/src/pages/domains/components/TrackingDomainStatusCell.js
@@ -4,8 +4,9 @@ import { Box, Inline, Tag, Tooltip } from 'src/components/matchbox';
 import { TranslatableText } from 'src/components/text';
 import useUniqueId from 'src/hooks/useUniqueId';
 
-export default function TrackingDomainStatusCell({ domainStatus }) {
-  const { defaultTrackingDomain, unverified, blocked } = domainStatus;
+export default function TrackingDomainStatusCell({ row }) {
+  const { defaultTrackingDomain } = row;
+  const { unverified, blocked } = row?.DomainStatus;
   const tooltipId = useUniqueId('default-tracking-domain');
 
   if (blocked) return <Tag color="red">Blocked</Tag>;

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useRef, useReducer } from 'react';
+import React, { useCallback, useReducer } from 'react';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import { ApiErrorBanner, Empty, Loading } from 'src/components';
 import { Pagination } from 'src/components/collection';
@@ -11,7 +11,6 @@ import TrackingDomainsTable from './TrackingDomainsTable';
 import {
   getReactTableFilters,
   customDomainStatusFilter,
-  getActiveStatusFilters,
   setCheckboxIsChecked,
   filterStateToParams,
 } from '../helpers';
@@ -97,6 +96,8 @@ export default function TrackingDomainsTab() {
     trackingDomainsListError,
   } = useDomains();
 
+  // TODO: Persist the selection
+  // eslint-disable-next-line no-unused-vars
   const { filters, updateFilters } = usePageFilters(initFiltersForTracking);
   const [filtersState, filtersStateDispatch] = useReducer(tableFiltersReducer, filtersInitialState);
 
@@ -148,43 +149,6 @@ export default function TrackingDomainsTab() {
   const { rows, setAllFilters, toggleSortBy, state, gotoPage, setPageSize } = tableInstance;
 
   const isEmpty = !listPending && rows?.length === 0;
-
-  // synce query params -> page state
-  const firstLoad = useRef(true);
-  useEffect(() => {
-    if (!rows || (rows && rows.length === 0) || listPending) {
-      return;
-    }
-
-    if (firstLoad.current) {
-      const allStatusCheckboxNames = Object.keys(filters).filter(i => i !== 'domainName'); // remove the domainName
-      const activeStatusFilters = getActiveStatusFilters(filters);
-      const statusFiltersToApply = !activeStatusFilters.length
-        ? allStatusCheckboxNames
-        : activeStatusFilters.map(i => i.name);
-
-      firstLoad.current = false;
-
-      let newFiltersState = {
-        ...filtersState,
-        checkboxes: filtersState.checkboxes.map(checkbox => {
-          return {
-            ...checkbox,
-            isChecked: statusFiltersToApply.indexOf(checkbox.name) >= 0,
-          };
-        }),
-      };
-      newFiltersState['domainName'] = filters['domainName'];
-
-      filtersStateDispatch({
-        type: 'LOAD',
-        filtersState: newFiltersState,
-      }); // NOTE: Sets the filters display
-      batchDispatchUrlAndTable(newFiltersState);
-      return;
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows, listPending]);
 
   function batchDispatchUrlAndTable(newFiltersState) {
     const flattenedFilters = filterStateToParams(newFiltersState);

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -26,22 +26,22 @@ const filtersInitialState = {
     {
       label: 'Select All',
       name: 'selectAll',
-      isChecked: true,
+      isChecked: false,
     },
     {
       label: 'Verified',
       name: 'verified',
-      isChecked: true,
+      isChecked: false,
     },
     {
       label: 'Unverified',
       name: 'unverified',
-      isChecked: true,
+      isChecked: false,
     },
     {
       label: 'Blocked',
       name: 'blocked',
-      isChecked: true,
+      isChecked: false,
     },
   ],
 };

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -165,7 +165,7 @@ export default function TrackingDomainsTab() {
   // synce query params -> page state
   const firstLoad = useRef(true);
   useEffect(() => {
-    if (!rows || (rows && rows.length === 0) || listPending) {
+    if (!rows || rows.length === 0 || listPending) {
       return;
     }
 

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -123,6 +123,20 @@ export default function TrackingDomainsTab() {
   );
 
   const sortBy = React.useMemo(() => [{ id: 'domainName', desc: false }], []);
+
+  const flattenedFilters = filterStateToParams(filtersState);
+
+  const domainStatusValues = {
+    blocked: flattenedFilters['blocked'],
+    unverified: flattenedFilters['unverified'],
+    verified: flattenedFilters['verified'],
+  };
+
+  const reactTableFilters = getReactTableFilters({
+    domainName: flattenedFilters['domainName'],
+    DomainStatus: domainStatusValues,
+  });
+
   const tableInstance = useTable(
     {
       columns,
@@ -131,7 +145,7 @@ export default function TrackingDomainsTab() {
       initialState: {
         pageIndex: DEFAULT_CURRENT_PAGE - 1, // react-table takes a 0 base pageIndex
         pageSize: DEFAULT_PER_PAGE,
-        filters: [],
+        filters: reactTableFilters,
         sortBy: [
           {
             id: 'domainName',

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -97,8 +97,6 @@ export default function TrackingDomainsTab() {
     trackingDomainsListError,
   } = useDomains();
 
-  // TODO: Persist the selection
-  // eslint-disable-next-line no-unused-vars
   const { filters, updateFilters } = usePageFilters(initFiltersForTracking);
   const [filtersState, filtersStateDispatch] = useReducer(tableFiltersReducer, filtersInitialState);
 

--- a/src/pages/domains/components/TrackingDomainsTab.js
+++ b/src/pages/domains/components/TrackingDomainsTab.js
@@ -114,7 +114,6 @@ export default function TrackingDomainsTab() {
         Header: 'DomainStatus',
         accessor: row => ({
           blocked: row.blocked,
-          defaultTrackingDomain: row.defaultTrackingDomain,
           unverified: row.unverified,
           verified: row.verified,
         }),
@@ -157,7 +156,6 @@ export default function TrackingDomainsTab() {
 
     const domainStatusValues = {
       blocked: flattenedFilters['blocked'],
-      defaultTrackingDomain: flattenedFilters['defaultTrackingDomain'],
       unverified: flattenedFilters['unverified'],
       verified: flattenedFilters['verified'],
     };

--- a/src/pages/domains/components/TrackingDomainsTable.js
+++ b/src/pages/domains/components/TrackingDomainsTable.js
@@ -22,6 +22,7 @@ export default function TrackingDomainsTable({ tableInstance }) {
       <tbody>
         {page?.map((row, index) => {
           prepareRow(row);
+
           return (
             <Table.Row key={`table-row-${index}`}>
               <Table.Cell>
@@ -29,7 +30,7 @@ export default function TrackingDomainsTable({ tableInstance }) {
               </Table.Cell>
 
               <Table.Cell>
-                <TrackingDomainStatusCell domainStatus={row?.values?.DomainStatus} />
+                <TrackingDomainStatusCell row={row?.values} />
               </Table.Cell>
             </Table.Row>
           );

--- a/src/pages/domains/helpers/customDomainStatusFilter.js
+++ b/src/pages/domains/helpers/customDomainStatusFilter.js
@@ -6,6 +6,15 @@
 const customDomainStatusFilter = function(rows, columnIds, value) {
   const appliedFilters = value;
   const tableColumnName = columnIds[0];
+  const noneSelected = Object.keys(appliedFilters)
+    .map(i => appliedFilters[i])
+    .every(i => i === false);
+
+  // none = all, dont filter
+  if (noneSelected) {
+    return rows;
+  }
+
   const mappedRows = rows
     .map(row => {
       let trueForAtleastOne = 0;


### PR DESCRIPTION
### What Changed
- All domain status filters are unchecked by default, then preserved using the url query params between page loads and using the browser back button.
- Clears filter state when switching from sending -> bounce tab. (request from UX)
- Leaves filter state when switching from bounce -> sending tab. (request from UX)

### How To Test
- go to /domains/list/sending and test the domain status filter on all three tabs
- test navigating away from the page and using the browser back button
- Test landing the page, updating the filters, switching between the tabs and refreshing the page (note the filter state reset logic mentioned in "what changed")

### To Do
- [ ] Feedback
