### PR TITLE
SA-2194 - Resolves (UI) Compare by aggregated UI should be responsive

### DIFF
--- a/src/components/reportBuilder/CompareByAggregatedRow.js
+++ b/src/components/reportBuilder/CompareByAggregatedRow.js
@@ -13,7 +13,15 @@ const MetricsGrid = styled.div`
   display: inline-grid;
   width: 100%;
   grid-gap: ${props => props.theme.space['200']};
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: 1fr;
+
+  @media (min-width: ${props => props.theme.breakpoints[0]}) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (min-width: ${props => props.theme.breakpoints[1]}) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
 `;
 
 export default function CompareByAggregatedRow({ comparison, reportOptions, hasDivider }) {
@@ -40,7 +48,7 @@ export default function CompareByAggregatedRow({ comparison, reportOptions, hasD
 
   return (
     <Stack>
-      <Columns>
+      <Columns collapseBelow="sm">
         <Column width={1 / 6}>
           <LabelValue dark>
             <LabelValue.Label>{getFilterTypeLabel(comparison.type)}</LabelValue.Label>


### PR DESCRIPTION
[SA-2194](https://sparkpost.atlassian.net/browse/SA-2139)

### What Changed

- Updated styles to collapse on certain breakpoints

### How To Test

- Resize the browser window on both `/signals/analytics` and `/dashboard` with comparisons active on a report (Click "Add Comparisons" if none are present or swap to a saved report with active comparisons)
- Verify the content within the aggregates UI is responsive:

<img width="713" alt="Screen Shot 2021-02-24 at 9 12 44 AM" src="https://user-images.githubusercontent.com/3613392/109012862-7bcf3280-7680-11eb-98bc-f2234095a8e0.png">


### To Do

- [ ] Incorporate feedback
