### PR TITLE
[FE-1370] Added the Re-verify Domain button to domain details page(Sending, Bounce and Tracking)

### DIFF
--- a/cypress/fixtures/tracking-domains/verify/200.post.json
+++ b/cypress/fixtures/tracking-domains/verify/200.post.json
@@ -1,0 +1,7 @@
+{
+  "results": {
+    "verified": true,
+    "cname_status": "",
+    "compliance_status": "valid"
+  }
+}

--- a/cypress/tests/integration/configuration/domains/detailsPage.spec.js
+++ b/cypress/tests/integration/configuration/domains/detailsPage.spec.js
@@ -10,7 +10,7 @@ describe('The domains details page', () => {
     cy.login({ isStubbed: true });
   });
 
-  describe('The domains details page - hibana version', () => {
+  describe('The domains details page', () => {
     beforeEach(() => {
       cy.stubRequest({
         url: '/api/v1/account',
@@ -106,6 +106,13 @@ describe('The domains details page', () => {
           requestAlias: 'deleteDomain',
         });
 
+        cy.stubRequest({
+          method: 'POST',
+          url: `/api/v1/tracking-domains/${domainName}/verify`,
+          fixture: 'tracking-domains/verify/200.post.json',
+          request: 'reverifyDomain',
+        });
+
         cy.visit(`${TRACKING_DETAILS_URL}/${domainName}`);
 
         cy.wait(['@accountDomainsReq', '@trackingDomainsList', '@subaccountList']);
@@ -115,6 +122,11 @@ describe('The domains details page', () => {
         cy.findByText('Subaccount Assignment').should('be.visible');
         cy.findByText('Fake Subaccount 4 (104)').should('be.visible');
         cy.findByRole('checkbox', { label: 'Set as Default Tracking Domain' }).should('be.checked');
+
+        cy.findByRole('button', { name: 'Re-Verify Domain' }).should('be.visible');
+        cy.findByRole('button', { name: 'Re-Verify Domain' }).click();
+        cy.findByText('Successfully verified CNAME for track1.spappteam.com').should('be.visible');
+
         cy.findByRole('heading', { name: 'Tracking' }).should('be.visible');
         cy.findByRole('button', { name: 'Verify Domain' }).should('not.exist');
         cy.findByRole('heading', { name: 'Delete Domain' }).should('be.visible');
@@ -439,6 +451,12 @@ describe('The domains details page', () => {
           fixture: 'sending-domains/200.get.all-verified.json',
           requestAlias: 'verifiedDomains',
         });
+        cy.stubRequest({
+          method: 'POST',
+          url: '/api/v1/sending-domains/bounce2.spappteam.com/verify',
+          fixture: 'sending-domains/verify/200.post.json',
+          requestAlias: 'verifyDomain',
+        });
         cy.visit(`${SENDING_BOUNCE_DETAILS_URL}/bounce2.spappteam.com`);
         cy.wait(['@verifiedDomains']);
         cy.wait('@accountDomainsReq');
@@ -451,6 +469,15 @@ describe('The domains details page', () => {
         cy.findByRole('heading', { name: 'Bounce' }).should('not.exist');
         cy.findByRole('heading', { name: 'DNS Verification' }).should('not.exist');
         cy.findByRole('heading', { name: 'Email Verification' }).should('not.exist');
+
+        cy.findByRole('button', { name: 'Re-Verify Domain' }).should('be.visible');
+        cy.findByRole('button', { name: 'Re-Verify Domain' }).click();
+        cy.findByText('You have successfully verified DKIM record of bounce2.spappteam.com').should(
+          'be.visible',
+        );
+        cy.findByText(
+          'You have successfully verified cname record of bounce2.spappteam.com',
+        ).should('be.visible');
       });
 
       it('renders correct sections for verified bounce domain and unverified sending domain', () => {
@@ -458,6 +485,12 @@ describe('The domains details page', () => {
           url: '/api/v1/sending-domains/bounce2.spappteam.com',
           fixture: 'sending-domains/200.get.bounce-verified-sending-unverified.json',
           requestAlias: 'verifiedDomains',
+        });
+        cy.stubRequest({
+          method: 'POST',
+          url: '/api/v1/sending-domains/bounce2.spappteam.com/verify',
+          fixture: 'sending-domains/verify/200.post.json',
+          requestAlias: 'verifyDomain',
         });
         cy.visit(`${SENDING_BOUNCE_DETAILS_URL}/bounce2.spappteam.com`);
         cy.wait(['@verifiedDomains', '@accountDomainsReq']);
@@ -470,6 +503,12 @@ describe('The domains details page', () => {
         cy.findByRole('button', { name: 'Verify Domain' }).should('be.visible');
         cy.findByRole('heading', { name: 'DNS Verification' }).should('be.visible');
         cy.findByRole('heading', { name: 'Email Verification' }).should('be.visible');
+
+        cy.findByRole('button', { name: 'Re-Verify Domain' }).should('be.visible');
+        cy.findByRole('button', { name: 'Re-Verify Domain' }).click();
+        cy.findByText('Successfully verified cname record of bounce2.spappteam.com').should(
+          'be.visible',
+        );
       });
 
       it('renders snackbar after sharing and un-sharing the domain.', () => {

--- a/src/actions/tests/__snapshots__/trackingDomains.test.js.snap
+++ b/src/actions/tests/__snapshots__/trackingDomains.test.js.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Action Creator: Tracking Domains  chained dispatches Action Creator: Tracking Domains createTrackingDomain description 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {},
+      "headers": Object {},
+      "method": "POST",
+      "url": "/v1/tracking-domains",
+    },
+    "type": "CREATE_TRACKING_DOMAIN",
+  },
+  Object {
+    "payload": Object {
+      "message": "Successfully added undefined",
+      "type": "success",
+    },
+    "type": "SHOW_GLOBAL_ALERT",
+  },
+]
+`;
+
+exports[`Action Creator: Tracking Domains  chained dispatches Action Creator: Tracking Domains deleteTrackingDomain description 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "domain": undefined,
+      "headers": Object {},
+      "method": "DELETE",
+      "url": "/v1/tracking-domains/undefined",
+    },
+    "type": "DELETE_TRACKING_DOMAIN",
+  },
+  Object {
+    "payload": Object {
+      "message": "Successfully deleted undefined",
+      "type": "success",
+    },
+    "type": "SHOW_GLOBAL_ALERT",
+  },
+]
+`;
+
+exports[`Action Creator: Tracking Domains  chained dispatches Action Creator: Tracking Domains updateTrackingDomain description 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "data": Object {},
+      "domain": undefined,
+      "headers": Object {},
+      "method": "PUT",
+      "url": "/v1/tracking-domains/undefined",
+    },
+    "type": "UPDATE_TRACKING_DOMAIN",
+  },
+  Object {
+    "payload": Object {
+      "message": "Successfully updated undefined",
+      "type": "success",
+    },
+    "type": "SHOW_GLOBAL_ALERT",
+  },
+]
+`;
+
+exports[`Action Creator: Tracking Domains  chained dispatches Action Creator: Tracking Domains verifyTrackingDomains description 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "domain": undefined,
+      "headers": Object {},
+      "method": "POST",
+      "url": "/v1/tracking-domains/undefined/verify",
+    },
+    "type": "VERIFY_TRACKING_DOMAIN",
+  },
+  Object {
+    "payload": Object {
+      "message": "Successfully verified CNAME for undefined",
+      "type": "success",
+    },
+    "type": "SHOW_GLOBAL_ALERT",
+  },
+]
+`;
+
+exports[`Action Creator: Tracking Domains  non-chained dispatches Action Creator: Tracking Domains listTrackingDomains description 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "method": "GET",
+      "showErrorAlert": false,
+      "url": "/v1/tracking-domains",
+    },
+    "type": "LIST_TRACKING_DOMAINS",
+  },
+]
+`;

--- a/src/actions/tests/trackingDomains.test.js
+++ b/src/actions/tests/trackingDomains.test.js
@@ -4,16 +4,13 @@ jest.mock('../helpers/sparkpostApiRequest');
 
 // https://github.com/facebook/jest/issues/2582#issuecomment-346886018
 // TODO: Finish the tests for tracking domains actions
-describe.skip('Action Creator: Tracking Domains ', () => {
+describe('Action Creator: Tracking Domains ', () => {
   describe('non-chained dispatches', () => {
     const trackingDomains = require('../trackingDomains');
 
-    snapshotActionCases('Action Creator: Sending Domains', {
+    snapshotActionCases('Action Creator: Tracking Domains', {
       'listTrackingDomains description': {
         actionCreator: () => trackingDomains.listTrackingDomains({}),
-      },
-      'verifyTrackingDomains description': {
-        actionCreator: () => trackingDomains.verifyTrackingDomains({}),
       },
     });
   });
@@ -27,7 +24,7 @@ describe.skip('Action Creator: Tracking Domains ', () => {
 
     const trackingDomains = require('../trackingDomains');
 
-    snapshotActionCases('Action Creator: Sending Domains', {
+    snapshotActionCases('Action Creator: Tracking Domains', {
       'createTrackingDomain description': {
         actionCreator: () => trackingDomains.createTrackingDomain({}),
       },
@@ -36,6 +33,9 @@ describe.skip('Action Creator: Tracking Domains ', () => {
       },
       'deleteTrackingDomain description': {
         actionCreator: () => trackingDomains.deleteTrackingDomain({}),
+      },
+      'verifyTrackingDomains description': {
+        actionCreator: () => trackingDomains.verifyTrackingDomain({}),
       },
     });
   });

--- a/src/actions/trackingDomains.js
+++ b/src/actions/trackingDomains.js
@@ -66,13 +66,20 @@ export function deleteTrackingDomain({ domain, subaccountId }) {
 }
 
 export function verifyTrackingDomain({ domain, subaccountId }) {
-  return sparkpostApiRequest({
-    type: 'VERIFY_TRACKING_DOMAIN',
-    meta: {
-      method: 'POST',
-      url: `/v1/tracking-domains/${domain}/verify`,
-      headers: setSubaccountHeader(subaccountId),
-      domain,
-    },
-  });
+  return dispatch =>
+    dispatch(
+      sparkpostApiRequest({
+        type: 'VERIFY_TRACKING_DOMAIN',
+        meta: {
+          method: 'POST',
+          url: `/v1/tracking-domains/${domain}/verify`,
+          headers: setSubaccountHeader(subaccountId),
+          domain,
+        },
+      }),
+    ).then(() =>
+      dispatch(
+        showAlert({ type: 'success', message: `Successfully verified CNAME for ${domain}` }),
+      ),
+    );
 }

--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -10,7 +10,7 @@ import useDomains from '../hooks/useDomains';
 import { ExternalLink, SubduedLink } from 'src/components/links';
 import { CopyField } from 'src/components';
 import { TranslatableText } from 'src/components/text';
-import { Telegram } from '@sparkpost/matchbox-icons';
+import { Autorenew, Telegram } from '@sparkpost/matchbox-icons';
 import { EXTERNAL_LINKS } from '../constants';
 
 export default function SendingAndBounceDomainSection({ domain, isSectionVisible }) {
@@ -31,8 +31,8 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
 
   const readyFor = resolveReadyFor(domain.status);
 
-  const onSubmit = () => {
-    if (!readyFor.bounce) {
+  const onSubmit = ({ reVerify = false }) => {
+    if (!readyFor.bounce || reVerify) {
       const type = watchVerificationType.toLowerCase();
 
       verify({ id, subaccount: subaccount_id, type }).then(result => {
@@ -51,7 +51,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
       });
     }
 
-    if (!readyFor.dkim) {
+    if (!readyFor.dkim || reVerify) {
       const { id, subaccount_id: subaccount } = domain;
 
       verifyDkim({ id, subaccount }).then(results => {
@@ -130,6 +130,10 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
             ) : (
               <Panel.Section>
                 Below is the records for this domain at your DNS provider
+                <Panel.Action onClick={() => onSubmit({ reVerify: true })}>
+                  <TranslatableText>Re-Verify Domain </TranslatableText>
+                  <Autorenew size={18} />
+                </Panel.Action>
               </Panel.Section>
             )}
 

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Layout, Stack, Select, Text } from 'src/components/matchbox';
 import { Checkbox, Panel } from 'src/components/matchbox';
 import { SubduedText, TranslatableText } from 'src/components/text';
-import { Telegram } from '@sparkpost/matchbox-icons';
+import { Telegram, Autorenew } from '@sparkpost/matchbox-icons';
 import { resolveReadyFor } from 'src/helpers/domains';
 import { ExternalLink, PageLink, SubduedLink } from 'src/components/links';
 import { useForm, Controller } from 'react-hook-form';
@@ -111,6 +111,10 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
                   record for the Hostname and Value for this domain at your DNS provider.
                 </TranslatableText>
               </p>
+              <Panel.Action onClick={onSubmit}>
+                <TranslatableText>Re-Verify Domain </TranslatableText>
+                <Autorenew size={18} />
+              </Panel.Action>
             </Panel.Section>
           )}
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Layout, Stack, Tag, Text } from 'src/components/matchbox';
 import { Checkbox, Panel } from 'src/components/matchbox';
 import { SubduedText, TranslatableText } from 'src/components/text';
-import { Telegram } from '@sparkpost/matchbox-icons';
+import { Autorenew, Telegram } from '@sparkpost/matchbox-icons';
 import { resolveReadyFor } from 'src/helpers/domains';
 import useDomains from '../hooks/useDomains';
 import { ExternalLink, SubduedLink } from 'src/components/links';
@@ -105,6 +105,10 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                     record for the Hostname and DKIM value of this domain.
                   </TranslatableText>
                 </p>
+                <Panel.Action onClick={onSubmit}>
+                  <TranslatableText>Re-Verify Domain </TranslatableText>
+                  <Autorenew size={18} />
+                </Panel.Action>
               </Panel.Section>
             )}
             <Panel.Section>

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button, Layout, Stack, Text } from 'src/components/matchbox';
-import { Panel, Checkbox } from 'src/components/matchbox';
+import { Button, Layout, Stack, Text, Panel, Checkbox } from 'src/components/matchbox';
+import { Autorenew } from '@sparkpost/matchbox-icons';
 import { SubduedText, TranslatableText } from 'src/components/text';
 import { ExternalLink, SubduedLink } from 'src/components/links';
 import useDomains from '../hooks/useDomains';
@@ -71,6 +71,10 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
                   </Text>
                   <TranslatableText>record for this domain at your DNS provider.</TranslatableText>
                 </p>
+                <Panel.Action onClick={onSubmit}>
+                  <TranslatableText>Re-Verify Domain </TranslatableText>
+                  <Autorenew size={18} />
+                </Panel.Action>
               </Panel.Section>
             )}
             <Panel.Section>


### PR DESCRIPTION
FE-1370 - Added the Re-verify Domain button to domain details page(Sending, Bounce and Tracking)

### What Changed

- Added the Re-Verify Domain Buttons to 
    - Verified Sending / Bounce Domain Page eg - http://localhost:3100/domains/details/sending-bounce/staging-test.spappteam.com
    - Verified Tracking Domain Pages eg - http://localhost:3100/domains/details/tracking/newbob.spappteam.com

### How To Test

- Navigate to any sending/bounce/tracking domain detail pages
- there should be Re-Verify Domain button that should trigger the api to verify these domains
- Should throw appropriate alerts on success/failure

### To Do

- [ ] Address feedback
