### PR TITLE
[AC-1849] -  Prevent Segment installation when you are a bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20722,6 +20722,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
+    "isbot": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.0.23.tgz",
+      "integrity": "sha512-WrZLX9ilDBY2XpwUNCF0LD6kHkU4qQGWF3uv1PbmgxmDPfwBLC1d46GsZu1N1Kv3/2AyKn/TQZ0Qjkoxcuyfvw=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "downshift": "^6.0.6",
     "email-addresses": "^3.0.1",
     "history": "^4.6.1",
+    "isbot": "^3.0.23",
     "js-cookie": "^2.1.4",
     "localforage": "^1.5.3",
     "lodash": "^4.17.19",

--- a/src/App.js
+++ b/src/App.js
@@ -11,9 +11,9 @@ import AppRoutes from 'src/components/appRoutes';
 import GlobalBanner from 'src/context/GlobalBanner';
 
 import config from 'src/config';
-
+import isbot from 'isbot';
 import { BrowserRouter } from 'react-router-dom';
-const isbot = require('isbot');
+
 const App = ({ RouterComponent = BrowserRouter }) => (
   <>
     <RouterComponent>

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import GlobalBanner from 'src/context/GlobalBanner';
 import config from 'src/config';
 
 import { BrowserRouter } from 'react-router-dom';
-
+const isbot = require('isbot');
 const App = ({ RouterComponent = BrowserRouter }) => (
   <>
     <RouterComponent>
@@ -22,7 +22,7 @@ const App = ({ RouterComponent = BrowserRouter }) => (
         <BoomerangBanner />
         {config.gtmId && <GoogleTagManager id={config.gtmId} />}
         <VisualWebsiteOptimizer />
-        <Segment />
+        {!isbot(window.navigator.userAgent) && <Segment />}
         <AuthenticationGate />
         <SuspensionAlerts />
         <CookieConsent />


### PR DESCRIPTION
[AC-1849] -  Prevent Segment installation when you are a bot

### What Changed

- Do not load segment if a bot is detected at user agent.
- Added the isBot npm library to help identify the user agent. - _Decided to go with ibot since it has better [npm trends](https://www.npmtrends.com/crawler-user-agents-vs-isbot-vs-spider-detector-vs-bot-detector) than other packages_

### How To Test

- One way to test this set the useragent to `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36(KHTML, like Gecko) Chrome/61.0.3116.0 Safari/537.36 Chrome-Lighthouse` following instructions here https://developers.google.com/web/tools/chrome-devtools/device-mode/override-user-agent 

### To Do

- [x] Find a way to mock a bot in cypress
In cypress.dev.json add 
{
  "baseUrl": "http://localhost:3100",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36(KHTML, like Gecko) Chrome/61.0.3116.0 Safari/537.36 Chrome-Lighthouse"
} 
and then running any cypress test it can be seen no request to segment is made.
- [ ] Address Feedback


[AC-1849]: https://sparkpost.atlassian.net/browse/AC-1849