### PR TITLE
FE-1367 - Addresses test flakiness for templates create page spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
   version: 2
   test-and-build:
     jobs:
-      # - 'Unit Testing'
+      - 'Unit Testing'
       - 'Build'
       - 'Integration Testing':
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
   version: 2
   test-and-build:
     jobs:
-      - 'Unit Testing'
+      # - 'Unit Testing'
       - 'Build'
       - 'Integration Testing':
           requires:

--- a/cypress/tests/integration/content/templates/createPage.spec.js
+++ b/cypress/tests/integration/content/templates/createPage.spec.js
@@ -213,6 +213,14 @@ describe('The create template page', () => {
       cy.findByRole('button', { name: 'Save and Publish' }).click();
     });
     cy.wait('@publishTemplate');
+    cy.url().should('include', 'published');
+    cy.wait([
+      '@getTemplate',
+      '@stubbedSendingDomains',
+      '@getSubaccounts',
+      '@getPublishedTemplate',
+      '@getPreview',
+    ]);
     cy.findByRole('button', { name: 'Open Menu' }).click();
     cy.findByRole('button', { name: 'Duplicate' }).click();
 


### PR DESCRIPTION
### What Changed

- Adds missing `cy.wait()` commands to reduce the risk of flakiness

### How To Test

- [Retry the pipeline repeatedly](https://app.circleci.com/pipelines/github/SparkPost/2web2ui/4436/workflows/0b93d5f9-7195-48ff-a75a-f9f282de449f) and see if the `createPage.spec.js` passes consistently

### To Do

- [ ] Incorporate feedback
