### PR TITLE
AC-1905 - Track /join to /onboarding/plan in segment

### DIFF
--- a/src/components/segment/SegmentPage.js
+++ b/src/components/segment/SegmentPage.js
@@ -8,7 +8,6 @@ export const SegmentPage = () => {
 
   // On URL path changes, inform segment via "PAGE" event
   useEffect(() => {
-    // NOTE: Only register listener after the user is authed
     const unlisten = history.listen(location => {
       if (prevPathname.current !== location.pathname) {
         prevPathname.current = location.pathname;

--- a/src/components/segment/SegmentPage.js
+++ b/src/components/segment/SegmentPage.js
@@ -1,24 +1,23 @@
 import { useEffect, useRef } from 'react';
-import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { segmentPage } from 'src/helpers/segment';
 
-export const SegmentPage = ({ accessControlReady }) => {
+export const SegmentPage = () => {
   const history = useHistory();
   const prevPathname = useRef(history.location.pathname);
 
   // On URL path changes, inform segment via "PAGE" event
   useEffect(() => {
-    if (accessControlReady) {
-      const unlisten = history.listen(location => {
-        if (prevPathname.current !== location.pathname) {
-          prevPathname.current = location.pathname;
-          segmentPage();
-        }
-      });
-      return () => unlisten();
-    }
-  }, [accessControlReady, history]);
+    // NOTE: Only register listener after the user is authed
+    const unlisten = history.listen(location => {
+      if (prevPathname.current !== location.pathname) {
+        prevPathname.current = location.pathname;
+        segmentPage();
+      }
+    });
+
+    return () => unlisten();
+  }, [history]);
 
   // "PAGE" on app load
   useEffect(() => {
@@ -28,8 +27,4 @@ export const SegmentPage = ({ accessControlReady }) => {
   return null;
 };
 
-const mapStateToProps = state => ({
-  accessControlReady: state.accessControlReady,
-});
-
-export default connect(mapStateToProps, {})(SegmentPage);
+export default SegmentPage;

--- a/src/components/segment/tests/SegmentPage.test.js
+++ b/src/components/segment/tests/SegmentPage.test.js
@@ -18,7 +18,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('Segment', () => {
-  const getSubject = props => mount(<SegmentPage accessControlReady {...props} />);
+  const getSubject = props => mount(<SegmentPage {...props} />);
 
   beforeEach(() => {
     helpers.segmentPage = jest.fn();

--- a/src/components/segment/tests/__snapshots__/Segment.test.js.snap
+++ b/src/components/segment/tests/__snapshots__/Segment.test.js.snap
@@ -15,7 +15,7 @@ analytics.load("abcdefg1234567");
     </script>
   </HelmetWrapper>
   <Connect(SegmentIdentify) />
-  <Connect(SegmentPage) />
+  <SegmentPage />
 </Fragment>
 `;
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -4,6 +4,7 @@ import { invert } from 'lodash';
 
 export const DEFAULT_REDIRECT_ROUTE = '/landing';
 export const AFTER_JOIN_REDIRECT_ROUTE = '/onboarding/plan';
+export const RV_AFTER_JOIN_REDIRECT_ROUTE = '/onboarding/recipient-validation';
 export const SIGN_UP_ROUTE = '/join';
 export const AUTH_ROUTE = '/auth';
 export const TFA_ROUTE = '/auth/tfa';

--- a/src/pages/join/JoinPage.js
+++ b/src/pages/join/JoinPage.js
@@ -20,6 +20,7 @@ import { loadScript } from 'src/helpers/loadScript';
 import * as analytics from 'src/helpers/analytics';
 import {
   AFTER_JOIN_REDIRECT_ROUTE,
+  RV_AFTER_JOIN_REDIRECT_ROUTE,
   LINKS,
   AWS_COOKIE_NAME,
   ANALYTICS_CREATE_ACCOUNT,
@@ -85,8 +86,9 @@ export class JoinPage extends Component {
         });
 
         if (product === 'rv') {
-          return this.props.history.push('/onboarding/recipient-validation');
+          return this.props.history.push(RV_AFTER_JOIN_REDIRECT_ROUTE);
         }
+
         return this.props.history.push(AFTER_JOIN_REDIRECT_ROUTE, { plan });
       });
   };


### PR DESCRIPTION
### What Changed
- Removed the check for access control in the segment page call

### How To Test
- Create a new account and make sure segment is getting the /onboarding/join data after account creation

### To Do
- [ ] Double check things and test that removing the access control won't be a problem
