### PR TITLE
AC-1917 - (UI) Incorporate valid HTML form elements in the app

### DIFF
--- a/src/pages/abTesting/EditMode.js
+++ b/src/pages/abTesting/EditMode.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { reduxForm, getFormValues } from 'redux-form';
 import { withRouter } from 'react-router-dom';
 import { list as listSubaccounts } from 'src/actions/subaccounts';
-
+import { Form } from 'src/components/form';
 import { showAlert } from 'src/actions/globalAlert';
 import {
   updateDraft,
@@ -77,12 +77,12 @@ export class EditMode extends Component {
   };
 
   getPrimaryAction = () => {
-    const { handleSubmit, test, rescheduling, rescheduleLoading } = this.props;
+    const { test, rescheduling, rescheduleLoading } = this.props;
 
     if (rescheduling) {
       return {
         content: 'Finalize and Reschedule Test',
-        onClick: handleSubmit(this.handleReschedule),
+        type: 'submit',
         disabled: rescheduleLoading,
       };
     }
@@ -90,14 +90,28 @@ export class EditMode extends Component {
     if (test.status === 'draft') {
       return {
         content: 'Finalize and Schedule Test',
-        onClick: handleSubmit(this.handleSchedule),
+        type: 'submit',
       };
     }
 
     return {
       content: 'Update Test',
-      onClick: handleSubmit(this.handleUpdateScheduled),
+      type: 'submit',
     };
+  };
+
+  getSubmitAction = () => {
+    const { test, rescheduling } = this.props;
+
+    if (rescheduling) {
+      return this.handleReschedule;
+    }
+
+    if (test.status === 'draft') {
+      return this.handleSchedule;
+    }
+
+    return this.handleUpdateScheduled;
   };
 
   getSecondaryActions = () => {
@@ -125,54 +139,56 @@ export class EditMode extends Component {
     } = this.props;
 
     return (
-      <Page
-        title={test.name}
-        breadcrumbAction={breadcrumbAction}
-        primaryAction={this.getPrimaryAction()}
-        secondaryActions={this.getSecondaryActions()}
-      >
-        <Stack>
-          <Section title="Basic Information">
-            <Section.Left>
-              <StatusContent test={test} rescheduling={rescheduling} />
-            </Section.Left>
-            <Section.Right>
-              <Box as={Panel.LEGACY} marginTop="400">
-                <StatusPanel
-                  test={test}
+      <Form id="abtest-edit-form" onSubmit={this.props.handleSubmit(this.getSubmitAction())}>
+        <Page
+          title={test.name}
+          breadcrumbAction={breadcrumbAction}
+          primaryAction={this.getPrimaryAction()}
+          secondaryActions={this.getSecondaryActions()}
+        >
+          <Stack>
+            <Section title="Basic Information">
+              <Section.Left>
+                <StatusContent test={test} rescheduling={rescheduling} />
+              </Section.Left>
+              <Section.Right>
+                <Box as={Panel.LEGACY} marginTop="400">
+                  <StatusPanel
+                    test={test}
+                    subaccountId={subaccountId}
+                    subaccountName={subaccountName}
+                  />
+                  <StatusFields disabled={submitting} />
+                </Box>
+              </Section.Right>
+            </Section>
+
+            <Section title="Settings">
+              <Section.Left>
+                <SettingsContent test={test} />
+              </Section.Left>
+              <Section.Right>
+                <Box as={Panel.LEGACY} marginTop="400">
+                  <SettingsFields formValues={formValues} disabled={submitting} />
+                </Box>
+              </Section.Right>
+            </Section>
+
+            <Section title="Variants">
+              <Section.Left>
+                <VariantsContent />
+              </Section.Left>
+              <Section.Right>
+                <VariantsFields
+                  formValues={formValues}
+                  disabled={submitting}
                   subaccountId={subaccountId}
-                  subaccountName={subaccountName}
                 />
-                <StatusFields disabled={submitting} />
-              </Box>
-            </Section.Right>
-          </Section>
-
-          <Section title="Settings">
-            <Section.Left>
-              <SettingsContent test={test} />
-            </Section.Left>
-            <Section.Right>
-              <Box as={Panel.LEGACY} marginTop="400">
-                <SettingsFields formValues={formValues} disabled={submitting} />
-              </Box>
-            </Section.Right>
-          </Section>
-
-          <Section title="Variants">
-            <Section.Left>
-              <VariantsContent />
-            </Section.Left>
-            <Section.Right>
-              <VariantsFields
-                formValues={formValues}
-                disabled={submitting}
-                subaccountId={subaccountId}
-              />
-            </Section.Right>
-          </Section>
-        </Stack>
-      </Page>
+              </Section.Right>
+            </Section>
+          </Stack>
+        </Page>
+      </Form>
     );
   }
 }

--- a/src/pages/abTesting/tests/EditMode.test.js
+++ b/src/pages/abTesting/tests/EditMode.test.js
@@ -20,9 +20,9 @@ describe('Page: A/B Test Edit Mode', () => {
         name: 'my ab test 1',
         status: 'draft',
         default_template: {
-          template_id: 'ab-test-1'
+          template_id: 'ab-test-1',
         },
-        updated_at: '2018-10-21T10:10:10.000Z'
+        updated_at: '2018-10-21T10:10:10.000Z',
       },
       getAbTest: jest.fn(),
       showAlert: jest.fn(),
@@ -36,21 +36,21 @@ describe('Page: A/B Test Edit Mode', () => {
       rescheduleLoading: false,
       deleteAction: {
         content: 'delete test',
-        onClick: jest.fn()
+        onClick: jest.fn(),
       },
       cancelAction: {
         content: 'cancel test',
-        onClick: jest.fn()
+        onClick: jest.fn(),
       },
-      handleSubmit: jest.fn((a) => a),
+      handleSubmit: jest.fn(a => a),
       formValues: 'test values',
       submitting: false,
       history: {
-        push: jest.fn()
-      }
+        push: jest.fn(),
+      },
     };
     wrapper = shallow(<EditMode {...props} />);
-    formatFormValues.mockImplementation((a) => a);
+    formatFormValues.mockImplementation(a => a);
   });
 
   it('should render draft status correctly', () => {
@@ -59,51 +59,89 @@ describe('Page: A/B Test Edit Mode', () => {
   });
 
   it('should render scheduled status correctly', () => {
-    wrapper.setProps({ test: { ...props.test, status: 'scheduled' }});
+    wrapper.setProps({ test: { ...props.test, status: 'scheduled' } });
     expect(wrapper).toMatchSnapshot();
   });
 
   describe('draft actions', () => {
     it('should call save as draft method from secondary action', () => {
-      wrapper.find('Page').prop('secondaryActions')[0].onClick();
+      wrapper
+        .find('Page')
+        .prop('secondaryActions')[0]
+        .onClick();
       expect(props.handleSubmit).toHaveBeenCalledWith(wrapper.instance().handleSaveAsDraft);
     });
 
     it('should call handle save as draft', async () => {
       await wrapper.instance().handleSaveAsDraft(props.formValues);
-      expect(props.updateDraft).toHaveBeenCalledWith({ data: props.formValues, id: props.test.id, subaccountId: props.subaccountId });
-      expect(props.getAbTest).toHaveBeenCalledWith({ id: props.test.id, version: props.test.version, subaccountId: props.subaccountId });
-      expect(props.showAlert).toHaveBeenCalledWith({ message: 'A/B Test Draft Updated', type: 'success' });
+      expect(props.updateDraft).toHaveBeenCalledWith({
+        data: props.formValues,
+        id: props.test.id,
+        subaccountId: props.subaccountId,
+      });
+      expect(props.getAbTest).toHaveBeenCalledWith({
+        id: props.test.id,
+        version: props.test.version,
+        subaccountId: props.subaccountId,
+      });
+      expect(props.showAlert).toHaveBeenCalledWith({
+        message: 'A/B Test Draft Updated',
+        type: 'success',
+      });
     });
   });
 
   describe('schedule actions', () => {
     it('should call schedule method from primary action', () => {
-      wrapper.find('Page').prop('primaryAction').onClick();
+      const form = wrapper.find('Form').first();
+      form.simulate('submit');
       expect(props.handleSubmit).toHaveBeenCalledWith(wrapper.instance().handleSchedule);
     });
 
     it('should call handle schedule', async () => {
       await wrapper.instance().handleSchedule(props.formValues);
-      expect(props.scheduleAbTest).toHaveBeenCalledWith({ data: props.formValues, id: props.test.id, subaccountId: props.subaccountId });
-      expect(props.getAbTest).toHaveBeenCalledWith({ id: props.test.id, version: props.test.version, subaccountId: props.subaccountId });
-      expect(props.showAlert).toHaveBeenCalledWith({ message: 'A/B Test Draft Scheduled', type: 'success' });
+      expect(props.scheduleAbTest).toHaveBeenCalledWith({
+        data: props.formValues,
+        id: props.test.id,
+        subaccountId: props.subaccountId,
+      });
+      expect(props.getAbTest).toHaveBeenCalledWith({
+        id: props.test.id,
+        version: props.test.version,
+        subaccountId: props.subaccountId,
+      });
+      expect(props.showAlert).toHaveBeenCalledWith({
+        message: 'A/B Test Draft Scheduled',
+        type: 'success',
+      });
     });
   });
 
   describe('update actions', () => {
     it('should call update method from primary action', () => {
-      wrapper.setProps({ test: { ...props.test, status: 'scheduled' }});
-      wrapper.find('Page').prop('primaryAction').onClick();
+      wrapper.setProps({ test: { ...props.test, status: 'scheduled' } });
+      const form = wrapper.find('Form').first();
+      form.simulate('submit');
       expect(props.handleSubmit).toHaveBeenCalledWith(wrapper.instance().handleUpdateScheduled);
     });
 
     it('should call handle update', async () => {
-      wrapper.setProps({ test: { ...props.test, status: 'scheduled' }});
+      wrapper.setProps({ test: { ...props.test, status: 'scheduled' } });
       await wrapper.instance().handleUpdateScheduled(props.formValues);
-      expect(props.updateAbTest).toHaveBeenCalledWith({ data: props.formValues, id: props.test.id, subaccountId: props.subaccountId });
-      expect(props.getAbTest).toHaveBeenCalledWith({ id: props.test.id, version: props.test.version, subaccountId: props.subaccountId });
-      expect(props.showAlert).toHaveBeenCalledWith({ message: 'A/B Test Updated', type: 'success' });
+      expect(props.updateAbTest).toHaveBeenCalledWith({
+        data: props.formValues,
+        id: props.test.id,
+        subaccountId: props.subaccountId,
+      });
+      expect(props.getAbTest).toHaveBeenCalledWith({
+        id: props.test.id,
+        version: props.test.version,
+        subaccountId: props.subaccountId,
+      });
+      expect(props.showAlert).toHaveBeenCalledWith({
+        message: 'A/B Test Updated',
+        type: 'success',
+      });
     });
   });
 
@@ -123,8 +161,15 @@ describe('Page: A/B Test Edit Mode', () => {
 
     it('should handle reschedule action', async () => {
       await wrapper.instance().handleReschedule(props.formValues);
-      expect(props.rescheduleAbTest).toHaveBeenCalledWith({ data: props.formValues, id: props.test.id, subaccountId: props.subaccountId });
-      expect(props.showAlert).toHaveBeenCalledWith({ message: 'A/B Test Rescheduled', type: 'success' });
+      expect(props.rescheduleAbTest).toHaveBeenCalledWith({
+        data: props.formValues,
+        id: props.test.id,
+        subaccountId: props.subaccountId,
+      });
+      expect(props.showAlert).toHaveBeenCalledWith({
+        message: 'A/B Test Rescheduled',
+        type: 'success',
+      });
       expect(props.history.push).toHaveBeenCalledWith('/ab-testing/id-1/2?subaccount=101');
     });
   });

--- a/src/pages/abTesting/tests/__snapshots__/EditMode.test.js.snap
+++ b/src/pages/abTesting/tests/__snapshots__/EditMode.test.js.snap
@@ -4,66 +4,48 @@ exports[`Page: A/B Test Edit Mode rescheduling should render reschedule primary 
 Object {
   "content": "Finalize and Reschedule Test",
   "disabled": false,
-  "onClick": [Function],
+  "type": "submit",
 }
 `;
 
 exports[`Page: A/B Test Edit Mode should render draft status correctly 1`] = `
-<Page
-  primaryAction={
-    Object {
-      "content": "Finalize and Schedule Test",
-      "onClick": [Function],
-    }
-  }
-  secondaryActions={
-    Array [
-      Object {
-        "content": "Save as Draft",
-        "onClick": [Function],
-        "visible": true,
-      },
-      Object {
-        "content": "cancel test",
-        "onClick": [MockFunction],
-      },
-      Object {
-        "content": "delete test",
-        "onClick": [MockFunction],
-      },
-    ]
-  }
-  title="my ab test 1"
+<Form
+  id="abtest-edit-form"
+  onSubmit={[Function]}
 >
-  <Stack>
-    <Section
-      title="Basic Information"
-    >
-      <Left>
-        <StatusContent
-          rescheduling={false}
-          test={
-            Object {
-              "default_template": Object {
-                "template_id": "ab-test-1",
-              },
-              "id": "id-1",
-              "name": "my ab test 1",
-              "status": "draft",
-              "updated_at": "2018-10-21T10:10:10.000Z",
-              "version": 1,
-            }
-          }
-        />
-      </Left>
-      <Right>
-        <Box
-          as={[Function]}
-          marginTop="400"
-        >
-          <withRouter(Connect(StatusPanel))
-            subaccountId="101"
-            subaccountName={null}
+  <Page
+    primaryAction={
+      Object {
+        "content": "Finalize and Schedule Test",
+        "type": "submit",
+      }
+    }
+    secondaryActions={
+      Array [
+        Object {
+          "content": "Save as Draft",
+          "onClick": [Function],
+          "visible": true,
+        },
+        Object {
+          "content": "cancel test",
+          "onClick": [MockFunction],
+        },
+        Object {
+          "content": "delete test",
+          "onClick": [MockFunction],
+        },
+      ]
+    }
+    title="my ab test 1"
+  >
+    <Stack>
+      <Section
+        title="Basic Information"
+      >
+        <Left>
+          <StatusContent
+            rescheduling={false}
             test={
               Object {
                 "default_template": Object {
@@ -77,117 +59,122 @@ exports[`Page: A/B Test Edit Mode should render draft status correctly 1`] = `
               }
             }
           />
-          <StatusFields
-            disabled={false}
-          />
-        </Box>
-      </Right>
-    </Section>
-    <Section
-      title="Settings"
-    >
-      <Left>
-        <SettingsContent
-          test={
-            Object {
-              "default_template": Object {
-                "template_id": "ab-test-1",
-              },
-              "id": "id-1",
-              "name": "my ab test 1",
-              "status": "draft",
-              "updated_at": "2018-10-21T10:10:10.000Z",
-              "version": 1,
+        </Left>
+        <Right>
+          <Box
+            as={[Function]}
+            marginTop="400"
+          >
+            <withRouter(Connect(StatusPanel))
+              subaccountId="101"
+              subaccountName={null}
+              test={
+                Object {
+                  "default_template": Object {
+                    "template_id": "ab-test-1",
+                  },
+                  "id": "id-1",
+                  "name": "my ab test 1",
+                  "status": "draft",
+                  "updated_at": "2018-10-21T10:10:10.000Z",
+                  "version": 1,
+                }
+              }
+            />
+            <StatusFields
+              disabled={false}
+            />
+          </Box>
+        </Right>
+      </Section>
+      <Section
+        title="Settings"
+      >
+        <Left>
+          <SettingsContent
+            test={
+              Object {
+                "default_template": Object {
+                  "template_id": "ab-test-1",
+                },
+                "id": "id-1",
+                "name": "my ab test 1",
+                "status": "draft",
+                "updated_at": "2018-10-21T10:10:10.000Z",
+                "version": 1,
+              }
             }
-          }
-        />
-      </Left>
-      <Right>
-        <Box
-          as={[Function]}
-          marginTop="400"
-        >
-          <SettingsFields
+          />
+        </Left>
+        <Right>
+          <Box
+            as={[Function]}
+            marginTop="400"
+          >
+            <SettingsFields
+              disabled={false}
+              formValues="test values"
+            />
+          </Box>
+        </Right>
+      </Section>
+      <Section
+        title="Variants"
+      >
+        <Left>
+          <VariantsContent />
+        </Left>
+        <Right>
+          <VariantsFields
             disabled={false}
             formValues="test values"
+            subaccountId="101"
           />
-        </Box>
-      </Right>
-    </Section>
-    <Section
-      title="Variants"
-    >
-      <Left>
-        <VariantsContent />
-      </Left>
-      <Right>
-        <VariantsFields
-          disabled={false}
-          formValues="test values"
-          subaccountId="101"
-        />
-      </Right>
-    </Section>
-  </Stack>
-</Page>
+        </Right>
+      </Section>
+    </Stack>
+  </Page>
+</Form>
 `;
 
 exports[`Page: A/B Test Edit Mode should render scheduled status correctly 1`] = `
-<Page
-  primaryAction={
-    Object {
-      "content": "Update Test",
-      "onClick": [Function],
-    }
-  }
-  secondaryActions={
-    Array [
-      Object {
-        "content": "Save as Draft",
-        "onClick": [Function],
-        "visible": false,
-      },
-      Object {
-        "content": "cancel test",
-        "onClick": [MockFunction],
-      },
-      Object {
-        "content": "delete test",
-        "onClick": [MockFunction],
-      },
-    ]
-  }
-  title="my ab test 1"
+<Form
+  id="abtest-edit-form"
+  onSubmit={[Function]}
 >
-  <Stack>
-    <Section
-      title="Basic Information"
-    >
-      <Left>
-        <StatusContent
-          rescheduling={false}
-          test={
-            Object {
-              "default_template": Object {
-                "template_id": "ab-test-1",
-              },
-              "id": "id-1",
-              "name": "my ab test 1",
-              "status": "scheduled",
-              "updated_at": "2018-10-21T10:10:10.000Z",
-              "version": 1,
-            }
-          }
-        />
-      </Left>
-      <Right>
-        <Box
-          as={[Function]}
-          marginTop="400"
-        >
-          <withRouter(Connect(StatusPanel))
-            subaccountId="101"
-            subaccountName={null}
+  <Page
+    primaryAction={
+      Object {
+        "content": "Update Test",
+        "type": "submit",
+      }
+    }
+    secondaryActions={
+      Array [
+        Object {
+          "content": "Save as Draft",
+          "onClick": [Function],
+          "visible": false,
+        },
+        Object {
+          "content": "cancel test",
+          "onClick": [MockFunction],
+        },
+        Object {
+          "content": "delete test",
+          "onClick": [MockFunction],
+        },
+      ]
+    }
+    title="my ab test 1"
+  >
+    <Stack>
+      <Section
+        title="Basic Information"
+      >
+        <Left>
+          <StatusContent
+            rescheduling={false}
             test={
               Object {
                 "default_template": Object {
@@ -201,57 +188,80 @@ exports[`Page: A/B Test Edit Mode should render scheduled status correctly 1`] =
               }
             }
           />
-          <StatusFields
-            disabled={false}
-          />
-        </Box>
-      </Right>
-    </Section>
-    <Section
-      title="Settings"
-    >
-      <Left>
-        <SettingsContent
-          test={
-            Object {
-              "default_template": Object {
-                "template_id": "ab-test-1",
-              },
-              "id": "id-1",
-              "name": "my ab test 1",
-              "status": "scheduled",
-              "updated_at": "2018-10-21T10:10:10.000Z",
-              "version": 1,
+        </Left>
+        <Right>
+          <Box
+            as={[Function]}
+            marginTop="400"
+          >
+            <withRouter(Connect(StatusPanel))
+              subaccountId="101"
+              subaccountName={null}
+              test={
+                Object {
+                  "default_template": Object {
+                    "template_id": "ab-test-1",
+                  },
+                  "id": "id-1",
+                  "name": "my ab test 1",
+                  "status": "scheduled",
+                  "updated_at": "2018-10-21T10:10:10.000Z",
+                  "version": 1,
+                }
+              }
+            />
+            <StatusFields
+              disabled={false}
+            />
+          </Box>
+        </Right>
+      </Section>
+      <Section
+        title="Settings"
+      >
+        <Left>
+          <SettingsContent
+            test={
+              Object {
+                "default_template": Object {
+                  "template_id": "ab-test-1",
+                },
+                "id": "id-1",
+                "name": "my ab test 1",
+                "status": "scheduled",
+                "updated_at": "2018-10-21T10:10:10.000Z",
+                "version": 1,
+              }
             }
-          }
-        />
-      </Left>
-      <Right>
-        <Box
-          as={[Function]}
-          marginTop="400"
-        >
-          <SettingsFields
+          />
+        </Left>
+        <Right>
+          <Box
+            as={[Function]}
+            marginTop="400"
+          >
+            <SettingsFields
+              disabled={false}
+              formValues="test values"
+            />
+          </Box>
+        </Right>
+      </Section>
+      <Section
+        title="Variants"
+      >
+        <Left>
+          <VariantsContent />
+        </Left>
+        <Right>
+          <VariantsFields
             disabled={false}
             formValues="test values"
+            subaccountId="101"
           />
-        </Box>
-      </Right>
-    </Section>
-    <Section
-      title="Variants"
-    >
-      <Left>
-        <VariantsContent />
-      </Left>
-      <Right>
-        <VariantsFields
-          disabled={false}
-          formValues="test values"
-          subaccountId="101"
-        />
-      </Right>
-    </Section>
-  </Stack>
-</Page>
+        </Right>
+      </Section>
+    </Stack>
+  </Page>
+</Form>
 `;

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -110,7 +110,7 @@ export default function SetupBounceDomainSection({
                   record for the Hostname and Value for this domain at your DNS provider.
                 </TranslatableText>
               </p>
-              <Panel.Action type="submit">
+              <Panel.Action type="submit" form="verify-bounce-form">
                 <TranslatableText>Re-Verify Domain </TranslatableText>
                 <Autorenew size={18} />
               </Panel.Action>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -110,7 +110,7 @@ export default function SetupBounceDomainSection({
                   record for the Hostname and Value for this domain at your DNS provider.
                 </TranslatableText>
               </p>
-              <Panel.Action onClick={onSubmit}>
+              <Panel.Action type="submit">
                 <TranslatableText>Re-Verify Domain </TranslatableText>
                 <Autorenew size={18} />
               </Panel.Action>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -106,7 +106,7 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                     record for the Hostname and DKIM value of this domain.
                   </TranslatableText>
                 </p>
-                <Panel.Action onClick={onSubmit}>
+                <Panel.Action type="submit">
                   <TranslatableText>Re-Verify Domain </TranslatableText>
                   <Autorenew size={18} />
                 </Panel.Action>

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -72,7 +72,7 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
                   </Text>
                   <TranslatableText>record for this domain at your DNS provider.</TranslatableText>
                 </p>
-                <Panel.Action onClick={onSubmit}>
+                <Panel.Action type="submit">
                   <TranslatableText>Re-Verify Domain </TranslatableText>
                   <Autorenew size={18} />
                 </Panel.Action>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -71,7 +71,7 @@ export default function VerifyEmailSection({ domain, isSectionVisible }) {
 
 function VerifyButton({ onClick, variant = 'primary', submitting }) {
   return (
-    <Button variant={variant} loading={submitting} onClick={onClick}>
+    <Button variant={variant} loading={submitting} onClick={onClick} type="submit">
       Send Email
     </Button>
   );
@@ -169,36 +169,38 @@ function MailboxVerificationModal(props) {
             Start sending email from this domain by sending a verification email to one of the
             addresses below.
           </p>
-
-          <Grid middle="xs">
-            <Grid.Column xs={6}>
-              <p>
-                <strong>{`postmaster@${id}`}</strong>
-              </p>
-            </Grid.Column>
-            <Grid.Column xs={6}>
-              <VerifyButton
-                onClick={verifyWithPostmaster}
-                variant="secondary"
-                submitting={verifyEmailLoading}
-              />
-            </Grid.Column>
-          </Grid>
-
-          <Grid middle="xs">
-            <Grid.Column xs={6}>
-              <p>
-                <strong>{`abuse@${id}`}</strong>
-              </p>
-            </Grid.Column>
-            <Grid.Column xs={6}>
-              <VerifyButton
-                onClick={verifyWithAbuse}
-                variant="secondary"
-                submitting={verifyEmailLoading}
-              />
-            </Grid.Column>
-          </Grid>
+          <Form id="domain-email-verification-postmaster">
+            <Grid middle="xs">
+              <Grid.Column xs={6}>
+                <p>
+                  <strong>{`postmaster@${id}`}</strong>
+                </p>
+              </Grid.Column>
+              <Grid.Column xs={6}>
+                <VerifyButton
+                  onClick={verifyWithPostmaster}
+                  variant="secondary"
+                  submitting={verifyEmailLoading}
+                />
+              </Grid.Column>
+            </Grid>
+          </Form>
+          <Form id="domain-email-verification-abuse">
+            <Grid middle="xs">
+              <Grid.Column xs={6}>
+                <p>
+                  <strong>{`abuse@${id}`}</strong>
+                </p>
+              </Grid.Column>
+              <Grid.Column xs={6}>
+                <VerifyButton
+                  onClick={verifyWithAbuse}
+                  variant="secondary"
+                  submitting={verifyEmailLoading}
+                />
+              </Grid.Column>
+            </Grid>
+          </Form>
         </Stack>
       </Modal.Content>
     </Modal>

--- a/src/pages/join/components/JoinForm.js
+++ b/src/pages/join/components/JoinForm.js
@@ -54,7 +54,10 @@ export class JoinForm extends Component {
     this.setState({ recaptcha_response: response }, this.props.handleSubmit(this.onSubmit));
   };
 
-  executeRecaptcha = () => this.state.reCaptchaInstance.execute();
+  executeRecaptcha = event => {
+    event.preventDefault();
+    this.state.reCaptchaInstance.execute();
+  };
 
   linkRecaptcha = instance => {
     if (!this.state.reCaptchaInstance) {
@@ -70,7 +73,7 @@ export class JoinForm extends Component {
     const pending = loading || submitting || !reCaptchaReady;
 
     return (
-      <Form id="sign-up-form">
+      <Form id="sign-up-form" onSubmit={this.executeRecaptcha}>
         <Stack>
           <Field
             name="first_name"
@@ -150,12 +153,9 @@ export class JoinForm extends Component {
           <Box>
             <Button
               id="submit"
-              // todo, need to refactor this form to add type="submit" to the button and move
-              //  this onClick to onSubmit
-              // type="submit"
+              type="submit"
               variant="primary"
               disabled={pending || pristine || invalid}
-              onClick={this.executeRecaptcha}
             >
               {loading ? 'Loading' : 'Create Account'}
             </Button>

--- a/src/pages/join/components/tests/JoinForm.test.js
+++ b/src/pages/join/components/tests/JoinForm.test.js
@@ -6,20 +6,19 @@ let props;
 let instance;
 let wrapper;
 
-
 describe('JoinForm', () => {
   let mockRecaptcha;
 
   beforeEach(() => {
     mockRecaptcha = {
       execute: jest.fn(),
-      reset: jest.fn()
+      reset: jest.fn(),
     };
 
     props = {
       loading: false,
       onSubmit: jest.fn(),
-      handleSubmit: jest.fn()
+      handleSubmit: jest.fn(),
     };
 
     wrapper = shallow(<JoinForm {...props} />);
@@ -50,7 +49,8 @@ describe('JoinForm', () => {
 
     describe('submit', () => {
       it('invokes recaptcha challenge on click', () => {
-        wrapper.find('Button').simulate('click');
+        const form = wrapper.find('Form').first();
+        form.simulate('submit', { preventDefault: jest.fn() });
         expect(mockRecaptcha.execute).toHaveBeenCalledTimes(1);
       });
     });
@@ -58,7 +58,7 @@ describe('JoinForm', () => {
     describe('executeRecaptcha', () => {
       it('invokes recaptcha on click of submit button', () => {
         wrapper.setState({ reCaptchaInstance: mockRecaptcha });
-        instance.executeRecaptcha();
+        instance.executeRecaptcha({ preventDefault: jest.fn() });
         expect(mockRecaptcha.execute).toHaveBeenCalledTimes(1);
       });
     });
@@ -90,7 +90,12 @@ describe('JoinForm', () => {
       });
 
       it('sets recaptcha response to state & invokes handleSubmit', () => {
-        const formValues = { first_name: 'foo', last_name: 'bar', email: 'foo@bar.com', password: '***' };
+        const formValues = {
+          first_name: 'foo',
+          last_name: 'bar',
+          email: 'foo@bar.com',
+          password: '***',
+        };
         wrapper.setProps({ formValues });
         instance.recaptchaVerifyCallback('foobar');
         expect(wrapper.state().recaptcha_response).toEqual('foobar');
@@ -104,9 +109,18 @@ describe('JoinForm', () => {
       });
 
       it('submits with correct data', () => {
-        const formValues = { first_name: 'foo', last_name: 'bar', email: 'foo@bar.com', password: '***' };
+        const formValues = {
+          first_name: 'foo',
+          last_name: 'bar',
+          email: 'foo@bar.com',
+          password: '***',
+        };
         instance.onSubmit(formValues);
-        expect(props.onSubmit).toHaveBeenCalledWith({ ...formValues, recaptcha_response: 'some-response', recaptcha_type: 'invisible' });
+        expect(props.onSubmit).toHaveBeenCalledWith({
+          ...formValues,
+          recaptcha_response: 'some-response',
+          recaptcha_type: 'invisible',
+        });
       });
     });
   });

--- a/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
+++ b/src/pages/join/components/tests/__snapshots__/JoinForm.test.js.snap
@@ -3,6 +3,7 @@
 exports[`JoinForm render disables form when loading 1`] = `
 <Form
   id="sign-up-form"
+  onSubmit={[Function]}
 >
   <Stack>
     <Field
@@ -101,7 +102,7 @@ exports[`JoinForm render disables form when loading 1`] = `
       <Button
         disabled={true}
         id="submit"
-        onClick={[Function]}
+        type="submit"
         variant="primary"
       >
         Loading
@@ -130,6 +131,7 @@ exports[`JoinForm render disables form when loading 1`] = `
 exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
 <Form
   id="sign-up-form"
+  onSubmit={[Function]}
 >
   <Stack>
     <Field
@@ -228,7 +230,7 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
       <Button
         disabled={true}
         id="submit"
-        onClick={[Function]}
+        type="submit"
         variant="primary"
       >
         Create Account
@@ -257,6 +259,7 @@ exports[`JoinForm render disables form when recaptcha is not loaded 1`] = `
 exports[`JoinForm render enables form correctly 1`] = `
 <Form
   id="sign-up-form"
+  onSubmit={[Function]}
 >
   <Stack>
     <Field
@@ -355,7 +358,7 @@ exports[`JoinForm render enables form correctly 1`] = `
       <Button
         disabled={false}
         id="submit"
-        onClick={[Function]}
+        type="submit"
         variant="primary"
       >
         Create Account

--- a/src/pages/reportBuilder/components/MetricsForm/MetricsForm.js
+++ b/src/pages/reportBuilder/components/MetricsForm/MetricsForm.js
@@ -5,6 +5,7 @@ import {
   hasProductOnBillingSubscription,
 } from 'src/helpers/conditions/account';
 import { Box, Button, Checkbox, Drawer, Expandable, Stack, Tooltip } from 'src/components/matchbox';
+import { Form } from 'src/components/form';
 import { DeliverabilityBanner } from './components';
 import { categorizedMetricsList, list } from 'src/config/metrics';
 import _ from 'lodash';
@@ -79,7 +80,8 @@ export default function MetricsForm(props) {
     setSelectedMetrics(newSelectedMetric);
   };
 
-  const handleApply = () => {
+  const handleApply = event => {
+    event.preventDefault();
     props.handleSubmit({ metrics: getSelectedMetrics() });
   };
 
@@ -97,7 +99,7 @@ export default function MetricsForm(props) {
   //Needs this for current tests as hibana is not enabled for tests but is required for the Drawer component
   const { DrawerFooter = Drawer.Footer } = props;
   return (
-    <>
+    <Form id="reportbuilder-metrics-form" onSubmit={handleApply}>
       <Box padding="500" paddingBottom="100px">
         <Stack>
           {Boolean(hasD12yMetricsEnabled && !hasD12yProduct) && <DeliverabilityBanner />}
@@ -154,7 +156,7 @@ export default function MetricsForm(props) {
           <Box pr="100" flex="1">
             <Button
               width="100%"
-              onClick={handleApply}
+              type="submit"
               variant="primary"
               disabled={
                 getSelectedMetrics().length < 1 || isSelectedMetricsSameAsCurrentlyAppliedMetrics
@@ -174,6 +176,6 @@ export default function MetricsForm(props) {
           </Box>
         </Box>
       </DrawerFooter>
-    </>
+    </Form>
   );
 }

--- a/src/pages/snippets/CreatePage.js
+++ b/src/pages/snippets/CreatePage.js
@@ -55,16 +55,16 @@ export default class CreatePage extends React.Component {
     }
 
     return (
-      <Page
-        title={snippetToDuplicate ? 'Duplicate Snippet' : 'Create a Snippet'}
-        breadcrumbAction={{ Component: PageLink, content: 'View All Snippets', to: '/snippets' }}
-        primaryAction={{
-          Component: Button,
-          content: 'Create Snippet',
-          onClick: handleSubmit(this.submitSnippet),
-        }}
-      >
-        <Form onSubmit={this.submitSnippet} id="snippets-create-form">
+      <Form id="snippets-create-form" onSubmit={handleSubmit(this.submitSnippet)}>
+        <Page
+          title={snippetToDuplicate ? 'Duplicate Snippet' : 'Create a Snippet'}
+          breadcrumbAction={{ Component: PageLink, content: 'View All Snippets', to: '/snippets' }}
+          primaryAction={{
+            Component: Button,
+            content: 'Create Snippet',
+            type: 'submit',
+          }}
+        >
           <Grid>
             <Grid.Column xs={12} lg={4}>
               <Panel.LEGACY sectioned>
@@ -98,8 +98,8 @@ export default class CreatePage extends React.Component {
               <ContentEditor contentOnly={true} />
             </Grid.Column>
           </Grid>
-        </Form>
-      </Page>
+        </Page>
+      </Form>
     );
   }
 }

--- a/src/pages/snippets/EditPage.js
+++ b/src/pages/snippets/EditPage.js
@@ -95,18 +95,18 @@ export default class EditPage extends React.Component {
     }
 
     return (
-      <Page
-        title="Edit Snippet"
-        breadcrumbAction={{ Component: PageLink, content: 'View All Snippets', to: '/snippets' }}
-        primaryAction={{
-          Component: Button,
-          content: 'Save Snippet',
-          disabled,
-          onClick: handleSubmit(this.submitSnippet),
-        }}
-        secondaryActions={this.secondaryActions.filter(({ visible = () => true }) => visible())}
-      >
-        <Form onSubmit={this.submitSnippet} id="snippets-edit-form">
+      <Form id="snippets-edit-form" onSubmit={handleSubmit(this.submitSnippet)}>
+        <Page
+          title="Edit Snippet"
+          breadcrumbAction={{ Component: PageLink, content: 'View All Snippets', to: '/snippets' }}
+          primaryAction={{
+            Component: Button,
+            content: 'Save Snippet',
+            type: 'submit',
+            disabled,
+          }}
+          secondaryActions={this.secondaryActions.filter(({ visible = () => true }) => visible())}
+        >
           <Grid>
             <Grid.Column xs={12} lg={4}>
               <Panel.LEGACY sectioned>
@@ -145,8 +145,8 @@ export default class EditPage extends React.Component {
               <ContentEditor contentOnly={true} readOnly={disabled} />
             </Grid.Column>
           </Grid>
-        </Form>
-      </Page>
+        </Page>
+      </Form>
     );
   }
 }

--- a/src/pages/snippets/tests/CreatePage.test.js
+++ b/src/pages/snippets/tests/CreatePage.test.js
@@ -28,7 +28,7 @@ describe('CreatePage', () => {
     });
 
     expect(getSnippet).toHaveBeenCalledWith({ id: 'duplicate-snippet', subaccountId: '123' });
-    expect(wrapper.prop('title')).toEqual('Duplicate Snippet');
+    expect(wrapper.find('Page').prop('title')).toEqual('Duplicate Snippet');
   });
 
   it('renders spinner when loading snippet to duplicate', () => {
@@ -49,8 +49,8 @@ describe('CreatePage', () => {
     const createSnippet = jest.fn(() => Promise.resolve());
     const historyPush = jest.fn();
     const wrapper = subject({ createSnippet, history: { push: historyPush } });
-
-    await wrapper.prop('primaryAction').onClick({ id: 'test-snippet', subaccount: { id: 123 } });
+    const form = wrapper.find('Form').first();
+    await form.simulate('submit', { id: 'test-snippet', subaccount: { id: 123 } });
 
     expect(createSnippet).toHaveBeenCalled();
     expect(historyPush).toHaveBeenCalledWith('/snippets/edit/test-snippet?subaccount=123');
@@ -63,8 +63,8 @@ describe('CreatePage', () => {
         const createSnippet = jest.fn(() => Promise.resolve());
         const historyPush = jest.fn();
         const wrapper = subject({ createSnippet, history: { push: historyPush } });
-
-        wrapper.prop('primaryAction').onClick({
+        const form = wrapper.find('Form').first();
+        form.simulate('submit', {
           ...values,
           id: 'example-snippet',
           name: 'Example Snippet',

--- a/src/pages/snippets/tests/EditPage.test.js
+++ b/src/pages/snippets/tests/EditPage.test.js
@@ -4,17 +4,18 @@ import EditPage from '../EditPage';
 import SubaccountSection from 'src/components/subaccountSection';
 
 describe('EditPage', () => {
-  const subject = (props = {}) => shallow(
-    <EditPage
-      canModify={true}
-      getSnippet={() => {}}
-      handleSubmit={(fn) => fn}
-      hasSubaccounts={true}
-      canViewSubaccount={true}
-      id="test-snippet"
-      {...props}
-    />
-  );
+  const subject = (props = {}) =>
+    shallow(
+      <EditPage
+        canModify={true}
+        getSnippet={() => {}}
+        handleSubmit={fn => fn}
+        hasSubaccounts={true}
+        canViewSubaccount={true}
+        id="test-snippet"
+        {...props}
+      />,
+    );
 
   it('renders edit form', () => {
     expect(subject()).toMatchSnapshot();
@@ -73,18 +74,19 @@ describe('EditPage', () => {
     const showAlert = jest.fn();
     const updateSnippet = jest.fn(() => Promise.resolve());
     const wrapper = subject({ showAlert, updateSnippet, isAmpLive: true });
+    const form = wrapper.find('Form').first();
 
-    await wrapper.prop('primaryAction').onClick({
+    await form.simulate('submit', {
       content: {
         html: '<p>Testing</p>',
-        amp_html: '<span>Testing</span>'
+        amp_html: '<span>Testing</span>',
       },
       id: 'test-snippet',
       name: 'Test Snippet',
       shared_with_subaccounts: false,
       subaccount: {
-        id: 345
-      }
+        id: 345,
+      },
     });
 
     expect(updateSnippet).toHaveBeenCalledWith({
@@ -94,7 +96,7 @@ describe('EditPage', () => {
       name: 'Test Snippet',
       sharedWithSubaccounts: false,
       subaccountId: 345,
-      text: undefined
+      text: undefined,
     });
     expect(showAlert).toHaveBeenCalled();
   });

--- a/src/pages/snippets/tests/__snapshots__/CreatePage.test.js.snap
+++ b/src/pages/snippets/tests/__snapshots__/CreatePage.test.js.snap
@@ -77,26 +77,26 @@ exports[`CreatePage .submitSnippet succeeds with shared subaccounts assignment 1
 `;
 
 exports[`CreatePage renders form 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "View All Snippets",
-      "to": "/snippets",
-    }
-  }
-  primaryAction={
-    Object {
-      "Component": [Function],
-      "content": "Create Snippet",
-      "onClick": [Function],
-    }
-  }
-  title="Create a Snippet"
+<Form
+  id="snippets-create-form"
+  onSubmit={[Function]}
 >
-  <Form
-    id="snippets-create-form"
-    onSubmit={[Function]}
+  <Page
+    breadcrumbAction={
+      Object {
+        "Component": [Function],
+        "content": "View All Snippets",
+        "to": "/snippets",
+      }
+    }
+    primaryAction={
+      Object {
+        "Component": [Function],
+        "content": "Create Snippet",
+        "type": "submit",
+      }
+    }
+    title="Create a Snippet"
   >
     <Grid>
       <Grid.Column
@@ -151,6 +151,6 @@ exports[`CreatePage renders form 1`] = `
         />
       </Grid.Column>
     </Grid>
-  </Form>
-</Page>
+  </Page>
+</Form>
 `;

--- a/src/pages/snippets/tests/__snapshots__/EditPage.test.js.snap
+++ b/src/pages/snippets/tests/__snapshots__/EditPage.test.js.snap
@@ -13,49 +13,49 @@ exports[`EditPage redirects with alert when load request fails 1`] = `
 `;
 
 exports[`EditPage renders disabled form when submitting 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "View All Snippets",
-      "to": "/snippets",
-    }
-  }
-  primaryAction={
-    Object {
-      "Component": [Function],
-      "content": "Save Snippet",
-      "disabled": true,
-      "onClick": [Function],
-    }
-  }
-  secondaryActions={
-    Array [
-      Object {
-        "Component": [Function],
-        "content": "Delete",
-        "to": "/",
-        "visible": [Function],
-      },
-      Object {
-        "Component": [Function],
-        "content": "Duplicate",
-        "to": Object {
-          "pathname": "/snippets/create",
-          "state": Object {
-            "id": "test-snippet",
-            "subaccountId": undefined,
-          },
-        },
-        "visible": [Function],
-      },
-    ]
-  }
-  title="Edit Snippet"
+<Form
+  id="snippets-edit-form"
+  onSubmit={[Function]}
 >
-  <Form
-    id="snippets-edit-form"
-    onSubmit={[Function]}
+  <Page
+    breadcrumbAction={
+      Object {
+        "Component": [Function],
+        "content": "View All Snippets",
+        "to": "/snippets",
+      }
+    }
+    primaryAction={
+      Object {
+        "Component": [Function],
+        "content": "Save Snippet",
+        "disabled": true,
+        "type": "submit",
+      }
+    }
+    secondaryActions={
+      Array [
+        Object {
+          "Component": [Function],
+          "content": "Delete",
+          "to": "/",
+          "visible": [Function],
+        },
+        Object {
+          "Component": [Function],
+          "content": "Duplicate",
+          "to": Object {
+            "pathname": "/snippets/create",
+            "state": Object {
+              "id": "test-snippet",
+              "subaccountId": undefined,
+            },
+          },
+          "visible": [Function],
+        },
+      ]
+    }
+    title="Edit Snippet"
   >
     <Grid>
       <Grid.Column
@@ -115,33 +115,33 @@ exports[`EditPage renders disabled form when submitting 1`] = `
         />
       </Grid.Column>
     </Grid>
-  </Form>
-</Page>
+  </Page>
+</Form>
 `;
 
 exports[`EditPage renders disabled form when user does not have authorization to modify snippets 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "View All Snippets",
-      "to": "/snippets",
-    }
-  }
-  primaryAction={
-    Object {
-      "Component": [Function],
-      "content": "Save Snippet",
-      "disabled": true,
-      "onClick": [Function],
-    }
-  }
-  secondaryActions={Array []}
-  title="Edit Snippet"
+<Form
+  id="snippets-edit-form"
+  onSubmit={[Function]}
 >
-  <Form
-    id="snippets-edit-form"
-    onSubmit={[Function]}
+  <Page
+    breadcrumbAction={
+      Object {
+        "Component": [Function],
+        "content": "View All Snippets",
+        "to": "/snippets",
+      }
+    }
+    primaryAction={
+      Object {
+        "Component": [Function],
+        "content": "Save Snippet",
+        "disabled": true,
+        "type": "submit",
+      }
+    }
+    secondaryActions={Array []}
+    title="Edit Snippet"
   >
     <Grid>
       <Grid.Column
@@ -201,54 +201,54 @@ exports[`EditPage renders disabled form when user does not have authorization to
         />
       </Grid.Column>
     </Grid>
-  </Form>
-</Page>
+  </Page>
+</Form>
 `;
 
 exports[`EditPage renders edit form 1`] = `
-<Page
-  breadcrumbAction={
-    Object {
-      "Component": [Function],
-      "content": "View All Snippets",
-      "to": "/snippets",
-    }
-  }
-  primaryAction={
-    Object {
-      "Component": [Function],
-      "content": "Save Snippet",
-      "disabled": undefined,
-      "onClick": [Function],
-    }
-  }
-  secondaryActions={
-    Array [
-      Object {
-        "Component": [Function],
-        "content": "Delete",
-        "to": "/",
-        "visible": [Function],
-      },
-      Object {
-        "Component": [Function],
-        "content": "Duplicate",
-        "to": Object {
-          "pathname": "/snippets/create",
-          "state": Object {
-            "id": "test-snippet",
-            "subaccountId": undefined,
-          },
-        },
-        "visible": [Function],
-      },
-    ]
-  }
-  title="Edit Snippet"
+<Form
+  id="snippets-edit-form"
+  onSubmit={[Function]}
 >
-  <Form
-    id="snippets-edit-form"
-    onSubmit={[Function]}
+  <Page
+    breadcrumbAction={
+      Object {
+        "Component": [Function],
+        "content": "View All Snippets",
+        "to": "/snippets",
+      }
+    }
+    primaryAction={
+      Object {
+        "Component": [Function],
+        "content": "Save Snippet",
+        "disabled": undefined,
+        "type": "submit",
+      }
+    }
+    secondaryActions={
+      Array [
+        Object {
+          "Component": [Function],
+          "content": "Delete",
+          "to": "/",
+          "visible": [Function],
+        },
+        Object {
+          "Component": [Function],
+          "content": "Duplicate",
+          "to": Object {
+            "pathname": "/snippets/create",
+            "state": Object {
+              "id": "test-snippet",
+              "subaccountId": undefined,
+            },
+          },
+          "visible": [Function],
+        },
+      ]
+    }
+    title="Edit Snippet"
   >
     <Grid>
       <Grid.Column
@@ -305,6 +305,6 @@ exports[`EditPage renders edit form 1`] = `
         />
       </Grid.Column>
     </Grid>
-  </Form>
-</Page>
+  </Page>
+</Form>
 `;


### PR DESCRIPTION
AC-1917 - (UI) Incorporate valid HTML form elements in the app

### What Changed


**On Ab testing page**
- [ ] EditMode.js - Reschedule and Finalize test button should be a submit button inside a `<form>`

**On Domain Pages**
- [ ] In SetupForSending : Re-verify Domain Panel action should be type="submit" instead of having onClick, as they are already inside a `<form>`
- [ ] In SetupBounceDomainSection - Re-verify Domain Panel action should be type="submit" instead of having onClick, as they are already inside a `<form>`
- [ ] In SendingAndBounceDomainSection - Re-verify Domain Panel action should be type="submit" instead of having onClick, as they are already inside a `<form>`
- [ ] In TrackingDnsSection - Re-verify Domain Panel action should be type="submit" instead of having onClick, as they are already inside a `<form>`
- [ ] In VerifyEmailSection | MailboxVerificationModal - should be wrapped in `<form>`


**On Report Builder**
- [ ] MetricsDrawer - this should be wrapped in a `<form>`


**On Snippet**
- [ ] CreatePage and EditPage Save Snippet and Create Snippet should have associated form id and type submit.

**On JoinForm**
- [ ] JoinForm submits on form submit instead of button click.

### How To Test

- onSubmit of these newly added forms work correctly

### To Do

- [ ] Address feedback
- [ ] Check if all form have submit buttons.
