### PR TITLE
AC-1850 - ChoosePlanPage flashes before redirecting to dashboard when adding a paid plan

### DIFF
--- a/src/actions/billingCreate.js
+++ b/src/actions/billingCreate.js
@@ -13,7 +13,6 @@ import {
 export default function billingCreate(values) {
   return (dispatch, getState) => {
     const { corsData, billingData } = formatDataForCors(values);
-
     // action creator wrappers for chaining as callbacks
     const corsCreateBilling = ({ meta }) =>
       cors({ meta, context: 'create-account', data: corsData });
@@ -42,6 +41,10 @@ export default function billingCreate(values) {
         consumePromoCode({ meta, promoCode: values.promoCode, billingId: billingData.billingId });
       actions.push(consumePromo);
     }
-    return dispatch(chainActions(...actions)());
+    dispatch({ type: 'BILLING_CREATE_PENDING' });
+
+    return dispatch(chainActions(...actions)())
+      .then(() => dispatch({ type: 'BILLING_CREATE_SUCCESS' }))
+      .catch(() => dispatch({ type: 'BILLING_CREATE__ERROR' }));
   };
 }

--- a/src/actions/billingCreate.js
+++ b/src/actions/billingCreate.js
@@ -45,6 +45,6 @@ export default function billingCreate(values) {
 
     return dispatch(chainActions(...actions)())
       .then(() => dispatch({ type: 'BILLING_CREATE_SUCCESS' }))
-      .catch(() => dispatch({ type: 'BILLING_CREATE__ERROR' }));
+      .catch(() => dispatch({ type: 'BILLING_CREATE_ERROR' }));
   };
 }

