### PR TITLE
AC-1917 - with Domain changes only

### DIFF
--- a/src/pages/domains/components/SendingAndBounceDomainSection.js
+++ b/src/pages/domains/components/SendingAndBounceDomainSection.js
@@ -131,7 +131,7 @@ export default function SendingAndBounceDomainSection({ domain, isSectionVisible
             ) : (
               <Panel.Section>
                 Below is the records for this domain at your DNS provider
-                <Panel.Action onClick={() => onSubmit({ reVerify: true })}>
+                <Panel.Action onClick={() => onSubmit({ reVerify: true })} type="submit">
                   <TranslatableText>Re-Verify Domain </TranslatableText>
                   <Autorenew size={18} />
                 </Panel.Action>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -110,7 +110,7 @@ export default function SetupBounceDomainSection({
                   record for the Hostname and Value for this domain at your DNS provider.
                 </TranslatableText>
               </p>
-              <Panel.Action type="submit">
+              <Panel.Action type="submit" form="verify-bounce-form">
                 <TranslatableText>Re-Verify Domain </TranslatableText>
                 <Autorenew size={18} />
               </Panel.Action>

--- a/src/pages/domains/components/SetupBounceDomainSection.js
+++ b/src/pages/domains/components/SetupBounceDomainSection.js
@@ -110,7 +110,7 @@ export default function SetupBounceDomainSection({
                   record for the Hostname and Value for this domain at your DNS provider.
                 </TranslatableText>
               </p>
-              <Panel.Action onClick={onSubmit}>
+              <Panel.Action type="submit">
                 <TranslatableText>Re-Verify Domain </TranslatableText>
                 <Autorenew size={18} />
               </Panel.Action>

--- a/src/pages/domains/components/SetupForSending.js
+++ b/src/pages/domains/components/SetupForSending.js
@@ -106,7 +106,7 @@ export default function SetupForSending({ domain, isSectionVisible }) {
                     record for the Hostname and DKIM value of this domain.
                   </TranslatableText>
                 </p>
-                <Panel.Action onClick={onSubmit}>
+                <Panel.Action type="submit">
                   <TranslatableText>Re-Verify Domain </TranslatableText>
                   <Autorenew size={18} />
                 </Panel.Action>

--- a/src/pages/domains/components/TrackingDnsSection.js
+++ b/src/pages/domains/components/TrackingDnsSection.js
@@ -72,7 +72,7 @@ export default function TrackingDnsSection({ domain, isSectionVisible, title }) 
                   </Text>
                   <TranslatableText>record for this domain at your DNS provider.</TranslatableText>
                 </p>
-                <Panel.Action onClick={onSubmit}>
+                <Panel.Action type="submit">
                   <TranslatableText>Re-Verify Domain </TranslatableText>
                   <Autorenew size={18} />
                 </Panel.Action>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -71,7 +71,7 @@ export default function VerifyEmailSection({ domain, isSectionVisible }) {
 
 function VerifyButton({ onClick, variant = 'primary', submitting }) {
   return (
-    <Button variant={variant} loading={submitting} onClick={onClick}>
+    <Button variant={variant} loading={submitting} onClick={onClick} type="submit">
       Send Email
     </Button>
   );
@@ -169,36 +169,38 @@ function MailboxVerificationModal(props) {
             Start sending email from this domain by sending a verification email to one of the
             addresses below.
           </p>
-
-          <Grid middle="xs">
-            <Grid.Column xs={6}>
-              <p>
-                <strong>{`postmaster@${id}`}</strong>
-              </p>
-            </Grid.Column>
-            <Grid.Column xs={6}>
-              <VerifyButton
-                onClick={verifyWithPostmaster}
-                variant="secondary"
-                submitting={verifyEmailLoading}
-              />
-            </Grid.Column>
-          </Grid>
-
-          <Grid middle="xs">
-            <Grid.Column xs={6}>
-              <p>
-                <strong>{`abuse@${id}`}</strong>
-              </p>
-            </Grid.Column>
-            <Grid.Column xs={6}>
-              <VerifyButton
-                onClick={verifyWithAbuse}
-                variant="secondary"
-                submitting={verifyEmailLoading}
-              />
-            </Grid.Column>
-          </Grid>
+          <Form id="domain-email-verification-postmaster">
+            <Grid middle="xs">
+              <Grid.Column xs={6}>
+                <p>
+                  <strong>{`postmaster@${id}`}</strong>
+                </p>
+              </Grid.Column>
+              <Grid.Column xs={6}>
+                <VerifyButton
+                  onClick={verifyWithPostmaster}
+                  variant="secondary"
+                  submitting={verifyEmailLoading}
+                />
+              </Grid.Column>
+            </Grid>
+          </Form>
+          <Form id="domain-email-verification-abuse">
+            <Grid middle="xs">
+              <Grid.Column xs={6}>
+                <p>
+                  <strong>{`abuse@${id}`}</strong>
+                </p>
+              </Grid.Column>
+              <Grid.Column xs={6}>
+                <VerifyButton
+                  onClick={verifyWithAbuse}
+                  variant="secondary"
+                  submitting={verifyEmailLoading}
+                />
+              </Grid.Column>
+            </Grid>
+          </Form>
         </Stack>
       </Modal.Content>
     </Modal>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -182,11 +182,7 @@ function MailboxVerificationModal(props) {
                 </p>
               </Grid.Column>
               <Grid.Column xs={6}>
-                <VerifyButton
-                  onClick={verifyWithPostmaster}
-                  variant="secondary"
-                  submitting={verifyEmailLoading}
-                />
+                <VerifyButton variant="secondary" submitting={verifyEmailLoading} />
               </Grid.Column>
             </Grid>
           </Form>
@@ -204,11 +200,7 @@ function MailboxVerificationModal(props) {
                 </p>
               </Grid.Column>
               <Grid.Column xs={6}>
-                <VerifyButton
-                  onClick={verifyWithAbuse}
-                  variant="secondary"
-                  submitting={verifyEmailLoading}
-                />
+                <VerifyButton variant="secondary" submitting={verifyEmailLoading} />
               </Grid.Column>
             </Grid>
           </Form>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -69,9 +69,9 @@ export default function VerifyEmailSection({ domain, isSectionVisible }) {
   );
 }
 
-function VerifyButton({ onClick, variant = 'primary', submitting }) {
+function VerifyButton({ variant = 'primary', submitting }) {
   return (
-    <Button variant={variant} loading={submitting} onClick={onClick} type="submit">
+    <Button variant={variant} loading={submitting} type="submit">
       Send Email
     </Button>
   );
@@ -168,7 +168,13 @@ function MailboxVerificationModal(props) {
             Start sending email from this domain by sending a verification email to one of the
             addresses below.
           </p>
-          <Form id="domain-email-verification-postmaster">
+          <Form
+            id="domain-email-verification-postmaster"
+            onSubmit={e => {
+              e.preventDefault();
+              verifyWithPostmaster();
+            }}
+          >
             <Grid middle="xs">
               <Grid.Column xs={6}>
                 <p>
@@ -184,7 +190,13 @@ function MailboxVerificationModal(props) {
               </Grid.Column>
             </Grid>
           </Form>
-          <Form id="domain-email-verification-abuse">
+          <Form
+            id="domain-email-verification-abuse"
+            onSubmit={e => {
+              e.preventDefault();
+              verifyWithAbuse();
+            }}
+          >
             <Grid middle="xs">
               <Grid.Column xs={6}>
                 <p>

--- a/src/pages/domains/components/VerifyEmailSection.js
+++ b/src/pages/domains/components/VerifyEmailSection.js
@@ -96,16 +96,15 @@ function AllowAnyoneAtModal(props) {
   };
 
   return (
-    <Form onSubmit={handleSubmit(onSubmit)} id="domain-verify-by-email">
-      <Modal open onClose={onCancel} showCloseButton>
-        <Modal.Header>Verify through Email</Modal.Header>
-        <Modal.Content>
-          <Stack>
-            <p>
-              Start sending email from this domain by sending a verification email to any mailbox on
-              your domain using the form below.
-            </p>
-
+    <Modal open onClose={onCancel} showCloseButton>
+      <Modal.Header>Verify through Email</Modal.Header>
+      <Modal.Content>
+        <Stack>
+          <p>
+            Start sending email from this domain by sending a verification email to any mailbox on
+            your domain using the form below.
+          </p>
+          <Form onSubmit={handleSubmit(onSubmit)} id="domain-verify-by-email">
             <Grid>
               <Grid.Column xs={6}>
                 <div>
@@ -124,21 +123,21 @@ function AllowAnyoneAtModal(props) {
                 </div>
               </Grid.Column>
             </Grid>
-          </Stack>
-        </Modal.Content>
+          </Form>
+        </Stack>
+      </Modal.Content>
 
-        <Modal.Footer>
-          <Button
-            variant="primary"
-            type="submit"
-            form="domain-verify-by-email"
-            loading={verifyEmailLoading}
-          >
-            Send Email
-          </Button>
-        </Modal.Footer>
-      </Modal>
-    </Form>
+      <Modal.Footer>
+        <Button
+          variant="primary"
+          type="submit"
+          form="domain-verify-by-email"
+          loading={verifyEmailLoading}
+        >
+          Send Email
+        </Button>
+      </Modal.Footer>
+    </Modal>
   );
 }
 


### PR DESCRIPTION
### What Changed

**On Domain Pages**
- [ ] In SetupForSending : Re-verify Domain Panel action should be type="submit" instead of having onClick, as they are already inside a `<form>`
- [ ] In SetupBounceDomainSection - Re-verify Domain Panel action should be type="submit" instead of having onClick, as they are already inside a `<form>`
- [ ] In SendingAndBounceDomainSection - Re-verify Domain Panel action should be type="submit"
- [ ] In TrackingDnsSection - Re-verify Domain Panel action should be type="submit" instead of having onClick, as they are already inside a `<form>`
- [ ] In VerifyEmailSection | MailboxVerificationModal - should be wrapped in `<form>`

### How To Test

- onSubmit of these newly added forms work correctly
- Easier approach to testing this section would be take a existing verified sending/bounce domain and navigate to 
     - /domains/details/:domainName/verify-sending-bounce
     - domains/details/:domainName/verify-bounce
     - domains/details/:domainName/verify-sending
     for tracking domain
    - domains/details/:domainName/verify-tracking
- For email verification Modal
   - For testing MailboxVerificationModal open src/config/env/dev-config.js change allow_anyone_at_verification = false and allow_mailbox_verification = true, no spc/spceu/staging account(we can't test for enterprise account in staging) has this feature flag disabled, so the default AllowAnyoneVerificationModal currently is the most used one. Testing the MailboxVerificationModal locally should be fine
   - For testing AllowAnyoneVerificationModal open src/config/env/dev-config.js change allow_anyone_at_verification = true and allow_mailbox_verification = true

### To Do

- [ ] Address feedback
- [ ] Check if Re-Verify works correctly.

