### PR TITLE
SA-2042: Fixed issue with dates not formatting to timezone 

### DIFF
--- a/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
@@ -73,4 +73,23 @@ describe('Date Time Section on Summary Report & Report Builder', () => {
       expect(xhr.url).to.contain(`from=2020-01-29T14:00`);
     });
   });
+
+  it.only('should show appropriate date ranges based on timezone (and not local timezone)', () => {
+    cy.visit(
+      `/signals/analytics?from=2021-01-13T23%3A00%3A00-06%3A00&to=2021-01-29T22%3A59%3A59-06%3A00&range=custom`,
+    );
+    cy.wait('@getSubaccounts');
+    cy.findByDataId('aggregate-metrics-date-range').within(() => {
+      cy.findByText('Jan 14th, 2021 - Jan 29th, 2021').should('be.visible');
+    });
+    cy.findByLabelText('Time Zone')
+      .focus()
+      .clear()
+      .type('Belize');
+    cy.tick(300);
+    cy.findByRole('option', { name: '(UTC-06:00) America/Belize' }).click({ force: true });
+    cy.findByDataId('aggregate-metrics-date-range').within(() => {
+      cy.findByText('Jan 13th, 2021 - Jan 29th, 2021').should('be.visible');
+    });
+  });
 });

--- a/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
@@ -74,7 +74,7 @@ describe('Date Time Section on Summary Report & Report Builder', () => {
     });
   });
 
-  it.only('should show appropriate date ranges based on timezone (and not local timezone)', () => {
+  it('should show appropriate date ranges based on timezone (and not local timezone)', () => {
     cy.visit(
       `/signals/analytics?from=2021-01-13T23%3A00%3A00-06%3A00&to=2021-01-29T22%3A59%3A59-06%3A00&range=custom`,
     );

--- a/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
@@ -80,7 +80,7 @@ describe('Date Time Section on Summary Report & Report Builder', () => {
     );
     cy.wait('@getSubaccounts');
     cy.findByDataId('aggregate-metrics-date-range').within(() => {
-      cy.findByText('Jan 14th, 2021 - Jan 29th, 2021').should('be.visible');
+      cy.findByText('Jan 14th - Jan 29th, 2021').should('be.visible');
     });
     cy.findByLabelText('Time Zone')
       .focus()

--- a/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
+++ b/cypress/tests/integration/signals-analytics/analytics-report/dateAndTimeSection.spec.js
@@ -89,7 +89,7 @@ describe('Date Time Section on Summary Report & Report Builder', () => {
     cy.tick(300);
     cy.findByRole('option', { name: '(UTC-06:00) America/Belize' }).click({ force: true });
     cy.findByDataId('aggregate-metrics-date-range').within(() => {
-      cy.findByText('Jan 13th, 2021 - Jan 29th, 2021').should('be.visible');
+      cy.findByText('Jan 13th - Jan 29th, 2021').should('be.visible');
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "lint-staged": {
-    "{config,cypress,src,.eslintplugin}/**/*[.spec][.test].js": [
+    "{config,cypress,src,.eslintplugin}/**/*.js": [
       "eslint --fix",
       "git add"
     ],

--- a/src/components/reportBuilder/AggregatedMetrics.js
+++ b/src/components/reportBuilder/AggregatedMetrics.js
@@ -21,7 +21,7 @@ export default function AggregatedMetrics({
   return (
     <Box padding="400" backgroundColor="gray.1000">
       <Grid>
-        <Grid.Column sm={showFiltersButton ? 9 : 3}>
+        <Grid.Column sm={showFiltersButton ? 9 : 3} data-id="aggregate-metrics-date-range">
           <LabelValue dark>
             <LabelValue.Label>Date</LabelValue.Label>
 

--- a/src/components/reportBuilder/CompareByAggregatedMetrics.js
+++ b/src/components/reportBuilder/CompareByAggregatedMetrics.js
@@ -21,7 +21,7 @@ export default function CompareByAggregatedMetrics({
   const renderDate = () => {
     return (
       <Column width={showFiltersButton ? 2 / 5 : 1 / 5}>
-        <Box mb={showFiltersButton && '500'}>
+        <Box mb={showFiltersButton && '500'} data-id="aggregate-metrics-date-range">
           <LabelValue dark>
             <LabelValue.Label>Date</LabelValue.Label>
 

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -174,7 +174,7 @@ export function getFormattedDateRangeForAggregateData(from, to, timezone = getLo
   if (!from || !to) {
     return '';
   }
-  return `${formatToTimezone(new Date(from), "MMM do',' yyyy", timezone)} - ${formatToTimezone(
+  return `${formatToTimezone(new Date(from), 'MMM do', timezone)} - ${formatToTimezone(
     new Date(to),
     "MMM do',' yyyy",
     timezone,

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -170,8 +170,15 @@ export function formatDateTimeWithoutYear(datetime) {
   return formatDateTime(datetime, `${config.dateFormatWithoutYear}, ${config.timeFormat}`);
 }
 
-export function getFormattedDateRangeForAggregateData(from, to) {
-  return `${formatDate(from, 'MMM Do')} - ${formatDate(to, 'MMM Do, YYYY')}`;
+export function getFormattedDateRangeForAggregateData(from, to, timezone = getLocalTimezone()) {
+  if (!from || !to) {
+    return '';
+  }
+  return `${formatToTimezone(new Date(from), "MMM do',' yyyy", timezone)} - ${formatToTimezone(
+    new Date(to),
+    "MMM do',' yyyy",
+    timezone,
+  )}`;
 }
 // format as ISO 8601 timestamp to match SP API
 export const formatApiTimestamp = time => moment.utc(time).format();

--- a/src/pages/dashboardV2/DashboardPageV2.js
+++ b/src/pages/dashboardV2/DashboardPageV2.js
@@ -115,6 +115,7 @@ export default function DashboardPageV2() {
   const dateValue = getFormattedDateRangeForAggregateData(
     pinnedReport?.options?.from,
     pinnedReport?.options?.to,
+    pinnedReport?.options?.timezone,
   );
   if (pending) return <Loading />;
 

--- a/src/pages/reportBuilder/ReportBuilder.js
+++ b/src/pages/reportBuilder/ReportBuilder.js
@@ -231,8 +231,8 @@ export function ReportBuilder({
     setShowTable(true);
   }, [tabs]);
 
-  const { to, from } = summarySearchOptions;
-  const dateValue = getFormattedDateRangeForAggregateData(from, to);
+  const { to, from, timezone } = summarySearchOptions;
+  const dateValue = getFormattedDateRangeForAggregateData(from, to, timezone);
 
   if (!reportOptions.isReady) {
     return <Loading />;


### PR DESCRIPTION
### What Changed

-Dates account for timezone in  report builder

### How To Test

- Go to report report builder
- Set a time that is on the edge of a new day (previous or forward)
- Change timezone to move day to next day (or previous day)
- Verify that date is correct in aggregate data (relative to timezone)

### To Do

- [ ] Add testing around this
