### PR TITLE
FE-1371 - Remove all SPF related information from domain pages and remove Create a separate bounce domain link where not necessary

### DIFF
--- a/cypress/tests/integration/configuration/domains/listPage.spec.js
+++ b/cypress/tests/integration/configuration/domains/listPage.spec.js
@@ -827,20 +827,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Blocked').should('not.be.checked');
     });
 
-    it('syncs query param validSPF checkbox', () => {
-      stubSendingDomains({ fixture: 'sending-domains/200.get.multiple-results.json' });
-      stubSubaccounts();
-      cy.visit(`${PAGE_URL}/list/sending?validSPF=true`);
-      cy.wait(['@sendingDomainsReq', '@subaccountsReq']);
-
-      cy.findByRole('button', { name: 'Domain Status' }).click();
-      cy.findByLabelText('Verified').should('not.be.checked');
-      cy.findByLabelText('DKIM Signing').should('not.be.checked');
-      cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('Unverified').should('not.be.checked');
-      cy.findByLabelText('Blocked').should('not.be.checked');
-    });
-
     it('syncs query param unverified checkbox', () => {
       stubSendingDomains({ fixture: 'sending-domains/200.get.multiple-results.json' });
       stubSubaccounts();
@@ -1149,24 +1135,6 @@ describe('The domains list page', () => {
       cy.findByText('There is no data to display').should('be.visible');
       cy.location().should(loc => {
         expect(loc.search).to.eq('?readyForDKIM=true');
-      });
-    });
-
-    it('syncs query param validSPF checkbox', () => {
-      stubSendingDomains({ fixture: 'sending-domains/200.get.multiple-results.json' });
-      stubSubaccounts();
-      cy.visit(`${PAGE_URL}/list/bounce?validSPF=true`);
-      cy.wait(['@sendingDomainsReq', '@subaccountsReq']);
-
-      cy.findByRole('button', { name: 'Domain Status' }).click();
-      cy.findByLabelText('Verified').should('not.be.checked');
-      cy.findByLabelText('DKIM Signing').should('not.be.checked');
-      cy.findByLabelText('Unverified').should('not.be.checked');
-      cy.findByLabelText('Blocked').should('not.be.checked');
-
-      cy.findByText('There is no data to display').should('be.visible');
-      cy.location().should(loc => {
-        expect(loc.search).to.eq('?validSPF=true');
       });
     });
 

--- a/cypress/tests/integration/configuration/domains/listPage.spec.js
+++ b/cypress/tests/integration/configuration/domains/listPage.spec.js
@@ -147,7 +147,7 @@ describe('The domains list page', () => {
         domainName: 'spf-valid.com',
         creationDate: 'Aug 5, 2017',
         subaccount: 'Assignment: Primary Account',
-        statusTags: ['SPF Valid'],
+        statusTags: [],
       });
       verifyTableRow({
         rowIndex: 3,
@@ -419,7 +419,7 @@ describe('The domains list page', () => {
         rowIndex: 5,
         domainName: 'spf-valid.com',
         creationDate: 'Aug 5, 2017',
-        statusTags: ['SPF Valid'],
+        statusTags: [],
       });
       verifyTableRow({
         rowIndex: 6,
@@ -443,7 +443,7 @@ describe('The domains list page', () => {
         rowIndex: 1,
         domainName: 'spf-valid.com',
         creationDate: 'Aug 5, 2017',
-        statusTags: ['SPF Valid'],
+        statusTags: ['Sending'],
       });
       verifyTableRow({
         rowIndex: 2,
@@ -505,7 +505,7 @@ describe('The domains list page', () => {
         rowIndex: 2,
         domainName: 'spf-valid.com',
         creationDate: 'Aug 5, 2017',
-        statusTags: ['SPF Valid'],
+        statusTags: [],
       });
       verifyTableRow({
         rowIndex: 3,
@@ -563,7 +563,7 @@ describe('The domains list page', () => {
         rowIndex: 4,
         domainName: 'spf-valid.com',
         creationDate: 'Aug 5, 2017',
-        statusTags: ['SPF Valid'],
+        statusTags: [],
       });
       verifyTableRow({
         rowIndex: 5,
@@ -591,14 +591,12 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').uncheck({ force: true });
       cy.findByLabelText('Unverified').uncheck({ force: true });
       cy.findByLabelText('Blocked').uncheck({ force: true });
-      cy.findByLabelText('SPF Valid').uncheck({ force: true });
       cy.findByLabelText('Bounce').uncheck({ force: true });
       cy.findByLabelText('DKIM Signing').uncheck({ force: true });
       cy.findByLabelText('Select All').check({ force: true });
       cy.findByLabelText('Verified').should('be.checked');
       cy.findByLabelText('Unverified').should('be.checked');
       cy.findByLabelText('Blocked').should('be.checked');
-      cy.findByLabelText('SPF Valid').should('be.checked');
       cy.findByLabelText('Bounce').should('be.checked');
       cy.findByLabelText('DKIM Signing').should('be.checked');
 
@@ -617,7 +615,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('be.visible');
       cy.findByLabelText('Unverified').should('be.visible');
       cy.findByLabelText('Blocked').should('be.visible');
-      cy.findByLabelText('SPF Valid').should('be.visible');
       cy.findByLabelText('Bounce').should('be.visible');
       cy.findByLabelText('DKIM Signing').should('be.visible');
 
@@ -636,9 +633,6 @@ describe('The domains list page', () => {
         creationDate: 'Aug 6, 2017',
         statusTags: ['Blocked'],
       });
-      cy.get('tbody tr')
-        .eq(1)
-        .should('not.exist');
 
       cy.findByLabelText('Unverified').check({ force: true });
       verifyTableRow({
@@ -663,35 +657,6 @@ describe('The domains list page', () => {
         .eq(3)
         .should('not.exist');
 
-      cy.findByLabelText('SPF Valid').check({ force: true });
-      verifyTableRow({
-        rowIndex: 0,
-        domainName: 'with-a-subaccount.com',
-        creationDate: 'Aug 7, 2017',
-        statusTags: ['Unverified'],
-      });
-      verifyTableRow({
-        rowIndex: 1,
-        domainName: 'blocked.com',
-        creationDate: 'Aug 6, 2017',
-        statusTags: ['Blocked'],
-      });
-      verifyTableRow({
-        rowIndex: 2,
-        domainName: 'spf-valid.com',
-        creationDate: 'Aug 5, 2017',
-        statusTags: ['Sending', 'SPF Valid'],
-      });
-      verifyTableRow({
-        rowIndex: 3,
-        domainName: 'fake1.domain.com',
-        creationDate: 'Aug 3, 2017',
-        statusTags: ['Unverified'],
-      });
-      cy.get('tbody tr')
-        .eq(4)
-        .should('not.exist');
-
       cy.findByLabelText('Bounce').check({ force: true });
       verifyTableRow({
         rowIndex: 0,
@@ -707,18 +672,12 @@ describe('The domains list page', () => {
       });
       verifyTableRow({
         rowIndex: 2,
-        domainName: 'spf-valid.com',
-        creationDate: 'Aug 5, 2017',
-        statusTags: ['Sending', 'SPF Valid'],
-      });
-      verifyTableRow({
-        rowIndex: 3,
         domainName: 'fake1.domain.com',
         creationDate: 'Aug 3, 2017',
         statusTags: ['Unverified'],
       });
       verifyTableRow({
-        rowIndex: 4,
+        rowIndex: 3,
         domainName: 'default-bounce.com',
         creationDate: 'Aug 1, 2017',
         statusTags: ['Sending', 'Bounce'],
@@ -742,30 +701,24 @@ describe('The domains list page', () => {
       });
       verifyTableRow({
         rowIndex: 2,
-        domainName: 'spf-valid.com',
-        creationDate: 'Aug 5, 2017',
-        statusTags: ['Sending', 'SPF Valid'],
-      });
-      verifyTableRow({
-        rowIndex: 3,
         domainName: 'dkim-signing.com',
         creationDate: 'Aug 4, 2017',
         statusTags: ['Sending', 'DKIM Signing'],
       });
       verifyTableRow({
-        rowIndex: 4,
+        rowIndex: 3,
         domainName: 'fake1.domain.com',
         creationDate: 'Aug 3, 2017',
         statusTags: ['Unverified'],
       });
       verifyTableRow({
-        rowIndex: 5,
+        rowIndex: 4,
         domainName: 'default-bounce.com',
         creationDate: 'Aug 1, 2017',
         statusTags: ['Sending', 'Bounce'],
       });
       cy.get('tbody tr')
-        .eq(6)
+        .eq(5)
         .should('not.exist');
 
       cy.findByLabelText('Verified').check({ force: true });
@@ -782,28 +735,10 @@ describe('The domains list page', () => {
         statusTags: ['Blocked'],
       });
       verifyTableRow({
-        rowIndex: 2,
-        domainName: 'spf-valid.com',
-        creationDate: 'Aug 5, 2017',
-        statusTags: ['Sending', 'SPF Valid'],
-      });
-      verifyTableRow({
-        rowIndex: 3,
-        domainName: 'dkim-signing.com',
-        creationDate: 'Aug 4, 2017',
-        statusTags: ['Sending', 'DKIM Signing'],
-      });
-      verifyTableRow({
         rowIndex: 4,
         domainName: 'fake1.domain.com',
         creationDate: 'Aug 3, 2017',
         statusTags: ['Unverified'],
-      });
-      verifyTableRow({
-        rowIndex: 5,
-        domainName: 'ready-for-sending.com',
-        creationDate: 'Aug 2, 2017',
-        statusTags: ['Sending'],
       });
       verifyTableRow({
         rowIndex: 6,
@@ -825,7 +760,7 @@ describe('The domains list page', () => {
       verifyTableRow({
         rowIndex: 0,
         domainName: 'spf-valid.com',
-        statusTags: ['Sending', 'SPF Valid'],
+        statusTags: ['Sending'],
       });
     });
 
@@ -839,14 +774,13 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
       cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
 
       verifyTableRow({
         rowIndex: 0,
         domainName: 'spf-valid.com',
-        statusTags: ['Sending', 'SPF Valid'],
+        statusTags: ['Sending'],
       });
       verifyTableRow({
         rowIndex: 1,
@@ -875,7 +809,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('be.checked');
       cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
     });
@@ -890,7 +823,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
       cy.findByLabelText('Bounce').should('be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
     });
@@ -905,7 +837,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
       cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
     });
@@ -920,7 +851,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
       cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
     });
@@ -935,7 +865,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
       cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('be.checked');
     });
@@ -952,7 +881,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
       cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('be.checked');
 
@@ -961,7 +889,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Select All').should('not.be.checked');
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
 
@@ -988,7 +915,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Select All').should('not.be.checked');
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
 
@@ -1017,7 +943,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
       cy.findByLabelText('Bounce').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
     });
@@ -1065,7 +990,6 @@ describe('The domains list page', () => {
       cy.findByLabelText('Verified').should('be.visible');
       cy.findByLabelText('Unverified').should('be.visible');
       cy.findByLabelText('Blocked').should('be.visible');
-      cy.findByLabelText('SPF Valid').should('be.visible');
       cy.findByLabelText('Bounce').should('not.exist');
       cy.findByLabelText('DKIM Signing').should('be.visible');
     });
@@ -1197,7 +1121,6 @@ describe('The domains list page', () => {
       cy.findByRole('button', { name: 'Domain Status' }).click();
       cy.findByLabelText('Verified').should('be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
 
@@ -1220,7 +1143,6 @@ describe('The domains list page', () => {
       cy.findByRole('button', { name: 'Domain Status' }).click();
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
 
@@ -1239,7 +1161,6 @@ describe('The domains list page', () => {
       cy.findByRole('button', { name: 'Domain Status' }).click();
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
 
@@ -1258,7 +1179,6 @@ describe('The domains list page', () => {
       cy.findByRole('button', { name: 'Domain Status' }).click();
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('be.checked');
       cy.findByLabelText('Blocked').should('not.be.checked');
 
@@ -1277,7 +1197,6 @@ describe('The domains list page', () => {
       cy.findByRole('button', { name: 'Domain Status' }).click();
       cy.findByLabelText('Verified').should('not.be.checked');
       cy.findByLabelText('DKIM Signing').should('not.be.checked');
-      cy.findByLabelText('SPF Valid').should('not.be.checked');
       cy.findByLabelText('Unverified').should('not.be.checked');
       cy.findByLabelText('Blocked').should('be.checked');
 

--- a/src/pages/domains/VerifyBounceDomainPage.js
+++ b/src/pages/domains/VerifyBounceDomainPage.js
@@ -38,6 +38,7 @@ function VerifyBounceDomainPage(props) {
         <Domains.SetupBounceDomainSection
           title="DNS Verification"
           domain={domain}
+          isBounceOnly={true}
           isSectionVisible={true}
         />
       </Page>

--- a/src/pages/domains/components/LinkTrackingDomainSection.js
+++ b/src/pages/domains/components/LinkTrackingDomainSection.js
@@ -41,7 +41,7 @@ function LinkTrackingDomainSection({ domain, isSectionVisible, trackingDomainOpt
       <Layout.Section annotated>
         <Layout.SectionTitle as="h2">Link Tracking Domain</Layout.SectionTitle>
         <Stack>
-          <SubduedText fontSize="200">Assign a tracking domain?</SubduedText>
+          <SubduedText fontSize="200">Assign a tracking domain.</SubduedText>
           <SubduedLink
             as={ExternalLink}
             to={EXTERNAL_LINKS.TRACKING_DOMAIN_DOCUMENTATION}

--- a/src/pages/domains/components/SendingDomainStatusCell.js
+++ b/src/pages/domains/components/SendingDomainStatusCell.js
@@ -7,9 +7,10 @@ import useUniqueId from 'src/hooks/useUniqueId';
 
 export function SendingDomainStatusCell({ domain }) {
   const tooltipId = useUniqueId('default-bounce-domain');
-  const resolvedStatus = resolveStatus(domain.status);
-  const readyFor = resolveReadyFor(domain.status);
   const { is_default_bounce_domain, status } = domain;
+
+  const resolvedStatus = resolveStatus(status);
+  const readyFor = resolveReadyFor(status);
 
   if (resolvedStatus === 'blocked') return <Tag color="red">Blocked</Tag>;
 
@@ -38,8 +39,6 @@ export function SendingDomainStatusCell({ domain }) {
       )}
 
       {readyFor?.dkim && <Tag color="darkGray">DKIM Signing</Tag>}
-
-      {status?.spf_status === 'valid' && <Tag color="darkGray">SPF Valid</Tag>}
     </Inline>
   );
 }

--- a/src/pages/domains/components/SendingDomainsTab.js
+++ b/src/pages/domains/components/SendingDomainsTab.js
@@ -45,11 +45,6 @@ const filtersInitialState = {
       isChecked: false,
     },
     {
-      label: 'SPF Valid',
-      name: 'validSPF',
-      isChecked: false,
-    },
-    {
       label: 'Unverified',
       name: 'unverified',
       isChecked: false,
@@ -78,12 +73,6 @@ const initFiltersForSending = {
     },
   },
   readyForBounce: {
-    defaultValue: undefined,
-    validate: val => {
-      return val === 'true' || val === 'false' || typeof val === 'boolean';
-    },
-  },
-  validSPF: {
     defaultValue: undefined,
     validate: val => {
       return val === 'true' || val === 'false' || typeof val === 'boolean';
@@ -171,7 +160,6 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
           readyForDKIM: row.readyForDKIM,
           readyForSending: row.readyForSending,
           unverified: row.unverified,
-          validSPF: row.validSPF,
         }),
         filter,
       },
@@ -194,7 +182,6 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
     readyForDKIM: flattenedFilters['readyForDKIM'],
     readyForSending: flattenedFilters['readyForSending'],
     unverified: flattenedFilters['unverified'],
-    validSPF: flattenedFilters['validSPF'],
   };
 
   if (!renderBounceOnly) {
@@ -255,7 +242,6 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
         readyForDKIM: flattenedFilters['readyForDKIM'],
         readyForSending: flattenedFilters['readyForSending'],
         unverified: flattenedFilters['unverified'],
-        validSPF: flattenedFilters['validSPF'],
       };
       domainStatusValues['readyForBounce'] = flattenedFilters['readyForBounce'];
       const reactTableFilters = getReactTableFilters({
@@ -313,7 +299,6 @@ export default function SendingDomainsTab({ renderBounceOnly = false }) {
       readyForDKIM: flattenedFilters['readyForDKIM'],
       readyForSending: flattenedFilters['readyForSending'],
       unverified: flattenedFilters['unverified'],
-      validSPF: flattenedFilters['validSPF'],
     };
 
     if (!renderBounceOnly) {

--- a/src/pages/domains/components/SendingDomainsTable.js
+++ b/src/pages/domains/components/SendingDomainsTable.js
@@ -81,14 +81,7 @@ function MainCell({ row }) {
 }
 
 function StatusCell({ row }) {
-  const {
-    blocked,
-    readyForBounce,
-    readyForDKIM,
-    readyForSending,
-    validSPF,
-    unverified,
-  } = row.DomainStatus;
+  const { blocked, readyForBounce, readyForDKIM, readyForSending, unverified } = row.DomainStatus;
   const { defaultBounceDomain } = row;
   const { subaccountId } = row;
 
@@ -122,8 +115,6 @@ function StatusCell({ row }) {
       )}
 
       {readyForDKIM && <Tag color="darkGray">DKIM Signing</Tag>}
-
-      {validSPF && <Tag color="darkGray">SPF Valid</Tag>}
     </Inline>
   );
 }

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -55,8 +55,7 @@ export default function SetupBounceDomainSection({
           {!readyFor.bounce && (
             <SubduedText fontSize="200">
               Adding the CNAME record in your DNS provider settings will set this domain up for
-              Bounce as well resulting in SPF (sender policy framework) authentication which is a
-              sending best practice.
+              Bounce which is a sending best practice.
             </SubduedText>
           )}
 

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -12,7 +12,12 @@ import { CopyField } from 'src/components';
 import useDomains from '../hooks/useDomains';
 import { EXTERNAL_LINKS } from '../constants';
 
-export default function SetupBounceDomainSection({ domain, isSectionVisible, title }) {
+export default function SetupBounceDomainSection({
+  domain,
+  isSectionVisible,
+  title,
+  isBounceOnly,
+}) {
   const { id, status, subaccount_id } = domain;
   const { verify, showAlert, userName, isByoipAccount, verifyBounceLoading } = useDomains();
   const readyFor = resolveReadyFor(status);
@@ -54,14 +59,6 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
               sending best practice.
             </SubduedText>
           )}
-          {!readyFor.bounce && (
-            <SubduedText fontSize="200">
-              SPF is an email authentication method used to determine if a bounce domain is allowed
-              to be used with a given sending IP. SPF failures can cause mail to be rejected at some
-              providers, so SparkPost requires our CNAME record to be published in DNS for all
-              bounce domains to ensure that they pass SPF checks.
-            </SubduedText>
-          )}
 
           <SubduedLink
             as={ExternalLink}
@@ -70,9 +67,11 @@ export default function SetupBounceDomainSection({ domain, isSectionVisible, tit
           >
             Bounce Domain Documentation
           </SubduedLink>
-          <PageLink to="/domains/create" fontSize="200">
-            Create a seperate bounce subdomain
-          </PageLink>
+          {!isBounceOnly && !readyFor.bounce && (
+            <PageLink to="/domains/create" fontSize="200">
+              Create a seperate bounce subdomain
+            </PageLink>
+          )}
         </Stack>
       </Layout.Section>
       <Layout.Section>


### PR DESCRIPTION
FE-1371 - Remove all SPF related information from domain pages and remove Create a separate bounce domain link where not necessary

### What Changed

- [ ] Removed the SPF Valid label from domains/list/sending and domains/list/bounce
- [ ] Removed the SPF Valid label from Domain Status Filter on domains/list/sending and domains/list/bounce
- [ ] Removed SPF Valid label from Domain Detail pages
- [ ] Removed the SPF related text from domain detail pages and from domain verification pages
- [ ] Removed the 'Create a separate bounce subdomain' link from the left column on domain details pages when the domain is verified for bounce
- [ ] Removed the 'Create a separate bounce subdomain' from domain verification pages when the domain is created for bounce only. /domains/details/{{domainname}}/verify-bounce 

### How To Test

- Check if any SPF related information is present on the domain pages (as mentioned above)
- Check whether  'Create a separate bounce subdomain' link doesn't show on domain detail page for bounce verified domains.
- Check whether 'Create a separate bounce subdomain'  link is not present on /domains/details/{{domainname}}/verify-bounce.

### To Do

- [ ] Address feedback
