### PR TITLE
AC-1911: Unable to re-enter webui when using SSO and Safari

### DIFF
--- a/src/pages/defaultRedirect/DefaultRedirect.js
+++ b/src/pages/defaultRedirect/DefaultRedirect.js
@@ -6,11 +6,17 @@ import { useLocation, useHistory } from 'react-router-dom';
 import selectAccessConditionState from 'src/selectors/accessConditionState';
 import { useHibana } from 'src/context/HibanaContext';
 import config from 'src/config';
+import authCookie from 'src/helpers/authCookie';
 
-export function DefaultRedirect({ currentUser, ready }) {
+export function DefaultRedirect({ currentUser, ready, auth }) {
   const [{ isHibanaEnabled }] = useHibana();
   const location = useLocation();
   const history = useHistory();
+
+  if (!authCookie.get()) {
+    //in case of safari because of multiple redirects auth cookie is not being set on SSOPage
+    authCookie.save(auth.authCookieData);
+  }
   useEffect(() => {
     const handleRedirect = () => {
       const { state: routerState = {}, ...locationWithoutState } = location;
@@ -46,5 +52,8 @@ export function DefaultRedirect({ currentUser, ready }) {
   return <Loading />;
 }
 
-const mapStateToProps = state => selectAccessConditionState(state);
+const mapStateToProps = state => ({
+  ...selectAccessConditionState(state),
+  auth: state.auth,
+});
 export default connect(mapStateToProps)(DefaultRedirect);

--- a/src/pages/defaultRedirect/tests/DefaultRedirect.test.js
+++ b/src/pages/defaultRedirect/tests/DefaultRedirect.test.js
@@ -5,6 +5,7 @@ import { useHibana } from 'src/context/HibanaContext';
 import routeData from 'react-router-dom';
 import cases from 'jest-in-case';
 import { ROLES } from 'src/constants';
+jest.mock('src/helpers/authCookie');
 jest.mock('src/context/HibanaContext');
 useHibana.mockImplementation(() => [{ isHibanaEnabled: false }]);
 const mockHistoryPush = jest.fn();
@@ -23,6 +24,9 @@ describe('DefaultRedirect', () => {
     defaultProps = {
       currentUser: {
         access_level: 'admin',
+      },
+      auth: {
+        authCookieData: {},
       },
       ready: false,
     };
@@ -67,6 +71,9 @@ describe('DefaultRedirect', () => {
           access_level: accessLevel,
         },
         ready: true,
+        auth: {
+          authCookieData: {},
+        },
       });
       expect(mockHistoryReplace).toHaveBeenCalledTimes(1);
       expect(mockHistoryReplace).toHaveBeenCalledWith({

--- a/src/pages/sso/SSOPage.js
+++ b/src/pages/sso/SSOPage.js
@@ -1,14 +1,13 @@
-import { Component } from 'react';
+import React, { useEffect } from 'react';
 import qs from 'query-string';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { login } from 'src/actions/auth';
 import { DEFAULT_REDIRECT_ROUTE, AUTH_ROUTE } from 'src/constants';
 
-export class SSOPage extends Component {
-
-  componentWillMount () {
-    const params = qs.parse(this.props.location.search);
+export function SSOPage(props) {
+  useEffect(() => {
+    const params = qs.parse(props.location.search);
 
     const token = params.ad || params.token; // 'token' for azure, 'ad' for saml/heroku
 
@@ -16,29 +15,27 @@ export class SSOPage extends Component {
       const data = JSON.parse(atob(token));
 
       if (data.accessToken && data.username) {
-        this.props.login({
+        props.login({
           authData: {
             access_token: data.accessToken,
             username: data.username,
-            refresh_token: ''
+            refresh_token: '',
           },
-          saveCookie: true
+          saveCookie: true,
         });
 
-        return this.props.history.push(DEFAULT_REDIRECT_ROUTE);
+        return props.history.push(DEFAULT_REDIRECT_ROUTE);
       } else {
-        return this.props.history.push(AUTH_ROUTE);
+        return props.history.push(AUTH_ROUTE);
       }
     } catch (e) {
       // something went wrong while parsing
-      return this.props.history.push(AUTH_ROUTE);
+      return props.history.push(AUTH_ROUTE);
     }
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  render () {
-    return null;
-  }
+  return <></>;
 }
-
 
 export default withRouter(connect(null, { login })(SSOPage));

--- a/src/pages/sso/tests/SSOPage.test.js
+++ b/src/pages/sso/tests/SSOPage.test.js
@@ -1,10 +1,9 @@
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 import { SSOPage } from '../SSOPage';
 import { DEFAULT_REDIRECT_ROUTE } from 'src/constants';
 
 describe('SSOPage', () => {
-
   let props;
   let wrapper;
 
@@ -12,11 +11,11 @@ describe('SSOPage', () => {
     props = {
       login: jest.fn(),
       location: {
-        search: '?ad=eyJhY2Nlc3NUb2tlbiI6MTIzLCJ1c2VybmFtZSI6InNhbWxfdGVzdCJ9' //{accessToken: 123, username: "saml_test"}
+        search: '?ad=eyJhY2Nlc3NUb2tlbiI6MTIzLCJ1c2VybmFtZSI6InNhbWxfdGVzdCJ9', //{accessToken: 123, username: "saml_test"}
       },
       history: {
-        push: jest.fn()
-      }
+        push: jest.fn(),
+      },
     };
   });
 
@@ -25,35 +24,39 @@ describe('SSOPage', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-
   it('calls login with correct data (saml)', () => {
-    wrapper = shallow(<SSOPage {...props} />);
+    wrapper = mount(<SSOPage {...props} />);
     expect(props.login).toHaveBeenCalledTimes(1);
-    expect(props.login).toHaveBeenCalledWith({ authData: { access_token: 123, username: 'saml_test', refresh_token: '' }, saveCookie: true });
+    expect(props.login).toHaveBeenCalledWith({
+      authData: { access_token: 123, username: 'saml_test', refresh_token: '' },
+      saveCookie: true,
+    });
   });
 
   it('calls login with correct data (azure)', () => {
     props.location.search = '?token=eyJhY2Nlc3NUb2tlbiI6MTIzLCJ1c2VybmFtZSI6ImF6dXJlX3Rlc3QifQ=='; //{accessToken: 123, username: "azure_test"}
-    wrapper = shallow(<SSOPage {...props} />);
+    wrapper = mount(<SSOPage {...props} />);
     expect(props.login).toHaveBeenCalledTimes(1);
-    expect(props.login).toHaveBeenCalledWith({ authData: { access_token: 123, username: 'azure_test', refresh_token: '' }, saveCookie: true });
+    expect(props.login).toHaveBeenCalledWith({
+      authData: { access_token: 123, username: 'azure_test', refresh_token: '' },
+      saveCookie: true,
+    });
   });
 
   it('redirects correctly after login', () => {
-    wrapper = shallow(<SSOPage {...props} />);
+    wrapper = mount(<SSOPage {...props} />);
     expect(props.history.push).toHaveBeenCalledWith(DEFAULT_REDIRECT_ROUTE);
   });
 
   it('redirects to auth after login fail (unknown payload)', () => {
     props.location.search = 'eyJmb28iOiJiYXIifQ=='; //btoa(JSON.stringify({foo: 'bar'}))
-    wrapper = shallow(<SSOPage {...props} />);
+    wrapper = mount(<SSOPage {...props} />);
     expect(props.history.push).toHaveBeenCalledWith('/auth');
   });
 
   it('redirects to auth after login fail (invalid data: error parsing)', () => {
     props.location.search = null;
-    wrapper = shallow(<SSOPage {...props} />);
+    wrapper = mount(<SSOPage {...props} />);
     expect(props.history.push).toHaveBeenCalledWith('/auth');
   });
-
 });

--- a/src/pages/sso/tests/__snapshots__/SSOPage.test.js.snap
+++ b/src/pages/sso/tests/__snapshots__/SSOPage.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SSOPage renders correctly 1`] = `""`;
+exports[`SSOPage renders correctly 1`] = `<Fragment />`;

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,4 +1,3 @@
-
 const initialState = { loggedIn: false, ssoUser: null };
 
 export default (state = initialState, action) => {
@@ -11,7 +10,7 @@ export default (state = initialState, action) => {
       const {
         access_token: token,
         username = state.username,
-        refresh_token: refreshToken
+        refresh_token: refreshToken,
       } = action.payload;
 
       return {
@@ -20,7 +19,8 @@ export default (state = initialState, action) => {
         token,
         username,
         refreshToken,
-        loggedIn: true
+        loggedIn: true,
+        authCookieData: action.payload,
       };
     }
 


### PR DESCRIPTION
AC-1911: Unable to re-enter webui when using SSO and Safari

Note - Reason for the below change - https://sparkpost.atlassian.net/browse/AC-1911?focusedCommentId=204739
Related to https://bugs.webkit.org/show_bug.cgi?id=77538

### What Changed

- Added an extra check on DefaultRedirect to set the authCookie, if it is not already set

### How To Test

- Not sure of a way to test this locally, Can be easily tested in staging though using the credentials we have in 1pass.

### To Do

- [ ] Address feedback
- [ ] Add a test to check this functionality for non safari browsers