--- a/src/actions/tests/billingCreate.test.js
+++ b/src/actions/tests/billingCreate.test.js
@@ -57,7 +57,7 @@ describe('Action Creator: Billing Create', () => {
       invoiceCollect: true,
     };
     getState = () => ({ currentUser });
-    dispatch = jest.fn(a => a);
+    dispatch = jest.fn(a => Promise.resolve(a));
     accountConditions.isCustomBilling = jest.fn(() => false);
     billingActions.createZuoraAccount = jest.fn(({ meta }) => meta.onSuccess({}));
     billingActions.syncSubscription = jest.fn(({ meta }) => meta.onSuccess({}));

--- a/src/components/billing/PromoCodeNew.js
+++ b/src/components/billing/PromoCodeNew.js
@@ -3,7 +3,7 @@ import { LoadingSVG } from 'src/components';
 import { Button, TextField } from 'src/components/matchbox';
 import _ from 'lodash';
 
-const PromoCodeNew = ({ promoCodeObj, handlePromoCode }) => {
+const PromoCodeNew = ({ promoCodeObj, handlePromoCode, disabled }) => {
   const { applyPromoCode, clearPromoCode } = handlePromoCode;
   const { promoError, promoPending, selectedPromo } = promoCodeObj;
   const [promoCode, setPromoCode] = useState(selectedPromo.promoCode || '');
@@ -16,19 +16,19 @@ const PromoCodeNew = ({ promoCodeObj, handlePromoCode }) => {
   const renderActionButton = condition => {
     if (condition) {
       return (
-        <Button variant="connected" onClick={clearPromoCode}>
+        <Button variant="connected" onClick={clearPromoCode} disabled={disabled}>
           Remove
         </Button>
       );
     }
     return (
-      <Button variant="connected" onClick={handleClick} disabled={promoPending}>
+      <Button variant="connected" onClick={handleClick} disabled={promoPending || disabled}>
         Apply
       </Button>
     );
   };
   const renderLoading = condition => (condition ? <LoadingSVG size="XSmall" /> : null);
-  const isDisabled = () => promoPending || _.has(selectedPromo, 'promoCode');
+  const isDisabled = () => promoPending || _.has(selectedPromo, 'promoCode') || disabled;
   const displayErrorMessage = () => (promoError ? promoError.message : '');
 
   return (

--- a/src/components/billing/tests/__snapshots__/PromoCodeNew.test.js.snap
+++ b/src/components/billing/tests/__snapshots__/PromoCodeNew.test.js.snap
@@ -4,7 +4,6 @@ exports[`promoCode should render correctly 1`] = `
 <TextField
   connectRight={
     <Button
-      disabled={false}
       onClick={[Function]}
       variant="connected"
     >
@@ -12,7 +11,6 @@ exports[`promoCode should render correctly 1`] = `
     </Button>
   }
   defaultValue=""
-  disabled={false}
   error=""
   id="promo-code"
   label="Promo Code"

--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { Grid, Button, Panel } from 'src/components/matchbox';
 import { Heading } from 'src/components/text';
 import { showAlert } from 'src/actions/globalAlert';
@@ -27,20 +28,21 @@ export function OnboardingPlanPage({
   getBundles,
   getBillingCountries,
   billingCreate,
+  billingCreateSuccess,
   showAlert,
-  history,
+  submitting,
   billing,
   verifyPromoCode,
   clearPromoCode,
   currentPlan,
   loading,
-  submitting,
   selectedPlan = {},
   handleSubmit,
   hasError,
   bundles,
 }) {
   const next_step = DASHBOARD_ROUTE;
+  const history = useHistory();
   useEffect(() => {
     getPlans();
   }, [getPlans]);
@@ -123,13 +125,13 @@ export function OnboardingPlanPage({
     clearPromoCode,
   };
 
-  if (loading || !bundles.length) {
+  if (loading || !bundles.length || billingCreateSuccess) {
     return <Loading />;
   }
+
   const disableSubmit = submitting || promoPending;
 
   const buttonText = submitting ? 'Updating Subscription...' : 'Get Started';
-
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <CenteredLogo />

--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -91,13 +91,10 @@ export function OnboardingPlanPage({
     }
 
     // Note: billingCreate will update the subscription if the account is AWS
-    return action
-      .then(({ discount_id }) => {
-        newValues.discountId = discount_id;
-        return billingCreate({ ...newValues, billingId });
-      })
-      .then(() => history.push(next_step))
-      .then(() => showAlert({ type: 'success', message: 'Added your plan' }));
+    return action.then(({ discount_id }) => {
+      newValues.discountId = discount_id;
+      return billingCreate({ ...newValues, billingId });
+    });
   };
 
   const applyPromoCode = promoCode => {
@@ -125,7 +122,14 @@ export function OnboardingPlanPage({
     clearPromoCode,
   };
 
-  if (loading || !bundles.length || billingCreateSuccess) {
+  useEffect(() => {
+    if (billingCreateSuccess) {
+      history.push(next_step);
+      showAlert({ type: 'success', message: 'Added your plan' });
+    }
+  }, [billingCreateSuccess, history, next_step, showAlert]);
+
+  if (loading || !bundles.length) {
     return <Loading />;
   }
 

--- a/src/pages/onboarding/ChoosePlan.js
+++ b/src/pages/onboarding/ChoosePlan.js
@@ -28,6 +28,7 @@ export function OnboardingPlanPage({
   getBundles,
   getBillingCountries,
   billingCreate,
+  billingCreateLoading,
   billingCreateSuccess,
   showAlert,
   submitting,
@@ -127,9 +128,10 @@ export function OnboardingPlanPage({
       history.push(next_step);
       showAlert({ type: 'success', message: 'Added your plan' });
     }
-  }, [billingCreateSuccess, history, next_step, showAlert]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [billingCreateSuccess]);
 
-  if (loading || !bundles.length) {
+  if (loading || !bundles.length || (!submitting && billingCreateLoading)) {
     return <Loading />;
   }
 
@@ -155,6 +157,7 @@ export function OnboardingPlanPage({
               <Panel.LEGACY.Section>
                 <PromoCodeNew
                   key={selectedPromo.promoCode || 'promocode'}
+                  disabled={disableSubmit}
                   promoCodeObj={promoCodeObj}
                   handlePromoCode={handlePromoCode}
                 />

--- a/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
+++ b/src/pages/onboarding/tests/__snapshots__/ChoosePlan.test.js.snap
@@ -30,6 +30,7 @@ exports[`ChoosePlan page tests should disable submit and plan picker when submit
         />
         <Panel.LEGACY.Section>
           <PromoCodeNew
+            disabled={true}
             handlePromoCode={
               Object {
                 "applyPromoCode": [Function],
@@ -102,6 +103,7 @@ exports[`ChoosePlan page tests should render correctly 1`] = `
         />
         <Panel.LEGACY.Section>
           <PromoCodeNew
+            disabled={false}
             handlePromoCode={
               Object {
                 "applyPromoCode": [Function],
@@ -174,6 +176,7 @@ exports[`ChoosePlan page tests should show free bullets when isFree is selected 
         />
         <Panel.LEGACY.Section>
           <PromoCodeNew
+            disabled={false}
             handlePromoCode={
               Object {
                 "applyPromoCode": [Function],

--- a/src/reducers/billingCreate.js
+++ b/src/reducers/billingCreate.js
@@ -1,33 +1,27 @@
 const initialState = {
   loading: null,
   success: null,
-  error: false,
+  error: null,
 };
 
 export default (state = initialState, { type }) => {
   switch (type) {
     case 'BILLING_CREATE_SUCCESS':
       return {
-        ...state,
+        ...initialState,
         success: true,
-        loading: false,
-        error: false,
       };
 
     case 'BILLING_CREATE_PENDING':
       return {
-        ...state,
-        success: false,
+        ...initialState,
         loading: true,
-        error: false,
       };
 
     case 'BILLING_CREATE_ERROR':
       return {
-        ...state,
-        loading: false,
+        ...initialState,
         error: true,
-        success: false,
       };
     default:
       return state;

--- a/src/reducers/billingCreate.js
+++ b/src/reducers/billingCreate.js
@@ -1,0 +1,35 @@
+const initialState = {
+  loading: null,
+  success: null,
+  error: false,
+};
+
+export default (state = initialState, { type }) => {
+  switch (type) {
+    case 'BILLING_CREATE_SUCCESS':
+      return {
+        ...state,
+        success: true,
+        loading: false,
+        error: false,
+      };
+
+    case 'BILLING_CREATE_PENDING':
+      return {
+        ...state,
+        success: false,
+        loading: true,
+        error: false,
+      };
+
+    case 'BILLING_CREATE_ERROR':
+      return {
+        ...state,
+        loading: false,
+        error: true,
+        success: false,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,6 +11,7 @@ import alerts from './alerts';
 import apiKeys from './api-keys';
 import auth from './auth';
 import billing from './billing';
+import billingCreate from './billingCreate';
 import bounceReport from './bounceReport';
 import blocklist from './blocklist';
 import cookieConsent from './cookieConsent';
@@ -62,6 +63,7 @@ const appReducer = combineReducers({
   apiKeys,
   auth,
   billing,
+  billingCreate,
   blocklist,
   bounceReport,
   cookieConsent,

--- a/src/selectors/onboarding.js
+++ b/src/selectors/onboarding.js
@@ -17,9 +17,9 @@ export const choosePlanMSTP = formName =>
         state.account.loading ||
           state.billing.countriesLoading ||
           state.billing.bundlesLoading ||
-          state.billing.bundlePlansLoading ||
-          state.billingCreate.loading,
+          state.billing.bundlePlansLoading,
       ),
+    billingCreateLoading: state => state.billingCreate.loading,
     billingCreateSuccess: state => state.billingCreate.success,
     billing: state => state.billing,
     bundles: state => selectAvailableBundles(state),

--- a/src/selectors/onboarding.js
+++ b/src/selectors/onboarding.js
@@ -20,7 +20,7 @@ export const choosePlanMSTP = formName =>
           state.billing.bundlePlansLoading ||
           state.billingCreate.loading,
       ),
-    billingCreateSuccess: state => state.billingCreate.loading,
+    billingCreateSuccess: state => state.billingCreate.success,
     billing: state => state.billing,
     bundles: state => selectAvailableBundles(state),
     initialValues: getChoosePlanInitialValues,

--- a/src/selectors/onboarding.js
+++ b/src/selectors/onboarding.js
@@ -17,8 +17,10 @@ export const choosePlanMSTP = formName =>
         state.account.loading ||
           state.billing.countriesLoading ||
           state.billing.bundlesLoading ||
-          state.billing.bundlePlansLoading,
+          state.billing.bundlePlansLoading ||
+          state.billingCreate.loading,
       ),
+    billingCreateSuccess: state => state.billingCreate.loading,
     billing: state => state.billing,
     bundles: state => selectAvailableBundles(state),
     initialValues: getChoosePlanInitialValues,

--- a/src/selectors/tests/__snapshots__/onboarding.test.js.snap
+++ b/src/selectors/tests/__snapshots__/onboarding.test.js.snap
@@ -3,6 +3,7 @@
 exports[`choosePlanMSTP should return mapped prop values 1`] = `
 Object {
   "billing": Object {},
+  "billingCreateSuccess": null,
   "bundles": Array [],
   "hasError": false,
   "initialValues": "change-plan-initial-values",

--- a/src/selectors/tests/__snapshots__/onboarding.test.js.snap
+++ b/src/selectors/tests/__snapshots__/onboarding.test.js.snap
@@ -3,6 +3,7 @@
 exports[`choosePlanMSTP should return mapped prop values 1`] = `
 Object {
   "billing": Object {},
+  "billingCreateLoading": null,
   "billingCreateSuccess": null,
   "bundles": Array [],
   "hasError": false,

--- a/src/selectors/tests/onboarding.test.js
+++ b/src/selectors/tests/onboarding.test.js
@@ -21,6 +21,11 @@ describe('choosePlanMSTP', () => {
     state = {
       account: {},
       billing: {},
+      billingCreate: {
+        loading: null,
+        success: null,
+        error: false,
+      },
     };
     props = {
       location: {},


### PR DESCRIPTION
AC-1850 - ChoosePlanPage flashes before redirecting to dashboard and adding a paid plan

### What Changed
_Note-_ 
_Cause of this bug seemed to be coming from the actions emitted by the redux form, the form would emit a redux/@Destroy action after a successful submit which would trigger rerender of the form before the redirect to dashboard._

- moved the redirect and alert to useEffect instead of then.

### How To Test

- Sign up for a new account.
- On Choose plan page, choose a paid plan
- check if the flasing of the page is gone and you get redirected to dashboard smoothly

### To Do

- [ ] Address feedback
