### PR TITLE
[FE-1372] subaccountid is sent with the  verifytoken request

### DIFF
--- a/cypress/tests/integration/configuration/domains/listPage.spec.js
+++ b/cypress/tests/integration/configuration/domains/listPage.spec.js
@@ -84,26 +84,38 @@ describe('The domains list page', () => {
   });
 
   it('successfully verifies the sending/bounce domain when url has token, mailbox and domain as query parameters and redirects to domain details page and navigating back to domains details does not show additional alerts', () => {
+    const domainName = 'with-a-subaccount.com';
     stubSendingDomains({ fixture: 'sending-domains/200.get.paginated-results.json' });
     stubSubaccounts();
     cy.stubRequest({
-      url: '/api/v1/sending-domains/fake1.domain.com/verify',
+      url: `/api/v1/sending-domains/${domainName}/verify`,
       method: 'POST',
       fixture: 'sending-domains/verify/200.post-abusetoken.json',
       requestAlias: 'sendingDomainVerifyReq',
     });
     cy.stubRequest({
-      url: '/api/v1/sending-domains/fake1.domain.com',
+      url: `/api/v1/sending-domains/${domainName}`,
       fixture: 'sending-domains/200.get.all-verified.json',
       requestAlias: 'sendingDomainsReq',
     });
-    cy.visit(`${PAGE_URL}/list/sending?token=faketoken&domain=fake1.domain.com&mailbox=abuse`);
+    cy.visit(`${PAGE_URL}/list/sending?token=faketoken&domain=${domainName}&mailbox=abuse`);
 
-    cy.wait(['@sendingDomainsReq', '@subaccountsReq', '@sendingDomainVerifyReq']);
-    cy.findByText('fake1.domain.com has been verified').should('be.visible');
+    cy.wait(['@sendingDomainsReq', '@subaccountsReq', '@sendingDomainVerifyReq']).then(xhr => {
+      const {
+        request: { headers },
+      } = xhr[2];
+      expect(headers).to.deep.equal({
+        Accept: 'application/json, text/plain, */*',
+        Authorization: 'fake_access_token',
+        'Content-Type': 'application/json;charset=utf-8',
+        'X-Sparky': '1d24c3473dd52a2f4a53fb6808cf9a73',
+        'x-msys-subaccount': 101,
+      });
+    });
+    cy.findByText(`${domainName} has been verified`).should('be.visible');
     cy.findByRole('heading', { name: 'Domain Details' }).should('be.visible');
     cy.findByText('All Domains').click();
-    cy.findByText('fake1.domain.com has been verified').should('be.visible');
+    cy.findByText(`${domainName} has been verified`).should('be.visible');
   });
 
   it('renders error when domain cannot be verified and the sending/bounce domain url has token, mailbox and domain as query parameters', () => {

--- a/src/pages/domains/components/VerifyToken.js
+++ b/src/pages/domains/components/VerifyToken.js
@@ -34,8 +34,8 @@ export function VerifyToken({
         const sendingDomain = _.find(domains, { domainName: domain });
 
         if (sendingDomain && mailbox && domain && token) {
-          const subaccount = !isNaN(parseInt(sendingDomain.subaccount_id))
-            ? sendingDomain.subaccount_id
+          const subaccount = !isNaN(parseInt(sendingDomain.subaccountId))
+            ? sendingDomain.subaccountId
             : undefined;
           let verifyAction = verifyMailboxToken;
           let tokenType = SENDING_DOMAIN_TOKEN_TYPE['MAILBOX'];
@@ -49,7 +49,6 @@ export function VerifyToken({
             verifyAction = verifyPostmasterToken;
             tokenType = SENDING_DOMAIN_TOKEN_TYPE['POSTMASTER'];
           }
-
           return verifyAction({ id: domain, token, subaccount }).then(result => {
             if (result[`${tokenType}_status`] !== 'valid') {
               showAlert({ type: 'error', message: `Unable to verify ${domain}` });


### PR DESCRIPTION
[FE-1372] subaccountid is sent with the  verifytoken request

### What Changed

- Corrected the misspelled key in domains VerifyToken component

### How To Test

- Added a cypress test to verify correct headers are sent with the request

### To Do

- [ ] Address feedback


[FE-1372]: https://sparkpost.atlassian.net/browse/FE-1372